### PR TITLE
[EMB-129] Don't show move button when not editing

### DIFF
--- a/app/components/file-browser/template.hbs
+++ b/app/components/file-browser/template.hbs
@@ -45,7 +45,7 @@
                     {{#if (if-filter 'view-button' display)}}
                         <button {{action 'viewItem'}} class='btn btn-light'>{{fa-icon "file-o"}} {{t 'general.view'}}</button>
                     {{/if}}
-                    {{#if (if-filter 'move-button' display)}}
+                    {{#if (and edit (if-filter 'move-button' display))}}
                         <button {{action 'openModal' 'move'}} class='btn btn-light'>{{fa-icon "level-up"}} {{t 'general.move'}}</button>
                     {{/if}}
                     {{#if (and edit (if-filter 'delete-button' display))}}


### PR DESCRIPTION
## Purpose
Move button is shown when not editing

## Summary of Changes
Add an edit check

## Ticket

https://openscience.atlassian.net/browse/EMB-129

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
