### PR TITLE
[EMB-195] Close secondary nav when using link-to on nav bar items

### DIFF
--- a/app/components/osf-navbar/component.ts
+++ b/app/components/osf-navbar/component.ts
@@ -1,3 +1,4 @@
+import { action } from '@ember-decorators/object';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
@@ -59,22 +60,25 @@ export default class OsfNavbar extends Component.extend() {
         return appName.toUpperCase();
     });
 
-    actions = {
-        ...this.actions, // from AnalyticsMixin
+    @action
+    toggleSearch() {
+        this.toggleProperty('showSearch');
+        this.send('closeSecondaryNavigation');
+    }
 
-        toggleSearch() {
-            this.toggleProperty('showSearch');
-            this.send('closeSecondaryNavigation');
-        },
-        closeSecondaryNavigation() {
-            this.$('.navbar-collapse').collapse('hide');
-        },
-        closeSearch() {
-            this.set('showSearch', false);
-        },
-        closeSecondaryAndSearch() {
-            this.send('closeSecondaryNavigation');
-            this.send('closeSearch');
-        },
-    };
+    @action
+    closeSecondaryNavigation() {
+        $('.navbar-collapse').collapse('hide');
+    }
+
+    @action
+    closeSearch() {
+        this.set('showSearch', false);
+    }
+
+    @action
+    closeSecondaryAndSearch() {
+        this.send('closeSecondaryNavigation');
+        this.send('closeSearch');
+    }
 }

--- a/app/components/osf-navbar/home-links/component.ts
+++ b/app/components/osf-navbar/home-links/component.ts
@@ -9,6 +9,7 @@ import { serviceLinks } from 'ember-osf-web/const/service-links';
  */
 export default class OsfNavbarHomeLinks extends Component.extend({
     tagName: '',
+    onLinkClick: 'onLinkClick',
 }) {
     session = service('session');
     analytics = service();

--- a/app/components/osf-navbar/home-links/component.ts
+++ b/app/components/osf-navbar/home-links/component.ts
@@ -1,3 +1,4 @@
+import { action } from '@ember-decorators/object';
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import { serviceLinks } from 'ember-osf-web/const/service-links';
@@ -18,4 +19,8 @@ export default class OsfNavbarHomeLinks extends Component.extend({
     donateUrl = 'https://cos.io/donate';
     myProjectsUrl = serviceLinks.myProjects;
     reviewsUrl = serviceLinks.reviewsHome;
+    @action
+    closeSecondaryNav() {
+        $('.navbar-collapse').collapse('hide');
+    }
 }

--- a/app/components/osf-navbar/home-links/component.ts
+++ b/app/components/osf-navbar/home-links/component.ts
@@ -1,4 +1,3 @@
-import { action } from '@ember-decorators/object';
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import { serviceLinks } from 'ember-osf-web/const/service-links';
@@ -19,8 +18,4 @@ export default class OsfNavbarHomeLinks extends Component.extend({
     donateUrl = 'https://cos.io/donate';
     myProjectsUrl = serviceLinks.myProjects;
     reviewsUrl = serviceLinks.reviewsHome;
-    @action
-    closeSecondaryNav() {
-        $('.navbar-collapse').collapse('hide');
-    }
 }

--- a/app/components/osf-navbar/home-links/template.hbs
+++ b/app/components/osf-navbar/home-links/template.hbs
@@ -1,6 +1,6 @@
 {{! template-lint-disable invalid-interactive }}
 {{#if session.isAuthenticated}}
-    <li {{action 'closeSecondaryNav'}}>
+    <li {{action onLinkClick}}>
         {{#link-to 'guid-user.quickfiles' currentUser.currentUserId clickAction=(action 'click' 'link' 'Navbar - navbar.my_quick_files' target=analytics)}}
             {{t 'navbar.my_quick_files'}}
         {{/link-to}}
@@ -16,7 +16,7 @@
         {{t 'navbar.search'}}
     </a>
 </li>
-<li {{action 'closeSecondaryNav'}}>
+<li {{action onLinkClick}}>
     {{#link-to 'support' clickAction=(action 'click' 'link' 'Navbar - navbar.support' target=analytics) }}
         {{t 'navbar.support'}}
     {{/link-to}}

--- a/app/components/osf-navbar/home-links/template.hbs
+++ b/app/components/osf-navbar/home-links/template.hbs
@@ -1,5 +1,6 @@
+{{! template-lint-disable invalid-interactive }}
 {{#if session.isAuthenticated}}
-    <li>
+    <li {{action 'closeSecondaryNav'}}>
         {{#link-to 'guid-user.quickfiles' currentUser.currentUserId clickAction=(action 'click' 'link' 'Navbar - navbar.my_quick_files' target=analytics)}}
             {{t 'navbar.my_quick_files'}}
         {{/link-to}}
@@ -15,7 +16,7 @@
         {{t 'navbar.search'}}
     </a>
 </li>
-<li>
+<li {{action 'closeSecondaryNav'}}>
     {{#link-to 'support' clickAction=(action 'click' 'link' 'Navbar - navbar.support' target=analytics) }}
         {{t 'navbar.support'}}
     {{/link-to}}

--- a/app/components/osf-navbar/template.hbs
+++ b/app/components/osf-navbar/template.hbs
@@ -68,7 +68,7 @@
             {{! Secondary nav links }}
             <div class="navbar-collapse collapse navbar-right" id="secondary-navigation">
                 <ul class="nav navbar-nav">
-                    {{component linksComponent}}
+                    {{component linksComponent onLinkClick=closeSecondaryNavigation}}
 
                     {{osf-navbar/auth-dropdown
                         signupUrl=signupUrl

--- a/app/components/osf-navbar/template.hbs
+++ b/app/components/osf-navbar/template.hbs
@@ -15,7 +15,7 @@
 
                 {{! Current app }}
                 <div class="service-name">
-                    {{#link-to indexRoute}}
+                    {{#link-to indexRoute clickAction=(action 'closeSecondaryAndSearch')}}
                         <span class="hidden-xs"> {{t 'general.OSF'}} </span>
                         <span class="current-service"><strong>{{currentApp}}</strong></span>
                     {{/link-to}}


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Make the secondary nav close when clicking on internal ember-osf-web links

## Summary of Changes

- Add action handler to home-links component for closing the nav
- Add action to *ahem* List Item surrounding the links to catch the click
- *ahem* Disable the template linting rule for ^^^
- Fix close secondary nav on nav-bar to work for clicking the home link

If we hate adding an action to the `<li>` tags, I could put a span around the button and attach the action to that instead, but trying to do it on the clickAction handler of the link-to helper just wasn't working; instead it would cause a full page reload.

## Side Effects / Testing Notes


## Ticket

https://openscience.atlassian.net/browse/EMB-195

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
