### PR TITLE
Promise initializer for global RSVP Promises

### DIFF
--- a/app/initializers/promise.ts
+++ b/app/initializers/promise.ts
@@ -1,0 +1,16 @@
+import RSVP from 'rsvp';
+
+export function initialize(): void {
+    window.Promise = RSVP.Promise;
+}
+
+export default {
+    name: 'promise',
+    initialize,
+};
+
+declare global {
+    interface Window {
+        Promise: any;
+    }
+}


### PR DESCRIPTION
## Purpose

Sometimes native promises don't work in ember h/t @aaxelb 

## Summary of Changes

Add initializer to set window.Promise to RSVP.Promise
Ref: https://github.com/emberjs/rfcs/issues/175#issuecomment-263896090

## Side Effects / Testing Notes

Should reduce unwanted side effects.

## Ticket

No ticket

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
