### PR TITLE
[EOSF-937] Only show tags widget if there are tags for non-contributors

### DIFF
--- a/app/file-detail/template.hbs
+++ b/app/file-detail/template.hbs
@@ -122,39 +122,41 @@
             openOnSelect=true
             openFile=(action 'openFile')
         }}
-        <div class='panel panel-default'>
-            <div class='panel-heading clearfix'>
-                <h3 class='panel-title'>Tags:</h3>
+        {{#if (or canEdit fileTags)}}
+            <div class='panel panel-default'>
+                <div class='panel-heading clearfix'>
+                    <h3 class='panel-title'>Tags:</h3>
+                </div>
+                <div class='panel-body'>
+                    {{#if canEdit}}
+                        {{#tag-input
+                            tags=fileTags
+                            addTag=(action 'addTag')
+                            removeTagAtIndex=(action 'removeTagAtIndex')
+                            allowSpacesInTags=true
+                            placeholder='add a tag to enhance discoverability'
+                            as |tag|
+                        }}
+                            {{tag}}
+                        {{/tag-input}}
+                    {{else}}
+                        {{!-- Passing a mutable value to readOnly breaks tag-input. Instead render it with a set value --}}
+                        {{#tag-input
+                            tags=fileTags
+                            addTag=(action 'addTag')
+                            removeTagAtIndex=(action 'removeTagAtIndex')
+                            allowSpacesInTags=true
+                            readOnly=true
+                            as |tag|
+                        }}
+                            {{tag}}
+                        {{/tag-input}}
+                    {{/if}}
+                <div class="tags_clear">
+                </div>
+                </div>
             </div>
-            <div class='panel-body'>
-                {{#if canEdit}}
-                    {{#tag-input
-                        tags=fileTags
-                        addTag=(action 'addTag')
-                        removeTagAtIndex=(action 'removeTagAtIndex')
-                        allowSpacesInTags=true
-                        placeholder='add a tag to enhance discoverability'
-                        as |tag|
-                    }}
-                        {{tag}}
-                    {{/tag-input}}
-                {{else}}
-                    {{!-- Passing a mutable value to readOnly breaks tag-input. Instead render it with a set value --}}
-                    {{#tag-input
-                        tags=fileTags
-                        addTag=(action 'addTag')
-                        removeTagAtIndex=(action 'removeTagAtIndex')
-                        allowSpacesInTags=true
-                        readOnly=true
-                        as |tag|
-                    }}
-                        {{tag}}
-                    {{/tag-input}}
-                {{/if}}
-            <div class="tags_clear">
-            </div>
-            </div>
-        </div>
+        {{/if}}
     </div>
     <div class='col-md-9'>
         <div id='mfrIframeParent' class='panel-view'>


### PR DESCRIPTION
## Purpose

Currently quickfiles will show the tags widget to non-contributors even if there aren't any.  On the current OSF, the tags widget will not show up if this is the case.  We should add a conditional to only show the tags widget if there are tags in order to make things more consistent.  

## Summary of Changes

Added conditional to check if there are tags/if the user can edit to decide if the tags widget should show or not.

If the user is a contributor, the tags widget will show up like normal on the page:
<img width="662" alt="screen shot 2017-11-24 at 8 00 17 pm" src="https://user-images.githubusercontent.com/19379783/33226403-2c9ea816-d152-11e7-81f9-2cb26ad2d4f3.png">

But if they are not the contributor and there aren't any tags, the widget will not show:
<img width="742" alt="screen shot 2017-11-24 at 8 00 01 pm" src="https://user-images.githubusercontent.com/19379783/33226407-3ca3dd58-d152-11e7-9c0c-0c4178140817.png">

## Ticket

https://openscience.atlassian.net/browse/EOSF-937

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(don't have initial release yet)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
