### PR TITLE
Use browser's timezone, not UTC

### DIFF
--- a/app/application/route.ts
+++ b/app/application/route.ts
@@ -1,16 +1,7 @@
-import { service } from '@ember-decorators/service';
 import Route from '@ember/routing/route';
 import OSFAgnosticAuthRouteMixin from 'ember-osf-web/mixins/osf-agnostic-auth-route';
 
 export default class Application extends Route.extend(OSFAgnosticAuthRouteMixin) {
-    @service moment;
-
-    beforeModel(this: Application, ...args) {
-        this.get('moment').setTimeZone('UTC');
-
-        return this._super(...args);
-    }
-
     afterModel(this: Application) {
         const availableLocales: [string] = this.get('i18n.locales').toArray();
         let locale: string | null = null;

--- a/app/components/dashboard-item/component.ts
+++ b/app/components/dashboard-item/component.ts
@@ -35,6 +35,6 @@ export default class DashboardItem extends Component {
     contributors = alias('node.contributors');
 
     date = computed('node.dateModified', function(): string {
-        return moment(this.get('node.dateModified')).utc().format('YYYY-MM-DD h:mm A');
+        return moment(this.get('node.dateModified')).format('YYYY-MM-DD h:mm A');
     });
 }

--- a/app/components/file-browser-item/component.ts
+++ b/app/components/file-browser-item/component.ts
@@ -53,7 +53,7 @@ export default class FileBrowserItem extends Component {
     get date(this: FileBrowserItem): string {
         const date = this.get('item').get('dateModified');
         // TODO: This should be i18n-ized
-        return moment(date).utc().format('YYYY-MM-DD h:mm A');
+        return moment(date).format('YYYY-MM-DD h:mm A');
     }
 
     @computed('item.guid')

--- a/tests/unit/application/route-test.ts
+++ b/tests/unit/application/route-test.ts
@@ -3,7 +3,6 @@ import { moduleFor, test } from 'ember-qunit';
 moduleFor('route:application', 'Unit | Route | application', {
     needs: [
         'service:session',
-        'service:moment',
         'service:metrics',
         'service:features',
         'service:analytics',


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
We're displaying times in UTC. Legacy OSF uses the browser's local timezone. We should do that.


## Summary of Changes
Don't explicitly set UTC.


## Side Effects / Testing Notes



## Ticket


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
