### PR TITLE
[IN-95][Ember-OSF-Web] Update to use latest navbar changes in osf-style

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@centerforopenscience/eslint-config": "^2.0.0",
-    "@centerforopenscience/osf-style": "1.5.1",
+    "@centerforopenscience/osf-style": "https://github.com/CenterForOpenScience/osf-style#b09451d759c8544d2fab4bd7dbd5ca8b6dc242b8",
     "@types/ember": "^2.8.8",
     "@types/ember-data": "^2.14.12",
     "@types/ember-qunit": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,9 +81,9 @@
     eslint-plugin-eslint-comments "^1.0.0"
     eslint-plugin-import "^2.7.0"
 
-"@centerforopenscience/osf-style@1.5.1":
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/@centerforopenscience/osf-style/-/osf-style-1.5.1.tgz#3ea1a0807c02d06d32bf346620a538613880bc59"
+"@centerforopenscience/osf-style@https://github.com/CenterForOpenScience/osf-style#b09451d759c8544d2fab4bd7dbd5ca8b6dc242b8":
+  version "1.6.0"
+  resolved "https://github.com/CenterForOpenScience/osf-style#b09451d759c8544d2fab4bd7dbd5ca8b6dc242b8"
 
 "@ember-decorators/argument@^0.8.10":
   version "0.8.12"


### PR DESCRIPTION
## Purpose

The navbar has recently been changed to use flexbox styling instead of what we had before.

## Summary of Changes

This PR updates `package.json` to use the latest merge commit for these changes in osf-style.  Will need to be updated to point to version after changes pass QA and are in an official release.

## Ticket

https://openscience.atlassian.net/browse/IN-95

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
