### PR TITLE
[EMB-182] Convert html special chars before filtering

### DIFF
--- a/app/dashboard/controller.ts
+++ b/app/dashboard/controller.ts
@@ -99,7 +99,7 @@ export default class Dashboard extends Controller.extend({
 
         const nodes = yield user.queryHasMany('nodes', {
             embed: 'contributors',
-            filter: filter ? { title: filter } : undefined,
+            filter: filter ? { title: $('<div>').text(filter).html() } : undefined,
             page: more ? this.incrementProperty('page') : this.set('page', 1),
             sort: this.get('sort') || undefined,
         });


### PR DESCRIPTION
## Purpose
Projects with HTML special characters in their title could not be filtered properly, as they are stored encoded (and presented as such through the api).


## Summary of Changes
Encode HTML special chars to allow for proper filtering.

## Ticket

https://openscience.atlassian.net/browse/EMB-182


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
