### PR TITLE
[EMB-248] Handle long quick filenames

### DIFF
--- a/app/components/file-browser/template.hbs
+++ b/app/components/file-browser/template.hbs
@@ -176,8 +176,10 @@
     {{#modal.body}}
         <p>{{t 'file_browser.delete_modal.body'}}</p>
         {{#each selectedItems as | item |}}
-            <b>{{item.itemName}}</b>
-            <hr style="margin-top: 5px">
+            <div class='break-word'>
+                <b>{{item.itemName}}</b>
+                <hr style="margin-top: 5px">
+            </div>
         {{/each}}
     {{/modal.body}}
     {{#modal.footer}}

--- a/app/guid-file/styles.scss
+++ b/app/guid-file/styles.scss
@@ -15,8 +15,29 @@
 }
 
 .TitleBar {
+    display: flex;
+    justify-content: space-between;
+    flex-flow: row wrap;
+
+    @media(min-width:992px) {
+        flex-wrap: nowrap;
+    }
+
+    &__title {
+        overflow-wrap: break-word;
+        word-wrap: break-word;
+        min-width: 10%;
+    }
+
+    &__buttons {
+        margin-left: auto;
+        flex-shrink: 0;
+        max-width: 100%;
+    }
+
     &__version-link {
         cursor: pointer;
+        white-space: nowrap;
     }
 
     &__button-label {

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -1,8 +1,8 @@
 {{title model.file.name}}
 <div class='container'>
     {{quickfile-nav user=model.user onQuickfiles=false}}
-    <div class='row TitleBar'>
-        <div class='col-sm-5'>
+    <div class='TitleBar'>
+        <div class='TitleBar__title'>
             <h2>
                 {{model.file.name}}
                 <a class='TitleBar__version-link' role="button" onclick={{action 'changeView' 'revision'}}>
@@ -10,7 +10,7 @@
                 </a>
             </h2>
         </div>
-        <div class='col-sm-7'>
+        <div class='TitleBar__buttons'>
             <div id='toggleBar' class='pull-right'>
                 <div class='btn-toolbar m-t-md'>
                     {{#if canDelete}}


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Long quick filenames don't wrap in the title of the file detail page or in the "delete multiple modal".


## Summary of Changes
<img width="661" alt="screen shot 2018-04-27 at 10 52 18 am" src="https://user-images.githubusercontent.com/6776190/39369145-824ad91c-4a09-11e8-9569-cfda94921ba7.png">
<img width="1140" alt="screen shot 2018-04-27 at 2 17 55 pm" src="https://user-images.githubusercontent.com/6776190/39378257-ddb24120-4a25-11e8-8826-afc976e941de.png">




## Side Effects / Testing Notes



## Ticket

https://openscience.atlassian.net/browse/EMB-248

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
