### PR TITLE
[EMB-133] New dimensions of Google Analytics

### DIFF
--- a/app/router.ts
+++ b/app/router.ts
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 import config from 'ember-get-config';
 
 const Router = EmberRouter.extend({
+    session: service('session'),
     metrics: service('metrics'),
 
     location: config.locationType,
@@ -18,8 +19,13 @@ const Router = EmberRouter.extend({
         scheduleOnce('afterRender', this, () => {
             const page = this.get('url');
             const title = this.getWithDefault('currentRouteName', 'unknown');
+            const authenticated = this.get('session.isAuthenticated') ? 'Logged in' : 'Logged out';
+            const isPublic = 'true'; // This will have to be changed when we have private things
+            const metrics = this.get('metrics');
 
-            this.get('metrics').trackPage({ page, title });
+            metrics.trackPage({
+                page, title, dimension1: authenticated, dimension2: 'undefined', dimension3: isPublic,
+            });
         });
     },
 });


### PR DESCRIPTION
Should be updated when the GUID routing stuff is fixed

<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Have google analytics tracking track the new items added to the core (logged in/out, resource type, and public vs. private.

## Summary of Changes

Add the dimensions to the router and send them along

## Side Effects / Testing Notes

There will need to be upgrades when GUID routing is in to actually track resources, and when we actually have pages which will differentiate between public and private, we'll have to track those.

I checked the URL being requested, and it *looked* right, but it will be a day or two before we can verify on GA


## Ticket

https://openscience.atlassian.net/browse/EMB-133

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~ Add tests when test methods are updated
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
