### PR TITLE
[EMB-128] Make edit computed property reload when currentUser does 

### DIFF
--- a/app/components/file-browser/component.js
+++ b/app/components/file-browser/component.js
@@ -62,7 +62,7 @@ export default Ember.Component.extend(Analytics, {
     },
     currentUser: Ember.inject.service(),
     dropzone: Ember.computed.alias('edit'),
-    edit: Ember.computed('user', function() {
+    edit: Ember.computed('user', 'currentUser.currentUserId', function() {
         return this.get('user.id') === this.get('currentUser.currentUserId');
     }),
     _loadFiles(user) {


### PR DESCRIPTION
## Purpose
Make edit behavior synchronous to current user's permission by hooking (indirectly) to the session service.

## Summary of Changes
Make edit computed property check when currentUser changes (which in turn is computed from the session) as well as user is loaded.

## Side Effects / Testing Notes
Whoever merges this, feel free to close the branch, accidentally pointed to cos's branch rather than mine.


## Ticket

https://openscience.atlassian.net/browse/EMB-128

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
