### PR TITLE
[EMB-261] Give the lower landing page logo enough space

### DIFF
--- a/app/home/styles.scss
+++ b/app/home/styles.scss
@@ -176,7 +176,7 @@ h6 {
 .logo-div-bottom {
     background-position-x: 50%;
     background-position-y: bottom;
-    height: 200px;
+    height: 201px;
     background-size: 200px;
     background-repeat: no-repeat;
     background-image: url('/static/img/osf_white-400.png');


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
The lower logo on the landing page is slightly cut off:
<img width="66" alt="screen shot 2018-05-02 at 2 07 52 pm" src="https://user-images.githubusercontent.com/6776190/39540962-4a211a8a-4e12-11e8-8363-77b0b4d9a178.png">



## Summary of Changes
<img width="69" alt="screen shot 2018-05-02 at 2 08 05 pm" src="https://user-images.githubusercontent.com/6776190/39540972-50dfa152-4e12-11e8-8cee-8c966d276760.png">



## Side Effects / Testing Notes
n/a


## Ticket

https://openscience.atlassian.net/browse/EMB-261

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
