### PR TITLE
Upgrade ember-cli-typescript

### DIFF
--- a/app/models/osf-model.ts
+++ b/app/models/osf-model.ts
@@ -3,7 +3,8 @@ import { alias } from '@ember-decorators/object/computed';
 import { service } from '@ember-decorators/service';
 import { get } from '@ember/object';
 import { task } from 'ember-concurrency';
-import DS, { ModelRegistry } from 'ember-data';
+// eslint-disable-next-line no-unused-vars
+import DS, { AdapterRegistry, ModelRegistry } from 'ember-data';
 import authenticatedAJAX from 'ember-osf-web/utils/ajax-helpers';
 
 const { Model } = DS;
@@ -47,7 +48,7 @@ export default class OsfModel extends Model.extend({
             url,
             data: queryParams,
             headers: get(store.adapterFor(
-                (this.constructor as typeof OsfModel).modelName as keyof ModelRegistry,
+                (this.constructor as typeof OsfModel).modelName as keyof AdapterRegistry,
             ), 'headers'),
             ...ajaxOptions,
         };

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "ember-cli-template-lint": "^0.7.5",
     "ember-cli-test-loader": "^2.2.0",
     "ember-cli-tslint": "^0.1.3",
-    "ember-cli-typescript": "1.3.0-beta.4",
+    "ember-cli-typescript": "^1.3.0",
     "ember-cli-uglify": "^2.0.2",
     "ember-click-outside": "^0.1.12",
     "ember-component-attributes": "^0.1.1",
@@ -129,7 +129,7 @@
     "toastr": "^2.1.4",
     "tslint-consistent-codestyle": "^1.11.1",
     "tslint-eslint-rules": "^5.0.0",
-    "typescript": "^2.8.1",
+    "typescript": "^2.8.3",
     "typescript-eslint-parser": "^15.0.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4123,9 +4123,9 @@ ember-cli-tslint@^0.1.3:
     tslint "^5.5.0"
     walk-sync "^0.3.2"
 
-ember-cli-typescript@1.3.0-beta.4:
-  version "1.3.0-beta.4"
-  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-1.3.0-beta.4.tgz#ce85c6d0e6f483dbb22e88ab90c06deb1b6a5b4d"
+ember-cli-typescript@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-1.3.0.tgz#4569e74f74898e2d2f5ebb86773e389dab35c32a"
   dependencies:
     broccoli-debug "^0.6.4"
     broccoli-funnel "^2.0.1"
@@ -11458,7 +11458,7 @@ typescript-eslint-parser@^15.0.0:
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-typescript@^2.8.1:
+typescript@^2.8.3:
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Upgrade to [ember-cli-typescript 1.3.0](https://github.com/typed-ember/ember-cli-typescript/releases/tag/v1.3.0)

## Summary of Changes

* upgrade to ember-cli-typescript 1.3.0
* adjust type wrangling of argument to `adapterFor()` in `OsfModel.queryHasMany()`

## Side Effects / Testing Notes

N/A

## Ticket

N/A

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
