### PR TITLE
[EMB-166] Explicitly pass 'reload' value for closeModal action on new-project-modal

### DIFF
--- a/app/components/new-project-modal/template.hbs
+++ b/app/components/new-project-modal/template.hbs
@@ -80,12 +80,12 @@
             </div>
         {{/modal.body}}
         {{#modal.footer}}
-            <button onclick={{action closeModal}} class="btn btn-default">{{t 'general.cancel'}}</button>
+            <button onclick={{action closeModal false}} class="btn btn-default">{{t 'general.cancel'}}</button>
             <button onclick={{action create nodeTitle description searchSelected.id}} class="btn btn-success {{unless nodeTitle.length 'disabled'}}">{{t 'general.create'}}</button>
         {{/modal.footer}}
     {{else}}
         {{#modal.body}}
-            <button data-dismiss="modal" aria-label="Close" class="close" onclick={{action closeModal}}>
+            <button data-dismiss="modal" aria-label="Close" class="close" onclick={{action closeModal true}}>
                 {{fa-icon 'times' size='sm'}}
             </button>
             <h4 class="add-project-success text-success">

--- a/app/dashboard/controller.ts
+++ b/app/dashboard/controller.ts
@@ -65,8 +65,10 @@ export default class Dashboard extends Controller.extend({
             this.toggleProperty('modalOpen');
         },
         closeModal(reload = false) {
-            this.closeModal();
+            // Need to explicitly pass reload when the action in the onclick event of a button
+            // otherwise the first argument is a mouse event which in turn is always truthy
 
+            this.closeModal();
             if (reload) {
                 this.get('findNodes').perform();
             }


### PR DESCRIPTION
## Purpose
Prevent reload of nodes when a user exits the new project modal on dashboard via the 'cancel' button.


## Summary of Changes
Explicitly set reload as true or false when attached the `closeModal` action to a button, otherwise it will always be true to the presence of mouse event as the first default argument, even though reload is set to be false when no arguments are passed.


## Side Effects / Testing Notes
Exit the new project modal on dashboard via all the available option, both post and prior to actually creating a node. Make sure the nodes list is reloaded post-successful node creation, and is preserved otherwise.

## Ticket

https://openscience.atlassian.net/browse/EMB-166

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
