### PR TITLE
[EMB-256] Use session storage instead of local storage

### DIFF
--- a/app/session-stores/application.ts
+++ b/app/session-stores/application.ts
@@ -1,0 +1,3 @@
+import SessionStorage from 'ember-simple-auth/session-stores/session-storage';
+
+export default class extends SessionStorage {}

--- a/types/ember-simple-auth/session-stores/session-storage.d.ts
+++ b/types/ember-simple-auth/session-stores/session-storage.d.ts
@@ -1,0 +1,3 @@
+declare module 'ember-simple-auth/session-stores/session-storage' {
+    export default class {}
+}


### PR DESCRIPTION
## Purpose

ember-simple-auth stores session information in localStorage by default. This causes issues when closing and re-opening the browser. Our cookies are session-based, so it's appropriate to use sessionStorage in this case.

## Summary of Changes

Implements the session-store from ember-simple-auth (See https://github.com/simplabs/ember-simple-auth#sessionstorage-store)

## Side Effects / Testing Notes

Steps to reproduce the current error:

1. Log in (wait for redirect back to OSF)
2. Clear cookies
3. Force quit browser (Alt + Right click in Dock)
4. Go to an ember page
5. You should see the logged in Navbar and if you click on Home, it will take you to a broken dashboard page

<img width="1297" alt="screen shot 2018-04-30 at 12 19 22" src="https://user-images.githubusercontent.com/3374510/39438054-c38ecfb4-4c70-11e8-91ca-89a848f2407d.png">

After applying this fix, you should see the normal logged out pages.

## Ticket

N/A

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
