### PR TITLE
Use non-legacy indent

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,14 +21,19 @@ module.exports = {
         'no-unused-vars': ['error', { argsIgnorePattern: '^this' }],
         'typescript/no-unused-vars': 'error',
         strict: 'off',
-        indent: 'off',
-        'indent-legacy': 'error',
         'ember/named-functions-in-promises': 'off',
         'function-paren-newline': ['error', 'consistent'],
         'ember/no-attrs-snapshot': 'off',
         'prefer-rest-params': 'error',
     },
     overrides: [
+        {
+            files: ['config/environment.d.ts'],
+            rules: {
+                indent: 'off',
+                'indent-legacy': 'error',
+            },
+        },
         {
             files: ['**/*.d.ts'],
             rules: {

--- a/tests/unit/adapters/metaschema-test.ts
+++ b/tests/unit/adapters/metaschema-test.ts
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 module('Unit | Adapter | metaschema', hooks => {
     setupTest(hooks);
 
-  // Replace this with your real tests.
+    // Replace this with your real tests.
     test('it exists', function(assert) {
         const adapter = this.owner.lookup('adapter:metaschema');
         assert.ok(adapter);


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Use non-legacy indent rule. We can use this everywhere except `config/environment.d.ts`, because of https://github.com/eslint/typescript-eslint-parser/issues/458.

## Summary of Changes

* only use legacy indent for [config/environment.d.ts](231/files#diff-e4403a877d80de653400d88d85e4801aR31)
* fix comment indentation in [tests/unit/adapters/metaschema-test.ts](231/files#diff-2b453e563c9892bb2fb49b62c6adf16eR7)

## Side Effects / Testing Notes

n/a

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
