### PR TITLE
[EMB-209] Fix a few things causing Quickfiles filtering to break and some other…

### DIFF
--- a/app/components/dropzone-widget/component.js
+++ b/app/components/dropzone-widget/component.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import config from 'ember-get-config';
 import diffAttrs from 'ember-diff-attrs';
+import $ from 'jquery';
 
 /**
  * @module ember-osf-web
@@ -27,6 +28,7 @@ import diffAttrs from 'ember-diff-attrs';
  */
 export default Component.extend({
     session: service(),
+    i18n: service(),
 
     classNameBindings: ['dropzone'],
     dropzone: true,
@@ -45,8 +47,17 @@ export default Component.extend({
                 }
             } else if (changedAttrs.clickable && this.get('enable')) {
                 // Dropzone must be reloaded for clickable changes to take effect.
-                this.destroyDropzone();
-                this.loadDropzone();
+                const [before, after] = changedAttrs.clickable;
+                const beforeSet = new Set(before);
+                const afterSet = new Set(after);
+
+                const reRender = beforeSet.size !== afterSet.size
+                    || (new Set([...beforeSet].filter(item => !afterSet.has(item)))).size;
+
+                if (reRender) {
+                    this.destroyDropzone();
+                    this.loadDropzone();
+                }
             }
         }
     }),
