### PR TITLE
[No ticket] Reinstate some useful linting rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,12 +6,15 @@ module.exports = {
         sourceType: 'module',
     },
     extends: '@centerforopenscience/eslint-config/ember',
+    plugins: [
+        'typescript',
+    ],
     env: {
         browser: true,
         es6: true,
     },
     rules: {
-        'arrow-parens': [ 'warn', 'as-needed' ],
+        'arrow-parens': [ 'error', 'as-needed' ],
         'class-methods-use-this': [ 'error', {
             exceptMethods: [
                 'resetController',
@@ -19,20 +22,27 @@ module.exports = {
                 'modelNameFromPayloadKey',
             ],
         }],
-        'ember/named-functions-in-promises': 'off',
+        'ember/named-functions-in-promises': 'warn',
         'max-len': [ 'warn', { code: 120 } ],
-        'no-confusing-arrow': 0,
         'no-undef': 0,
         'no-unused-vars': ['error', { argsIgnorePattern: '^this' }],
+        'typescript/no-unused-vars': 'error',
         strict: 0,
-        indent: 'off',
+        indent: 0,
+        'indent-legacy': 'error',
     },
     overrides: [
         {
-            files: ['**/*.ts'],
+            files: ['**/*.d.ts'],
             rules: {
                 'no-unused-vars': 0,
             }
-        }
+        },
+        {
+            files: ['app/locales/*/translations.ts'],
+            rules: {
+                'max-len': 0,
+            },
+        },
     ]
 };

