### PR TITLE
[EOSF-909] Add properties to toggle between view, edit, and revision views

### DIFF
--- a/app/file-detail/controller.js
+++ b/app/file-detail/controller.js
@@ -11,6 +11,8 @@ import Analytics from 'ember-osf/mixins/analytics';
 export default Controller.extend(Analytics, {
     currentUser: service(),
     toast: service(),
+    queryParams: ['show'],
+    show: null,
     revision: null,
     deleteModalOpen: false,
     showPopup: false,
@@ -102,39 +104,36 @@ export default Controller.extend(Analytics, {
             this.set('deleteModalOpen', false);
         },
 
-        changeViewPanel(panel, button) {
-            if (!this.get('isEditableFile')) {
-                $('#mainViewBtn, #revisionBtn').toggleClass('btn-primary btn-default');
-                $('#mfrIframeParent, #revisionsPanel').toggle();
-                return;
-            }
+        revisionBtnClick() {
+            this.set('show', 'revision');
+        },
 
-            if (button === 'revisionBtn') {
-                if ($(`#${panel}`).css('display') === 'none') {
-                    $('.panel-view').hide().removeClass('col-sm-6');
-                    $('.view-button').removeClass('btn-primary').addClass('btn-default');
-                } else {
-                    $('#mfrIframeParent').toggle();
-                    $('#mainViewBtn').toggleClass('btn-default btn-primary');
-                }
-                $(`#${panel}`).toggle();
-                $(`#${button}`).toggleClass('btn-default btn-primary');
-                return;
+        editBtnClick() {
+            if (this.get('show') === 'view') {
+                this.set('show', 'view_edit');
+            } else if (this.get('show') === 'view_edit') {
+                this.set('show', 'view');
+            } else if (this.get('show') === 'revision') {
+                this.set('show', 'edit');
             }
+        },
 
-            if ($(`#${button}`).hasClass('btn-primary') && $('.view-button.btn-primary').length === 1) {
-                return;
-            } else if ($('#revisionsPanel').css('display') !== 'none') {
-                $('#revisionsPanel').toggle();
-                $('#revisionBtn').toggleClass('btn-default btn-primary');
-            } else if ($('#mfrIframeParent').css('display') !== 'none' || $('#editPanel').css('display') !== 'none') {
-                $('.panel-view').toggleClass('col-sm-6');
+        viewBtnClick() {
+            if (this.get('show') === 'edit') {
+                this.set('show', 'view_edit');
+            } else if (this.get('show') === 'view_edit') {
+                this.set('show', 'edit');
+            } else if (this.get('show') === 'revision') {
+                this.set('show', 'view');
+            }
+        },
+
+        versionLinkToggle() {
+            if (this.get('show') === 'revision') {
+                this.set('show', 'view');
             } else {
-                $('.panel-view').removeClass('col-sm-6');
+                this.set('show', 'revision');
             }
-
-            $(`#${panel}`).toggle();
-            $(`#${button}`).toggleClass('btn-default btn-primary');
         },
 
         save(text) {
@@ -145,11 +144,10 @@ export default Controller.extend(Analytics, {
 
         openFile(file) {
             if (file.get('guid')) {
-                this.transitionToRoute('file-detail', file.get('guid'));
+                this.transitionToRoute('file-detail', file.get('guid'), { queryParams: { show: 'view' } });
             } else {
-                file.getGuid().then(() => this.transitionToRoute('file-detail', file.get('guid')));
+                file.getGuid().then(() => this.transitionToRoute('file-detail', file.get('guid'), { queryParams: { show: 'view' } }));
             }
-            this._resetPanels();
         },
 
         addTag(tag) {
@@ -209,14 +207,6 @@ export default Controller.extend(Analytics, {
 
     _handleSaveFail() {
         return this.get('toast').error('Error, unable to save file');
-    },
-
-    _resetPanels() {
-        // Resets the panels to original states
-        $('#revisionsPanel, #editPanel').hide();
-        $('#mfrIframeParent').show().removeClass('col-sm-6');
-        $('#revisionBtn, #editViewBtn').removeClass('btn-primary').addClass('btn-default');
-        $('#mainViewBtn').removeClass('btn-default').addClass('btn-primary');
     },
 
 });

--- a/app/file-detail/controller.js
+++ b/app/file-detail/controller.js
@@ -16,6 +16,26 @@ export default Controller.extend(Analytics, {
     revision: null,
     deleteModalOpen: false,
     showPopup: false,
+    lookupTable: {
+        view: {
+            edit: 'view_edit',
+            revision: 'revision',
+        },
+        edit: {
+            view: 'view_edit',
+            revision: 'revision',
+        },
+        view_edit: {
+            view: 'edit',
+            edit: 'view',
+            revision: 'revision',
+        },
+        revision: {
+            view: 'view',
+            edit: 'edit',
+            revision: 'view',
+        },
+    },
     displays: A([]),
 
     canDelete: computed.alias('canEdit'),
@@ -104,35 +124,9 @@ export default Controller.extend(Analytics, {
             this.set('deleteModalOpen', false);
         },
 
-        revisionBtnClick() {
-            this.set('show', 'revision');
-        },
-
-        editBtnClick() {
-            if (this.get('show') === 'view') {
-                this.set('show', 'view_edit');
-            } else if (this.get('show') === 'view_edit') {
-                this.set('show', 'view');
-            } else if (this.get('show') === 'revision') {
-                this.set('show', 'edit');
-            }
-        },
-
-        viewBtnClick() {
-            if (this.get('show') === 'edit') {
-                this.set('show', 'view_edit');
-            } else if (this.get('show') === 'view_edit') {
-                this.set('show', 'edit');
-            } else if (this.get('show') === 'revision') {
-                this.set('show', 'view');
-            }
-        },
-
-        versionLinkToggle() {
-            if (this.get('show') === 'revision') {
-                this.set('show', 'view');
-            } else {
-                this.set('show', 'revision');
+        changeView(button) {
+            if (this.get('lookupTable')[this.get('show')][button]) {
+                this.set('show', this.get('lookupTable')[this.get('show')][button]);
             }
         },
 

--- a/app/file-detail/template.hbs
+++ b/app/file-detail/template.hbs
@@ -2,7 +2,7 @@
 {{quickfile-nav user=model.user onQuickfiles=false}}
 <div class='quickfiles-content row'>
     <div class='col-sm-5'>
-        <h2>{{model.file.name}} <a id='versionLink' onclick={{action 'versionLinkToggle'}}>(Version: {{mfrVersion}})</a></h2>
+        <h2>{{model.file.name}} <a id='versionLink' onclick={{action 'changeView' 'revision'}}>(Version: {{mfrVersion}})</a></h2>
     </div>
     <div class='col-sm-7'>
         <div id='toggleBar' class='pull-right'>
@@ -76,21 +76,21 @@
                         <div class='btn-group btn-group-sm m-t-xs'>
                             {{#if canEdit}}
                                 <div class='btn btn-default disabled'>Toggle view: </div>
-                                <button class='btn {{if (or (eq show "view") (eq show "view_edit")) "btn-primary" "btn-default"}}' onclick={{action 'viewBtnClick'}}>View</button>
-                                <button class='btn {{if (or (eq show "edit") (eq show "view_edit")) "btn-primary" "btn-default"}}' onclick={{action 'editBtnClick'}}>Edit</button>
+                                <button class='btn {{if (or (eq show "view") (eq show "view_edit")) "btn-primary" "btn-default"}}' onclick={{action 'changeView' 'view'}}>View</button>
+                                <button class='btn {{if (or (eq show "edit") (eq show "view_edit")) "btn-primary" "btn-default"}}' onclick={{action 'changeView' 'edit'}}>Edit</button>
                             {{else}}
-                                <button class='btn {{if (or (eq show "view") (eq show "view_edit")) "btn-primary" "btn-default"}}' onclick={{action 'viewBtnClick'}}>View</button>
+                                <button class='btn {{if (or (eq show "view") (eq show "view_edit")) "btn-primary" "btn-default"}}' onclick={{action 'changeView' 'view'}}>View</button>
                             {{/if}}
                         </div>
                 {{else}}
                     <div class='btn-group m-l-xs m-t-xs'>
-                        <button class='btn btn-sm {{if (or (eq show "view") (eq show "view_edit")) "btn-primary" "btn-default"}}' onclick={{action 'viewBtnClick'}}>
+                        <button class='btn btn-sm {{if (or (eq show "view") (eq show "view_edit")) "btn-primary" "btn-default"}}' onclick={{action 'changeView' 'view'}}>
                             View
                         </button>
                     </div>
                 {{/if}}
                 <div class='btn-group m-l-xs m-t-xs'>
-                    <button class='btn btn-sm {{if (eq show "revision") "btn-primary" "btn-default"}}' onclick={{action 'revisionBtnClick'}}>
+                    <button class='btn btn-sm {{if (eq show "revision") "btn-primary" "btn-default"}}' onclick={{action 'changeView' 'revision'}}>
                         Revisions
                     </button>
                 </div>

--- a/app/file-detail/template.hbs
+++ b/app/file-detail/template.hbs
@@ -2,7 +2,7 @@
 {{quickfile-nav user=model.user onQuickfiles=false}}
 <div class='quickfiles-content row'>
     <div class='col-sm-5'>
-        <h2>{{model.file.name}} <a id='versionLink' onclick={{action 'changeViewPanel' 'revisionsPanel' 'revisionBtn'}}>(Version: {{mfrVersion}})</a></h2>
+        <h2>{{model.file.name}} <a id='versionLink' onclick={{action 'versionLinkToggle'}}>(Version: {{mfrVersion}})</a></h2>
     </div>
     <div class='col-sm-7'>
         <div id='toggleBar' class='pull-right'>
@@ -76,21 +76,21 @@
                         <div class='btn-group btn-group-sm m-t-xs'>
                             {{#if canEdit}}
                                 <div class='btn btn-default disabled'>Toggle view: </div>
-                                <button class='btn btn-primary view-button' id='mainViewBtn' onclick={{action 'changeViewPanel' 'mfrIframeParent' 'mainViewBtn'}}>View</button>
-                                <button class='btn btn-default view-button' id='editViewBtn' onclick={{action 'changeViewPanel' 'editPanel' 'editViewBtn'}}>Edit</button>
+                                <button class='btn {{if (or (eq show "view") (eq show "view_edit")) "btn-primary" "btn-default"}}' onclick={{action 'viewBtnClick'}}>View</button>
+                                <button class='btn {{if (or (eq show "edit") (eq show "view_edit")) "btn-primary" "btn-default"}}' onclick={{action 'editBtnClick'}}>Edit</button>
                             {{else}}
-                                <button class='btn btn-primary view-button' id='mainViewBtn' onclick={{action 'changeViewPanel' 'mfrIframeParent' 'mainViewBtn'}}>View</button>
+                                <button class='btn {{if (or (eq show "view") (eq show "view_edit")) "btn-primary" "btn-default"}}' onclick={{action 'viewBtnClick'}}>View</button>
                             {{/if}}
                         </div>
                 {{else}}
                     <div class='btn-group m-l-xs m-t-xs'>
-                        <button class='btn btn-sm btn-primary' id='mainViewBtn' onclick={{action 'changeViewPanel' 'mfrIframeParent' 'mainViewBtn'}}>
+                        <button class='btn btn-sm {{if (or (eq show "view") (eq show "view_edit")) "btn-primary" "btn-default"}}' onclick={{action 'viewBtnClick'}}>
                             View
                         </button>
                     </div>
                 {{/if}}
                 <div class='btn-group m-l-xs m-t-xs'>
-                    <button class='btn btn-sm btn-default' id='revisionBtn' onclick={{action 'changeViewPanel' 'revisionsPanel' 'revisionBtn'}}>
+                    <button class='btn btn-sm {{if (eq show "revision") "btn-primary" "btn-default"}}' onclick={{action 'revisionBtnClick'}}>
                         Revisions
                     </button>
                 </div>
@@ -159,65 +159,71 @@
         {{/if}}
     </div>
     <div class='col-md-9'>
-        <div id='mfrIframeParent' class='panel-view'>
-            {{#file-renderer download=model.file.links.download version=mfrVersion
-                height="700" width="99%"}}
-            {{/file-renderer}}
-        </div>
-        {{#if isEditableFile}}
-            {{#if canEdit}}
-                <div id='editPanel' class='panel-view panel panel-default'>
-                    {{#if (await fileText)}}
-                        {{#file-editor
-                            fileText=(await fileText)
-                            save=(action 'save')}}
-                        {{/file-editor}}
-                    {{/if}}
-                </div>
+        {{#if (or (eq show 'view') (eq show 'view_edit'))}}
+            <div id='mfrIframeParent' class='{{if (and (eq show "view_edit") canEdit) "col-sm-6"}}'>
+                {{#file-renderer download=model.file.links.download version=mfrVersion
+                    height="700" width="99%"}}
+                {{/file-renderer}}
+            </div>
+        {{/if}}
+        {{#if (or (eq show 'edit') (eq show 'view_edit'))}}
+            {{#if isEditableFile}}
+                {{#if canEdit}}
+                    <div id='editPanel' class='panel panel-default {{if (and (eq show "view_edit") canEdit) "col-sm-6"}}'>
+                        {{#if (await fileText)}}
+                            {{#file-editor
+                                fileText=(await fileText)
+                                save=(action 'save')}}
+                            {{/file-editor}}
+                        {{/if}}
+                    </div>
+                {{/if}}
             {{/if}}
         {{/if}}
-        <div id='revisionsPanel' class='panel panel-default'>
-            <div class='panel-heading clearfix'>
-                <h3 class='panel-title'>
-                    Revisions
-                </h3>
+        {{#if (eq show 'revision')}}
+            <div id='revisionsPanel' class='panel panel-default'>
+                <div class='panel-heading clearfix'>
+                    <h3 class='panel-title'>
+                        Revisions
+                    </h3>
+                </div>
+                <div class='panel-body'>
+                    <table class='table table-responsive'>
+                        <thead>
+                            <tr>
+                                <th class='col-md-4'>Version ID</th>
+                                <th class='col-md-6'>Date</th>
+                                <th colspan='2' class='col-xs-2'>Download</th>
+                                <th class='hidden-md hidden-sm hidden-xs'>
+                                    MD5
+                                    <span>
+                                        {{fa-icon "question-circle"}}
+                                        {{#bs-popover triggerEvents='hover' placement='top'}}MD5 is an algorithm used to verify data integrity.{{/bs-popover}}
+                                    </span>
+                                </th>
+                                <th class='hidden-md hidden-sm hidden-xs'>
+                                    SHA2
+                                    <span>
+                                        {{fa-icon "question-circle"}}
+                                        {{#bs-popover triggerEvents='hover' placement='top'}}SHA-2 is a cryptographic hash function designed by the NSA used to verify data integrity.{{/bs-popover}}
+                                    </span>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {{#each (await fileVersions) as |version|}}
+                                {{file-version
+                                    version=version
+                                    download=(action 'download')
+                                    url=model.file.links.download
+                                    currentVersion=mfrVersion
+                                    versionChange=(action 'versionChange')
+                                }}
+                            {{/each}}
+                        </tbody>
+                    </table>
+                </div>
             </div>
-            <div class='panel-body'>
-                <table class='table table-responsive'>
-                    <thead>
-                        <tr>
-                            <th class='col-md-4'>Version ID</th>
-                            <th class='col-md-6'>Date</th>
-                            <th colspan='2' class='col-xs-2'>Download</th>
-                            <th class='hidden-md hidden-sm hidden-xs'>
-                                MD5
-                                <span>
-                                    {{fa-icon "question-circle"}}
-                                    {{#bs-popover triggerEvents='hover' placement='top'}}MD5 is an algorithm used to verify data integrity.{{/bs-popover}}
-                                </span>
-                            </th>
-                            <th class='hidden-md hidden-sm hidden-xs'>
-                                SHA2
-                                <span>
-                                    {{fa-icon "question-circle"}}
-                                    {{#bs-popover triggerEvents='hover' placement='top'}}SHA-2 is a cryptographic hash function designed by the NSA used to verify data integrity.{{/bs-popover}}
-                                </span>
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {{#each (await fileVersions) as |version|}}
-                            {{file-version
-                                version=version
-                                download=(action 'download')
-                                url=model.file.links.download
-                                currentVersion=mfrVersion
-                                versionChange=(action 'versionChange')
-                            }}
-                        {{/each}}
-                    </tbody>
-                </table>
-            </div>
-        </div>
+        {{/if}}
     </div>
 </div>

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -4,10 +4,6 @@
 #versionLink {
    cursor: pointer;
 }
-#revisionsPanel,
-#editPanel {
-   display: none;
-}
 #editPanel {
     padding:0px;
 }

--- a/app/user-quickfiles/controller.js
+++ b/app/user-quickfiles/controller.js
@@ -16,11 +16,12 @@ export default Controller.extend(Analytics, {
     }),
 
     actions: {
-        openFile(file) {
+        openFile(file, options) {
+            const view = options ? 'revision' : 'view';
             if (file.get('guid')) {
-                this.transitionToRoute('file-detail', file.get('guid'));
+                this.transitionToRoute('file-detail', file.get('guid'), { queryParams: { show: view } });
             } else {
-                file.getGuid().then(() => this.transitionToRoute('file-detail', file.get('guid')));
+                file.getGuid().then(() => this.transitionToRoute('file-detail', file.get('guid'), { queryParams: { show: view } }));
             }
         },
     },

--- a/app/user-quickfiles/controller.js
+++ b/app/user-quickfiles/controller.js
@@ -16,12 +16,11 @@ export default Controller.extend(Analytics, {
     }),
 
     actions: {
-        openFile(file, options) {
-            const view = options ? 'revision' : 'view';
+        openFile(file, qparams) {
             if (file.get('guid')) {
-                this.transitionToRoute('file-detail', file.get('guid'), { queryParams: { show: view } });
+                this.transitionToRoute('file-detail', file.get('guid'), { queryParams: { show: qparams } });
             } else {
-                file.getGuid().then(() => this.transitionToRoute('file-detail', file.get('guid'), { queryParams: { show: view } }));
+                file.getGuid().then(() => this.transitionToRoute('file-detail', file.get('guid'), { queryParams: { show: qparams } }));
             }
         },
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,7 +4,7 @@
 
 "@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-12-01T01:38:50Z":
   version "0.12.3"
-  resolved "https://github.com/CenterForOpenScience/ember-osf.git#8eae3e0237e2e1e9df14d88d0f9e6e88480dfb80"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#535b08c59a4e40a559c179b33d8b0fd2f750f2a7"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"
@@ -194,8 +194,8 @@ ajv@^4.9.1:
     json-stable-stringify "^1.0.1"
 
 ajv@^5.1.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.0.tgz#eb2840746e9dc48bd5e063a36e3fd400c5eab5a9"
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.1.tgz#b38bb8876d9e86bee994956a04e721e88b248eb2"
   dependencies:
     co "^4.6.0"
     fast-deep-equal "^1.0.0"
@@ -1922,8 +1922,8 @@ can-symlink@^1.0.0:
     tmp "0.0.28"
 
 caniuse-lite@^1.0.30000770:
-  version "1.0.30000775"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000775.tgz#74d27feddc47f3c84cfbcb130c3092a35ebc2de2"
+  version "1.0.30000778"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000778.tgz#f1e7cb8b13b1f6744402291d75f0bcd4c3160369"
 
 capture-exit@^1.1.0:
   version "1.2.0"
@@ -2616,8 +2616,8 @@ detective@^4.0.0:
     defined "^1.0.0"
 
 detective@^4.3.1:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/detective/-/detective-4.6.0.tgz#d1a793ad0bcc829fa225465061096b7bca040527"
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/detective/-/detective-4.7.0.tgz#6276e150f9e50829ad1f90ace4d9a2304188afcf"
   dependencies:
     acorn "^5.2.1"
     defined "^1.0.0"
@@ -4058,9 +4058,13 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
-extsprintf@1.3.0, extsprintf@^1.2.0:
+extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+
+extsprintf@^1.2.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
 fast-deep-equal@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Purpose

When clicking on the version number link on the landing page, the user should be taken to the file-detail page with the revisions table shown.  This currently doesn't happen.  

## Summary of Changes

Add a `shown` query parameter that toggles between views.  This makes it easier to link and go to a specific view.

## Ticket

https://openscience.atlassian.net/browse/EOSF-909

Relates to: 
https://github.com/CenterForOpenScience/ember-osf/pull/310

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(don't have initial release yet)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