@@ -60,6 +71,8 @@ export default Component.extend({
     loadDropzone() {
         const preUpload = this.get('preUpload');
         const dropzoneOptions = this.get('options') || {};
+        const i18n = this.get('i18n');
+
         function CustomDropzone() {
             Dropzone.call(this, ...arguments);
         }
@@ -68,12 +81,12 @@ export default Component.extend({
             if (this.options.preventMultipleFiles && e.dataTransfer) {
                 if ((e.dataTransfer.items && e.dataTransfer.items.length > 1) || e.dataTransfer.files.length > 1) {
                     this.emit('drop', e);
-                    this.emit('error', 'None', 'Cannot upload multiple files');
+                    this.emit('error', 'None', i18n.t('dropzone_widget.error_multiple_files'));
                     return;
                 }
                 if (e.dataTransfer.files.length === 0) {
                     this.emit('drop', e);
-                    this.emit('error', 'None', 'Cannot upload directories, applications, or packages');
+                    this.emit('error', 'None', i18n.t('dropzone_widget.error_directories'));
                     return;
                 }
             }
@@ -83,7 +96,7 @@ export default Component.extend({
             const directory = directory_;
             if (!this.options.acceptDirectories) {
                 directory.status = Dropzone.ERROR;
-                this.emit('error', directory, 'Cannot upload directories, applications, or packages');
+                this.emit('error', directory, i18n.t('dropzone_widget.error_directories'));
                 return;
             }
             return Dropzone.prototype._addFilesFromDirectory.call(directory, path);
@@ -96,7 +109,7 @@ export default Component.extend({
             autoProcessQueue: false,
             autoQueue: false,
             clickable: this.get('clickable'),
-            dictDefaultMessage: this.get('defaultMessage') || 'Drop files here to upload',
+            dictDefaultMessage: this.get('defaultMessage') || i18n.t('dropzone_widget.drop_files'),
             sending(file, xhr) {
                 // Monkey patch to send the raw file instead of formData
                 xhr.send = xhr.send.bind(xhr, file); // eslint-disable-line no-param-reassign
@@ -107,7 +120,7 @@ export default Component.extend({
         // Therefore, we remove the "multiple" attribute for the hidden file input element, so that users cannot select
         // multiple files for upload in the first place.
         if (this.get('options.preventMultipleFiles') && this.get('clickable')) {
-            Ember.$('.dz-hidden-input').removeAttr('multiple');
+            $('.dz-hidden-input').removeAttr('multiple');
         }
 
         this.set('dropzoneElement', drop);

--- a/app/components/file-browser/template.hbs
+++ b/app/components/file-browser/template.hbs
@@ -93,15 +93,17 @@
                         </button>
                     {{/if}}
                 {{/if}}
-            {{else}}
+            {{else if hasItems}}
                 <button class="btn btn-light" onclick={{unless canEdit (action 'click' 'button' 'Quick Files - Download zip' target=analytics preventDefault=false)}} {{action 'downloadZip'}}>
                     {{fa-icon "download"}} {{t 'file_browser.download_zip'}}
                 </button>
             {{/if}}
-            <button {{action (mut showFilterClicked) true}} class="btn btn-light">
-                {{fa-icon "search"}}
-                {{t 'general.filter'}}
-            </button>
+            {{#if hasItems}}
+                <button {{action (mut showFilterClicked) true}} class="btn btn-light">
+                    {{fa-icon "search"}}
+                    {{t 'general.filter'}}
+                </button>
+            {{/if}}
             <button {{action (mut currentModal) 'info'}} class="btn btn-light">
                 {{fa-icon "info"}}
                 {{t 'general.help'}}
@@ -285,7 +287,7 @@
                 <div></div>
             </div>
         {{else if (not (or items.length filter))}}
-            {{#if uploading.length}}
+            {{#if isUploading}}
                 {{#each uploading as |file|}}
                     <div class="row">
                         <div class="col-xs-5 file-browser-header">

--- a/app/components/file-icon/component.ts
+++ b/app/components/file-icon/component.ts
@@ -119,7 +119,7 @@ export default class FileIcon extends Component {
         // TODO: More icons!
         const item = this.get('item');
 
-        if (item.status === 'uploading') {
+        if (item.status && item.name) {
             return iconFromName(item.name);
         }
 

--- a/app/guid-user/quickfiles/controller.ts
+++ b/app/guid-user/quickfiles/controller.ts
@@ -60,7 +60,7 @@ export default class UserQuickfiles extends Controller {
 
         const i18n = this.get('i18n');
         this.get('toast').success(i18n.t('file_browser.file_added_toast'));
-        yield this.get('flash').perform(file, i18n.t('file_browser.file_added'));
+        this.get('flash').perform(file, i18n.t('file_browser.file_added'));
     });
 
     deleteFile = task(function* (this: UserQuickfiles, file: File) {

--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -455,4 +455,9 @@ export default {
         privacy: 'Privacy Policy',
         separator: ' | ',
     },
+    dropzone_widget: {
+        drop_files: 'Drop files here to upload',
+        error_multiple_files: 'Cannot upload multiple files',
+        error_directories: 'Cannot upload directories, applications, or packages',
+    },
 };

--- a/app/locales/ja/translations.ts
+++ b/app/locales/ja/translations.ts
@@ -455,4 +455,9 @@ export default {
         privacy: 'Privacy Policy',
         separator: ' | ',
     },
+    dropzone_widget: {
+        drop_files: 'Drop files here to upload',
+        error_multiple_files: 'Cannot upload multiple files',
+        error_directories: 'Cannot upload directories, applications, or packages',
+    },
 };

--- a/app/locales/zh/translations.ts
+++ b/app/locales/zh/translations.ts
@@ -455,4 +455,9 @@ export default {
         privacy: 'Privacy Policy',
         separator: ' | ',
     },
+    dropzone_widget: {
+        drop_files: 'Drop files here to upload',
+        error_multiple_files: 'Cannot upload multiple files',
+        error_directories: 'Cannot upload directories, applications, or packages',
+    },
 };


### PR DESCRIPTION
… goodness

<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Filtering is kind of broken on Quickfiles, mostly due to the dropzone widget's clickable property being updated incorrectly

## Summary of Changes

* Dropzone rerender when the dropzone clickable attribute is actually updated
* i18n
* Clear selection on willDestroy
* Only show filter button if there are items to filter
* Wait until the new item is in the list before clearing the uploading item

## Side Effects / Testing Notes



## Ticket

https://openscience.atlassian.net/browse/EMB-209

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
