### PR TITLE
[EMB-233] Updates for accessibility

### DIFF
--- a/app/components/file-browser/template.hbs
+++ b/app/components/file-browser/template.hbs
@@ -2,13 +2,14 @@
     {{#if (or showFilterClicked showFilterInput)}}
         <div class="col-xs-9 filter-input">
             {{input
+                (html-attributes aria-label=(t 'file_browser.filtering'))
                 placeholder=(t 'file_browser.filtering')
                 class="form-control"
                 keyUp=(action updateFilter value='target.value')
             }}
         </div>
         <div class="col-xs-3">
-            <button {{action 'closeFilter'}} class="btn pull-right">
+            <button {{action 'closeFilter'}} class="btn pull-right" aria-label={{t 'general.close'}}>
                 {{fa-icon "times"}}
             </button>
         </div>

--- a/app/components/file-share-button/styles.scss
+++ b/app/components/file-share-button/styles.scss
@@ -11,6 +11,7 @@
 
         &__mfr-url {
             height: 33px;
+            color: $color-text-black;
         }
 
         &__button-group {

--- a/app/components/file-share-button/template.hbs
+++ b/app/components/file-share-button/template.hbs
@@ -1,14 +1,14 @@
 <button class='btn btn-sm btn-default popover-toggler' {{action 'togglePopup'}}>
     {{t "general.share"}}
     {{#bs-popover placement='bottom' class=popoverClass title=(t 'general.share') visible=showPopup}}
-        {{#click-outside action=(action 'hidePopup')}}
-            {{#bs-tab customTabs=true as |tab|}}
+        {{#click-outside action=(action 'hidePopup') }}
+            {{#bs-tab customTabs=true as |tab| }}
                 {{#bs-nav class='nav-justified' type='tabs' as |nav|}}
                     {{#nav.item active=(bs-eq tab.activeId sharePaneId)}}
-                        <a role='tab' {{action tab.select sharePaneId}} class='SharePane__tab'>{{t "general.share"}}</a>
+                        <a role='button' {{action tab.select sharePaneId}} class='SharePane__tab'>{{t "general.share"}}</a>
                     {{/nav.item}}
                     {{#nav.item active=(bs-eq tab.activeId embedPaneId)}}
-                        <a role='tab' {{action tab.select embedPaneId}} class='SharePane__tab'>
+                        <a role='button' {{action tab.select embedPaneId}} class='SharePane__tab'>
                             {{t "general.embed"}}
                             <span class='badge'>{{badge}}</span>
                         </a>
@@ -21,17 +21,20 @@
                         <div class='input-group'>
                             <span class='input-group-btn SharePane__copy-url-container'>
                                 <button type='button' class='btn btn-default btn-md'
+                                        aria-label={{t 'general.clipboard_copy'}}
                                         onclick={{action 'click' 'button' 'Quick Files - Share file' target=analytics}}
                                     {{action 'share'}}>
                                     <div class='fa fa-copy'></div>
                                 </button>
                             </span>
                             <input readonly='true' type='text' class='form-control SharePane__mfr-url'
+                                   aria-label={{t 'general.download_url'}}
                                    value='{{mfrUrl}}'>
                         </div>
                         <div class='SharePane__button-group'>
                             <a
                                 class='SharePane__share-link'
+                                aria-label={{t 'social.twitter'}}
                                 href='{{twitterUrl}}'
                                 target='_blank'
                                 rel='noopener'
@@ -43,6 +46,7 @@
                             </a>
                             <a
                                 class='SharePane__share-link'
+                                aria-label={{t 'social.facebook'}}
                                 href='{{facebookUrl}}'
                                 target='_blank'
                                 rel='noopener'
@@ -54,6 +58,7 @@
                             </a>
                             <a
                                 class='SharePane__share-link'
+                                aria-label={{t 'social.linkedin'}}
                                 href='{{linkedInUrl}}'
                                 target='_blank'
                                 rel='noopener'
@@ -65,6 +70,7 @@
                             </a>
                             <a
                                 class='SharePane__share-link'
+                                aria-label={{t 'quickfiles.share_by_email'}}
                                 href='{{emailUrl}}'
                                 target='_blank'
                                 rel='noopener'
@@ -79,10 +85,10 @@
                     {{#tab.pane elementId=embedPaneId title='Embed' class='EmbedPane'}}
                         <br>
                         <p>{{t "file_detail.embed.dynamic"}}</p>
-                        <textarea readonly='true' type='text' class='form-control'>{{shareiFrameDynamic}}</textarea>
+                        <textarea aria-label={{t 'file_detail.embed_js_label'}} readonly='true' type='text' class='form-control'>{{shareiFrameDynamic}}</textarea>
                         <br>
                         <p>{{t "file_detail.embed.direct"}}</p>
-                        <textarea readonly='true' class='form-control'>{{shareiFrameDirect}}</textarea>
+                        <textarea aria-label={{t 'file_detail.embed_iframe_label'}} readonly='true' class='form-control'>{{shareiFrameDirect}}</textarea>
                     {{/tab.pane}}
                 </div>
             {{/bs-tab}}

--- a/app/components/institution-carousel/template.hbs
+++ b/app/components/institution-carousel/template.hbs
@@ -1,6 +1,7 @@
 {{#if slides}}
     {{#bs-carousel
         interval=0
+        tabindex=0
         showIndicators=false
         prevControlLabel=(t 'general.previous')
         nextControlLabel=(t 'general.next')

--- a/app/components/new-project-modal/styles.scss
+++ b/app/components/new-project-modal/styles.scss
@@ -18,5 +18,9 @@
             opacity: 0.25;
             filter: grayscale(100%);
         }
+
+        &__placeholder {
+            color: $color-text-gray-dark;
+        }
     }
 }

--- a/app/components/new-project-modal/template.hbs
+++ b/app/components/new-project-modal/template.hbs
@@ -63,6 +63,7 @@
                             {{t 'new_project.template_title'}}
                             <p class="f-w-xs help-text">{{t 'new_project.template_search_help'}}</p>
                             {{#power-select
+                                class='{{styleNamespace}}__placeholder'
                                 search=search
                                 selected=searchSelected
                                 noMatchesMessage=(t 'new_project.no_matches')

--- a/app/components/osf-footer/template.hbs
+++ b/app/components/osf-footer/template.hbs
@@ -51,11 +51,11 @@
                     </a>
                 </p>
                 <p>
-                    <a href="{{twitter}}" aria-label="Twitter" onclick={{action 'click' 'link' 'Footer - social_twitter' target=analytics}}><i class="fa fa-twitter fa-2x"></i></a>
-                    <a href="{{facebook}}" aria-label="Facebook" onclick={{action 'click' 'link' 'Footer - social_facebook' target=analytics}}><i class="fa fa-facebook fa-2x"></i></a>
-                    <a href="{{googleGroup}}" aria-label="Google Group" onclick={{action 'click' 'link' 'Footer - social_google_group' target=analytics}}><i class="fa fa-group fa-2x"></i></a>
-                    <a href="{{github}}" aria-label="GitHub" onclick={{action 'click' 'link' 'Footer - social_github' target=analytics}}><i class="fa fa-github fa-2x"></i></a>
-                    <a href="{{googlePlus}}" aria-label="Google Plus" rel="publisher" onclick={{action 'click' 'link' 'Footer - social_google_plus' target=analytics}}><i class="fa fa-google-plus fa-2x"></i></a>
+                    <a href="{{twitter}}" aria-label={{t 'social.twitter'}} onclick={{action 'click' 'link' 'Footer - social_twitter' target=analytics}}><i class="fa fa-twitter fa-2x"></i></a>
+                    <a href="{{facebook}}" aria-label={{t 'social.facebook'}} onclick={{action 'click' 'link' 'Footer - social_facebook' target=analytics}}><i class="fa fa-facebook fa-2x"></i></a>
+                    <a href="{{googleGroup}}" aria-label={{t 'social.google_group'}} onclick={{action 'click' 'link' 'Footer - social_google_group' target=analytics}}><i class="fa fa-group fa-2x"></i></a>
+                    <a href="{{github}}" aria-label={{t 'social.github'}} onclick={{action 'click' 'link' 'Footer - social_github' target=analytics}}><i class="fa fa-github fa-2x"></i></a>
+                    <a href="{{googlePlus}}" aria-label={{t 'social.google_plus'}} rel="publisher" onclick={{action 'click' 'link' 'Footer - social_google_plus' target=analytics}}><i class="fa fa-google-plus fa-2x"></i></a>
                 </p>
             </div>
         </div>

--- a/app/components/osf-navbar/auth-dropdown/template.hbs
+++ b/app/components/osf-navbar/auth-dropdown/template.hbs
@@ -9,29 +9,29 @@
         {{/dd.toggle}}
         {{#dd.menu classNames='dropdown-menu auth-dropdown' as |ddm|}}
             {{#if headline}}
-                {{#ddm.item}}
+                {{#ddm.item (html-attributes role='menuitem')}}
                     {{headline}}
                 {{/ddm.item}}
             {{/if}}
-            {{#ddm.item}}
+            {{#ddm.item (html-attributes role='menuitem')}}
                 <a href="{{serviceLinks.profile}}" onclick={{action 'clicked' 'link' 'Navbar - MyProfile'}}>
                     <i class="fa fa-user fa-lg p-r-xs"></i>
                     {{t 'auth_dropdown.my_profile'}}
                 </a>
             {{/ddm.item}}
-            {{#ddm.item}}
+            {{#ddm.item (html-attributes role='menuitem')}}
                 {{#link-to 'support' clickAction=(action 'clicked' 'link' 'Navbar - Support')}}
                     <i class="fa fa-life-ring fa-lg p-r-xs"></i>
                     {{t 'auth_dropdown.osf_support'}}
                 {{/link-to}}
             {{/ddm.item}}
-            {{#ddm.item}}
+            {{#ddm.item (html-attributes role='menuitem')}}
                 <a href="{{serviceLinks.settings}}" onclick={{action 'clicked' 'link' 'Navbar - Settings'}}>
                     <i class="fa fa-cog fa-lg p-r-xs"></i>
                     {{t 'auth_dropdown.settings'}}
                 </a>
             {{/ddm.item}}
-            {{#ddm.item}}
+            {{#ddm.item (html-attributes role='menuitem')}}
                 <a class="logoutLink" {{action (perform logout)}} onclick={{action 'clicked' 'button' 'Navbar - Logout'}} role="button">
                     <i class="fa fa-sign-out fa-lg p-r-xs"></i>
                     {{t 'auth_dropdown.log_out'}}

--- a/app/components/osf-navbar/template.hbs
+++ b/app/components/osf-navbar/template.hbs
@@ -25,14 +25,16 @@
                 {{#bs-dropdown
                     classNames='dropdown primary-nav'
                     onShow=(action 'onClickPrimaryDropdown')
-                    as |dd|
+                as |dd|
                 }}
-                    {{#dd.toggle classNames='btn-link PrimaryNav__toggle'}}
+                    {{#dd.toggle
+                        (html-attributes aria-label=(t 'navbar.other_views'))
+                        classNames='btn-link PrimaryNav__toggle'}}
                         {{fa-icon 'caret-down' size='2'}}
                     {{/dd.toggle}}
                     {{#dd.menu classNames='dropdown-menu service-dropdown' as |ddm|}}
                         {{#each osfApps as |app|}}
-                            {{#ddm.item}}
+                            {{#ddm.item (html-attributes role='menuitem')}}
                                 {{#if (eq app.name currentApp)}}
                                     {{#link-to indexRoute clickAction=(action 'click' 'link' (concat 'Navbar - ' app.name ) target=analytics) }}
                                         {{t 'general.OSF'}}<b>{{app.name}}</b>

--- a/app/components/project-selector/template.hbs
+++ b/app/components/project-selector/template.hbs
@@ -59,7 +59,7 @@
                 {{t 'move_to_project.no_projects_exist_error'}}
             </p>
         {{/if}}
-        <p class="text-muted text-smaller m-t-xs">
+        <p class="text-smaller m-t-xs">
             {{t 'move_to_project.project_select_message'}}
         </p>
     {{/if}}

--- a/app/components/quickfile-nav/template.hbs
+++ b/app/components/quickfile-nav/template.hbs
@@ -1,11 +1,9 @@
 <div class="container">
-    <h3>
-        {{#if user}}
+    {{#if user}}
+        <h3>
             {{#link-to 'guid-user.quickfiles' user.id}}
                 {{t 'quickfiles.title' user-name=user.fullName}}
             {{/link-to}}
-        {{else}}
-            &nbsp;
-        {{/if}}
-    </h3>
+        </h3>
+    {{/if}}
 </div>

--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -6,6 +6,7 @@ export default {
         share: 'Share',
         embed: 'Embed',
         download: 'Download',
+        download_url: 'Download url',
         delete: 'Delete',
         view: 'View',
         edit: 'Edit',
@@ -61,6 +62,7 @@ export default {
         description: 'Files uploaded here are <b>publicly accessible</b> and easy to share with others using the share link.',
         feedback_dialog_text: 'Tell us what you think of Quick Files',
         transition_auth: 'You must be logged in to view your Quick Files. Redirecting to the login page.',
+        share_by_email: 'Share by email',
     },
     feedback: {
         button_text: 'Feedback',
@@ -96,6 +98,8 @@ export default {
         save_fail: 'Error, unable to save file',
         mfr_iframe_title: 'Rendering of document',
         add_tag: 'add a tag to enhance discoverability',
+        embed_js_label: 'Embeddable javascript',
+        embed_iframe_label: 'Embeddable iframe',
     },
     file_browser: {
         loading: 'Loading...',
@@ -239,6 +243,7 @@ export default {
         support: 'Support',
         toggle_primary: 'Toggle primary navigation',
         toggle_secondary: 'Toggle secondary navigation',
+        other_views: 'Other OSF views',
     },
     auth_dropdown: {
         log_out: 'Log out',
@@ -479,5 +484,13 @@ export default {
         create_account: 'Create an account',
         learn_more: 'learn more',
         hide_message: 'Hide this message',
+    },
+    social: {
+        twitter: 'Twitter',
+        facebook: 'Facebook',
+        google_group: 'Google Group',
+        github: 'GitHub',
+        google_plus: 'Google Plus',
+        linkedin: 'LinkedIn',
     },
 };

--- a/app/locales/ja/translations.ts
+++ b/app/locales/ja/translations.ts
@@ -6,6 +6,7 @@ export default {
         share: '共有',
         embed: '埋込み',
         download: 'ダウンロード',
+        download_url: 'Download url',
         delete: '削除',
         view: '表示',
         edit: '編集',
@@ -61,6 +62,7 @@ export default {
         description: 'ここにアップロードされたファイルは<b>一般公開</b>されており、共有リンクを使用して他のユーザーと簡単に共有できます。',
         feedback_dialog_text: 'クイックファイルの考え方を我々に教えて下さい',
         transition_auth: 'クイックファイルを表示するには、ログインしている必要があります。ログインページにリダイレクトします。',
+        share_by_email: 'Share by email',
     },
     feedback: {
         button_text: 'フィードバック',
@@ -96,6 +98,8 @@ export default {
         save_fail: 'エラー、ファイルを保存できません',
         mfr_iframe_title: 'ドキュメントのレンダリング',
         add_tag: '検索性を高めるタグを追加する',
+        embed_js_label: 'Embeddable javascript',
+        embed_iframe_label: 'Embeddable iframe',
     },
     file_browser: {
         loading: 'ローディング中...',
@@ -239,6 +243,7 @@ export default {
         support: 'サポート',
         toggle_primary: 'プライマリー・ナビゲーション切替',
         toggle_secondary: 'セカンダリー・ナビゲーション切替',
+        other_views: 'Other OSF views',
     },
     auth_dropdown: {
         log_out: 'ログアウト',
@@ -480,4 +485,13 @@ export default {
         learn_more: 'learn more',
         hide_message: 'Hide this message',
     },
+    social: {
+        twitter: 'Twitter',
+        facebook: 'Facebook',
+        google_group: 'Google Group',
+        github: 'GitHub',
+        google_plus: 'Google Plus',
+        linkedin: 'LinkedIn',
+    },
+
 };

--- a/app/locales/zh/translations.ts
+++ b/app/locales/zh/translations.ts
@@ -6,6 +6,7 @@ export default {
         share: '分享',
         embed: '嵌入',
         download: '下载',
+        download_url: 'Download url',
         delete: '删除',
         view: '查看',
         edit: '编辑',
@@ -61,6 +62,7 @@ export default {
         description: '在这里上传的文件都将被公开，并且可以使用共享链接轻松与他人分享。',
         feedback_dialog_text: '告诉我们您对 Quick Files 的看法',
         transition_auth: '您必须登陆才能查看您的 Quick Files。重新定向到登陆页面。',
+        share_by_email: 'Share by email',
     },
     feedback: {
         button_text: '反馈',
@@ -96,6 +98,8 @@ export default {
         save_fail: '错误，无法保存文件',
         mfr_iframe_title: 'Rendering of document',
         add_tag: 'add a tag to enhance discoverability',
+        embed_js_label: 'Embeddable javascript',
+        embed_iframe_label: 'Embeddable iframe',
     },
     file_browser: {
         loading: 'Loading...',
@@ -239,6 +243,7 @@ export default {
         support: 'Support',
         toggle_primary: 'Toggle primary navigation',
         toggle_secondary: 'Toggle secondary navigation',
+        other_views: 'Other OSF views',
     },
     auth_dropdown: {
         log_out: 'Log out',
@@ -480,4 +485,13 @@ export default {
         learn_more: 'learn more',
         hide_message: 'Hide this message',
     },
+    social: {
+        twitter: 'Twitter',
+        facebook: 'Facebook',
+        google_group: 'Google Group',
+        github: 'GitHub',
+        google_plus: 'Google Plus',
+        linkedin: 'LinkedIn',
+    },
+
 };

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -48,3 +48,5 @@ $brand-success: #357935;
 $brand-info: #1b6d85;
 $btn-success-high-contrast-color: #fff;
 $btn-info-high-contrast-color: #fff;
+
+$ember-power-select-placeholder-color: #555;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,3 +1,6 @@
+// Variable up top to override properly with SASS
+@import 'variables';
+
 // 3rd parties
 @import 'ember-bootstrap/bootstrap';
 @import 'ember-power-select';
@@ -6,7 +9,6 @@
 @import 'osf-style';
 
 // 1st parties
-@import 'variables';
 @import 'global';
 @import 'mixins';
 @import 'pod-styles';

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "chai": "^4.1.2",
     "coveralls": "^3.0.0",
     "dropzone": "^5.3.0",
-    "ember-a11y-testing": "^0.5.0",
+    "ember-a11y-testing": "^0.5.1",
     "ember-ace": "^1.3.1",
     "ember-ajax": "^3.0.0",
     "ember-bootstrap": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3484,7 +3484,7 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
-ember-a11y-testing@^0.5.0:
+ember-a11y-testing@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/ember-a11y-testing/-/ember-a11y-testing-0.5.1.tgz#30cc67119a0c49b4138a8a5dec08175caa187e8f"
   dependencies:


### PR DESCRIPTION
## Purpose

Eliminate the majority of the remaining a11y linting errors, and hopefully all of the errors that aren't embedded in third-party components.


## Summary of Changes

In short: Make things more contrasty, add labels, and add roles.

- Add aria labels to quickfiles file-browser filtering controls
- Make the color of the mfr file download url darker
- Change quickfiles file-detail sharing popup tabs to buttons, because ember-bootstrap doesn't seem to have the supporting parent container role working properly
- Add aria labels to most of the things in the quickfiles file-detail sharing popup
- Make the institutions carousel tab-index equal to 0, because the tab-index of a carousel can't be greater than 0
- Make the placeholder text darker on the new project modal
- Make the aria labels for social icons in the footer i18n compliant (oops)
- Add menuitem roles to the menu items in the navbar
- Un-mute the text in the project selector's project select text
- Instead of making the h3 element effectively empty before we know the user's name, don't add the element until we have a name (the rendering flash isn't terrible)
- Override ember-power-select's placeholder text color
- Move the variables.scss to the top of the app.scss so that it can override variables lower down
- Upgrade ember-a11y-testing to 0.5.1, which upgrades the axe package to fix one of the other things I couldn't do from my original PR.
- Add translation strings for all the new labels

## Side Effects / Testing Notes

Moving the variables so that they actually override things may cause some CSS color changes that weren't active before to become active. There are less invasive ways to do this, but I _think_ this is the proper way, and I didn't see weird color changes.


## Ticket

https://openscience.atlassian.net/browse/EMB-233

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~changes described in `CHANGELOG.md`~

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
