### PR TITLE
[EOSF-873] Add analytics to Quick Files

### DIFF
--- a/app/file-detail/controller.js
+++ b/app/file-detail/controller.js
@@ -6,8 +6,9 @@ import Controller from '@ember/controller';
 import { mimeTypes } from 'ember-osf/const/mime-types';
 import outsideClick from 'ember-osf/utils/outside-click';
 import mime from 'npm:mime-types';
+import Analytics from 'ember-osf/mixins/analytics';
 
-export default Controller.extend({
+export default Controller.extend(Analytics, {
     currentUser: service(),
     toast: service(),
     revision: null,

--- a/app/file-detail/route.js
+++ b/app/file-detail/route.js
@@ -1,11 +1,20 @@
 import { hash } from 'rsvp';
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import Analytics from 'ember-osf/mixins/analytics';
 
-export default Route.extend({
+export default Route.extend(Analytics, {
+    currentUser: service(),
+
     model(params) {
         return hash({
             file: this.store.findRecord('file', params.file_id),
             user: this.store.findRecord('file', params.file_id).then(file => file.get('user')).then(user => user.reload()),
         });
+    },
+    afterModel(model, transition) {
+        if (model.user.id !== this.get('currentUser.currentUserId')) {
+            transition.send('track', 'page view', 'track', 'Quick Files - Non-owner page view');
+        }
     },
 });

--- a/app/file-detail/route.js
+++ b/app/file-detail/route.js
@@ -14,7 +14,7 @@ export default Route.extend(Analytics, {
     },
     afterModel(model, transition) {
         if (model.user.id !== this.get('currentUser.currentUserId')) {
-            transition.send('track', 'page view', 'track', 'Quick Files - Non-owner page view');
+            transition.send('track', 'page view', 'track', 'Quick Files - File detail page view');
         }
     },
 });

--- a/app/file-detail/template.hbs
+++ b/app/file-detail/template.hbs
@@ -44,16 +44,16 @@
                                             </span>
                                             <input readonly='true' type='text' class='form-control' value='{{{mfrUrl}}}' id='sharePaneUrl'>
                                             <div class='share-buttons'>
-                                                <a href='{{twitterUrl}}' target='_blank' onclick={{action 'click' 'link' 'Quick Files - Share file' preventDefault=false}}>
+                                                <a href='{{twitterUrl}}' target='_blank' onclick={{action 'click' 'link' 'Quick Files - Share file on Twitter' preventDefault=false}}>
                                                     <i aria-hidden='true' class='fa fa-twitter'></i>
                                                 </a>
-                                                <a href='{{facebookUrl}}' target='_blank' onclick={{action 'click' 'link' 'Quick Files - Share file' preventDefault=false}}>
+                                                <a href='{{facebookUrl}}' target='_blank' onclick={{action 'click' 'link' 'Quick Files - Share file on Facebook' preventDefault=false}}>
                                                     <i aria-hidden='true' class='fa fa-facebook'></i>
                                                 </a>
-                                                <a href='{{linkedInUrl}}' target='_blank' data-toggle='tooltip' data-placement='bottom' data-original-title='Disable adblock for full sharing functionality' onclick={{action 'click' 'link' 'Quick Files - Share file' preventDefault=false}}>
+                                                <a href='{{linkedInUrl}}' target='_blank' data-toggle='tooltip' data-placement='bottom' data-original-title='Disable adblock for full sharing functionality' onclick={{action 'click' 'link' 'Quick Files - Share file on LinkedIn' preventDefault=false}}>
                                                     <i aria-hidden='true' class='fa fa-linkedin'></i>
                                                 </a>
-                                                <a href='{{emailUrl}}' target='_blank' onclick={{action 'click' 'link' 'Quick Files - Share file' preventDefault=false}}>
+                                                <a href='{{emailUrl}}' target='_blank' onclick={{action 'click' 'link' 'Quick Files - Share file in email' preventDefault=false}}>
                                                     <i aria-hidden='true' class='fa fa-envelope'></i>
                                                 </a>
                                             </div>

--- a/app/file-detail/template.hbs
+++ b/app/file-detail/template.hbs
@@ -15,7 +15,7 @@
                     </div>
                 {{/if}}
                 <div class='btn-group m-l-xs m-t-xs'>
-                    <button class='btn btn-sm btn-primary' onclick={{action 'download' model.file.currentVersion}}>
+                    <button class='btn btn-sm btn-primary' onclick={{unless edit (action 'click' 'button' 'Quick Files - Download')}} {{action 'download' model.file.currentVersion}}>
                         Download
                     </button>
                 </div>
@@ -38,22 +38,22 @@
                                         <br>
                                         <div class='input-group'>
                                             <span class='input-group-btn share-btn-container'>
-                                                <button type='button' class='btn btn-default btn-md' onclick={{action 'share'}}>
+                                                <button type='button' class='btn btn-default btn-md' onclick={{action 'click' 'button' 'Quick Files - Share file'}} {{action 'share'}}>
                                                     <div class='fa fa-copy'></div>
                                                 </button>
                                             </span>
                                             <input readonly='true' type='text' class='form-control' value='{{{mfrUrl}}}' id='sharePaneUrl'>
                                             <div class='share-buttons'>
-                                                <a href='{{twitterUrl}}' target='_blank'>
+                                                <a href='{{twitterUrl}}' target='_blank' onclick={{action 'click' 'link' 'Quick Files - Share file' preventDefault=false}}>
                                                     <i aria-hidden='true' class='fa fa-twitter'></i>
                                                 </a>
-                                                <a href='{{facebookUrl}}' target='_blank'>
+                                                <a href='{{facebookUrl}}' target='_blank' onclick={{action 'click' 'link' 'Quick Files - Share file' preventDefault=false}}>
                                                     <i aria-hidden='true' class='fa fa-facebook'></i>
                                                 </a>
-                                                <a href='{{linkedInUrl}}' target='_blank' data-toggle='tooltip' data-placement='bottom' data-original-title='Disable adblock for full sharing functionality'>
+                                                <a href='{{linkedInUrl}}' target='_blank' data-toggle='tooltip' data-placement='bottom' data-original-title='Disable adblock for full sharing functionality' onclick={{action 'click' 'link' 'Quick Files - Share file' preventDefault=false}}>
                                                     <i aria-hidden='true' class='fa fa-linkedin'></i>
                                                 </a>
-                                                <a href='{{emailUrl}}' target='_blank'>
+                                                <a href='{{emailUrl}}' target='_blank' onclick={{action 'click' 'link' 'Quick Files - Share file' preventDefault=false}}>
                                                     <i aria-hidden='true' class='fa fa-envelope'></i>
                                                 </a>
                                             </div>

--- a/app/user-quickfiles/controller.js
+++ b/app/user-quickfiles/controller.js
@@ -1,8 +1,9 @@
 import { computed } from '@ember/object';
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
+import Analytics from 'ember-osf/mixins/analytics';
 
-export default Controller.extend({
+export default Controller.extend(Analytics, {
     currentUser: service(),
 
     canEdit: computed('currentUser', 'model', function() {

--- a/app/user-quickfiles/route.js
+++ b/app/user-quickfiles/route.js
@@ -23,7 +23,7 @@ export default Route.extend(Analytics, {
     },
     afterModel(model, transition) {
         if (model.id !== this.get('currentUser.currentUserId')) {
-            transition.send('track', 'view', 'track', 'Quick Files - Non-owner page view');
+            transition.send('track', 'view', 'track', 'Quick Files - Main page view');
         }
     },
 });

--- a/app/user-quickfiles/route.js
+++ b/app/user-quickfiles/route.js
@@ -1,6 +1,10 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import Analytics from 'ember-osf/mixins/analytics';
 
-export default Route.extend({
+export default Route.extend(Analytics, {
+    currentUser: service(),
+
     model(params) {
         return this.store.findRecord('user', params.user_id);
     },
@@ -15,6 +19,11 @@ export default Route.extend({
             e.preventDefault();
             e.dataTransfer.effectAllowed = 'none';
             e.dataTransfer.dropEffect = 'none';
+        }
+    },
+    afterModel(model, transition) {
+        if (model.id !== this.get('currentUser.currentUserId')) {
+            transition.send('track', 'view', 'track', 'Quick Files - Non-owner page view');
         }
     },
 });

--- a/config/environment.js
+++ b/config/environment.js
@@ -32,6 +32,16 @@ module.exports = function(environment) {
             includeTimezone: 'all',
             outputFormat: 'YYYY-MM-DD h:mm A z',
         },
+        metricsAdapters: [
+            {
+                name: 'GoogleAnalytics',
+                environments: ['all'],
+                config: {
+                    id: process.env.GOOGLE_ANALYTICS_ID
+                }
+            },
+        ],
+        FB_APP_ID: process.env.FB_APP_ID,
     };
 
     if (environment === 'development') {
@@ -40,6 +50,8 @@ module.exports = function(environment) {
         // ENV.APP.LOG_TRANSITIONS = true;
         // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
         // ENV.APP.LOG_VIEW_LOOKUPS = true;
+
+        ENV.metricsAdapters[0].config.cookieDomain = 'none';
     }
 
     if (environment === 'test') {
@@ -51,6 +63,12 @@ module.exports = function(environment) {
         ENV.APP.LOG_VIEW_LOOKUPS = false;
 
         ENV.APP.rootElement = '#ember-testing';
+    }
+
+    if (environment !== 'production') {
+        // Fallback to throwaway defaults if the environment variables are not set
+        ENV.metricsAdapters[0].config.id = ENV.metricsAdapters[0].config.id || 'UA-84580271-1';
+        ENV.FB_APP_ID = ENV.FB_APP_ID || '1039002926217080';
     }
 
     return ENV;

--- a/tests/unit/file-detail/controller-test.js
+++ b/tests/unit/file-detail/controller-test.js
@@ -4,6 +4,7 @@ moduleFor('controller:file-detail', 'Unit | Controller | file detail', {
     needs: [
         'service:currentUser',
         'service:toast',
+        'service:metrics',
     ],
 });
 

--- a/tests/unit/user-quickfiles/controller-test.js
+++ b/tests/unit/user-quickfiles/controller-test.js
@@ -3,6 +3,7 @@ import { moduleFor, test } from 'ember-qunit';
 moduleFor('controller:user-quickfiles', 'Unit | Controller | user quickfiles', {
     needs: [
         'service:currentUser',
+        'service:metrics',
     ],
 });
 

--- a/tests/unit/user-quickfiles/route-test.js
+++ b/tests/unit/user-quickfiles/route-test.js
@@ -1,8 +1,10 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:user-quickfiles', 'Unit | Route | user quickfiles', {
-    // Specify the other units that are required for this test.
-    // needs: ['controller:foo']
+    needs: [
+        'service:currentUser',
+        'service:metrics',
+    ],
 });
 
 test('it exists', function(assert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -178,6 +178,10 @@ acorn@^5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.2.tgz#911cb53e036807cf0fa778dc5d370fbd864246d7"
 
+acorn@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
+
 after@0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.1.tgz#ab5d4fb883f596816d3515f8f791c0af486dd627"
@@ -2612,7 +2616,7 @@ detective@^4.0.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/detective/-/detective-4.5.0.tgz#6e5a8c6b26e6c7a254b1c6b6d7490d98ec91edd1"
   dependencies:
-    acorn "^4.0.3"
+    acorn "^5.2.1"
     defined "^1.0.0"
 
 detective@^4.3.1:


### PR DESCRIPTION
## Purpose

Upon the initial release of Quick Files, it would be great to monitor how things are being used.  This PR will add analytics to parts of Quick Files in order to track this.

## Summary of Changes

Added analytics to:
### Overview page
- Upload drag and drop
- Upload button
- Copy share link
- Page visit by user who isn't the owner
- Download by user who isn't the owner
- Download zip by user who isn't the owner

### File detail page
- Upload by drag and drop
- Twitter share button
- Facebook share button
- LinkedIn share button
- Email share button
- Copy share link
- Page visit by user who isn't the owner
- Download by user who isn't the owner

## Ticket

https://openscience.atlassian.net/browse/EOSF-873

Is also related to the ember-osf PR: https://github.com/CenterForOpenScience/ember-osf/pull/298

# Reviewer Checklist

- [x] meets requirements
- [x] easy to understand
- [x] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(don't have initial release yet)*