### PR TITLE
[EOSF-770] Add action for clicking off of the delete modal

### DIFF
--- a/app/file-detail/template.hbs
+++ b/app/file-detail/template.hbs
@@ -98,7 +98,7 @@
         </div>
     </div>
 </div>
-{{#bs-modal open=deleteModalOpen onSubmit=(action 'delete') as |modal|}}
+{{#bs-modal open=deleteModalOpen onSubmit=(action 'delete') onHidden=(action 'closeDeleteModal') as |modal|}}
     {{#modal.header onClose=(action 'closeDeleteModal')}}
         <h4 class="modal-title">Delete file?</h4>
     {{/modal.header}}


### PR DESCRIPTION
## Purpose

There are three ways to close the delete modal on the file-detail page: clicking the `x` and `Close` buttons or by clicking off of the modal.  At the moment, only the button clicks are being properly handled; when clicking off of the modal it will not change the value of the `open` computed value and will not be able to re-open the modal.

## Summary of Changes

Add the `onHidden` property to the modal to use the `closeDeleteModal` function when the modal is hidden (mainly via clicking off of the modal itself).

## Side Effects / Testing Notes

None

## Ticket

https://openscience.atlassian.net/browse/EOSF-770

# Reviewer Checklist

- [x] meets requirements
- [x] easy to understand
- [x] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(don't have initial release yet)*