### PR TITLE
close the footer gap

### DIFF
--- a/app/home/styles.scss
+++ b/app/home/styles.scss
@@ -369,7 +369,6 @@ h6 {
     background-color: #474747;
     color: #fff;
     padding: 50px 0;
-    margin-bottom: 20px;
 
     h2 {
         font-size: 48px;


### PR DESCRIPTION
No ticket, quick CSS fix

### Before
<img width="1019" alt="screen shot 2018-03-22 at 10 19 08" src="https://user-images.githubusercontent.com/3374510/37775927-9850b5c6-2dba-11e8-9cbf-7da370b13b40.png">

### After
<img width="1031" alt="screen shot 2018-03-22 at 10 19 21" src="https://user-images.githubusercontent.com/3374510/37775940-9e081ab8-2dba-11e8-8f01-3191e9809f2b.png">
