### PR TITLE
[EMB-211] Handle email already registered error in signup on home page

### DIFF
--- a/app/home/controller.ts
+++ b/app/home/controller.ts
@@ -21,11 +21,7 @@ export default class Home extends Controller.extend({
         } catch (e) {
             // Handle email already exists error
             if (+e.errors[0].status === 400) {
-                const { options } = model.get('validations')._validators.email1
-                    .find(validator => validator._type === 'exclusion');
-
-                options.in.push(model.get('email1'));
-
+                model.addExistingEmail();
                 yield model.validate();
             }
 

--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -435,6 +435,7 @@ export default {
         phone: '{{description}} must be a valid phone number',
         url: '{{description}} must be a valid url',
         // custom
+        email_registered: 'This email address has already been registered.',
         email_match: 'Email addresses must match.',
         password_email: 'Your password cannot be the same as your email address.',
         password_old: 'Your new password cannot be the same as your old password.',

--- a/app/locales/ja/translations.ts
+++ b/app/locales/ja/translations.ts
@@ -435,6 +435,7 @@ export default {
         phone: '{{description}}は有効な電話番号でなければなりません',
         url: '{{description}}は有効なURLである必要があります',
         // custom
+        email_registered: 'This email address has already been registered.',
         email_match: 'メールアドレスは一致する必要があります。',
         password_email: 'パスワードはあなたのメールアドレスと同じであってはなりません。',
         password_old: '新しいパスワードと古いパスワードを同じにすることはできません。',

--- a/app/locales/zh/translations.ts
+++ b/app/locales/zh/translations.ts
@@ -435,6 +435,7 @@ export default {
         phone: '{{description}} must be a valid phone number',
         url: '{{description}} must be a valid url',
         // custom
+        email_registered: 'This email address has already been registered.',
         email_match: 'Email addresses must match.',
         password_email: 'Your password cannot be the same as your email address.',
         password_old: 'Your new password cannot be the same as your old password.',

--- a/app/models/user-registration.ts
+++ b/app/models/user-registration.ts
@@ -7,6 +7,10 @@ const Validations = buildValidations({
     email1: [
         validator('presence', true),
         validator('format', { type: 'email' }),
+        validator('exclusion', {
+            messageKey: 'validationErrors.email_registered',
+            in: [],
+        }),
     ],
     email2: [
         validator('presence', true),

--- a/app/models/user-registration.ts
+++ b/app/models/user-registration.ts
@@ -1,3 +1,4 @@
+import { computed } from '@ember/object';
 import { buildValidations, validator } from 'ember-cp-validations';
 import DS from 'ember-data';
 
@@ -9,7 +10,9 @@ const Validations = buildValidations({
         validator('format', { type: 'email' }),
         validator('exclusion', {
             messageKey: 'validationErrors.email_registered',
-            in: [],
+            in: computed(function(): string[] {
+                return [...this.get('model').get('existingEmails')];
+            }).volatile(),
         }),
     ],
     email2: [
@@ -56,7 +59,13 @@ export default class UserRegistration extends Model.extend(Validations, {
     fullName: attr('string'),
     recaptchaResponse: attr('string'),
     password: attr('string'),
-}) {}
+}) {
+    existingEmails: Set<string> = new Set();
+
+    addExistingEmail(this: UserRegistration, email?) {
+        this.get('existingEmails').add(email || this.get('email1'));
+    }
+}
 
 declare module 'ember-data' {
     interface ModelRegistry {


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Unhandled 400 API error if the the email address is already registered

## Summary of Changes

* Add an exclusion to the model and push the current email address into the exclusions array
* Update translations with the appropriate message
* Decorators for home controller

## Side Effects / Testing Notes

Slightly different message and placement of the message from production, but this follows the standard ember-cp-validations workflow and shows it under the invalid email field instead of at the bottom of the form.

To test, simply try to register with an existing email and you should see the error message under the first email field.

## Ticket

https://openscience.atlassian.net/browse/EMB-211

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
