### PR TITLE
[EMB-180] Set `prerenderReady` when ready

### DIFF
--- a/app/application/route.ts
+++ b/app/application/route.ts
@@ -1,26 +1,19 @@
+import { service } from '@ember-decorators/service';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
 import OSFAgnosticAuthRouteMixin from 'ember-osf-web/mixins/osf-agnostic-auth-route';
 
-export default class Application extends Route.extend(OSFAgnosticAuthRouteMixin, {
-    beforeModel(...args) {
+export default class Application extends Route.extend(OSFAgnosticAuthRouteMixin) {
+    @service moment;
+
+    beforeModel(this: Application, ...args) {
         this.get('moment').setTimeZone('UTC');
 
         return this._super(...args);
-    },
+    }
 
-    actions: {
-        didTransition() {
-            Object.assign(window, { prerenderReady: true });
-            return true; // Bubble the didTransition event
-        },
-    },
-}) {
-    moment = service('moment');
-
-    afterModel() {
+    afterModel(this: Application) {
         const availableLocales: [string] = this.get('i18n.locales').toArray();
-        let locale: string;
+        let locale: string | null = null;
 
         // Works in Chrome and Firefox (editable in settings)
         if (navigator.languages && navigator.languages.length) {

--- a/app/components/file-browser/component.ts
+++ b/app/components/file-browser/component.ts
@@ -71,6 +71,7 @@ export default class FileBrowser extends Component.extend({
     @service analytics;
     @service currentUser;
     @service i18n;
+    @service ready;
     @service store;
     @service toast;
 

--- a/app/dashboard/controller.ts
+++ b/app/dashboard/controller.ts
@@ -81,7 +81,7 @@ export default class Dashboard extends Controller.extend({
     }).restartable(),
 
     initialLoad: task(function* (this: Dashboard) {
-        const blocker = this.get('ready').block();
+        const blocker = this.get('ready').getBlocker();
         yield this.get('findNodes').perform();
         blocker.done();
     }),
@@ -118,7 +118,7 @@ export default class Dashboard extends Controller.extend({
     }).restartable(),
 
     getPopularAndNoteworthy: task(function* (this: Dashboard, id, dest) {
-        const blocker = this.get('ready').block();
+        const blocker = this.get('ready').getBlocker();
         try {
             const node = yield this.get('store').findRecord('node', id);
             const linkedNodes = yield node.queryHasMany('linkedNodes', {

--- a/app/dashboard/controller.ts
+++ b/app/dashboard/controller.ts
@@ -17,6 +17,7 @@ const {
 export default class Dashboard extends Controller.extend({
     currentUser: service('current-user'),
     analytics: service(),
+    ready: service('ready'),
 
     filter: null,
     loading: false,
@@ -42,7 +43,7 @@ export default class Dashboard extends Controller.extend({
             this.setProperties({ sort });
             this.get('findNodes').perform();
         },
-        selectInstitution(this: NewProjectModal, institution) {
+        selectInstitution(this: Dashboard, institution) {
             const selected = this.set('institutionsSelected', this.get('institutionsSelected').slice());
 
             if (selected.includes(institution)) {
@@ -51,10 +52,10 @@ export default class Dashboard extends Controller.extend({
                 selected.pushObject(institution);
             }
         },
-        selectAllInstitutions(this: NewProjectModal) {
+        selectAllInstitutions(this: Dashboard) {
             this.set('institutionsSelected', this.get('user.institutions').slice());
         },
-        removeAllInstitutions(this: NewProjectModal) {
+        removeAllInstitutions(this: Dashboard) {
             this.set('institutionsSelected', A([]));
         },
         toggleModal() {
@@ -64,7 +65,7 @@ export default class Dashboard extends Controller.extend({
 
             this.toggleProperty('modalOpen');
         },
-        closeModal(reload = false) {
+        closeModal(this: Dashboard, reload = false) {
             // Need to explicitly pass reload when the action in the onclick event of a button
             // otherwise the first argument is a mouse event which in turn is always truthy
 
@@ -80,7 +81,9 @@ export default class Dashboard extends Controller.extend({
     }).restartable(),
 
     initialLoad: task(function* (this: Dashboard) {
+        const blocker = this.get('ready').block();
         yield this.get('findNodes').perform();
+        blocker.done();
     }),
 
     filterNodes: task(function* (this: Dashboard, filter) {
@@ -115,6 +118,7 @@ export default class Dashboard extends Controller.extend({
     }).restartable(),
 
     getPopularAndNoteworthy: task(function* (this: Dashboard, id, dest) {
+        const blocker = this.get('ready').block();
         try {
             const node = yield this.get('store').findRecord('node', id);
             const linkedNodes = yield node.queryHasMany('linkedNodes', {
@@ -122,8 +126,10 @@ export default class Dashboard extends Controller.extend({
                 page: { size: 5 },
             });
             this.set(dest, linkedNodes);
+            blocker.done();
         } catch (e) {
             this.set(`failedLoading-${dest}`, true);
+            blocker.errored(e);
         }
     }),
 
@@ -174,7 +180,8 @@ export default class Dashboard extends Controller.extend({
         return this.get('nodes.length') < this.get('nodes.meta.total');
     });
 
-    init() {
+    constructor() {
+        super();
         this.get('initialLoad').perform();
         this.get('getInstitutions').perform();
         this.get('getPopularAndNoteworthy').perform(popularNode, 'popular');

--- a/app/guid-user/quickfiles/route.ts
+++ b/app/guid-user/quickfiles/route.ts
@@ -32,7 +32,7 @@ export default class UserQuickfiles extends Route.extend({
     @service ready;
 
     loadModel = task(function* (this: UserQuickfiles, userModel) {
-        const blocker = this.get('ready').block();
+        const blocker = this.get('ready').getBlocker();
         try {
             const user = yield userModel.taskInstance;
 

--- a/app/guid-user/quickfiles/route.ts
+++ b/app/guid-user/quickfiles/route.ts
@@ -29,21 +29,26 @@ export default class UserQuickfiles extends Route.extend({
 }) {
     @service analytics;
     @service currentUser;
+    @service ready;
 
-    loadModel = task(function* (this: UserQuickfiles, model) {
+    loadModel = task(function* (this: UserQuickfiles, userModel) {
+        const blocker = this.get('ready').block();
         try {
-            const user = yield model.taskInstance;
+            const user = yield userModel.taskInstance;
 
-            return {
+            const model = {
                 user,
                 files: yield loadAll(user, 'quickfiles', { 'page[size]': 100 }),
             };
+            blocker.done();
+            return model;
         } catch (error) {
+            blocker.errored(error);
             this.transitionTo('not-found', this.get('router.currentURL').slice(1));
         }
     });
 
-    model() {
+    model(this: UserQuickfiles) {
         return {
             taskInstance: this.get('loadModel').perform(this.modelFor('guid-user')),
         };

--- a/app/instance-initializers/prerender.ts
+++ b/app/instance-initializers/prerender.ts
@@ -1,0 +1,12 @@
+import ApplicationInstance from '@ember/application/instance';
+
+export function initialize(appInstance: ApplicationInstance): void {
+    const ready = appInstance.lookup('service:ready');
+    ready.ready().then(() => {
+        window.prerenderReady = true;
+    });
+}
+
+export default {
+    initialize,
+};

--- a/app/instance-initializers/prerender.ts
+++ b/app/instance-initializers/prerender.ts
@@ -1,10 +1,9 @@
 import ApplicationInstance from '@ember/application/instance';
 
-export function initialize(appInstance: ApplicationInstance): void {
+export async function initialize(appInstance: ApplicationInstance) {
     const ready = appInstance.lookup('service:ready');
-    ready.ready().then(() => {
-        window.prerenderReady = true;
-    });
+    await ready.ready();
+    window.prerenderReady = true;
 }
 
 export default {

--- a/app/resolve-guid/resolved-guid-route.ts
+++ b/app/resolve-guid/resolved-guid-route.ts
@@ -12,7 +12,7 @@ export default Route.extend({
     ready: service('ready'),
 
     loadModel: task(function* (typeName: string, id: string) {
-        const blocker = get(this, 'ready').block();
+        const blocker = get(this, 'ready').getBlocker();
         try {
             const model = yield get(this, 'store').findRecord(typeName, id);
             blocker.done();

--- a/app/router.ts
+++ b/app/router.ts
@@ -2,11 +2,15 @@ import EmberRouter from '@ember/routing/router';
 import { inject as service } from '@ember/service';
 import config from 'ember-get-config';
 
+import { Blocker } from 'ember-osf-web/services/ready';
+
 const Router = EmberRouter.extend({
     metrics: service('metrics'),
     currentUser: service('current-user'),
     features: service('features'),
     session: service('session'),
+    ready: service('ready'),
+    readyBlocker: null as Blocker|null,
 
     location: config.locationType,
     rootURL: config.rootURL,
@@ -20,12 +24,18 @@ const Router = EmberRouter.extend({
                 }
             });
         }
+        this.set('readyBlocker', this.get('ready').block());
         this._super(...arguments);
     },
 
     didTransition() {
         this._super(...arguments);
         window.scrollTo(0, 0);
+
+        const readyBlocker = this.get('readyBlocker');
+        if (readyBlocker) {
+            readyBlocker.done();
+        }
     },
 });
 

--- a/app/router.ts
+++ b/app/router.ts
@@ -24,7 +24,7 @@ const Router = EmberRouter.extend({
                 }
             });
         }
-        this.set('readyBlocker', this.get('ready').block());
+        this.set('readyBlocker', this.get('ready').getBlocker());
         this._super(...arguments);
     },
 

--- a/app/services/current-user.ts
+++ b/app/services/current-user.ts
@@ -117,8 +117,8 @@ export default class CurrentUserService extends Service {
     }
 }
 
-declare module 'ember' {
-    interface ServiceRegistry {
+declare module '@ember/service' {
+    interface Registry {
         'current-user': CurrentUserService;
     }
 }

--- a/app/services/ready.ts
+++ b/app/services/ready.ts
@@ -1,0 +1,96 @@
+import { A } from '@ember/array';
+import { get, set } from '@ember/object';
+import Evented from '@ember/object/evented';
+import Service from '@ember/service';
+
+import { task, waitForQueue } from 'ember-concurrency';
+import { Promise as EmberPromise } from 'rsvp';
+
+interface Blocker {
+    done: () => void;
+    errored: (e: any) => void;
+}
+
+enum Events {
+    IsReady = 'ready',
+    Reset = 'reset',
+    Error = 'error',
+}
+
+export default class Ready extends Service.extend(Evented) {
+    isReady = false;
+
+    lastId = 0;
+    blockers = A();
+
+    tryReady = task(function* (this: Ready) {
+        // Waiting until `destroy` makes sure that everyone in `render` and `afterRender`
+        // (e.g. components, jQuery plugins, etc.) has a chance to call `block`, and that
+        // all DOM manipulation has settled.
+        yield waitForQueue('destroy');
+        if (!get(this, 'blockers').length) {
+            set(this, 'isReady', true);
+            this.trigger(Events.IsReady);
+        }
+    }).drop();
+
+    block(this: Ready): Blocker {
+        if (get(this, 'isReady')) {
+            return {
+                done: () => null,
+                errored: () => null,
+            };
+        }
+        const id = this.incrementProperty('lastId');
+        get(this, 'blockers').pushObject(id);
+        return {
+            done: this.doneCallback(id),
+            errored: this.errorCallback(),
+        };
+    }
+
+    blockOn(this: Ready, promise: PromiseLike<any>): void {
+        const blocker = this.block();
+        promise.then(
+            blocker.done,
+            blocker.errored,
+        );
+    }
+
+    ready(this: Ready) {
+        return new EmberPromise((resolve, reject) => {
+            this.on(Events.IsReady, resolve);
+            this.on(Events.Reset, reject);
+            this.on(Events.Error, reject);
+        });
+    }
+
+    reset(this: Ready): void {
+        // Invalidate all prior blockers
+        get(this, 'blockers').clear();
+        set(this, 'isReady', false);
+        this.trigger(Events.Reset);
+    }
+
+    private doneCallback(this: Ready, id: number) {
+        return () => {
+            const blockers = get(this, 'blockers');
+            blockers.removeObject(id);
+            if (!blockers.length) {
+                get(this, 'tryReady').perform();
+            }
+        };
+    }
+
+    private errorCallback(this: Ready) {
+        return (e: any) => {
+            this.trigger(Events.Error, e);
+        };
+    }
+}
+
+declare module '@ember/service' {
+    interface Registry {
+        'ready': Ready;
+    }
+}

--- a/app/services/ready.ts
+++ b/app/services/ready.ts
@@ -25,7 +25,7 @@ export default class Ready extends Service.extend(Evented) {
 
     tryReady = task(function* (this: Ready) {
         // Waiting until `destroy` makes sure that everyone in `render` and `afterRender`
-        // (e.g. components, jQuery plugins, etc.) has a chance to call `block`, and that
+        // (e.g. components, jQuery plugins, etc.) has a chance to call `getBlocker`, and that
         // all DOM manipulation has settled.
         yield waitForQueue('destroy');
         if (!get(this, 'blockers').length) {
@@ -34,7 +34,7 @@ export default class Ready extends Service.extend(Evented) {
         }
     }).drop();
 
-    block(this: Ready): Blocker {
+    getBlocker(this: Ready): Blocker {
         if (get(this, 'isReady')) {
             return {
                 done: () => null,
@@ -47,14 +47,6 @@ export default class Ready extends Service.extend(Evented) {
             done: this.doneCallback(id),
             errored: this.errorCallback(),
         };
-    }
-
-    blockOn(this: Ready, promise: PromiseLike<any>): void {
-        const blocker = this.block();
-        promise.then(
-            blocker.done,
-            blocker.errored,
-        );
     }
 
     ready(this: Ready) {

--- a/app/services/ready.ts
+++ b/app/services/ready.ts
@@ -6,12 +6,12 @@ import Service from '@ember/service';
 import { task, waitForQueue } from 'ember-concurrency';
 import { Promise as EmberPromise } from 'rsvp';
 
-interface Blocker {
+export interface Blocker {
     done: () => void;
     errored: (e: any) => void;
 }
 
-enum Events {
+export enum Events {
     IsReady = 'ready',
     Reset = 'reset',
     Error = 'error',

--- a/tests/unit/application/controller-test.ts
+++ b/tests/unit/application/controller-test.ts
@@ -7,6 +7,7 @@ moduleFor('controller:application', 'Unit | Controller | application', {
         'service:features',
         'service:analytics',
         'service:currentUser',
+        'service:ready',
     ],
 });
 

--- a/tests/unit/application/route-test.ts
+++ b/tests/unit/application/route-test.ts
@@ -8,6 +8,7 @@ moduleFor('route:application', 'Unit | Route | application', {
         'service:features',
         'service:analytics',
         'service:currentUser',
+        'service:ready',
     ],
 });
 

--- a/tests/unit/dashboard/route-test.js
+++ b/tests/unit/dashboard/route-test.js
@@ -8,6 +8,7 @@ moduleFor('route:dashboard', 'Unit | Route | dashboard', {
         'service:features',
         'service:analytics',
         'service:currentUser',
+        'service:ready',
     ],
 });
 

--- a/tests/unit/guid-file/controller-test.ts
+++ b/tests/unit/guid-file/controller-test.ts
@@ -9,6 +9,7 @@ moduleFor('controller:guid-file', 'Unit | Controller | guid file', {
         'service:features',
         'service:analytics',
         'service:session',
+        'service:ready',
     ],
 });
 

--- a/tests/unit/guid-user/quickfiles/controller-test.ts
+++ b/tests/unit/guid-user/quickfiles/controller-test.ts
@@ -9,6 +9,7 @@ moduleFor('controller:guid-user/quickfiles', 'Unit | Controller | guid-user/quic
         'service:analytics',
         'service:session',
         'service:toast',
+        'service:ready',
     ],
 });
 

--- a/tests/unit/guid-user/quickfiles/route-test.ts
+++ b/tests/unit/guid-user/quickfiles/route-test.ts
@@ -7,6 +7,7 @@ moduleFor('route:guid-user/quickfiles', 'Unit | Route | guid-user/quickfiles', {
         'service:features',
         'service:analytics',
         'service:session',
+        'service:ready',
     ],
 });
 

--- a/tests/unit/instance-initializers/prerender-test.ts
+++ b/tests/unit/instance-initializers/prerender-test.ts
@@ -1,0 +1,31 @@
+import Application from '@ember/application';
+
+import { initialize } from 'ember-osf-web/instance-initializers/prerender';
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import destroyApp from '../../helpers/destroy-app';
+
+module('Unit | Instance Initializer | prerender', hooks => {
+    setupTest(hooks);
+
+    hooks.beforeEach(function() {
+        this.TestApplication = Application.extend();
+        this.TestApplication.instanceInitializer({
+            name: 'initializer under test',
+            initialize,
+        });
+        this.application = this.TestApplication.create({ autoboot: false });
+        this.instance = this.application.buildInstance();
+    });
+    hooks.afterEach(function() {
+        destroyApp(this.application);
+        destroyApp(this.instance);
+    });
+
+    // Replace this with your real tests.
+    test('it works', async function(assert) {
+        await this.instance.boot();
+
+        assert.ok(true);
+    });
+});

--- a/tests/unit/instance-initializers/prerender-test.ts
+++ b/tests/unit/instance-initializers/prerender-test.ts
@@ -1,9 +1,16 @@
 import Application from '@ember/application';
+import Service from '@ember/service';
 
 import { initialize } from 'ember-osf-web/instance-initializers/prerender';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import destroyApp from '../../helpers/destroy-app';
+
+class ReadyStub extends Service {
+    ready() {
+        return Promise.resolve();
+    }
+}
 
 module('Unit | Instance Initializer | prerender', hooks => {
     setupTest(hooks);
@@ -15,6 +22,7 @@ module('Unit | Instance Initializer | prerender', hooks => {
             initialize,
         });
         this.application = this.TestApplication.create({ autoboot: false });
+        this.application.register('service:ready', ReadyStub);
         this.instance = this.application.buildInstance();
     });
     hooks.afterEach(function() {
@@ -22,10 +30,11 @@ module('Unit | Instance Initializer | prerender', hooks => {
         destroyApp(this.instance);
     });
 
-    // Replace this with your real tests.
-    test('it works', async function(assert) {
+    test('it sets prerenderReady', async function(assert) {
+        assert.notOk(window.prerenderReady, 'prerenderReady starts false');
+
         await this.instance.boot();
 
-        assert.ok(true);
+        assert.ok(window.prerenderReady, 'prerenderReady set true');
     });
 });

--- a/tests/unit/quickfiles/route-test.ts
+++ b/tests/unit/quickfiles/route-test.ts
@@ -7,6 +7,7 @@ moduleFor('route:quickfiles', 'Unit | Route | quickfiles', {
         'service:metrics',
         'service:features',
         'service:analytics',
+        'service:ready',
     ],
 });
 

--- a/tests/unit/services/ready-test.ts
+++ b/tests/unit/services/ready-test.ts
@@ -1,0 +1,97 @@
+import { settled } from '@ember/test-helpers';
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Service | ready', hooks => {
+    setupTest(hooks);
+
+    // Set up ready/error listeners with assertions inside.
+    // Adds 2 expected assertions for either success or failure.
+    function setUpListeners(assert, ready, expectSuccess: boolean) {
+        ready.on('ready', () => { assert.ok(expectSuccess); });
+        ready.on('error', () => { assert.ok(!expectSuccess); });
+
+        ready.ready().then(
+            () => { assert.ok(expectSuccess); },
+            () => { assert.ok(!expectSuccess); },
+        );
+    }
+
+    test('one blocker', async function(assert) {
+        assert.expect(4);
+
+        const ready = this.owner.lookup('service:ready');
+        const blocker = ready.block();
+
+        setUpListeners(assert, ready, true);
+
+        assert.notOk(ready.get('isReady'));
+
+        blocker.done();
+        await settled();
+        assert.ok(ready.get('isReady'));
+    });
+
+    test('three blockers', async function(assert) {
+        assert.expect(5);
+
+        const ready = this.owner.lookup('service:ready');
+        const blocker1 = ready.block();
+        const blocker2 = ready.block();
+        const blocker3 = ready.block();
+
+        setUpListeners(assert, ready, true);
+
+        assert.notOk(ready.get('isReady'));
+
+        blocker2.done();
+        blocker3.done();
+        await settled();
+        assert.notOk(ready.get('isReady'));
+
+        blocker1.done();
+        await settled();
+        assert.ok(ready.get('isReady'));
+    });
+
+    // block => errored => isReady false
+    // block => errored => error event
+    // block => errored => promise reject
+
+    test('one blocker errors', async function(assert) {
+        assert.expect(4);
+
+        const ready = this.owner.lookup('service:ready');
+        const blocker = ready.block();
+
+        setUpListeners(assert, ready, false);
+
+        assert.notOk(ready.get('isReady'));
+
+        blocker.errored();
+        await settled();
+        assert.ok(ready.get('isReady'));
+    });
+
+    test('three blockers error', async function(assert) {
+        assert.expect(5);
+
+        const ready = this.owner.lookup('service:ready');
+        const blocker1 = ready.block();
+        const blocker2 = ready.block();
+        const blocker3 = ready.block();
+
+        setUpListeners(assert, ready, false);
+
+        assert.notOk(ready.get('isReady'));
+
+        blocker2.done();
+        blocker3.done();
+        await settled();
+        assert.notOk(ready.get('isReady'));
+
+        blocker1.done();
+        await settled();
+        assert.ok(ready.get('isReady'));
+    });
+});

--- a/tests/unit/services/ready-test.ts
+++ b/tests/unit/services/ready-test.ts
@@ -22,7 +22,7 @@ module('Unit | Service | ready', hooks => {
         assert.expect(4);
 
         const ready = this.owner.lookup('service:ready');
-        const blocker = ready.block();
+        const blocker = ready.getBlocker();
 
         setUpListeners(assert, ready, true);
 
@@ -39,9 +39,9 @@ module('Unit | Service | ready', hooks => {
         assert.expect(5);
 
         const ready = this.owner.lookup('service:ready');
-        const blocker1 = ready.block();
-        const blocker2 = ready.block();
-        const blocker3 = ready.block();
+        const blocker1 = ready.getBlocker();
+        const blocker2 = ready.getBlocker();
+        const blocker3 = ready.getBlocker();
 
         setUpListeners(assert, ready, true);
 
@@ -65,7 +65,7 @@ module('Unit | Service | ready', hooks => {
         assert.expect(4);
 
         const ready = this.owner.lookup('service:ready');
-        const blocker = ready.block();
+        const blocker = ready.getBlocker();
 
         setUpListeners(assert, ready, false);
 
@@ -80,9 +80,9 @@ module('Unit | Service | ready', hooks => {
         assert.expect(5);
 
         const ready = this.owner.lookup('service:ready');
-        const blocker1 = ready.block();
-        const blocker2 = ready.block();
-        const blocker3 = ready.block();
+        const blocker1 = ready.getBlocker();
+        const blocker2 = ready.getBlocker();
+        const blocker3 = ready.getBlocker();
 
         setUpListeners(assert, ready, false);
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Wait to set `window.prerenderReady = true` until all relevant data loading and rendering has finished.


## Summary of Changes
- Add `ready` service that allows different parts of the app to report when they're done loading, and delaying actions until the whole app is ready.
    - `blocker = ready.block()`: Blocks ready actions until `blocker.done()` is called.
    - `ready.get('isReady')`: Boolean set to `true` when all blockers are done and all rendering activity has settled.
    - `ready.ready()`: Promise that resolves when `isReady` is set to true.
    - Once the initial load is complete and `ready.isReady` is true, the service stops doing anything and `ready.block()` returns blockers with no-op methods.
- Use `ready` service to set `window.prerenderReady` once the initial transition has completed and all data has loaded and been rendered.


## Side Effects / Testing Notes
Does not need QA, should not visibly affect anything. 

Going forward, when we add pages or components that load initial data before rendering, we should use `ready.block()` to delay prerender.

## Ticket

https://openscience.atlassian.net/browse/EMB-180

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
