### PR TITLE
[EMB-140] i18n improvements

### DIFF
--- a/app/application/route.ts
+++ b/app/application/route.ts
@@ -2,13 +2,42 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import OSFAgnosticAuthRouteMixin from 'ember-osf/mixins/osf-agnostic-auth-route';
 
-export default class Application extends Route.extend(OSFAgnosticAuthRouteMixin) {
+export default class Application extends Route.extend(OSFAgnosticAuthRouteMixin, {
+    actions: {
+        didTransition() {
+            Object.assign(window, { prerenderReady: true });
+            return true; // Bubble the didTransition event
+        },
+    },
+}) {
     moment = service('moment');
 
     beforeModel(...args) {
         this.get('moment').setTimeZone('UTC');
 
         return this._super(...args);
+    }
+
+    afterModel() {
+        const availableLocales: [string] = this.get('i18n.locales').toArray();
+        let locale: string;
+
+        // Works in Chrome and Firefox (editable in settings)
+        if (navigator.languages && navigator.languages.length) {
+            for (const lang of navigator.languages) {
+                if (availableLocales.includes(lang)) {
+                    locale = lang;
+                    break;
+                }
+            }
+        // Backup for Safari (uses system settings)
+        } else if (navigator.language && availableLocales.includes(navigator.language)) {
+            locale = navigator.language;
+        }
+
+        if (locale) {
+            this.set('i18n.locale', locale);
+        }
     }
 }
 

--- a/app/file-detail/controller.ts
+++ b/app/file-detail/controller.ts
@@ -110,7 +110,6 @@ export default class FileDetail extends Controller.extend(Analytics, {
     },
 }) {
     currentUser = service('currentUser');
-    i18n = service('i18n');
     toast = service('toast');
 
     queryParams = ['show'];

--- a/app/index.html
+++ b/app/index.html
@@ -25,6 +25,7 @@
         <a href='https://www.enable-javascript.com/' target='_blank'> instructions for enabling JavaScript in your web browser</a>.
       </p>
     </noscript>
+    <script> window.prerenderReady = false; </script>
     {{content-for "body"}}
 
     <script src="{{rootURL}}ember_osf_web/assets/vendor.js"></script>

--- a/app/utils/i18n/missing-message.js
+++ b/app/utils/i18n/missing-message.js
@@ -1,0 +1,25 @@
+import { getOwner } from '@ember/application';
+import { makeArray } from '@ember/array';
+import { get } from '@ember/object';
+import config from 'ember-get-config';
+import Locale from 'ember-i18n/utils/locale';
+
+const fallbackLocale = config.i18n.defaultLocale;
+
+export default function(locale, key, data) {
+    if (locale === fallbackLocale) {
+        return `Missing translation: ${key}`;
+    }
+    // NOTE This relies on internal APIs and is brittle.
+    // Emulating the internals of ember-i18n's translate method.
+
+    const count = get(data, 'count');
+
+    const defaults = makeArray(get(data, 'default'));
+    defaults.unshift(key);
+
+    const localeObj = new Locale(fallbackLocale, getOwner(this));
+    const template = localeObj.getCompiledTemplate(defaults, count);
+
+    return template(data);
+}

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-font-awesome": "3.0.5",
     "ember-i18n": "^5.0.2",
+    "ember-i18n-inject": "^0.0.2",
     "ember-load-initializers": "^0.6.0",
     "ember-page-title": "3.2.2",
     "ember-promise-helpers": "1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3903,6 +3903,12 @@ ember-getowner-polyfill@^1.0.0, ember-getowner-polyfill@^1.2.2:
     ember-cli-version-checker "^2.1.0"
     ember-factory-for-polyfill "^1.3.1"
 
+ember-i18n-inject@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/ember-i18n-inject/-/ember-i18n-inject-0.0.2.tgz#5c95a687b9b51fae7b2885ccfb80450ac9166e89"
+  dependencies:
+    ember-cli-babel "^5.0.0"
+
 ember-i18n@5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ember-i18n/-/ember-i18n-5.0.1.tgz#6e20732ff5c825b50ca08aa49025964dacc100c4"


### PR DESCRIPTION
## Purpose

Adds translation support for the browser's preferred or default language, with fallback to the default locale. Follow-up from #83 by @Yusuke-KOMIYAMA 

## Summary of Changes

- Adds dependency for automatically injecting the i18n service
- Overrides the default missing translation helper to fallback to the defaultLocale (defined in the configuration). The implementation is based on comments from jamesarosen/ember-i18n#256

### Bonus:

- Better prerender support (had to update the application route anyway)

## Side Effects / Testing Notes

To test, add Japanese to the top of the languages in your browser preferences (Chrome/Firefox).

## Ticket

https://openscience.atlassian.net/browse/EMB-140

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
