### PR TITLE
[EMB-251] Nuanced tag display

### DIFF
--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -83,27 +83,29 @@
                 updateFilter=(perform updateFilter)
                 openFile=(action 'openFile')
             }}
-            <div class='panel panel-default TagsPanel'>
-                <div class='panel-heading clearfix TagsPanel__heading'>
-                    <h3 class='panel-title'>{{t "file_detail.tags"}}</h3>
+            {{#if (or canEdit tags)}}
+                <div class='panel panel-default TagsPanel'>
+                    <div class='panel-heading clearfix TagsPanel__heading'>
+                        <h3 class='panel-title'>{{t "file_detail.tags"}}</h3>
+                    </div>
+                    <div class='panel-body'>
+                        {{!-- Passing a mutable value to readOnly breaks tag-input. Instead render it with a set value --}}
+                        {{#tag-input
+                            tags=tags
+                            addTag=(action 'addTag')
+                            removeTagAtIndex=(action 'removeTagAtIndex')
+                            allowSpacesInTags=true
+                            placeholder=(t 'file_detail.add_tag')
+                            aria_label=(t 'file_detial.tags')
+                            readOnly=(unless canEdit true false)
+                            as |tag|
+                        }}
+                            <a href='{{searchUrl}}?q=(tags:"{{tag}}")'>{{tag}}</a>
+                        {{/tag-input}}
+                        <div class="tags_clear"></div>
+                    </div>
                 </div>
-                <div class='panel-body'>
-                    {{!-- Passing a mutable value to readOnly breaks tag-input. Instead render it with a set value --}}
-                    {{#tag-input
-                        tags=tags
-                        addTag=(action 'addTag')
-                        removeTagAtIndex=(action 'removeTagAtIndex')
-                        allowSpacesInTags=true
-                        placeholder=(t 'file_detail.add_tag')
-                        aria_label=(t 'file_detial.tags')
-                        readOnly=(unless canEdit true false)
-                        as |tag|
-                    }}
-                        <a href='{{searchUrl}}?q=(tags:"{{tag}}")'>{{tag}}</a>
-                    {{/tag-input}}
-                    <div class="tags_clear"></div>
-                </div>
-            </div>
+            {{/if}}
         </div>
         <div class='col-md-9'>
             {{#if (or


### PR DESCRIPTION
## Purpose

Pull back a bit on showing tags. If the quickfiles user is not the same as the current user, tags should show if there are tags on a quick file, but should not show if there are no tags. If the current user is the quickfiles user, the tag widget should always show.

## Summary of Changes

1. Revert previous change (i.e. put the if statement back)
2. Change the second half of the or condition to use a real property, and not a property that was changed at some point in the last couple of months.


## Side Effects / Testing Notes

This one should be much better. Although wouldn't it be awesome if we knew that we tried to access an invalid property or variable in a template?

## Ticket

https://openscience.atlassian.net/browse/EMB-251

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~
- [ ] ~~changes described in `CHANGELOG.md`~~

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
