### PR TITLE
[EOSF-925] Remove file upload message if not owner of files

### DIFF
--- a/app/user-quickfiles/controller.js
+++ b/app/user-quickfiles/controller.js
@@ -1,10 +1,19 @@
 import { computed } from '@ember/object';
 import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
 
 export default Controller.extend({
+    currentUser: service(),
+
+    canEdit: computed('currentUser', 'model', function() {
+        if (!this.get('model.id')) return false;
+        return (this.get('model.id') === this.get('currentUser.currentUserId'));
+    }),
+
     title: computed('model.fullName', function() {
         return `${this.get('model.fullName')}'s Quick Files`;
     }),
+
     actions: {
         openFile(file) {
             if (file.get('guid')) {

--- a/app/user-quickfiles/template.hbs
+++ b/app/user-quickfiles/template.hbs
@@ -4,6 +4,8 @@
 <div class='quickfiles-content container'>
     {{#if canEdit}}
         <h5><i>Files uploaded here are <b>publicly accessible</b> and easy to share with others using the share link.</i></h5>
+    {{else}}
+        <div style='height:14px;'></div>
     {{/if}}
     {{file-browser user=model openFile=(action 'openFile') dropZoneId='quickfiles-dropzone'}}
 </div>

--- a/app/user-quickfiles/template.hbs
+++ b/app/user-quickfiles/template.hbs
@@ -2,6 +2,8 @@
 
 {{quickfile-nav user=model onQuickfiles=true}}
 <div class='quickfiles-content container'>
-    <h5><i>Files uploaded here are <b>publicly accessible</b> and easy to share with others using the share link.</i></h5>
+    {{#if canEdit}}
+        <h5><i>Files uploaded here are <b>publicly accessible</b> and easy to share with others using the share link.</i></h5>
+    {{/if}}
     {{file-browser user=model openFile=(action 'openFile') dropZoneId='quickfiles-dropzone'}}
 </div>

--- a/tests/unit/user-quickfiles/controller-test.js
+++ b/tests/unit/user-quickfiles/controller-test.js
@@ -1,8 +1,9 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:user-quickfiles', 'Unit | Controller | user quickfiles', {
-    // Specify the other units that are required for this test.
-    // needs: ['controller:foo']
+    needs: [
+        'service:currentUser',
+    ],
 });
 
 // Replace this with your real tests.


### PR DESCRIPTION
## Purpose

To remove the `Files uploaded here are publicly accessible and easy to share with others using the share link.` message if the user is not the owner of the quickfiles.

## Summary of Changes

Add conditional to check if the user is the owner of the files to determine whether or not to show the message.

## Ticket

https://openscience.atlassian.net/browse/EOSF-925

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(don't have initial release yet)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
