### PR TITLE
[EMB-125] Add analytics tracking for all route transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Inject jQuery properly in `file-share-button` dynamic iframe code
 
+### Added
+- Analytics tracking on all page transitions
+
 ## [0.1.1] - 2018-02-08
 ### Changed
 - In the `file-share-button` component:

--- a/app/router.js
+++ b/app/router.js
@@ -1,9 +1,26 @@
 import EmberRouter from '@ember/routing/router';
+import { inject as service } from '@ember/service';
+import { scheduleOnce } from '@ember/runloop';
 import config from './config/environment';
 
 const Router = EmberRouter.extend({
     location: config.locationType,
     rootURL: config.rootURL,
+    metrics: service(),
+
+    didTransition() {
+        this._super(...arguments);
+        this._trackPage();
+    },
+
+    _trackPage() {
+        scheduleOnce('afterRender', this, () => {
+            const page = this.get('url');
+            const title = this.getWithDefault('currentRouteName', 'unknown');
+
+            this.get('metrics').trackPage({ page, title });
+        });
+    },
 });
 
 /* eslint-disable array-callback-return */

--- a/tests/unit/application/controller-test.js
+++ b/tests/unit/application/controller-test.js
@@ -1,7 +1,10 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:application', 'Unit | Controller | application', {
-    needs: ['service:session'],
+    needs: [
+        'service:session',
+        'service:metrics',
+    ],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/application/route-test.js
+++ b/tests/unit/application/route-test.js
@@ -1,7 +1,11 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:application', 'Unit | Route | application', {
-    needs: ['service:session', 'service:moment'],
+    needs: [
+        'service:session',
+        'service:moment',
+        'service:metrics',
+    ],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/quickfiles/route-test.js
+++ b/tests/unit/quickfiles/route-test.js
@@ -1,7 +1,11 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:quickfiles', 'Unit | Route | quickfiles', {
-    needs: ['service:session', 'service:currentUser'],
+    needs: [
+        'service:session',
+        'service:currentUser',
+        'service:metrics',
+    ],
 });
 
 test('it exists', function(assert) {


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Add analytics tracking to all route transitions in ember-osf-web, so we can tell whether people are using quickfiles.


## Summary of Changes
Add logic to the router to track route transitions, à la [ember-metrics docs](https://github.com/poteto/ember-metrics#usage)


## Side Effects / Testing Notes
On initial load and each page transition, check that a GET request is made to https://www.google-analytics.com/collect with appropriate query params.


## Ticket

https://openscience.atlassian.net/browse/EMB-125

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
