### PR TITLE
Ignore alphabetical properties rule in stylelint

### DIFF
--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -6,3 +6,4 @@ rules:
     selector-class-pattern:
       - "^([A-Z][a-z]*)+(__[a-z-]+)*(--[a-z-]+)*$"
       - { resolveNestedSelectors: true }
+    order/properties-alphabetical-order: null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Ignore `order/properties-alphabetical-order` rule in stylelint.
 
 ## [0.1.1] - 2018-02-08
 ### Changed


### PR DESCRIPTION
## Purpose

Alphabetizing properties doesn't significantly improve readability. More importantly, I want to be able to add comments for related things. For example:

```css
.MyButton {
    /* This is wacky */
    background-color: rebeccapurple;
    color: gray(30);

    /* Reset styles */
    border: none;
    margin: 0;
    width: auto;
    overflow: visible;
}
```


## Summary of Changes

Ignore the alphabetical property rule in stylelint

## Side Effects / Testing Notes



## Ticket

No ticket

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
