### PR TITLE
use .get() for ObjectProxies in get-ancestor-descriptor

### DIFF
--- a/app/helpers/get-ancestor-descriptor.ts
+++ b/app/helpers/get-ancestor-descriptor.ts
@@ -26,7 +26,7 @@ function fetchIdFromRelationshipLink(node: Node, relationship: keyof Node) {
 
 function fetchTitle(node: Node, relationship: keyof Node) {
     // Fetches parent or root title.  If null, marks 'Private'.
-    const { title } = node.get(relationship);
+    const title = node.get(relationship).get('title');
 
     return typeof title !== 'undefined' ? title : 'Private';
 }
@@ -36,10 +36,10 @@ export function getAncestorDescriptor(params: any[]): string {
     // For example, Root Name / ... / Parent Name / Node Name.
     const node = params[0] as Node;
     const nodeId = node.id;
-    let rootId = node.root.id;
-    let parentId = node.parent.id;
+    let rootId = node.root.get('id');
+    let parentId = node.parent.get('id');
     const parent: Node = node.parent instanceof ObjectProxy ? node.get('parent').content as Node : node.parent;
-    let parentParentId = parent ? parent.parent.id : undefined;
+    let parentParentId = parent ? parent.parent && parent.parent.get('id') : undefined;
 
     const separator = ' / ';
     const ellipsis = '\u2026';


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Locally (though, for some reason, not on staging) I'm getting the "You attempted to access a property of an ObjectProxy without using .get()" error when trying to move a Quick File (specifically, when trying to choose a project). I traced it back to overeager ungetting in the `get-ancestor-descriptor` helper (guilty).

## Summary of Changes

use .get() for ObjectProxies in `get-ancestor-descriptor` helper

## Side Effects / Testing Notes

Ancestor descriptors should always work.

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
