### PR TITLE
[EOSF-711] Update file-browser on file-detail page to take more properties

### DIFF
--- a/app/file-detail/template.hbs
+++ b/app/file-detail/template.hbs
@@ -117,6 +117,9 @@
             selectedFile=model.file
             display=displays
             user=model.user
+            multiple=false
+            unselect=false
+            openOnSelect=true
             openFile=(action 'openFile')
         }}
         <div class='panel panel-default'>

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "*.js": "eslint"
   },
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-11-13T14:21:47Z",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-11-13T15:07:17Z",
     "@centerforopenscience/eslint-config": "^2.0.0",
     "@centerforopenscience/osf-style": "1.5.1",
     "bootstrap": "^3.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-11-13T14:21:47Z":
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-11-13T15:07:17Z":
   version "0.12.0"
-  resolved "https://github.com/CenterForOpenScience/ember-osf.git#f199f9a9af6ccea4b80046c18831d9279b64c0fe"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#2051f4c11f2aaf7831462b83d4e9f59fadf3d53f"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"


### PR DESCRIPTION
## Purpose

To add more properties to the file-browser on the file-detail page.  Properties added via https://github.com/CenterForOpenScience/ember-osf/pull/300#pullrequestreview-76130320

## Summary of Changes

Set `multiple` to `false`, `unselect` to `false`, and `openOnSelect` to `true`.

## Ticket

https://openscience.atlassian.net/browse/EOSF-711

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(don't have initial release yet)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
