### PR TITLE
[EOSF-965] Remove need for lint exceptions on file-detail page

### DIFF
--- a/app/file-detail/controller.js
+++ b/app/file-detail/controller.js
@@ -9,6 +9,7 @@ import mime from 'npm:mime-types';
 import Analytics from 'ember-osf/mixins/analytics';
 import config from 'ember-get-config';
 import pathJoin from 'ember-osf/utils/path-join';
+import { htmlSafe } from '@ember/string';
 
 export default Controller.extend(Analytics, {
     currentUser: service(),
@@ -90,11 +91,11 @@ export default Controller.extend(Analytics, {
     }),
 
     shareiFrameDynamic: computed('model.file', function() {
-        return `<style>.embed-responsive{position:relative;height:100%;}.embed-responsive iframe{position:absolute;height:100%;}</style><script>window.jQuery || document.write('<script src="//code.jquery.com/jquery-1.11.2.min.js">\x3C/script>') </script><link href="https://mfr.osf.io/static/css/mfr.css" media="all" rel="stylesheet"><div id="mfrIframe" class="mfr mfr-file"></div><script src="https://mfr.osf.io/static/js/mfr.js"></script> <script>var mfrRender = new mfr.Render("mfrIframe", "${this.get('mfrUrl')}");</script>`;
+        return htmlSafe(`<style>.embed-responsive{position:relative;height:100%;}.embed-responsive iframe{position:absolute;height:100%;}</style><script>window.jQuery || document.write('<script src="//code.jquery.com/jquery-1.11.2.min.js">\x3C/script>') </script><link href="https://mfr.osf.io/static/css/mfr.css" media="all" rel="stylesheet"><div id="mfrIframe" class="mfr mfr-file"></div><script src="https://mfr.osf.io/static/js/mfr.js"></script> <script>var mfrRender = new mfr.Render("mfrIframe", "${this.get('mfrUrl')}");</script>`);
     }),
 
     shareiFrameDirect: computed('model.file', function() {
-        return `<iframe src="${this.get('mfrUrl')}" width="100%" scrolling="yes" height="677px" marginheight="0" frameborder="0" allowfullscreen webkitallowfullscreen>`;
+        return htmlSafe(`<iframe src="${this.get('mfrUrl')}" width="100%" scrolling="yes" height="677px" marginheight="0" frameborder="0" allowfullscreen webkitallowfullscreen>`);
     }),
 
     fileTags: computed('model.file', function() {

--- a/app/file-detail/template.hbs
+++ b/app/file-detail/template.hbs
@@ -1,9 +1,8 @@
-{{! template-lint-disable triple-curlies invalid-interactive }}
 {{title model.file.name}}
 {{quickfile-nav user=model.user onQuickfiles=false}}
 <div class='quickfiles-content row'>
     <div class='col-sm-5'>
-        <h2>{{model.file.name}} <a id='versionLink' onclick={{action 'changeView' 'revision'}}>{{t 'file_detail.version.title' version-number=mfrVersion}}</a></h2>
+        <h2>{{model.file.name}} <a id='versionLink' role="button" onclick={{action 'changeView' 'revision'}}>{{t 'file_detail.version.title' version-number=mfrVersion}}</a></h2>
     </div>
     <div class='col-sm-7'>
         <div id='toggleBar' class='pull-right'>
@@ -43,7 +42,7 @@
                                                     <div class='fa fa-copy'></div>
                                                 </button>
                                             </span>
-                                            <input readonly='true' type='text' class='form-control' value='{{{mfrUrl}}}' id='sharePaneUrl'>
+                                            <input readonly='true' type='text' class='form-control' value='{{mfrUrl}}' id='sharePaneUrl'>
                                             <div class='share-buttons'>
                                                 <a href='{{twitterUrl}}' target='_blank' rel='noopener' onclick={{action 'click' 'link' 'Quick Files - Share file on Twitter' preventDefault=false}}>
                                                     <i aria-hidden='true' class='fa fa-twitter'></i>
@@ -63,10 +62,10 @@
                                     {{#tab.pane elementId='embedPane' title='Embed'}}
                                         <br>
                                         <p>{{t "file_detail.embed.dynamic"}}</p>
-                                        <textarea readonly='true' type='text' class='form-control'>{{{shareiFrameDynamic}}}</textarea>
+                                        <textarea readonly='true' type='text' class='form-control'>{{shareiFrameDynamic}}</textarea>
                                         <br>
                                         <p>{{t "file_detail.embed.direct"}}</p>
-                                        <textarea readonly='true' class='form-control'>{{{shareiFrameDirect}}}</textarea>
+                                        <textarea readonly='true' class='form-control'>{{shareiFrameDirect}}</textarea>
                                     {{/tab.pane}}
                                 </div>
                             {{/bs-tab}}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -34,6 +34,9 @@
   max-width: 450px;
   width: 450px;
 }
+#sharePaneUrl {
+    height: 33px;
+}
 .share-btn-container {
   height: 34px;
   vertical-align: top;


### PR DESCRIPTION
## Purpose

To remove the need for template lint exceptions for [triple-curlies](https://github.com/rwjblue/ember-template-lint/blob/master/docs/rule/triple-curlies.md) and [invalid-interactive](https://github.com/rwjblue/ember-template-lint/blob/master/docs/rule/invalid-interactive.md) on the file-detail page.

Also to make the mfr url box the same height as it's copy button.

## Summary of Changes

- Used `htmlSafe` when making html strings to remove the `{{{  }}}`'s
- Added a role of `button` to the version number

- Also added a height of `33px` to the mfr url input box so that it is the same height as the copy button

## Ticket

https://openscience.atlassian.net/browse/EOSF-965

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(don't have initial release yet)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
