### PR TITLE
[EOSF-921] prevent open in browser on drop outside dropzone

### DIFF
--- a/app/user-quickfiles/route.js
+++ b/app/user-quickfiles/route.js
@@ -4,4 +4,17 @@ export default Route.extend({
     model(params) {
         return this.store.findRecord('user', params.user_id);
     },
+    actions: {
+        didTransition() {
+            window.addEventListener('dragover', e => this._preventDrop(e));
+            window.addEventListener('drop', e => this._preventDrop(e));
+        },
+    },
+    _preventDrop(e) {
+        if (e.target.id !== 'quickfiles-dropzone') {
+            e.preventDefault();
+            e.dataTransfer.effectAllowed = 'none';
+            e.dataTransfer.dropEffect = 'none';
+        }
+    },
 });

--- a/app/user-quickfiles/template.hbs
+++ b/app/user-quickfiles/template.hbs
@@ -3,5 +3,5 @@
 {{quickfile-nav user=model onQuickfiles=true}}
 <div class='quickfiles-content container'>
     <h5><i>Files uploaded here are <b>publicly accessible</b> and easy to share with others using the share link.</i></h5>
-    {{file-browser user=model openFile=(action 'openFile')}}
+    {{file-browser user=model openFile=(action 'openFile') dropZoneId='quickfiles-dropzone'}}
 </div>

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "*.js": "eslint"
   },
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-11-20T19:21:19Z",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-11-30T16:05:13Z",
     "@centerforopenscience/eslint-config": "^2.0.0",
     "@centerforopenscience/osf-style": "1.5.1",
     "bootstrap": "^3.3.7",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "*.js": "eslint"
   },
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-11-30T16:05:13Z",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-11-30T16:56:20Z",
     "@centerforopenscience/eslint-config": "^2.0.0",
     "@centerforopenscience/osf-style": "1.5.1",
     "bootstrap": "^3.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-11-30T16:05:13Z":
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-11-30T16:56:20Z":
   version "0.12.3"
-  resolved "https://github.com/CenterForOpenScience/ember-osf.git#196e96c7f8c645355c590bb28094ec107cb360fb"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#b9855d08ac6cdbadb96bc6c9399fde94111915ad"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-11-20T19:21:19Z":
-  version "0.12.0"
-  resolved "https://github.com/CenterForOpenScience/ember-osf.git#55bfe2721d912441ac26c005960aa1d90382cfd3"
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-11-30T16:05:13Z":
+  version "0.12.3"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#196e96c7f8c645355c590bb28094ec107cb360fb"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Prevent the dropped file from being loaded into the browser when dropped outside of the drop zone.

## Summary of Changes

Added global dragover and drop listeners that prevent default action and effects if the target is not the drop zone. 

## Side Effects / Testing Notes

Make sure this works in all browsers.

## Ticket

https://openscience.atlassian.net/browse/EOSF-921

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(don't have initial release yet)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
