### PR TITLE
[EMB-152] Move application route beforeModel hook to Route.extend

### DIFF
--- a/app/application/route.ts
+++ b/app/application/route.ts
@@ -3,6 +3,12 @@ import { inject as service } from '@ember/service';
 import OSFAgnosticAuthRouteMixin from 'ember-osf-web/mixins/osf-agnostic-auth-route';
 
 export default class Application extends Route.extend(OSFAgnosticAuthRouteMixin, {
+    beforeModel(...args) {
+        this.get('moment').setTimeZone('UTC');
+
+        return this._super(...args);
+    },
+
     actions: {
         didTransition() {
             Object.assign(window, { prerenderReady: true });
@@ -11,12 +17,6 @@ export default class Application extends Route.extend(OSFAgnosticAuthRouteMixin,
     },
 }) {
     moment = service('moment');
-
-    beforeModel(...args) {
-        this.get('moment').setTimeZone('UTC');
-
-        return this._super(...args);
-    }
 
     afterModel() {
         const availableLocales: [string] = this.get('i18n.locales').toArray();


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Fixes the issue when you log out and log back in then go to your user-quickfiles page.

## Summary of Changes

* Move application route beforeModel hook back to `Route.extend` defintiion

## Side Effects / Testing Notes

Log out, log back in, check the affected routes.

## Ticket

https://openscience.atlassian.net/browse/EMB-152

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

## Notes for reviewers
In order for beforeModel to bubble with this._super, it must be in the `Route.extend` definition.

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
