### PR TITLE
Update assets links to use ember_osf_web instead of quickfiles

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -8,8 +8,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600,300,700' rel='stylesheet' type='text/css'>
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
-    <link rel="stylesheet" href="{{rootURL}}quickfiles/assets/vendor.css">
-    <link rel="stylesheet" href="{{rootURL}}quickfiles/assets/ember-osf-web.css">
+    <link rel="stylesheet" href="{{rootURL}}ember_osf_web/assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}ember_osf_web/assets/ember-osf-web.css">
     {{content-for "head"}}
     {{content-for "head-footer"}}
   </head>
@@ -17,8 +17,8 @@
     {{content-for "assets"}}
     {{content-for "body"}}
 
-    <script src="{{rootURL}}quickfiles/assets/vendor.js"></script>
-    <script src="{{rootURL}}quickfiles/assets/ember-osf-web.js"></script>
+    <script src="{{rootURL}}ember_osf_web/assets/vendor.js"></script>
+    <script src="{{rootURL}}ember_osf_web/assets/ember-osf-web.js"></script>
 
     {{content-for "raven"}}
     {{content-for "body-footer"}}


### PR DESCRIPTION
## Ticket

None

## Purpose

Change the assets to point at `ember_osf_web` instead of `quickfiles`