### PR TITLE
[EOSF-889] Add noscript message if javascript is disabled

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -18,6 +18,13 @@
   </head>
   <body>
     {{content-for "assets"}}
+    <noscript>
+      <p>
+        For full functionality of this site it is necessary to enable JavaScript.
+        Here are the
+        <a href='https://www.enable-javascript.com/' target='_blank'> instructions how to enable JavaScript in your web browser</a>.
+      </p>
+    </noscript>
     {{content-for "body"}}
 
     <script src="{{rootURL}}ember_osf_web/assets/vendor.js"></script>


### PR DESCRIPTION
## Purpose

If users do not have JavaScript enabled on their browser, ember-osf pages are displayed as blank white pages.  This will add an error message on the page that lets the user know what is happening and how to enable JavaScript to use the site.

## Summary of Changes

- Added `<noscript>` message

![screen shot 2017-12-07 at 2 21 27 pm](https://user-images.githubusercontent.com/19379783/33734440-50fdea52-db5a-11e7-90b6-1ad871a750c1.png)

## Ticket

https://openscience.atlassian.net/browse/EOSF-889

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(don't have initial release yet)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
