### PR TITLE
[EMB-261] Replace spinning logo with static image

### DIFF
--- a/app/home/styles.scss
+++ b/app/home/styles.scss
@@ -159,6 +159,30 @@ h6 {
     margin-top: -10%;
 }
 
+.logo-hero {
+    height: 200px;
+    margin-top: 130px;
+}
+
+.logo-hero img {
+    position: absolute;
+    left: 50%;
+    width: 200px;
+    height: 200px;
+    margin-top: -100px; /* Half the height */
+    margin-left: -100px; /* Half the width */
+}
+
+.logo-div-bottom {
+    background-position-x: 50%;
+    background-position-y: bottom;
+    height: 200px;
+    background-size: 200px;
+    background-repeat: no-repeat;
+    background-image: url('/static/img/osf_white-400.png');
+    margin-top: 20px;
+}
+
 .student-image {
     width: 100%;
     padding-bottom: 100%;
@@ -368,7 +392,7 @@ h6 {
 .feature-6 {
     background-color: #474747;
     color: #fff;
-    padding: 50px 0;
+    padding: 20px 0 40px;
 
     h2 {
         font-size: 48px;

--- a/app/home/template.hbs
+++ b/app/home/template.hbs
@@ -5,7 +5,7 @@
         classNames='text-center'
         onDismiss=(action 'click' 'button' 'Home - dismiss_alert' target=analytics)
     }}
-        <p>{{t 'home.alert_logged_out'}}</p>
+        <p>{{t 'home.alert_logged_out'}} </p>
     {{/bs-alert}}
 {{/if}}
 {{#bs-modal
@@ -28,7 +28,9 @@
         <div class="network-bg"></div>
         <h1 class="hero-brand">{{t 'home.brand'}}</h1>
         <h3 class="hero-tagline">{{t 'home.tagline'}}</h3>
-        {{osf-logo animate=true}}
+        <div class="logo-hero">
+            <img src="/static/img/osf_white-400.png" alt="{{t 'general.osf'}}" role="graphics-symbol" height="200px">
+        </div>
         <div id="hero-signup" class="container">
             <div class="row">
                 <div class="col-sm-6 hidden-xs">
@@ -234,8 +236,7 @@
                 <h4>{{t 'home.free_title2'}}</h4>
                 <a href="#signUp" class="btn btn-info btn-lg" onclick={{action 'click' 'link' 'Home - goto_signup' target=analytics}}>{{t 'home.free_link'}}</a>
             </div>
-            <div class="col-md-4 hidden-xs hidden-sm">
-                {{osf-logo double=true}}
+            <div class="col-md-4 hidden-xs hidden-sm logo-image logo-div-bottom">
             </div>
         </div>
     </div>


### PR DESCRIPTION

## Purpose

The spinning logo on the home page doesn't work on some browsers, so QA requested a cleanup.

## Summary of Changes

1. Replace top image
2. Replace bottom image
3. Clean up CSS

## Side Effects / Testing Notes

Everything's not exactly as it was before. Some things are arguably better (logo is more correct), some is arguable worse (in some screen widths there's more whitespace below the top logo than there was before), and some may be neutral (logo on the bottom is smaller and contained in the section rather than clipped and/or overflowing, depending).

<img width="957" alt="screen shot 2018-05-01 at 11 23 34 pm" src="https://user-images.githubusercontent.com/6599111/39503962-b2e195ee-4d96-11e8-8071-65e77c061782.png">

<img width="958" alt="screen shot 2018-05-01 at 11 12 39 pm" src="https://user-images.githubusercontent.com/6599111/39503928-98654148-4d96-11e8-93a1-fea4d379281c.png">
<img width="682" alt="screen shot 2018-05-01 at 11 12 01 pm" src="https://user-images.githubusercontent.com/6599111/39503929-98740584-4d96-11e8-8e66-67a8a9aaa9af.png">
<img width="1013" alt="screen shot 2018-05-01 at 11 11 03 pm" src="https://user-images.githubusercontent.com/6599111/39503932-989c393c-4d96-11e8-956e-5504db1124e0.png">

The extra whitespace is because the background network image is over top of the image tag. The way I fixed in this case was absolute positioning, but I ran low on time before I could really dial it in. There are a few ways to solve that problem, but I wanted to get something in if possible.

Also, I didn't yet remove the old logo component, just in case, but we probably should before long. And the logo's about twice as large as it needs to be if the bottom version of the logo is fine, because it was sized for the larger version. It would save 8ish k on the page load if we shrink it down at some point.

## Ticket

https://openscience.atlassian.net/browse/EMB-261

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~
- [ ] ~~changes described in `CHANGELOG.md`~~

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
