### PR TITLE
[EMB-190][Fix] Don't assume null parentId means no ancestors

### DIFF
--- a/app/components/dashboard-item/component.ts
+++ b/app/components/dashboard-item/component.ts
@@ -20,7 +20,7 @@ export default class DashboardItem extends Component {
         const rootId = node.belongsTo('root').id();
 
         // No ancestors
-        if (!parentId) {
+        if (node.get('id') === rootId) {
             return [];
         }
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Fix a bug in dashboard item ancestry, where a private parent would prevent the root from showing.


## Summary of Changes
If a node's parent is not visible to the current user, sometimes the parent relation's id will have the parent guid, while other times the id will be null. For that reason, don't use the parent id to tell whether a node has ancestors at all. Instead, check whether the node is its own root.


## Side Effects / Testing Notes
If the user:
- **can** see a node
- **cannot** see the node's parent
- **can** see the node's root

then the displayed dashboard item should be `root / node` instead of just `node`


## Ticket

https://openscience.atlassian.net/browse/EMB-190

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
