### PR TITLE
[Fix] Revert users => user rename

### DIFF
--- a/app/components/contributor-list/component.ts
+++ b/app/components/contributor-list/component.ts
@@ -23,7 +23,7 @@ export default class ContributorList extends Component {
 
         const names: string[] = contributors
             .slice(0, max)
-            .map(c => c.get('user.familyName') || c.get('user.givenName') || c.get('user.fullName'));
+            .map(c => c.get('users.familyName') || c.get('users.givenName') || c.get('users.fullName'));
 
         const i18n = this.get('i18n');
         const and = i18n.t('general.and');

--- a/app/models/contributor.ts
+++ b/app/models/contributor.ts
@@ -24,7 +24,7 @@ export default class Contributor extends OsfModel {
     @attr('fixstring') email: string;
     @attr('boolean') sendEmail: boolean;
 
-    @belongsTo('user') user: DS.PromiseObject<User> & User;
+    @belongsTo('user') users: DS.PromiseObject<User> & User;
 
     @belongsTo('node', { inverse: 'contributors' }) node: DS.PromiseObject<Node> & Node;
 }

--- a/app/serializers/contributor.ts
+++ b/app/serializers/contributor.ts
@@ -1,10 +1,6 @@
 import OsfSerializer from './osf-serializer';
 
 export default class Contributor extends OsfSerializer {
-    attrs = {
-        ...this.attrs, // from OsfSerializer
-        user: 'users',
-    };
 }
 
 declare module 'ember-data' {

--- a/tests/integration/components/contributor-list/component-test.ts
+++ b/tests/integration/components/contributor-list/component-test.ts
@@ -28,7 +28,7 @@ moduleForComponent('contributor-list', 'Integration | Component | contributor li
 
 function nameToUsersFamilyNames(familyName): EmberObject {
     return EmberObject.create({
-        user: EmberObject.create({
+        users: EmberObject.create({
             familyName,
         }),
     });


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Fix some bugs stemming from renaming the contributor `users` relationship to `user`.


## Summary of Changes
Turns out the serializer's `attrs` map works seamlessly for only attributes, not relationships, and there's various other code that depends on the specific name of the relationship. For example, extracting embeds.


## Side Effects / Testing Notes



## Ticket

https://openscience.atlassian.net/browse/EMB-

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
