### PR TITLE
[EOSF-873] Move afterModel hook to after the model in user-quickfiles

### DIFF
--- a/app/user-quickfiles/route.js
+++ b/app/user-quickfiles/route.js
@@ -8,6 +8,11 @@ export default Route.extend(Analytics, {
     model(params) {
         return this.store.findRecord('user', params.user_id);
     },
+    afterModel(model, transition) {
+        if (model.id !== this.get('currentUser.currentUserId')) {
+            transition.send('track', 'view', 'track', 'Quick Files - Main page view');
+        }
+    },
     actions: {
         didTransition() {
             window.addEventListener('dragover', e => this._preventDrop(e));
@@ -19,11 +24,6 @@ export default Route.extend(Analytics, {
             e.preventDefault();
             e.dataTransfer.effectAllowed = 'none';
             e.dataTransfer.dropEffect = 'none';
-        }
-    },
-    afterModel(model, transition) {
-        if (model.id !== this.get('currentUser.currentUserId')) {
-            transition.send('track', 'view', 'track', 'Quick Files - Main page view');
         }
     },
 });


### PR DESCRIPTION
## Purpose

The position of the `afterModel` hook on the `user-quickfiles` route is throwing linting errors.  `afterModel` should be moved to be right after the `model` hook to get rid of the error.

## Summary of Changes

Moved the position of the afterModel call

## Ticket

https://openscience.atlassian.net/browse/EOSF-873

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(don't have initial release yet)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
