### PR TITLE
[EMB-250] Allow embeds to keep meta

### DIFF
--- a/app/components/contributor-list/component.ts
+++ b/app/components/contributor-list/component.ts
@@ -1,17 +1,16 @@
 import { tagName } from '@ember-decorators/component';
 import { computed } from '@ember-decorators/object';
 import { service } from '@ember-decorators/service';
-import { A } from '@ember/array';
 import Component from '@ember/component';
+import DS from 'ember-data';
 import I18N from 'ember-i18n/services/i18n';
 import Contributor from 'ember-osf-web/models/contributor';
-import defaultTo from 'ember-osf-web/utils/default-to';
 
 @tagName('span')
 export default class ContributorList extends Component {
     @service i18n!: I18N;
 
-    contributors: Contributor[] = defaultTo(this.contributors, A([]));
+    contributors: DS.PromiseManyArray<Contributor> & { meta: { total: number } } = this.contributors;
 
     @computed('contributors.[]')
     get contributorList(): string {
@@ -21,7 +20,7 @@ export default class ContributorList extends Component {
             return '';
         }
 
-        const len = contributors.length;
+        const len = this.contributors.meta.total;
         const max = 3;
 
         const names: string[] = contributors

--- a/app/serializers/osf-serializer.ts
+++ b/app/serializers/osf-serializer.ts
@@ -56,6 +56,7 @@ export default class OsfSerializer extends JSONAPISerializer.extend({
                 relationships[relName] = {
                     data: embeddedObj.data.map(({ id, type }: { id: string, type: string}) => ({ id, type })),
                     links: embeddedLinks,
+                    meta: embeddedObj.meta,
                 };
             } else {
                 relationships[relName] = {
@@ -64,6 +65,7 @@ export default class OsfSerializer extends JSONAPISerializer.extend({
                         type: embeddedObj.data.type,
                     },
                     links: embeddedLinks,
+                    meta: embeddedObj.meta,
                 };
             }
         }

--- a/tests/integration/components/contributor-list/component-test.ts
+++ b/tests/integration/components/contributor-list/component-test.ts
@@ -64,7 +64,13 @@ test('it renders', function(assert) {
     ];
 
     for (const [input, expected] of testCases) {
-        this.set('contributors', A(input.map(nameToUsersFamilyNames)));
+        const contributors = {
+            toArray: () => A(input.map(nameToUsersFamilyNames)),
+            meta: {
+                total: input.length,
+            },
+        };
+        this.set('contributors', contributors);
         this.render(hbs`{{contributor-list contributors=contributors}}`);
         assert.equal(this.$().text().trim(), expected);
     }


### PR DESCRIPTION
## Purpose
Embeds no longer receive meta
Contributor-links does not show true total of contributors

## Summary of Changes
Make embeds keep their meta, and contributor-links using meta.total

## Side Effects / Testing Notes
Make sure nodes with more than 10 projects show the proper number of contributors on ` and x more ` in the dashboard


## Ticket

https://openscience.atlassian.net/browse/EMB-250

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
