### PR TITLE
[EMB-228] Restore loading indication and fix edge case

### DIFF
--- a/app/dashboard/controller.ts
+++ b/app/dashboard/controller.ts
@@ -40,6 +40,7 @@ export default class Dashboard extends Controller {
 
     filterNodes = task(function* (this: Dashboard, filter) {
         yield timeout(500);
+        this.set('loading', true);
         this.setProperties({ filter });
         yield this.get('findNodes').perform();
     }).restartable();
@@ -67,6 +68,7 @@ export default class Dashboard extends Controller {
 
         this.set(indicatorProperty, false);
         this.set('initialLoad', false);
+        this.set('loading', false);
     }).restartable();
 
     getPopularAndNoteworthy = task(function* (this: Dashboard, id: string, dest: 'noteworthy' | 'popular') {
@@ -114,7 +116,7 @@ export default class Dashboard extends Controller {
     @alias('currentUser.user') user;
     @oneWay('user.institutions') institutionsSelected;
 
-    @or('nodes.length', 'filter') hasNodes;
+    @or('nodes.length', 'filter', 'findNodes.isRunning') hasNodes;
 
     @computed('nodes.{length,meta.total}')
     get hasMore(this: Dashboard): boolean {


### PR DESCRIPTION
## Purpose

We lost the loading indication on the dashboard filter, and also there was an edge case where if you had projects and filtered all of them out, when you cleared the filter, it would show the "You should make a project" state rather than a loading state.

![dashboard-empty-filter](https://user-images.githubusercontent.com/6599111/39000978-41326734-43c3-11e8-8f17-a586feb7de74.gif)

## Summary of Changes

1. Add back in proper tracking of "loading" state
2. Ensure that we don't show the "you have no projects" if the filter task is running

![dashboard_filter_edge](https://user-images.githubusercontent.com/6599111/39001069-6d704500-43c3-11e8-9968-aaa74f14d908.gif)


## Side Effects / Testing Notes

Should be much better now.

## Ticket

https://openscience.atlassian.net/browse/EMB-228

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~testable and includes test(s)~
- [ ] ~changes described in `CHANGELOG.md`~ Functionality is already included in existing changelog

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
