### PR TITLE
[EOSF-769] Globally set moment format

### DIFF
--- a/app/application/route.js
+++ b/app/application/route.js
@@ -1,5 +1,10 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 import OSFAgnosticAuthRouteMixin from 'ember-osf/mixins/osf-agnostic-auth-route';
 
 export default Route.extend(OSFAgnosticAuthRouteMixin, {
+    moment: service(),
+    beforeModel() {
+        this.get('moment').setTimeZone('UTC');
+    },
 });

--- a/config/environment.js
+++ b/config/environment.js
@@ -28,6 +28,10 @@ module.exports = function(environment) {
             // Here you can pass flags/options to your application instance
             // when it is created
         },
+        moment: {
+            includeTimezone: 'all',
+            outputFormat: 'YYYY-MM-DD h:mm A z',
+        },
     };
 
     if (environment === 'development') {


### PR DESCRIPTION
## Ticket

An ember-osf-web side fix for version's dates to use UTC format:
https://openscience.atlassian.net/browse/EOSF-769

## Purpose

To format moment to use UTC format for all dates by default.