### PR TITLE
[EMB-197] Table header alignment -> bottom

### DIFF
--- a/app/components/file-browser/styles.scss
+++ b/app/components/file-browser/styles.scss
@@ -150,7 +150,7 @@ a {
 
 .sortable-column {
     padding-right: 10px;
-    vertical-align: middle;
+    vertical-align: bottom;
     padding: 2px 0;
     display: table-cell;
 }

--- a/app/components/sort-button/styles.scss
+++ b/app/components/sort-button/styles.scss
@@ -10,6 +10,7 @@ button {
     border: 0;
     background: transparent;
     font-size: large;
+    height: 24px;
 }
 
 .selected {

--- a/app/dashboard/styles.scss
+++ b/app/dashboard/styles.scss
@@ -140,7 +140,7 @@
 
     span {
         height: 28px;
-        vertical-align: middle;
+        vertical-align: bottom;
         display: table-cell;
     }
 }


### PR DESCRIPTION
## Purpose




## Summary of Changes

Set file-browser to `vertical-align: bottom`, but this should have no real impact.

The dashboard header should now be aligned for all browsers:
<img width="965" alt="screen shot 2018-04-09 at 11 01 25" src="https://user-images.githubusercontent.com/3374510/38505880-48edf2b6-3be6-11e8-9d54-80c22ec399cd.png">
<img width="769" alt="screen shot 2018-04-09 at 10 40 48" src="https://user-images.githubusercontent.com/3374510/38505966-8d55db30-3be6-11e8-8032-2962e961e96d.png">
<img width="554" alt="screen shot 2018-04-09 at 10 36 47" src="https://user-images.githubusercontent.com/3374510/38505979-94ccdbb6-3be6-11e8-97cd-c1196c274f08.png">




## Side Effects / Testing Notes



## Ticket

https://openscience.atlassian.net/browse/EMB-197

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