--- a/app/adapters/osf-adapter.ts
+++ b/app/adapters/osf-adapter.ts
@@ -184,14 +184,14 @@ export default class OsfAdapter extends JSONAPIAdapter.extend(GenericDataAdapter
     ): Promise<any> {
         return this._doRelatedRequest(store, snapshot, updatedSnapshots, relationship, url, 'PATCH', isBulk)
             .then(res => {
-            const relatedType = singularize(snapshot.record[relationship].meta().type);
-            res.data.forEach(item => {
-                const record = store.push(store.normalize(relatedType, item));
-                // TODO: This is now called addCanonicalInternalModel :|
-                snapshot.record.resolveRelationship(relationship).addCanonicalInternalModel(record._internalModel);
+                const relatedType = singularize(snapshot.record[relationship].meta().type);
+                res.data.forEach(item => {
+                    const record = store.push(store.normalize(relatedType, item));
+                    // TODO: This is now called addCanonicalInternalModel :|
+                    snapshot.record.resolveRelationship(relationship).addCanonicalInternalModel(record._internalModel);
+                });
+                return res;
             });
-            return res;
-        });
     },
     /**
      * Handle removal of related resources. This differs from DELETEs in that the related
@@ -335,7 +335,7 @@ export default class OsfAdapter extends JSONAPIAdapter.extend(GenericDataAdapter
     ): any {
         let related: any[] | { record?: any } = snapshot.record
             .get(`_dirtyRelationships.${relationship}.${change}`)
-            .map(r => r._internalModel ? r._internalModel.createSnapshot() : r.createSnapshot());
+            .map(r => (r._internalModel ? r._internalModel.createSnapshot() : r.createSnapshot()));
 
         if (!related.length) {
             return [];

--- a/app/authenticators/osf-cookie.js
+++ b/app/authenticators/osf-cookie.js
@@ -32,7 +32,7 @@ export default Base.extend({
             xhrFields: {
                 withCredentials: true,
             },
-        }).then((res) => {
+        }).then(res => {
             // Push the result into the store for later use by the current-user service
             // Note: we have to deepcopy res because pushPayload mutates our data
             // and causes an infinite loop because reasons

--- a/app/components/dropzone-widget/component.js
+++ b/app/components/dropzone-widget/component.js
@@ -97,7 +97,7 @@ export default Ember.Component.extend({
         dropzoneOptions.withCredentials = (config.authorizationType === 'cookie');
 
         // Attach preUpload to addedfile event
-        drop.on('addedfile', (file) => {
+        drop.on('addedfile', file => {
             if (preUpload) {
                 preUpload(this, drop, file).then(() => drop.processFile(file));
             } else {
@@ -109,7 +109,7 @@ export default Ember.Component.extend({
         drop.options = Ember.merge(drop.options, dropzoneOptions);
 
         // Attach dropzone event listeners: http://www.dropzonejs.com/#events
-        drop.events.forEach((event) => {
+        drop.events.forEach(event => {
             if (typeof this.get(event) === 'function') {
                 drop.on(event, (...args) => this.get(event)(this, drop, ...args));
             }

--- a/app/components/file-browser/component.js
+++ b/app/components/file-browser/component.js
@@ -70,7 +70,7 @@ export default Ember.Component.extend(Analytics, {
         loadAll(user, 'quickfiles', this.get('_items')).then(() => {
             this.set('loaded', true);
             this.set('_items', this.get('_items').sortBy('itemName'));
-            this.get('_items').forEach((item) => {
+            this.get('_items').forEach(item => {
                 if (this.get('selectedFile.id') && this.get('selectedFile.id') === item.id) {
                     item.isSelected = true; // eslint-disable-line no-param-reassign
                 }
@@ -94,7 +94,7 @@ export default Ember.Component.extend(Analytics, {
         }
         // items need to be reloaded when attrs are received
         // TODO: think about replacing _items with user.items, provided it's loaded properly
-        const _load = (user_) => {
+        const _load = user_ => {
             Ember.run(() => {
                 this.set('_items', Ember.A());
                 Ember.run.next(() => {
@@ -103,7 +103,7 @@ export default Ember.Component.extend(Analytics, {
             });
         };
         if (user.then) {
-            user.then((user_) => {
+            user.then(user_ => {
                 _load(user_);
             });
         } else {
@@ -437,7 +437,7 @@ export default Ember.Component.extend(Analytics, {
 
             if (this.get('projectSelectState') === 'newProject') {
                 this.set('newProject', true);
-                this._createProject(title).then((project) => {
+                this._createProject(title).then(project => {
                     this.set('node', project);
                     this._addNewNodeToList(this.get('user'), project);
                     this._moveFile(selectedItem, project);

--- a/app/helpers/build-secondary-nav-links.js
+++ b/app/helpers/build-secondary-nav-links.js
@@ -104,7 +104,7 @@ export default Ember.Helper.extend({ // Helper defined using a class, so can inj
                     href: serviceLinks.myProjects,
                 },
             );
-            this.get('currentUser.user').then((user) => {
+            this.get('currentUser.user').then(user => {
                 if (user.get('canViewReviews')) {
                     links.PREPRINTS.insertAt(1, {
                         name: 'navbar.reviews',

--- a/app/services/file-manager.js
+++ b/app/services/file-manager.js
@@ -106,7 +106,7 @@ export default Ember.Service.extend({
         return Ember.run(() => {
             const userID = this.get('session.data.authenticated.id');
             file.set('checkout', userID);
-            return file.save().catch((error) => {
+            return file.save().catch(error => {
                 file.rollbackAttributes();
                 throw error;
             });
@@ -124,7 +124,7 @@ export default Ember.Service.extend({
     checkIn(file) {
         return Ember.run(() => {
             file.set('checkout', null);
-            return file.save().catch((error) => {
+            return file.save().catch(error => {
                 file.rollbackAttributes();
                 throw error;
             });
@@ -251,7 +251,7 @@ export default Ember.Service.extend({
         options.data = JSON.stringify(defaultData);
 
         const p = this._waterbutlerRequest('POST', url, options);
-        return p.then((wbResponse) => {
+        return p.then(wbResponse => {
             const { name } = wbResponse.data.attributes;
             return this._getNewFileInfo(targetFolder, name);
         });
@@ -307,7 +307,7 @@ export default Ember.Service.extend({
         const options = options_;
         const url = file.get('links').delete;
         const p = this._waterbutlerRequest('DELETE', url, options);
-        return p.then(() => file.get('parentFolder').then((parent) => {
+        return p.then(() => file.get('parentFolder').then(parent => {
             if (parent) {
                 return this._reloadModel(parent.get('files'));
             } else {
@@ -362,12 +362,12 @@ export default Ember.Service.extend({
             this._reloadingUrls[reloadUrl] = true;
         }
 
-        return model.reload().then((freshModel) => {
+        return model.reload().then(freshModel => {
             if (reloadUrl) {
                 delete this._reloadingUrls[reloadUrl];
             }
             return freshModel;
-        }).catch((error) => {
+        }).catch(error => {
             if (reloadUrl) {
                 delete this._reloadingUrls[reloadUrl];
             }
@@ -430,7 +430,7 @@ export default Ember.Service.extend({
         const p = parentFolder.queryHasMany('files', {
             'filter[name]': name,
         });
-        return p.then((files) => {
+        return p.then(files => {
             const file = files.findBy('name', name);
             if (!file) {
                 throw 'Cannot load metadata for uploaded file.'; // eslint-disable-line no-throw-literal

--- a/app/utils/load-relationship.js
+++ b/app/utils/load-relationship.js
@@ -11,7 +11,7 @@ export default function loadAll(model, relationship, dest, options = {}) {
     query = Ember.merge(query, options || {});
     Ember.set(model, 'query-params', query);
 
-    return model.queryHasMany(relationship, query).then((results) => {
+    return model.queryHasMany(relationship, query).then(results => {
         dest.pushObjects(results.toArray());
         if (results.meta) {
             const { total } = results.meta;

--- a/app/utils/outside-click.js
+++ b/app/utils/outside-click.js
@@ -11,7 +11,7 @@ import Ember from 'ember';
  * @param {Function} clickFunction
  */
 export default function outsideClick(clickFunction) {
-    Ember.$('body').on('click', (e) => {
+    Ember.$('body').on('click', e => {
         if (Ember.$(e.target).parents('.popover.in').length === 0 &&
             Ember.$(e.target).attr('class') &&
             Ember.$(e.target).attr('class').indexOf('popover-toggler') === -1) {

--- a/node-tests/compile-and-test-translations.js
+++ b/node-tests/compile-and-test-translations.js
@@ -10,7 +10,7 @@ compileTranslation('en');
 // If args are passed and they don't include english transaltions.
 if (process.argv.length > 2 && !process.argv.slice(2).find(arg => /app\/locales\/en\/translations\.ts$/.test(arg))) {
     // Compile each arg that looks like a translation file.
-    process.argv.slice(2).forEach((arg) => {
+    process.argv.slice(2).forEach(arg => {
         const found = arg.match(/app\/locales\/([^/]+)\/translations\.ts$/);
         if (found && found[1]) {
             const locale = found[1];
@@ -20,7 +20,7 @@ if (process.argv.length > 2 && !process.argv.slice(2).find(arg => /app\/locales\
     });
 } else {
     // Compile all non-english translation files.
-    fs.readdirSync('app/locales/').forEach((locale) => {
+    fs.readdirSync('app/locales/').forEach(locale => {
         if (locale === 'en') return;
         compileTranslation(locale);
     });

--- a/node-tests/translations-test.js
+++ b/node-tests/translations-test.js
@@ -12,7 +12,7 @@ fs.unlinkSync('tmp/locales/en/translations.js');
 fs.rmdirSync('tmp/locales/en/');
 const englishTerms = flatten(english);
 
-fs.readdirSync('tmp/locales/').forEach((locale) => {
+fs.readdirSync('tmp/locales/').forEach(locale => {
     if (locale === 'en') return;
     describe(`locale: ${locale}`, () => {
         it('contains all terms', () => {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,8 @@
     "ember-welcome-page": "^2.0.2",
     "ember-wormhole": "^0.5.4",
     "flat": "^4.0.0",
+    "eslint-plugin-ember": "^5.0.0",
+    "eslint-plugin-typescript": "^0.10.0",
     "husky": "^0.14.3",
     "lint-staged": "^4.3.0",
     "loader.js": "^4.0.10",

--- a/tests/integration/components/file-editor/component-test.js
+++ b/tests/integration/components/file-editor/component-test.js
@@ -56,7 +56,7 @@ test('revert button', function(assert) {
 test('save new text', function(assert) {
     // Tests that the save function works
 
-    this.set('externalSaveAction', (actual) => {
+    this.set('externalSaveAction', actual => {
         const expected = 'Test to save this new text!';
         assert.equal(actual, expected, 'Save function properly passes new value');
     });

--- a/tests/unit/adapters/osf-adapter-test.js
+++ b/tests/unit/adapters/osf-adapter-test.js
@@ -62,7 +62,7 @@ test('#buildURL uses relationship links if available for delete, update, and fin
             self: url,
         },
     });
-    ['delete', 'update', 'find'].forEach((verb) => {
+    ['delete', 'update', 'find'].forEach(verb => {
         const result = adapter.buildURL(
             'user',
             'me',
@@ -178,7 +178,7 @@ test('#_createRelated maps over each createdSnapshots and adds records to the pa
             // infinite recursive calls when comparing the Ember DS.Models
             assert.equal(addCanonicalStub.args[0][0], contributors[0]._internalModel, 'First contributor did not match');
             assert.equal(addCanonicalStub.args[1][0], contributors[1]._internalModel, 'Second contributor did not match');
-        }).catch((err) => {
+        }).catch(err => {
             assert.ok(false, `An error occurred while running this test: ${err}`);
         });
     });
@@ -219,7 +219,7 @@ test('#_createRelated passes the nested:true as an adapterOption to save', funct
                     requestType: 'create',
                 },
             })));
-        }).catch((err) => {
+        }).catch(err => {
             assert.ok(false, `An error occurred while running this test: ${err}`);
         });
     });
@@ -244,7 +244,7 @@ test('#_addRelated defers to _doRelatedRequest and adds records to the parent\'s
             assert.ok(doRelatedStub.called, 'doRelated should be called');
             assert.ok(addCanonicalStub.calledOnce, 'addCanonical should be called');
             assert.ok(addCanonicalStub.calledWith(institution._internalModel), 'addCanonical should be called with the institution');
-        }).catch((err) => {
+        }).catch(err => {
             assert.ok(false, `An error occurred while running this test: ${err}`);
         });
     });
@@ -283,7 +283,7 @@ test('#_updateRelated defers to _doRelatedRequest, pushes the update response in
             assert.ok(addCanonicalStub.calledOnce);
             assert.ok(pushStub.calledOnce);
             assert.ok(normalizeStub.calledOnce);
-        }).catch((err) => {
+        }).catch(err => {
             assert.ok(false, `An error occurred while running this test: ${err}`);
         });
     });
@@ -308,7 +308,7 @@ test('#_removeRelated defers to _doRelatedRequest, and removes the records from 
             assert.ok(doRelatedStub.calledOnce, 'doRelated should be called');
             assert.ok(removeCanonicalStub.calledOnce, 'removeCanonical should be called');
             assert.ok(removeCanonicalStub.calledWith(inst._internalModel), 'removeCanonical should be called with institution as an argument');
-        }).catch((err) => {
+        }).catch(err => {
             assert.ok(false, `An error occurred while running this test: ${err}`);
         });
     });
@@ -329,7 +329,7 @@ test('#_deleteRelated defers to _doRelatedRequest, and unloads the deleted recor
         node.save().then(() => {
             assert.ok(doRelatedStub.calledOnce);
             assert.ok(unloadStub.calledOnce);
-        }).catch((err) => {
+        }).catch(err => {
             assert.ok(false, `An error occurred while running this test: ${err}`);
         });
     });
@@ -343,7 +343,7 @@ test('#_doRelatedRequest with array', function (assert) {
 
     const node = FactoryGuy.make('node');
     begin();
-    const children = FactoryGuy.buildList('node', 3).data.map((json) => {
+    const children = FactoryGuy.buildList('node', 3).data.map(json => {
         return store.createRecord('node', store.normalize('node', json).data.attributes);
     });
     end();
@@ -495,7 +495,7 @@ test('#updateRecord handles both dirtyRelationships and the parent record', func
     const ss = node._internalModel.createSnapshot();
 
     return adapter
-        .updateRecord(store, node, ss).then((res) => {
+        .updateRecord(store, node, ss).then(res => {
             // Note: 42 comes from promise resolution of stubbed updateRecord above
             assert.equal(res, 42);
             assert.ok(handleRelatedStub.calledWith(
@@ -536,7 +536,7 @@ skip('#findRecord can embed(via include) data with findRecord', function (assert
                     title: 'Bar',
                 }),
             ])
-            .then((res) => {
+            .then(res => {
                 children = res;
                 return node.get('children').pushObjects(res);
             })
@@ -544,7 +544,7 @@ skip('#findRecord can embed(via include) data with findRecord', function (assert
                 node.set('title', 'Parent');
                 return store.findRecord('node', node.id, { include: 'children' });
             })
-            .then((res) => {
+            .then(res => {
                 assert.equal(
                     res.get('children').toArray()[0].get('title'),
                     children[0].get('title'),

--- a/tests/unit/helpers/build-secondary-nav-links-test.js
+++ b/tests/unit/helpers/build-secondary-nav-links-test.js
@@ -29,7 +29,7 @@ const sessionStubAuthenticated = Ember.Service.extend({
 
 // currentUser Stub !canViewReviews
 const currentUserStubNoReviews = Ember.Service.extend({
-    user: new Ember.RSVP.Promise((resolve) => {
+    user: new Ember.RSVP.Promise(resolve => {
         const user = Ember.Object.create({
             canViewReviews: false,
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4592,6 +4592,14 @@ eslint-plugin-ember@^4.5.0:
     require-folder-tree "^1.4.5"
     snake-case "^2.1.0"
 
+eslint-plugin-ember@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-5.1.0.tgz#fb96abd2d8bf105678a0aa81dadd99d7ca441ba1"
+  dependencies:
+    ember-rfc176-data "^0.2.7"
+    require-folder-tree "^1.4.5"
+    snake-case "^2.1.0"
+
 eslint-plugin-eslint-comments@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-1.1.0.tgz#98e3784f0508b185260ea54491024bbaad54c5fa"
@@ -4612,6 +4620,12 @@ eslint-plugin-import@^2.7.0:
     lodash.cond "^4.3.0"
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
+
+eslint-plugin-typescript@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-typescript/-/eslint-plugin-typescript-0.10.0.tgz#009a8fcaf0ec7bf68f6fb71576df0d84ebd0b114"
+  dependencies:
+    requireindex "~1.1.0"
 
 eslint-restricted-globals@^0.1.1:
   version "0.1.1"
@@ -8956,6 +8970,10 @@ require-uncached@^1.0.3:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
 
 requires-port@1.x.x:
   version "1.0.0"


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Reactivate some useful linting rules which were disabled over the weekend.


## Summary of Changes
- Use `typescript` eslint plugin
  - Enable [`typescript/no-unused-vars`](https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/no-unused-vars.md)
  - Switch the `no-unused-vars` override back to disable for type declaration files (`*.d.ts`), instead of all `.ts` files
- Reenable rules:
  - [no-confusing-arrow](https://eslint.org/docs/rules/no-confusing-arrow)
  - [indent-legacy](https://eslint.org/docs/rules/indent-legacy)
  - [arrow-parens](https://eslint.org/docs/rules/arrow-parens)
  - [ember/named-functions-in-promises](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/named-functions-in-promises.md) (as a warning)
- Fix new errors from those rules (mostly just `eslint --fix`)
- Disable `max-len` rule for `locales/*/translations.ts`. Maybe someday we'll fix the rest of the `max-len` warnings and upgrade it to an error, but we shouldn't worry about that for translations.


## Side Effects / Testing Notes
No functional changes. Linting should be slightly more useful.


## Ticket

https://openscience.atlassian.net/browse/EMB-

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
