### PR TITLE
[EMB-137] reset loader state on file change

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
         'indent-legacy': 'error',
         'ember/named-functions-in-promises': 0,
         'function-paren-newline': ['error', 'consistent'],
+        'ember/no-attrs-snapshot': 0,
     },
     overrides: [
         {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,9 +14,9 @@ module.exports = {
         es6: true,
     },
     rules: {
-        'arrow-parens': [ 'error', 'as-needed' ],
+        'arrow-parens': ['error', 'as-needed'],
         'class-methods-use-this': 0,
-        'max-len': [ 'error', { code: 120 } ],
+        'max-len': ['error', { code: 120 }],
         'no-undef': 0,
         'no-unused-vars': ['error', { argsIgnorePattern: '^this' }],
         'typescript/no-unused-vars': 'error',
@@ -31,7 +31,7 @@ module.exports = {
             files: ['**/*.d.ts'],
             rules: {
                 'no-unused-vars': 0,
-            }
+            },
         },
         {
             files: ['app/locales/*/translations.ts'],
@@ -39,5 +39,5 @@ module.exports = {
                 'max-len': 0,
             },
         },
-    ]
+    ],
 };

--- a/app/components/file-renderer/component.ts
+++ b/app/components/file-renderer/component.ts
@@ -1,5 +1,4 @@
 import { action, computed } from '@ember-decorators/object';
-import { not } from '@ember-decorators/object/computed';
 import Component from '@ember/component';
 import config from 'ember-get-config';
 import defaultTo from 'ember-osf-web/utils/default-to';
@@ -22,13 +21,12 @@ import defaultTo from 'ember-osf-web/utils/default-to';
  */
 export default class FileRenderer extends Component {
     download: string;
+    lastDownload: string;
     width: string = defaultTo(this.width, '100%');
     height: string = defaultTo(this.height, '100%');
     allowfullscreen: boolean = defaultTo(this.allowfullscreen, true);
     version: string | null = defaultTo(this.version, null);
-    showLoadingIndicator: boolean = defaultTo(this.showLoadingIndicator, true);
-
-    @not('showLoadingIndicator') showIframe: boolean;
+    isLoading: boolean = true;
 
     @computed('download', 'version')
     get mfrUrl(this: FileRenderer) {
@@ -39,8 +37,15 @@ export default class FileRenderer extends Component {
         return `${config.OSF.renderUrl}?url=${encodeURIComponent(download)}`;
     }
 
+    didReceiveAttrs(this: FileRenderer) {
+        if (this.download !== this.lastDownload) {
+            this.set('isLoading', true);
+            this.set('lastDownload', this.download);
+        }
+    }
+
     @action
     loaded(this: FileRenderer) {
-        this.set('showLoadingIndicator', false);
+        this.set('isLoading', false);
     }
 }

--- a/app/components/file-renderer/template.hbs
+++ b/app/components/file-renderer/template.hbs
@@ -1,5 +1,5 @@
 {{#if download}}
-    {{#if showLoadingIndicator}}
+    {{#if isLoading}}
         {{loading-indicator dark=true}}
     {{/if}}
     <iframe
@@ -11,7 +11,7 @@
         marginheight="0"
         frameborder="0"
         allowfullscreen={{allowfullscreen}}
-        class={{if showIframe 'show' 'hidden'}}
+        hidden={{isLoading}}
         onload={{action 'loaded'}}
     >
     </iframe>

--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "lint": "eslint --ext js,ts --max-warnings=0 . && tslint -p . && stylelint 'app/**/*.scss'",
+    "lint": "eslint --ext js,ts --max-warnings=0 --ignore-pattern=!.eslintrc.js . && tslint -p . && stylelint 'app/**/*.scss'",
     "test": "ember test",
     "test:cover": "COVERAGE=true ember test",
     "test:translations": "node node-tests/compile-and-test-translations.js",
     "precommit": "lint-staged"
   },
   "lint-staged": {
-    "*.js": "eslint --max-warnings=0",
+    "*.js": "eslint --max-warnings=0 --ignore-pattern=!.eslintrc.js",
     "*.ts": [
       "eslint --max-warnings=0",
       "tslint"

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  env: {
-    embertest: true
-  }
+    env: {
+        embertest: true,
+    },
 };


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Show loading indicator when switching files on Quick File File Detail.

## Summary of Changes

Reset loader state when the file download link changes.

## Side Effects / Testing Notes

Loading indicator should now show on initial load and when switching files.

## Ticket

https://openscience.atlassian.net/browse/EMB-137

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
