### PR TITLE
[EOSF-769] Get guid then transition instead of file_redirect

### DIFF
--- a/app/file-detail/controller.js
+++ b/app/file-detail/controller.js
@@ -79,7 +79,7 @@ export default Controller.extend({
             if (file.get('guid')) {
                 this.transitionToRoute('file-detail', file.get('guid'));
             } else {
-                window.location = `/file_redirect${file.get('path')}`;
+                file.getGuid().then(() => this.transitionToRoute('file-detail', file.get('guid')));
             }
         },
 


### PR DESCRIPTION
When a file doesn't yet have a guid, get one from the API and then transition instead of using file_redirect.