### PR TITLE
[Fix] Update osf-style to fix sign-up button height

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@centerforopenscience/eslint-config": "^2.0.0",
-    "@centerforopenscience/osf-style": "https://github.com/CenterForOpenScience/osf-style#b09451d759c8544d2fab4bd7dbd5ca8b6dc242b8",
+    "@centerforopenscience/osf-style": "https://github.com/CenterForOpenScience/osf-style#ff5bd6b91cd5ef10634bf7510c2858fec2a9de6f",
     "@types/ember": "^2.8.8",
     "@types/ember-data": "^2.14.12",
     "@types/ember-qunit": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,9 +81,9 @@
     eslint-plugin-eslint-comments "^1.0.0"
     eslint-plugin-import "^2.7.0"
 
-"@centerforopenscience/osf-style@https://github.com/CenterForOpenScience/osf-style#b09451d759c8544d2fab4bd7dbd5ca8b6dc242b8":
+"@centerforopenscience/osf-style@https://github.com/CenterForOpenScience/osf-style#ff5bd6b91cd5ef10634bf7510c2858fec2a9de6f":
   version "1.6.0"
-  resolved "https://github.com/CenterForOpenScience/osf-style#b09451d759c8544d2fab4bd7dbd5ca8b6dc242b8"
+  resolved "https://github.com/CenterForOpenScience/osf-style#ff5bd6b91cd5ef10634bf7510c2858fec2a9de6f"
 
 "@ember-decorators/argument@^0.8.10":
   version "0.8.12"


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Fix the sign-up button height:
<img width="193" alt="screen shot 2018-03-23 at 12 08 22 pm" src="https://user-images.githubusercontent.com/6776190/37845077-f9debc08-2e9f-11e8-8374-aacdffe9b28e.png">



## Summary of Changes
Update osf-style dependency to a commit with the fix.


## Side Effects / Testing Notes



## Ticket

https://openscience.atlassian.net/browse/EMB-

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
