### PR TITLE
[EMB-136] Get meta tags and page titles working again

### DIFF
--- a/app/application/template.hbs
+++ b/app/application/template.hbs
@@ -1,3 +1,4 @@
+{{head-layout}}
 {{title (t 'general.OSF')}}
 <div class="Application">
     {{osf-navbar signupUrl=signupUrl loginAction=(action 'login')}}


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Get meta tags and page titles working again (they broke in #224).

## Summary of Changes

Add `{{head_layout}}` to application template [as required](https://github.com/tim-evans/ember-page-title/releases/tag/4.0.0) by `ember-cli-head` 0.4.0, which is a dependency of `ember-page-title` 4.0.0.

## Side Effects / Testing Notes

This affected both meta tags and page titles because they both depend on `ember-cli-head`.

## Ticket

https://openscience.atlassian.net/browse/EMB-136

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
