### PR TITLE
[EOSF-962] Revert revision to null when switching between files

### DIFF
--- a/app/file-detail/controller.js
+++ b/app/file-detail/controller.js
@@ -146,6 +146,7 @@ export default Controller.extend(Analytics, {
             } else {
                 file.getGuid().then(() => this.transitionToRoute('file-detail', file.get('guid'), { queryParams: { show: 'view' } }));
             }
+            this.set('revision', null);
         },
 
         addTag(tag) {


### PR DESCRIPTION
## Purpose

If the revision is changed on a file, that same number will persist as the revision number when switching between files.

## Summary of Changes

- Revert `revision` to `null` when switching between files.

## Ticket

https://openscience.atlassian.net/browse/EOSF-962

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(don't have initial release yet)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
