### PR TITLE
[EOSF-949] Add overflow-wrap and max-width to tags

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -90,6 +90,8 @@
   color: black;
   font-size: 13px;
   cursor: pointer;
+  max-width: 100%;
+  overflow-wrap: break-word;
   & > a {
     color: black;
   }


### PR DESCRIPTION
## Purpose

In the case that a user enters in a ridiculously long tag, the tag won't break onto a new line.  Instead, the tag will just stretch out of the bounds of the tag widget.  We should make the tag break onto new line(s) when needed.

## Summary of Changes

Add more styling to tags to prevent tags from going out of the tag-widget if there are REALLY long words.

## Ticket

https://openscience.atlassian.net/browse/EOSF-949

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(don't have initial release yet)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
