### PR TITLE
Use component's hbs template for feedback modal content

### DIFF
--- a/app/components/feedback-button/component.js
+++ b/app/components/feedback-button/component.js
@@ -35,22 +35,10 @@ export default Component.extend({
             backgroundColor: buttonColor,
             buttonAriaLabel: this.get('title'),
             showDialog: (btn) => {
-                const text = this.get('text');
-                const placeholder = this.get('placeholder');
-                const followUpLabel = this.get('followUpLabel');
-                const title = this.get('title');
                 const confirmButtonText = this.get('confirmButtonText');
                 const cancelButtonText = this.get('cancelButtonText');
                 return btn.alert({
-                    html: `
-                        <h2 class="swal2-title">${title}</h2>
-                        <div id="swal2-content" style="display: block;">${text}</div>
-                        <textarea id="microfeedback-input" class="${styleNamespace}Input swal2-textarea" placeholder="${placeholder}"></textarea>
-                        <label id="microfeedback-followup" for="swal2-checkbox" class="${styleNamespace}CheckboxLabel swal2-checkbox">
-                            <input class="${styleNamespace}Checkbox" type="checkbox">
-                            <span>${followUpLabel}</span>
-                        </label>
-                    `,
+                    html: this.$().html(),
                     customClass: styleNamespace,
                     buttonsStyling: false,
                     cancelButtonClass: 'btn btn-default',

--- a/app/components/feedback-button/styles.scss
+++ b/app/components/feedback-button/styles.scss
@@ -1,3 +1,7 @@
+& {
+    display: none;
+}
+
 &Input {
     display: block;
 }

--- a/app/components/feedback-button/template.hbs
+++ b/app/components/feedback-button/template.hbs
@@ -1,0 +1,7 @@
+<h2 class="swal2-title">{{title}}</h2>
+<div id="swal2-content" style="display: block;">{{text}}</div>
+<textarea id="microfeedback-input" class="{{styleNamespace}}Input swal2-textarea" placeholder="{{placeholder}}"></textarea>
+<label id="microfeedback-followup" for="swal2-checkbox" class="{{styleNamespace}}CheckboxLabel swal2-checkbox">
+    <input class="{{styleNamespace}}Checkbox" type="checkbox">
+    <span>{{followUpLabel}}</span>
+</label>


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

HTML string was still bothering me so I came up with a way to use a hbs template instead

## Summary of Changes

* move HTML from string to component template
* hide rendered component in DOM
* grab rendered component html for microfeedback
* remove now unneeded consts

## Side Effects / Testing Notes

Still works?

## Ticket

N/A

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
