### PR TITLE
[EMB-234] Handle institutions == slide length

### DIFF
--- a/app/components/institution-carousel/component.ts
+++ b/app/components/institution-carousel/component.ts
@@ -15,6 +15,11 @@ export default class InstitutionCarousel extends Component {
     itemsPerSlide: number = defaultTo(this.itemsPerSlide, 5);
     institutions = defaultTo(this.institutions, A([]));
 
+    @computed('institutions.length', 'itemsPerSlide')
+    get showControls() {
+        return this.institutions.length > this.itemsPerSlide;
+    }
+
     @computed('institutions.[]', 'itemsPerSlide')
     get slides() {
         const institutions = this.institutions.slice();
@@ -31,6 +36,6 @@ export default class InstitutionCarousel extends Component {
     @computed('institutions.length', 'itemsPerSlide')
     get columnOffset() {
         const numInstitutions = this.institutions.length;
-        return numInstitutions <= this.itemsPerSlide ? this.itemsPerSlide - numInstitutions : 1;
+        return numInstitutions < this.itemsPerSlide ? this.itemsPerSlide - numInstitutions : 1;
     }
 }

--- a/app/components/institution-carousel/template.hbs
+++ b/app/components/institution-carousel/template.hbs
@@ -9,6 +9,7 @@
         nextControlIcon='fa fa-angle-right'
         prevControlClassName='InstitutionCarousel__control carousel-control left'
         nextControlClassName='InstitutionCarousel__control carousel-control right'
+        showControls = showControls
         as |carousel|
     }}
         {{#each slides as |slide|}}


### PR DESCRIPTION
## Purpose

On the institutional carousel, we were not handling the case where the number of institutions equaled the size of the slide. This corrects the two major problems from that.

## Summary of Changes

1. Don't show controls if institutions.length > itemsPerSlide
2. Only subtract those numbers for offset if the institutions length is less than, not equal to, the items per slide

Note: I tried to do `@gt` instead of `@computed` but those decorators need values and not keys for the second parameter.


## Side Effects / Testing Notes

Should work for cases where there are more, the same, and fewer institutions on the server as there are items per slide.

## Ticket

https://openscience.atlassian.net/browse/EMB-234

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~
- [ ] ~~changes described in `CHANGELOG.md`~~

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
