### PR TITLE
Make footer always go the 

### DIFF
--- a/app/components/osf-footer/styles.scss
+++ b/app/components/osf-footer/styles.scss
@@ -1,3 +1,7 @@
+& {
+    flex-shrink: 0;
+}
+
 .Footer {
     &__container {
         padding-top: 10px;

--- a/app/styles/_global.scss
+++ b/app/styles/_global.scss
@@ -1,5 +1,23 @@
 // Global styles (Think: Do you really need to?)
 
+// stylelint-disable selector-class-pattern
+
+html,
+body,
+body > .ember-view,
+.Application {
+    height: 100%;
+}
+
+.Application {
+    display: flex;
+    flex-direction: column;
+}
+
+.Application__page {
+    flex: 1 0 auto;
+}
+
 #toast-container > div { // stylelint-disable-line selector-max-id
     opacity: 1;
 }


### PR DESCRIPTION
## Purpose

Footer in the middle of the page kind of looks weird, so let's fix it

## Summary of Changes

Just CSS flexbox

## Side Effects / Testing Notes

It should always be at the bottom, but not covering any content

## Ticket

N/A

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
