### PR TITLE
[EOSF-962] Set revision number back to null on transition

### DIFF
--- a/app/file-detail/route.js
+++ b/app/file-detail/route.js
@@ -17,4 +17,9 @@ export default Route.extend(Analytics, {
             transition.send('track', 'page view', 'track', 'Quick Files - File detail page view');
         }
     },
+    resetController(controller, isExiting, transition) {
+        if (isExiting && transition.targetName !== 'error') {
+            controller.set('revision', null);
+        }
+    },
 });


### PR DESCRIPTION
## Purpose

Fix revision numbers persisting through route transitions.

## Summary of Changes

Add a reset on the controller's routes to change `revision` back to `null`.

## Ticket

https://openscience.atlassian.net/browse/EOSF-962

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(don't have initial release yet)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
