### PR TITLE
[Fix] Some quick TS cleanup

### DIFF
--- a/app/application/controller.ts
+++ b/app/application/controller.ts
@@ -9,7 +9,7 @@ export default class Application extends Controller.extend(OSFAgnosticAuthContro
 }
 
 declare module '@ember/controller' {
-    interface IRegistry {
+    interface Registry {
         application: Application;
     }
 }

--- a/app/application/route.ts
+++ b/app/application/route.ts
@@ -40,9 +40,3 @@ export default class Application extends Route.extend(OSFAgnosticAuthRouteMixin,
         }
     }
 }
-
-declare module '@ember/routing/route' {
-    interface IRegistry {
-        application: Application;
-    }
-}

--- a/app/components/feedback-button/component.ts
+++ b/app/components/feedback-button/component.ts
@@ -9,7 +9,7 @@ const {
     OSF: { backend },
 } = config;
 
-interface IFeedbackOptionalArgs {
+interface FeedbackOptionalArgs {
     extra?: object;
     followup?: boolean;
     pageName?: string;
@@ -21,7 +21,7 @@ function sendFeedback(body: string, {
     followup,
     pageName,
     userID,
-}: IFeedbackOptionalArgs): Promise<any> {
+}: FeedbackOptionalArgs): Promise<any> {
     const payload = {
         body,
         extra: {
@@ -125,11 +125,5 @@ export default class FeedbackButton extends Component.extend({
     reset(): void {
         this.set('body', '');
         this.set('followup', false);
-    }
-}
-
-declare module '@ember/component' {
-    interface IRegistry {
-        'feedback-button': FeedbackButton;
     }
 }

--- a/app/components/file-share-button/component.ts
+++ b/app/components/file-share-button/component.ts
@@ -143,9 +143,3 @@ export default class FileShareButton extends Component.extend(Analytics, {
         `.trim().replace(/^\s{12}/mg, ''));
     });
 }
-
-declare module '@ember/component' {
-    interface IRegistry {
-        'file-share-button': FileShareButton;
-    }
-}

--- a/app/components/quickfile-nav/component.ts
+++ b/app/components/quickfile-nav/component.ts
@@ -9,9 +9,3 @@ export default class QuickfileNav extends Component.extend({
 
     role: 'navigation',
 }) {}
-
-declare module '@ember/component' {
-    interface IRegistry {
-        'quickfile-nav': QuickfileNav;
-    }
-}

--- a/app/file-detail/controller.ts
+++ b/app/file-detail/controller.ts
@@ -155,7 +155,7 @@ export default class FileDetail extends Controller.extend(Analytics, {
 }
 
 declare module '@ember/controller' {
-    interface IRegistry {
+    interface Registry {
         'file-detail': FileDetail;
     }
 }

--- a/app/file-detail/route.ts
+++ b/app/file-detail/route.ts
@@ -22,9 +22,3 @@ export default class FileDetail extends Route.extend(Analytics) {
         }
     }
 }
-
-declare module '@ember/routing/route' {
-    interface IRegistry {
-        'file-detail': FileDetail;
-    }
-}

--- a/app/quickfiles/route.ts
+++ b/app/quickfiles/route.ts
@@ -16,9 +16,3 @@ export default class Quickfiles extends Route.extend(CasAuthenticatedRouteMixin)
         }
     }
 }
-
-declare module '@ember/routing/route' {
-    interface IRegistry {
-        quickfiles: Quickfiles;
-    }
-}

--- a/app/user-quickfiles/controller.ts
+++ b/app/user-quickfiles/controller.ts
@@ -22,7 +22,7 @@ export default class UserQuickfiles extends Controller.extend(Analytics, {
 }
 
 declare module '@ember/controller' {
-    interface IRegistry {
+    interface Registry {
         'user-quickfiles': UserQuickfiles;
     }
 }

--- a/app/user-quickfiles/route.ts
+++ b/app/user-quickfiles/route.ts
@@ -26,9 +26,3 @@ export default class UserQuickfiles extends Route.extend(Analytics, {
         return this.store.findRecord('user', params.user_id);
     }
 }
-
-declare module '@ember/routing/route' {
-    interface IRegistry {
-        'user-quickfiles': UserQuickfiles;
-    }
-}

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ember-cli-template-lint": "^0.7.5",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-tslint": "^0.1.3",
-    "ember-cli-typescript": "^1.0.6",
+    "ember-cli-typescript": "^1.1.5",
     "ember-cli-uglify": "^1.2.0",
     "ember-concurrency": "^0.8.12",
     "ember-click-outside": "^0.1.12",

--- a/tslint.json
+++ b/tslint.json
@@ -15,7 +15,8 @@
     "arrow-parens": [true, "ban-single-arg-parens"],
     "quotemark": [true, "single", "avoid-escape", "avoid-template"],
     "member-access": false,
-    "no-namespace": [true, "allow-declarations"]
+    "no-namespace": [true, "allow-declarations"],
+    "interface-name": [true, "never-prefix"]
   },
   "rulesDirectory": []
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3526,9 +3526,9 @@ ember-cli-tslint@^0.1.3:
     tslint "^5.5.0"
     walk-sync "^0.3.2"
 
-ember-cli-typescript@^1.0.6:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-1.1.3.tgz#025ae62f2779decd5f8bd60a0d125ca1106dbf62"
+ember-cli-typescript@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-1.1.5.tgz#64dc940abd5273e1ad108209bf6fcb78dcc0a162"
   dependencies:
     broccoli-debug "^0.6.4"
     broccoli-funnel "^2.0.1"


### PR DESCRIPTION
Remove unused registry declarations for routes and components.

<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Let TS find our type registries, so it can infer the return type of things like `route.controllerFor('application')` 


## Summary of Changes
* Switch to `I`-less interface names, like the ember typings expect.
* Remove unused type registries on routes and components.
* Update ember-cli-typescript to 1.1.5


## Side Effects / Testing Notes
I flipped the `interface-name` linting rule, so no interfaces should start with `I`. I don't have strong feelings about this besides making the type registries work, but consistency is nice.


## Ticket

--

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
