### PR TITLE
[EMB-197] Fix scrolling issues with flexbox

### DIFF
--- a/app/components/file-browser/styles.scss
+++ b/app/components/file-browser/styles.scss
@@ -108,7 +108,7 @@ a {
 .items {
     z-index: 0;
     height: 100%;
-    overflow-y: scroll;
+    overflow-y: auto;
     overflow-x: hidden;
 }
 

--- a/app/components/file-list/styles.scss
+++ b/app/components/file-list/styles.scss
@@ -4,6 +4,8 @@
     border-top: none;
     height: 400px;
     margin-bottom: 20px;
+    display: flex;
+    flex-direction: column;
 }
 
 a {
@@ -43,9 +45,9 @@ a {
 
 .items {
     z-index: 0;
-    height: 100%;
-    overflow-y: scroll;
+    overflow-y: auto;
     overflow-x: hidden;
+    flex: 1;
 }
 
 .shade {


### PR DESCRIPTION
## Purpose

The height of the file-list component on the file detail page is not set properly, causing issues with the scrollbars (and the element itself) to overflow onto other elements

## Summary of Changes

### Before
<img width="407" alt="screen shot 2018-04-27 at 10 59 44" src="https://user-images.githubusercontent.com/3374510/39369458-5a7c6918-4a0a-11e8-8ac0-5d8d570594c0.png">

### After
<img width="386" alt="screen shot 2018-04-27 at 10 58 10" src="https://user-images.githubusercontent.com/3374510/39369454-57f2ca66-4a0a-11e8-98e0-7765f43e1b40.png">


## Side Effects / Testing Notes

Generally, the scrollbars only show up if you're connected to a traditional mouse (vice a trackpad), but to enable the scrollbars (always) on OS X, go to System Preferences > General.

<img width="780" alt="screen shot 2018-04-27 at 11 07 19" src="https://user-images.githubusercontent.com/3374510/39369934-93b2aa16-4a0b-11e8-86f6-94804c2e95fc.png">


## Ticket

https://openscience.atlassian.net/browse/EMB-197

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
