### PR TITLE
[EOSF-909] Fix url param issue on file-detail

### DIFF
--- a/app/file-detail/controller.js
+++ b/app/file-detail/controller.js
@@ -14,7 +14,7 @@ export default Controller.extend(Analytics, {
     currentUser: service(),
     toast: service(),
     queryParams: ['show'],
-    show: null,
+    show: 'view',
     revision: null,
     deleteModalOpen: false,
     showPopup: false,


### PR DESCRIPTION
## Purpose

When a user goes to the detail page for a quick file, there is a URL parameter that determines which view the user will be shown.  In the case that there isn't a URL parameter, the view breaks.  This will fix the issue by defaulting to the main view in the case that there isn't a parameter given.

## Summary of Changes

- Default the controller to use the main view in the case that there isn't anything passed in

## Ticket

https://openscience.atlassian.net/browse/EOSF-909

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(don't have initial release yet)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
