### PR TITLE
[EOSF-910] Add icons and tooltips to revisions table headers

### DIFF
--- a/app/file-detail/template.hbs
+++ b/app/file-detail/template.hbs
@@ -187,8 +187,18 @@
                             <th class='col-md-4'>Version ID</th>
                             <th class='col-md-6'>Date</th>
                             <th colspan='2' class='col-xs-2'>Download</th>
-                            <th class='hidden-md hidden-sm hidden-xs'>MD5</th>
-                            <th class='hidden-md hidden-sm hidden-xs'>SHA2</th>
+                            <th class='hidden-md hidden-sm hidden-xs'>
+                                MD5
+                                <i class='fa fa-question-circle'>
+                                    {{#bs-popover triggerEvents='hover' placement='top'}}MD5 is an algorithm used to verify data integrity.{{/bs-popover}}
+                                </i>
+                            </th>
+                            <th class='hidden-md hidden-sm hidden-xs'>
+                                SHA2
+                                <i class='fa fa-question-circle'>
+                                    {{#bs-popover triggerEvents='hover' placement='top'}}SHA-2 is a cryptographic hash function designed by the NSA used to verify data integrity.{{/bs-popover}}
+                                </i>
+                            </th>
                         </tr>
                     </thead>
                     <tbody>

--- a/app/file-detail/template.hbs
+++ b/app/file-detail/template.hbs
@@ -189,15 +189,17 @@
                             <th colspan='2' class='col-xs-2'>Download</th>
                             <th class='hidden-md hidden-sm hidden-xs'>
                                 MD5
-                                <i class='fa fa-question-circle'>
+                                <span>
+                                    {{fa-icon "question-circle"}}
                                     {{#bs-popover triggerEvents='hover' placement='top'}}MD5 is an algorithm used to verify data integrity.{{/bs-popover}}
-                                </i>
+                                </span>
                             </th>
                             <th class='hidden-md hidden-sm hidden-xs'>
                                 SHA2
-                                <i class='fa fa-question-circle'>
+                                <span>
+                                    {{fa-icon "question-circle"}}
                                     {{#bs-popover triggerEvents='hover' placement='top'}}SHA-2 is a cryptographic hash function designed by the NSA used to verify data integrity.{{/bs-popover}}
-                                </i>
+                                </span>
                             </th>
                         </tr>
                     </thead>


### PR DESCRIPTION
## Purpose

Currently there aren't any icons on the SHA2 and MD5 headers on the revisions table.  We should add them to match the revisions table used on the normal OSF.

## Summary of Changes

Add headers and ember-bootstrap pop-overs to match the OSF revisions table.

## Ticket

https://openscience.atlassian.net/browse/EOSF-910

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(don't have initial release yet)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
