### PR TITLE
[EOSF-770] Add edit features to file-detail page

### DIFF
--- a/app/file-detail/controller.js
+++ b/app/file-detail/controller.js
@@ -4,15 +4,15 @@ import { computed } from '@ember/object';
 import { A } from '@ember/array';
 import Controller from '@ember/controller';
 import { authenticatedAJAX } from 'ember-osf/utils/ajax-helpers';
+import { mimeTypes } from 'ember-osf/const/mime-types';
 
 export default Controller.extend({
     currentUser: service(),
     revision: null,
     openModal: false,
-    editableFileTypes: A(['txt']),
     displays: A([]),
 
-    mfrVersion: computed('model.file', 'revision', function() {
+    mfrVersion: computed('model.file.currentVersion', 'revision', function() {
         return this.get('revision') ? this.get('revision') : this.get('model.file.currentVersion');
     }),
 
@@ -52,7 +52,7 @@ export default Controller.extend({
         return this.get('model.file.tags');
     }),
 
-    fileVersions: computed('model.file', function() {
+    fileVersions: computed('model.file.currentVersion', function() {
         return $.getJSON(`${this.get('model.file.links.download')}?revisions=&`).then(this._returnFileVersion.bind(this));
     }),
 
@@ -62,9 +62,20 @@ export default Controller.extend({
     }),
 
     isEditableFile: computed('model.file', function() {
-        const fileExtension = this.get('model.file.name').split('.').pop();
-        if (this.get('editableFileTypes').includes(fileExtension)) return true;
+        const fileName = this.get('model.file.name');
+        const fileExtension = fileName.split('.').pop();
+        if (fileExtension in mimeTypes) return true;
         return false;
+    }),
+
+    fileText: computed('model.file', function() {
+        return authenticatedAJAX({
+            url: this.get('model.file.links.download'),
+            type: 'GET',
+            xhrFields: { withCredentials: true },
+        }).done((data) => {
+            return data;
+        });
     }),
 
     actions: {
@@ -97,10 +108,54 @@ export default Controller.extend({
             this.set('openModal', false);
         },
 
-        changeViewRevisionPane() {
-            $('#mfrIframeParent').toggle();
-            $('#revisionsPanel').toggle();
-            $('.view-button').toggleClass('btn-default btn-primary');
+        changeViewPanel(panel, button) {
+            if (!this.get('isEditableFile')) {
+                $('#mainViewBtn, #revisionBtn').toggleClass('btn-primary btn-default');
+                $('#mfrIframeParent, #revisionsPanel').toggle();
+                return;
+            }
+
+            if (button === 'revisionBtn' && $(`#${panel}`).css('display') === 'none') {
+                $('.panel-view').hide().removeClass('col-sm-6');
+                $('.view-button').removeClass('btn-primary').addClass('btn-default');
+                $(`#${panel}`).toggle();
+                $(`#${button}`).toggleClass('btn-default btn-primary');
+                return;
+            } else if (button === 'revisionBtn') {
+                $('#mfrIframeParent').toggle();
+                $('#mainViewBtn').toggleClass('btn-default btn-primary');
+                $(`#${panel}`).toggle();
+                $(`#${button}`).toggleClass('btn-default btn-primary');
+                return;
+            }
+
+            if ($(`#${button}`).hasClass('btn-primary') && $('.view-button.btn-primary').length === 1) {
+                return;
+            } else if ($('#revisionsPanel').css('display') !== 'none') {
+                $('#revisionsPanel').toggle();
+                $('#revisionBtn').toggleClass('btn-default btn-primary');
+            } else if ($('#mfrIframeParent').css('display') !== 'none' || $('#editPanel').css('display') !== 'none') {
+                $('.panel-view').toggleClass('col-sm-6');
+            } else {
+                $('.panel-view').removeClass('col-sm-6');
+            }
+
+            $(`#${panel}`).toggle();
+            $(`#${button}`).toggleClass('btn-default btn-primary');
+        },
+
+        save(text) {
+            const controller = this;
+            authenticatedAJAX({
+                url: this.get('model.file.links.upload'),
+                type: 'PUT',
+                xhrFields: { withCredentials: true },
+                data: text,
+            }).done(() => {
+                controller.get('model.file').reload().then(
+                    () => controller.set('revision', null),
+                );
+            });
         },
 
         openFile(file) {

--- a/app/file-detail/controller.js
+++ b/app/file-detail/controller.js
@@ -14,6 +14,11 @@ export default Controller.extend({
 
     canDelete: computed.alias('canEdit'),
 
+    canEdit: computed('currentUser', 'model.user', function() {
+        if (!this.get('model.user.id')) return false;
+        return (this.get('model.user.id') === this.get('currentUser.currentUserId'));
+    }),
+
     mfrVersion: computed('model.file.currentVersion', 'revision', function() {
         return this.get('revision') ? this.get('revision') : this.get('model.file.currentVersion');
     }),
@@ -58,11 +63,6 @@ export default Controller.extend({
         return $.getJSON(`${this.get('model.file.links.download')}?revisions=&`).then(this._returnFileVersion.bind(this));
     }),
 
-    canEdit: computed('currentUser', 'model.user', function() {
-        if (!this.get('model.user.id')) return false;
-        return (this.get('model.user.id') === this.get('currentUser.currentUserId'));
-    }),
-
     isEditableFile: computed('model.file.name', function() {
         const fileName = this.get('model.file.name');
         const fileExtension = fileName.split('.').pop();
@@ -88,11 +88,11 @@ export default Controller.extend({
         delete() {
             this.set('deleteModalOpen', false);
             this.get('model.file').destroyRecord()
-                .then(() => this._handleDeleteSuccess())
-                .catch(() => this._handleDeleteFail());
+                .then(this._handleDeleteSuccess.bind(this))
+                .catch(this._handleDeleteFail.bind(this));
         },
 
-        showDeleteModal() {
+        openDeleteModal() {
             this.set('deleteModalOpen', true);
         },
 
@@ -137,8 +137,8 @@ export default Controller.extend({
 
         save(text) {
             this.get('model.file').updateContents(text)
-                .then(() => this._handleSaveSuccess())
-                .catch(() => this._handleSaveFail());
+                .then(this._handleSaveSuccess.bind(this))
+                .catch(this._handleSaveFail.bind(this));
         },
 
         openFile(file) {

--- a/app/file-detail/controller.js
+++ b/app/file-detail/controller.js
@@ -68,7 +68,7 @@ export default Controller.extend({
         return false;
     }),
 
-    fileText: computed('model.file', function() {
+    fileText: computed('model.file.currentVersion', function() {
         return this.get('model.file').getContents();
     }),
 
@@ -145,6 +145,7 @@ export default Controller.extend({
             } else {
                 file.getGuid().then(() => this.transitionToRoute('file-detail', file.get('guid')));
             }
+            this._resetPanels();
         },
 
         addTag(tag) {
@@ -184,6 +185,14 @@ export default Controller.extend({
             return this.get('toast').success('File saved');
         }
         return this.get('toast').error('Error, unable to save file');
+    },
+
+    _resetPanels() {
+        // Resets the panels to original states
+        $('#revisionsPanel, #editPanel').hide();
+        $('#mfrIframeParent').show().removeClass('col-sm-6');
+        $('#revisionBtn, #editViewBtn').removeClass('btn-primary').addClass('btn-default');
+        $('#mainViewBtn').removeClass('btn-default').addClass('btn-primary');
     },
 
 });

--- a/app/file-detail/controller.js
+++ b/app/file-detail/controller.js
@@ -8,6 +8,7 @@ import { mimeTypes } from 'ember-osf/const/mime-types';
 
 export default Controller.extend({
     currentUser: service(),
+    toast: service(),
     revision: null,
     openModal: false,
     displays: A([]),
@@ -154,7 +155,10 @@ export default Controller.extend({
             }).done(() => {
                 controller.get('model.file').reload().then(
                     () => controller.set('revision', null),
+                    this.get('toast').success('File saved'),
                 );
+            }).fail(() => {
+                this.get('toast').error('Error, unable to save file');
             });
         },
 

--- a/app/file-detail/template.hbs
+++ b/app/file-detail/template.hbs
@@ -164,7 +164,7 @@
                     {{#if (await fileText)}}
                         {{#file-editor
                             fileText=(await fileText)
-                            save='save'}}
+                            save=(action 'save')}}
                         {{/file-editor}}
                     {{/if}}
                 </div>

--- a/app/file-detail/template.hbs
+++ b/app/file-detail/template.hbs
@@ -7,9 +7,9 @@
     <div class='col-sm-7'>
         <div id='toggleBar' class='pull-right'>
             <div class='btn-toolbar m-t-md'>
-                {{#if edit}}
+                {{#if canDelete}}
                     <div class='btn-group m-l-xs m-t-xs'>
-                        <button class='btn btn-sm btn-default' {{action 'showModal'}}>
+                        <button class='btn btn-sm btn-default' onclick={{action 'showDeleteModal'}}>
                             Delete
                         </button>
                     </div>
@@ -74,7 +74,7 @@
                 </div>
                 {{#if isEditableFile}}
                         <div class='btn-group btn-group-sm m-t-xs'>
-                            {{#if edit}}
+                            {{#if canEdit}}
                                 <div class='btn btn-default disabled'>Toggle view: </div>
                                 <button class='btn btn-primary view-button' id='mainViewBtn' {{action 'changeViewPanel' 'mfrIframeParent' 'mainViewBtn'}}>View</button>
                                 <button class='btn btn-default view-button' id='editViewBtn' {{action 'changeViewPanel' 'editPanel' 'editViewBtn'}}>Edit</button>
@@ -98,16 +98,16 @@
         </div>
     </div>
 </div>
-{{#bs-modal open=openModal onSubmit=(action 'delete') as |modal|}}
-    {{#modal.header onClose=(action 'closeModal')}}
+{{#bs-modal open=deleteModalOpen onSubmit=(action 'delete') as |modal|}}
+    {{#modal.header onClose=(action 'closeDeleteModal')}}
         <h4 class="modal-title">Delete file?</h4>
     {{/modal.header}}
     {{#modal.body}}
         <p>Are you sure you want to delete <b>{{model.file.name}}</b>?</p>
     {{/modal.body}}
     {{#modal.footer as |footer|}}
-        {{#bs-button onClick=(action 'closeModal') type="default"}}Cancel{{/bs-button}}
-        {{#bs-button onClick=(action modal.submit) type="danger"}}Delete{{/bs-button}}
+        {{#bs-button onClick=(action 'closeDeleteModal') type='default'}}Cancel{{/bs-button}}
+        {{#bs-button onClick=(action modal.submit) type='danger'}}Delete{{/bs-button}}
     {{/modal.footer}}
 {{/bs-modal}}
 <hr>
@@ -124,7 +124,7 @@
                 <h3 class='panel-title'>Tags:</h3>
             </div>
             <div class='panel-body'>
-                {{#if edit}}
+                {{#if canEdit}}
                     {{#tag-input
                         tags=fileTags
                         addTag=(action 'addTag')
@@ -159,7 +159,7 @@
             {{/file-renderer}}
         </div>
         {{#if isEditableFile}}
-            {{#if edit}}
+            {{#if canEdit}}
                 <div id='editPanel' class='panel-view panel panel-default'>
                     {{#if (await fileText)}}
                         {{#file-editor

--- a/app/file-detail/template.hbs
+++ b/app/file-detail/template.hbs
@@ -9,13 +9,13 @@
             <div class='btn-toolbar m-t-md'>
                 {{#if edit}}
                     <div class='btn-group m-l-xs m-t-xs'>
-                        <button class='btn btn-sm btn-danger' {{action 'showModal'}}>
+                        <button class='btn btn-sm btn-default' {{action 'showModal'}}>
                             Delete
                         </button>
                     </div>
                 {{/if}}
                 <div class='btn-group m-l-xs m-t-xs'>
-                    <button class='btn btn-sm btn-primary popover-toggler'>
+                    <button class='btn btn-sm btn-default popover-toggler'>
                         Share
                         {{#bs-popover placement='bottom' class='share-popover' title='Share'}}
                             {{#bs-tab customTabs=true as |tab|}}

--- a/app/file-detail/template.hbs
+++ b/app/file-detail/template.hbs
@@ -2,11 +2,18 @@
 {{quickfile-nav user=model.user onQuickfiles=false}}
 <div class='quickfiles-content row'>
     <div class='col-sm-5'>
-        <h2>{{model.file.name}} <a id='versionLink' onclick={{action 'changeViewRevisionPane'}}>(Version: {{mfrVersion}})</a></h2>
+        <h2>{{model.file.name}} <a id='versionLink' onclick={{action 'changeViewPanel' 'revisionsPanel' 'revisionBtn'}}>(Version: {{mfrVersion}})</a></h2>
     </div>
     <div class='col-sm-7'>
         <div id='toggleBar' class='pull-right'>
             <div class='btn-toolbar m-t-md'>
+                {{#if edit}}
+                    <div class='btn-group m-l-xs m-t-xs'>
+                        <button class='btn btn-sm btn-danger' {{action 'showModal'}}>
+                            Delete
+                        </button>
+                    </div>
+                {{/if}}
                 <div class='btn-group m-l-xs m-t-xs'>
                     <button class='btn btn-sm btn-primary popover-toggler'>
                         Share
@@ -65,28 +72,25 @@
                         Download
                     </button>
                 </div>
-                {{#if edit}}
-                    <div class='btn-group m-l-xs m-t-xs'>
-                        <button class='btn btn-sm btn-danger' {{action 'showModal'}}>
-                            Delete
-                        </button>
-                    </div>
-                {{/if}}
                 {{#if isEditableFile}}
-                    <div class='btn-group btn-group-sm m-t-xs'>
-                        <div class='btn btn-default disabled'>Toggle view: </div>
-                        <button class='btn btn-primary'>View</button>
-                        <button class='btn btn-default'>Edit</button>
-                    </div>
+                        <div class='btn-group btn-group-sm m-t-xs'>
+                            {{#if edit}}
+                                <div class='btn btn-default disabled'>Toggle view: </div>
+                                <button class='btn btn-primary view-button' id='mainViewBtn' {{action 'changeViewPanel' 'mfrIframeParent' 'mainViewBtn'}}>View</button>
+                                <button class='btn btn-default view-button' id='editViewBtn' {{action 'changeViewPanel' 'editPanel' 'editViewBtn'}}>Edit</button>
+                            {{else}}
+                                <button class='btn btn-primary view-button' id='mainViewBtn' {{action 'changeViewPanel' 'mfrIframeParent' 'mainViewBtn'}}>View</button>
+                            {{/if}}
+                        </div>
                 {{else}}
                     <div class='btn-group m-l-xs m-t-xs'>
-                        <button class='btn btn-sm btn-primary view-button' {{action 'changeViewRevisionPane'}}>
+                        <button class='btn btn-sm btn-primary' id='mainViewBtn' {{action 'changeViewPanel' 'mfrIframeParent' 'mainViewBtn'}}>
                             View
                         </button>
                     </div>
                 {{/if}}
                 <div class='btn-group m-l-xs m-t-xs'>
-                    <button class='btn btn-sm btn-default view-button' {{action 'changeViewRevisionPane'}}>
+                    <button class='btn btn-sm btn-default' id='revisionBtn' {{action 'changeViewPanel' 'revisionsPanel' 'revisionBtn'}}>
                         Revisions
                     </button>
                 </div>
@@ -131,7 +135,7 @@
                     }}
                         {{tag}}
                     {{/tag-input}}
-                {{else}} <!-- Passing a mutable value to readOnly breaks tag-input. INstead render it with a set value -->
+                {{else}} <!-- Passing a mutable value to readOnly breaks tag-input. Instead render it with a set value -->
                     {{#tag-input
                         tags=fileTags
                         addTag=(action 'addTag')
@@ -149,11 +153,23 @@
         </div>
     </div>
     <div class='col-md-9'>
-        <div id='mfrIframeParent'>
+        <div id='mfrIframeParent' class='panel-view'>
             {{#file-renderer download=model.file.links.download version=mfrVersion
                 height="700" width="99%"}}
             {{/file-renderer}}
         </div>
+        {{#if isEditableFile}}
+            {{#if edit}}
+                <div id='editPanel' class='panel-view panel panel-default'>
+                    {{#if (await fileText)}}
+                        {{#file-editor
+                            fileText=(await fileText)
+                            save='save'}}
+                        {{/file-editor}}
+                    {{/if}}
+                </div>
+            {{/if}}
+        {{/if}}
         <div id='revisionsPanel' class='panel panel-default'>
             <div class='panel-heading clearfix'>
                 <h3 class='panel-title'>

--- a/app/file-detail/template.hbs
+++ b/app/file-detail/template.hbs
@@ -9,7 +9,7 @@
             <div class='btn-toolbar m-t-md'>
                 {{#if canDelete}}
                     <div class='btn-group m-l-xs m-t-xs'>
-                        <button class='btn btn-sm btn-default' onclick={{action 'showDeleteModal'}}>
+                        <button class='btn btn-sm btn-default' onclick={{action 'openDeleteModal'}}>
                             Delete
                         </button>
                     </div>
@@ -33,7 +33,7 @@
                                         <br>
                                         <div class='input-group'>
                                             <span class='input-group-btn share-btn-container'>
-                                                <button type='button' class='btn btn-default btn-md' {{action 'share'}}>
+                                                <button type='button' class='btn btn-default btn-md' onclick={{action 'share'}}>
                                                     <div class='fa fa-copy'></div>
                                                 </button>
                                             </span>
@@ -68,7 +68,7 @@
                     </button>
                 </div>
                 <div class='btn-group m-l-xs m-t-xs'>
-                    <button class='btn btn-sm btn-primary' {{action 'download' model.file.currentVersion}}>
+                    <button class='btn btn-sm btn-primary' onclick={{action 'download' model.file.currentVersion}}>
                         Download
                     </button>
                 </div>
@@ -76,21 +76,21 @@
                         <div class='btn-group btn-group-sm m-t-xs'>
                             {{#if canEdit}}
                                 <div class='btn btn-default disabled'>Toggle view: </div>
-                                <button class='btn btn-primary view-button' id='mainViewBtn' {{action 'changeViewPanel' 'mfrIframeParent' 'mainViewBtn'}}>View</button>
-                                <button class='btn btn-default view-button' id='editViewBtn' {{action 'changeViewPanel' 'editPanel' 'editViewBtn'}}>Edit</button>
+                                <button class='btn btn-primary view-button' id='mainViewBtn' onclick={{action 'changeViewPanel' 'mfrIframeParent' 'mainViewBtn'}}>View</button>
+                                <button class='btn btn-default view-button' id='editViewBtn' onclick={{action 'changeViewPanel' 'editPanel' 'editViewBtn'}}>Edit</button>
                             {{else}}
-                                <button class='btn btn-primary view-button' id='mainViewBtn' {{action 'changeViewPanel' 'mfrIframeParent' 'mainViewBtn'}}>View</button>
+                                <button class='btn btn-primary view-button' id='mainViewBtn' onclick={{action 'changeViewPanel' 'mfrIframeParent' 'mainViewBtn'}}>View</button>
                             {{/if}}
                         </div>
                 {{else}}
                     <div class='btn-group m-l-xs m-t-xs'>
-                        <button class='btn btn-sm btn-primary' id='mainViewBtn' {{action 'changeViewPanel' 'mfrIframeParent' 'mainViewBtn'}}>
+                        <button class='btn btn-sm btn-primary' id='mainViewBtn' onclick={{action 'changeViewPanel' 'mfrIframeParent' 'mainViewBtn'}}>
                             View
                         </button>
                     </div>
                 {{/if}}
                 <div class='btn-group m-l-xs m-t-xs'>
-                    <button class='btn btn-sm btn-default' id='revisionBtn' {{action 'changeViewPanel' 'revisionsPanel' 'revisionBtn'}}>
+                    <button class='btn btn-sm btn-default' id='revisionBtn' onclick={{action 'changeViewPanel' 'revisionsPanel' 'revisionBtn'}}>
                         Revisions
                     </button>
                 </div>
@@ -135,7 +135,8 @@
                     }}
                         {{tag}}
                     {{/tag-input}}
-                {{else}} <!-- Passing a mutable value to readOnly breaks tag-input. Instead render it with a set value -->
+                {{else}}
+                    {{!-- Passing a mutable value to readOnly breaks tag-input. Instead render it with a set value --}}
                     {{#tag-input
                         tags=fileTags
                         addTag=(action 'addTag')

--- a/app/file-detail/template.hbs
+++ b/app/file-detail/template.hbs
@@ -1,10 +1,10 @@
 {{title model.file.name}}
 {{quickfile-nav user=model.user onQuickfiles=false}}
 <div class='quickfiles-content row'>
-    <div class='col-sm-8'>
-        <h2>{{model.file.name}} <a id='versionLink' onclick={{action 'changeView'}}>(Version: {{mfrVersion}})</a></h2>
+    <div class='col-sm-5'>
+        <h2>{{model.file.name}} <a id='versionLink' onclick={{action 'changeViewRevisionPane'}}>(Version: {{mfrVersion}})</a></h2>
     </div>
-    <div class='col-sm-4'>
+    <div class='col-sm-7'>
         <div id='toggleBar' class='pull-right'>
             <div class='btn-toolbar m-t-md'>
                 <div class='btn-group m-l-xs m-t-xs'>
@@ -65,13 +65,28 @@
                         Download
                     </button>
                 </div>
+                {{#if edit}}
+                    <div class='btn-group m-l-xs m-t-xs'>
+                        <button class='btn btn-sm btn-danger' {{action 'showModal'}}>
+                            Delete
+                        </button>
+                    </div>
+                {{/if}}
+                {{#if isEditableFile}}
+                    <div class='btn-group btn-group-sm m-t-xs'>
+                        <div class='btn btn-default disabled'>Toggle view: </div>
+                        <button class='btn btn-primary'>View</button>
+                        <button class='btn btn-default'>Edit</button>
+                    </div>
+                {{else}}
+                    <div class='btn-group m-l-xs m-t-xs'>
+                        <button class='btn btn-sm btn-primary view-button' {{action 'changeViewRevisionPane'}}>
+                            View
+                        </button>
+                    </div>
+                {{/if}}
                 <div class='btn-group m-l-xs m-t-xs'>
-                    <button class='btn btn-sm btn-primary view-button' {{action 'changeView'}}>
-                        View
-                    </button>
-                </div>
-                <div class='btn-group m-l-xs m-t-xs'>
-                    <button class='btn btn-sm btn-default view-button' {{action 'changeView'}}>
+                    <button class='btn btn-sm btn-default view-button' {{action 'changeViewRevisionPane'}}>
                         Revisions
                     </button>
                 </div>
@@ -79,6 +94,18 @@
         </div>
     </div>
 </div>
+{{#bs-modal open=openModal onSubmit=(action 'delete') as |modal|}}
+    {{#modal.header onClose=(action 'closeModal')}}
+        <h4 class="modal-title">Delete file?</h4>
+    {{/modal.header}}
+    {{#modal.body}}
+        <p>Are you sure you want to delete <b>{{model.file.name}}</b>?</p>
+    {{/modal.body}}
+    {{#modal.footer as |footer|}}
+        {{#bs-button onClick=(action 'closeModal') type="default"}}Cancel{{/bs-button}}
+        {{#bs-button onClick=(action modal.submit) type="danger"}}Delete{{/bs-button}}
+    {{/modal.footer}}
+{{/bs-modal}}
 <hr>
 <div class='row'>
     <div class='col-md-3'>

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -4,8 +4,15 @@
 #versionLink {
    cursor: pointer;
 }
-#revisionsPanel {
+#revisionsPanel,
+#editPanel {
    display: none;
+}
+#editPanel {
+    padding:0px;
+}
+.disabled {
+    pointer-events: none;
 }
 .panel {
    border: 1px solid transparent;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -133,3 +133,6 @@ td .input-group {
     /* Microsoft Edge */
     color: rgb(102, 102, 102);
 }
+#toast-container > div {
+    opacity: 1;
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "use-ember-osf-develop": "yarn upgrade @centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#$(date -u +%FT%TZ)"
   },
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-10-19T04:44:33Z",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#(data -u +%FT%TZ)",
     "@centerforopenscience/eslint-config": "^2.0.0",
     "@centerforopenscience/osf-style": "1.5.0",
     "bootstrap": "^3.3.7",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "use-ember-osf-develop": "yarn upgrade @centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#$(date -u +%FT%TZ)"
   },
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#(data -u +%FT%TZ)",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-10-26T18:27:52Z",
     "@centerforopenscience/eslint-config": "^2.0.0",
     "@centerforopenscience/osf-style": "1.5.0",
     "bootstrap": "^3.3.7",

--- a/tests/unit/file-detail/controller-test.js
+++ b/tests/unit/file-detail/controller-test.js
@@ -1,7 +1,10 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:file-detail', 'Unit | Controller | file detail', {
-    needs: ['service:currentUser'],
+    needs: [
+        'service:currentUser',
+        'service:toast',
+    ],
 });
 
 // Replace this with your real tests.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,14 +2,15 @@
 # yarn lockfile v1
 
 
-"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-10-19T04:44:33Z":
-  version "0.11.1"
-  resolved "https://github.com/CenterForOpenScience/ember-osf.git#585ec7d0296917f18d601df08d697e692aee18d5"
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-10-26T18:27:52Z":
+  version "0.11.3"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#9d4270c4e03303c0fa46ac806c672c9a27055c47"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"
     broccoli-sass-source-maps "2.0.0"
     config "1.26.1"
+    ember-ace "^1.2.0"
     ember-cli-babel "6.4.1"
     ember-cli-htmlbars "2.0.1"
     ember-cli-htmlbars-inline-precompile "0.4.3"
@@ -138,6 +139,10 @@ accepts@~1.3.4:
   dependencies:
     mime-types "~2.1.16"
     negotiator "0.6.1"
+
+ace-builds@^1.2.8:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/ace-builds/-/ace-builds-1.2.9.tgz#2947fb47a881005e914e3dd8d095b6e84e5e5216"
 
 acorn-jsx@^3.0.0:
   version "3.0.1"
@@ -354,10 +359,6 @@ ast-traverse@~0.1.1:
 ast-types@0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.12.tgz#a0d90e4351bb887716c83fd637ebf818af4adfcc"
-
-ast-types@0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.15.tgz#8eef0827f04dff0ec8857ba925abe3fea6194e52"
 
 ast-types@0.9.12:
   version "0.9.12"
@@ -2257,6 +2258,17 @@ electron-to-chromium@^1.3.24:
   version "1.3.26"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.26.tgz#996427294861a74d9c7c82b9260ea301e8c02d66"
 
+ember-ace@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ember-ace/-/ember-ace-1.2.0.tgz#93115b20f99c18c49ccaea026fcbf8c00c175997"
+  dependencies:
+    ace-builds "^1.2.8"
+    broccoli-merge-trees "^2.0.0"
+    broccoli-plugin "^1.2.1"
+    ember-cli-babel "^6.6.0"
+    ember-cli-htmlbars "^2.0.2"
+    ember-cli-node-assets "^0.2.2"
+
 ember-ajax@^2.4.1:
   version "2.5.6"
   resolved "https://registry.yarnpkg.com/ember-ajax/-/ember-ajax-2.5.6.tgz#a75f743ccf1b95e979a5cf96013b3dba8fa625e4"
@@ -2323,7 +2335,7 @@ ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.10, ember-cli-babel@^5.1.5, ember-c
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.1.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.7.1, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@~6.8.0:
+ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.1.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.1, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@~6.8.0:
   version "6.8.2"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.8.2.tgz#eac2785964f4743f4c815cd53c6288f00cc087d7"
   dependencies:
@@ -2522,6 +2534,17 @@ ember-cli-node-assets@0.1.6:
     broccoli-funnel "^1.0.1"
     broccoli-merge-trees "^1.1.1"
     broccoli-unwatched-tree "^0.1.1"
+    debug "^2.2.0"
+    lodash "^4.5.1"
+    resolve "^1.1.7"
+
+ember-cli-node-assets@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-node-assets/-/ember-cli-node-assets-0.2.2.tgz#d2d55626e7cc6619f882d7fe55751f9266022708"
+  dependencies:
+    broccoli-funnel "^1.0.1"
+    broccoli-merge-trees "^1.1.1"
+    broccoli-source "^1.1.0"
     debug "^2.2.0"
     lodash "^4.5.1"
     resolve "^1.1.7"
@@ -3847,7 +3870,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@7.1.1:
+glob@7.1.1, glob@^7.0.4, glob@^7.0.5:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -3868,7 +3891,7 @@ glob@^5.0.10, glob@^5.0.15:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5, glob@^7.1.2, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.2, glob@~7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -5229,17 +5252,13 @@ minimatch@^2.0.3:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
@@ -5914,20 +5933,11 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
-recast@0.10.33:
+recast@0.10.33, recast@^0.10.10:
   version "0.10.33"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.33.tgz#942808f7aa016f1fa7142c461d7e5704aaa8d697"
   dependencies:
     ast-types "0.8.12"
-    esprima-fb "~15001.1001.0-dev-harmony-fb"
-    private "~0.1.5"
-    source-map "~0.5.0"
-
-recast@^0.10.10:
-  version "0.10.43"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.43.tgz#b95d50f6d60761a5f6252e15d80678168491ce7f"
-  dependencies:
-    ast-types "0.8.15"
     esprima-fb "~15001.1001.0-dev-harmony-fb"
     private "~0.1.5"
     source-map "~0.5.0"
@@ -6523,11 +6533,7 @@ spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
-sprintf-js@^1.0.3:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.1.tgz#36be78320afe5801f6cea3ee78b6e5aab940ea0c"
-
-sprintf-js@~1.0.2:
+sprintf-js@^1.0.3, sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 


### PR DESCRIPTION
## Ticket 

https://openscience.atlassian.net/browse/EOSF-770

## Purpose

To add edit features to the file-detail page on quickfiles.

## Changes

- Add edit button to button bar, only accessible if the user is the owner of the files and if the files are actually editable
- Add delete button.  On click, delete button takes user back to quickfiles home page after deleting that file
- Add edit pane.  Will show the text of the file and is editable by the user/owner.  When the user clicks `Revert`, the text will go back to the way it was before their edits.  When they click `Save`, the updates will save as a new revision and the model will update with the new data.

Edit 10/25:
- Buttons were formatted to copy what it looks like currently on staging osf.io.  The only buttons with `btn-primary` class are `Download` and the `View/Edit/Revisions` buttons.
![screen shot 2017-10-25 at 2 36 51 pm](https://user-images.githubusercontent.com/19379783/32016461-0ae917a6-b992-11e7-9b37-98794fec1ed1.png)
## Notes

Should be used with https://github.com/CenterForOpenScience/ember-osf/pull/279 to get the file-editor widget