### PR TITLE
Let Handlebars encode the mfrUrl query string

### DIFF
--- a/app/components/file-share-button/component.ts
+++ b/app/components/file-share-button/component.ts
@@ -89,7 +89,7 @@ export default class FileShareButton extends Component.extend(Analytics, {
         const file = this.get('file');
 
         const params = {
-            url: encodeURIComponent(pathJoin(config.OSF.url, file.get('guid'), 'download')),
+            url: pathJoin(config.OSF.url, file.get('guid'), 'download'),
         };
 
         return `${config.OSF.renderUrl}?${$.param(params)}`;


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Fix issue where share url query string is double encoded

## Summary of Changes

Remove `encodeURIComponent()` on file download url

## Side Effects / Testing Notes

Make sure share link is valid

## Ticket

N/A

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
