### PR TITLE
Add notice to users about public files/add link to user profile

### DIFF
--- a/app/user-quickfiles/controller.js
+++ b/app/user-quickfiles/controller.js
@@ -2,7 +2,7 @@ import { computed } from '@ember/object';
 import Controller from '@ember/controller';
 
 export default Controller.extend({
-    title: computed('model.givenName', function() {
+    title: computed('model.fullName', function() {
         return `${this.get('model.fullName')}'s Quick Files`;
     }),
     actions: {

--- a/app/user-quickfiles/template.hbs
+++ b/app/user-quickfiles/template.hbs
@@ -2,6 +2,7 @@
 
 {{quickfile-nav user=model onQuickfiles=true}}
 <div class='quickfiles-content container'>
-    <h2>{{title}}</h2>
+    <h2><a href="{{model.links.html}}">{{model.fullName}}</a>'s Quick Files</h2>
+    <h5><i>Files uploaded here are <b>publicly accessible</b> and easy to share with others using the share link.</i></h5>
     {{file-browser user=model openFile=(action 'openFile')}}
 </div>


### PR DESCRIPTION
# Purpose

To add a link to the user's profile and a message below that informs users about files being publicly accessible on the Quick Files app.

# Changes

- Turned the user's name into a link that will take you to their profile page on the OSF
- Added wording below the user's name that tells the users about files being public

![screen shot 2017-09-28 at 4 00 15 pm](https://user-images.githubusercontent.com/19379783/30987800-39711448-a466-11e7-902f-e1f418db9965.png)


# Notes

Still kept the computed function in order to render the page's title with the right text.