### PR TITLE
[EOSF-767] Get guid from API then transition when guid not set

### DIFF
--- a/app/user-quickfiles/controller.js
+++ b/app/user-quickfiles/controller.js
@@ -10,7 +10,7 @@ export default Controller.extend({
             if (file.get('guid')) {
                 this.transitionToRoute('file-detail', file.get('guid'));
             } else {
-                window.location = `/file_redirect${file.get('path')}`;
+                file.getGuid().then(() => this.transitionToRoute('file-detail', file.get('guid')));
             }
         },
     },


### PR DESCRIPTION
When opening a file, if it doesn't yet have a guid, request one from the API, then transition to file detail route for the file.