### PR TITLE
Update and merge ember type versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   "devDependencies": {
     "@centerforopenscience/eslint-config": "^2.0.0",
     "@centerforopenscience/osf-style": "https://github.com/CenterForOpenScience/osf-style#ff5bd6b91cd5ef10634bf7510c2858fec2a9de6f",
-    "@types/ember": "^2.8.8",
-    "@types/ember-data": "^2.14.12",
+    "@types/ember": "^2.8.16",
+    "@types/ember-data": "^2.14.13",
     "@types/ember-qunit": "^3.0.1",
     "@types/ember-testing-helpers": "^0.0.3",
     "@types/rsvp": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,9 +214,9 @@
   dependencies:
     samsam "1.3.0"
 
-"@types/ember-data@^2.14.12":
-  version "2.14.12"
-  resolved "https://registry.yarnpkg.com/@types/ember-data/-/ember-data-2.14.12.tgz#015aa5e7fd561023f626eb0001c2203fafd27525"
+"@types/ember-data@^2.14.13":
+  version "2.14.13"
+  resolved "https://registry.yarnpkg.com/@types/ember-data/-/ember-data-2.14.13.tgz#69394c12136539e4da8e69241ddfd98a66e05438"
   dependencies:
     "@types/rsvp" "*"
 
@@ -243,17 +243,9 @@
     "@types/jquery" "*"
     "@types/rsvp" "*"
 
-"@types/ember@*":
-  version "2.8.15"
-  resolved "https://registry.yarnpkg.com/@types/ember/-/ember-2.8.15.tgz#1d0931c2906d026a2b5c034cf5f2177e226be071"
-  dependencies:
-    "@types/handlebars" "*"
-    "@types/jquery" "*"
-    "@types/rsvp" "*"
-
-"@types/ember@^2.8.8":
-  version "2.8.13"
-  resolved "https://registry.yarnpkg.com/@types/ember/-/ember-2.8.13.tgz#4577bb9684ef5b75b49c181dc56075a94e8002c8"
+"@types/ember@*", "@types/ember@^2.8.16":
+  version "2.8.16"
+  resolved "https://registry.yarnpkg.com/@types/ember/-/ember-2.8.16.tgz#d85d13bb898f27edad27cf5365348cd0a095fffd"
   dependencies:
     "@types/handlebars" "*"
     "@types/jquery" "*"


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Remove multiple instances of ember types (which [confuses TypeScript](https://github.com/typed-ember/ember-cli-typescript#typescript-is-complaining-about-multiple-copies-of-the-same-types)).

## Summary of Changes

* upgrade to latest `@types/ember`
* merge `@types/ember@*` and `@types/ember@^2.8.16` in `yarn.lock`
* also upgrade to latest `@types/ember-data` while we're here

## Side Effects / Testing Notes

Less TS errors

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
