### PR TITLE
Add home logo animation

### DIFF
--- a/app/components/osf-logo/component.ts
+++ b/app/components/osf-logo/component.ts
@@ -1,7 +1,7 @@
+import { className } from '@ember-decorators/component';
 import Component from '@ember/component';
 
-export default class OsfLogo extends Component.extend({
-    classNameBindings: ['double:Double'],
-}) {
-    double: boolean = this.double || false;
+export default class OsfLogo extends Component {
+    @className('Double') double: boolean = this.double || false;
+    @className('Animate') animate: boolean = this.animate || false;
 }

--- a/app/components/osf-logo/styles.scss
+++ b/app/components/osf-logo/styles.scss
@@ -6,7 +6,7 @@
     transition: all 1s ease-in-out;
 }
 
-& > div {
+div {
     position: absolute;
     width: 50px;
     height: 50px;
@@ -60,4 +60,49 @@
 
 &.Double {
     transform: scale(2);
+}
+
+&.Animate {
+    animation: 1s ease-in-out 0s 1 rotateHalf;
+
+    div::before {
+        animation: 0.4s ease-in-out 0s 1 slideFade;
+    }
+
+    div::after {
+        animation: 0.6s ease-in-out 0s 1 slideFade;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        animation: none;
+
+        div::before {
+            animation: none;
+        }
+
+        div::after {
+            animation: none;
+        }
+    }
+}
+
+@keyframes rotateHalf {
+    0% {
+        transform: rotateZ(0.5turn);
+    }
+
+    100% {
+        transform: rotateZ(0);
+    }
+}
+
+@keyframes slideFade {
+    0% {
+        opacity: 0;
+        transform: translate(0, -200px);
+    }
+
+    100% {
+        opacity: 1;
+    }
 }

--- a/app/home/template.hbs
+++ b/app/home/template.hbs
@@ -27,7 +27,7 @@
         <div class="network-bg"></div>
         <h1 class="hero-brand">{{t 'home.brand'}}</h1>
         <h3 class="hero-tagline">{{t 'home.tagline'}}</h3>
-        {{osf-logo}}
+        {{osf-logo animate=true}}
         <div id="hero-signup" class="container">
             <div class="row">
                 <div class="col-sm-6 hidden-xs">


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Home logo animation missing on page load

## Summary of Changes

* Adds back the home logo animation (spin, fade), but disables it if the reduced motion media query is present
* Decorators

## Side Effects / Testing Notes



## Ticket

none

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
