### PR TITLE
[IN-95][Ember-OSF-Web] Update navbar to fit changes in osf-style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - TypeScript: Rename files to .ts
 - Modified several templates and css properties for increased accessibility
+- Navbar to fit new styles in `osf-style`
 
 ## [0.2.0] - 2018-02-14
 ### Added

--- a/app/components/new-navbar-auth-dropdown/component.js
+++ b/app/components/new-navbar-auth-dropdown/component.js
@@ -27,7 +27,7 @@ export default Ember.Component.extend(AnalyticsMixin, {
     currentUser: Ember.inject.service(),
     i18n: Ember.inject.service(),
     tagName: 'li',
-    classNames: ['dropdown'],
+    classNames: ['dropdown', 'secondary-nav-dropdown'],
     classNameBindings: ['notAuthenticated:sign-in'],
     notAuthenticated: Ember.computed.not('session.isAuthenticated'),
     redirectUrl: null,

--- a/app/components/new-navbar-auth-dropdown/styles.scss
+++ b/app/components/new-navbar-auth-dropdown/styles.scss
@@ -1,5 +1,0 @@
-.Gravatar > img {
-    border: 1px solid #cdcdcd;
-    border-radius: 13px;
-    margin-right: 5px;
-}

--- a/app/components/new-navbar-auth-dropdown/template.hbs
+++ b/app/components/new-navbar-auth-dropdown/template.hbs
@@ -1,9 +1,10 @@
 {{# if session.isAuthenticated }}
     {{! TODO: Replace display name functionality if possible- for now truncate via CSS at end of label }}
     <a class="btn-link" data-toggle="dropdown" role="button" aria-expanded="false" aria-label={{t 'auth_dropdown.toggle_auth_dropdown'}} onclick={{action closeOtherNavigation}}>
-        <span class="Gravatar">
+        <div class="osf-profile-image">
             <img src="{{gravatarUrl}}" alt="{{t 'auth_dropdown.user_gravatar'}}">
-        </span> {{get-display-name user.fullName}}
+        </div>
+        <div class="nav-profile-name">{{user.fullName}}</div>
         <span class="caret"></span>
     </a>
     <ul class="dropdown-menu auth-dropdown" role="menu">

--- a/app/components/new-osf-navbar/template.hbs
+++ b/app/components/new-osf-navbar/template.hbs
@@ -2,12 +2,6 @@
     <nav class="navbar navbar-inverse navbar-fixed-top" id="navbarScope" role="navigation">
         <div class="container">
             <div class="navbar-header">
-                {{!TOGGLE NAVIGATION BUTTON - XS SCREEN}}
-                <a type="button" role="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#secondary-navigation" onclick={{action 'closeSearch'}} aria-label={{t 'navbar.toggle_secondary'}}>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                </a>
                 {{!OSF BRAND}}
                 <a class="navbar-brand" href="/" aria-label={{t 'navbar.go_home'}}>
                     <span class="osf-navbar-logo"></span>
@@ -32,6 +26,12 @@
                         {{/each}}
                     </ul>
                 </div>
+                {{!TOGGLE NAVIGATION BUTTON - XS SCREEN}}
+                <a type="button" role="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#secondary-navigation" onclick={{action 'closeSearch'}} aria-label={{t 'navbar.toggle_secondary'}}>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                </a>
             </div>
             <div class="navbar-collapse collapse navbar-right" id="secondary-navigation">
                 <ul class="nav navbar-nav">


### PR DESCRIPTION
## Purpose

To update the format of the navbar to use changes in the latest `osf-style`

## Summary of Changes

- Move  the `navbar-toggle collapsed` button to the right of the other elements in its container
- Added `secondary-nav-dropdown` class to the `new-navbar-auth-dropdown` component
- Changed classes and element tags to match styles needed for long name truncation

## Side Effects / Testing Notes

Just check that long names do not break to a new line.  It should truncate based on how much space it has in the navbar.

## Ticket

https://openscience.atlassian.net/browse/IN-95

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
