### PR TITLE
[EMB-127] Use task to get loading instance of file getContents to not show while loading

### DIFF
--- a/app/guid-file/controller.ts
+++ b/app/guid-file/controller.ts
@@ -150,7 +150,7 @@ export default class FileDetail extends Controller.extend(Analytics, {
     });
 
     fileText = computed('model.file.currentVersion', function(this: FileDetail) {
-        return this.get('model.file').getContents();
+        return this.get('model.file.getContents').perform();
     });
 }
 

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -110,14 +110,14 @@
             {{#if (or (eq show 'edit') (eq show 'view_edit'))}}
                 {{#if isEditableFile}}
                     {{#if canEdit}}
-                        <div class='panel panel-default EditPanel {{if (and (eq show "view_edit") canEdit) "col-sm-6"}}'>
-                            {{#if (await fileText)}}
+                        {{#if (not (eq (await fileText) null))}}
+                            <div class='panel panel-default EditPanel {{if (and (eq show "view_edit") canEdit) "col-sm-6"}}'>
                                 {{#file-editor
                                     fileText=(await fileText)
                                     save=(action 'save')}}
                                 {{/file-editor}}
-                            {{/if}}
-                        </div>
+                            </div>
+                        {{/if}}
                     {{/if}}
                 {{/if}}
             {{/if}}

--- a/app/models/file.ts
+++ b/app/models/file.ts
@@ -1,3 +1,4 @@
+import { task } from 'ember-concurrency';
 import DS from 'ember-data';
 import FileItemMixin from 'ember-osf-web/mixins/file-item';
 import authenticatedAJAX from 'ember-osf-web/utils/ajax-helpers';
@@ -53,6 +54,18 @@ export default class File extends OsfModel.extend(FileItemMixin, {
     _isFileModel: true,
 
 }) {
+    getContents = task(function* (this: File) {
+        const data = yield authenticatedAJAX({
+            url: this.get('links.download'),
+            type: 'GET',
+            data: {
+                direct: true,
+                mode: 'render',
+            },
+        });
+        return data;
+    });
+
     async rename(this: File, newName: string, conflict = 'replace'): Promise<null> {
         const { data } = await authenticatedAJAX({
             url: this.get('links.upload'),
@@ -85,16 +98,6 @@ export default class File extends OsfModel.extend(FileItemMixin, {
                 },
             },
         );
-    }
-    getContents(this: File): Promise<object> {
-        return authenticatedAJAX({
-            url: this.get('links.download'),
-            type: 'GET',
-            data: {
-                direct: true,
-                mode: 'render',
-            },
-        });
     }
     updateContents(this: File, data: object): Promise<null> {
         return authenticatedAJAX({


### PR DESCRIPTION
## Purpose
Empty files (like a text file that had everything erased)  would cause the file editor to not show.


## Summary of Changes
Make getContents a task, and check if fileText is null once completed, not if exists (since '' is falsy)

## Ticket

https://openscience.atlassian.net/browse/EMB-127

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
