### PR TITLE
[EMB-261] Fix OSF logo CSS for IE & Edge, add autoprefixer

### DIFF
--- a/app/components/osf-logo/styles.scss
+++ b/app/components/osf-logo/styles.scss
@@ -49,7 +49,7 @@ div {
 @for $i from 1 through 8 {
     :nth-child(#{$i}) {
         transform: translate(75px, 75px)
-            rotate(calc(1turn * #{$i - 1} / 8))
+            rotate(#{($i - 1) / 8}turn)
             translate(0, -75px);
     }
 }

--- a/app/home/styles.scss
+++ b/app/home/styles.scss
@@ -159,30 +159,6 @@ h6 {
     margin-top: -10%;
 }
 
-.logo-hero {
-    height: 200px;
-    margin-top: 130px;
-}
-
-.logo-hero img {
-    position: absolute;
-    left: 50%;
-    width: 200px;
-    height: 200px;
-    margin-top: -100px; /* Half the height */
-    margin-left: -100px; /* Half the width */
-}
-
-.logo-div-bottom {
-    background-position-x: 50%;
-    background-position-y: bottom;
-    height: 201px;
-    background-size: 200px;
-    background-repeat: no-repeat;
-    background-image: url('/static/img/osf_white-400.png');
-    margin-top: 20px;
-}
-
 .student-image {
     width: 100%;
     padding-bottom: 100%;
@@ -392,7 +368,7 @@ h6 {
 .feature-6 {
     background-color: #474747;
     color: #fff;
-    padding: 20px 0 40px;
+    padding: 50px 0;
 
     h2 {
         font-size: 48px;

--- a/app/home/template.hbs
+++ b/app/home/template.hbs
@@ -5,7 +5,7 @@
         classNames='text-center'
         onDismiss=(action 'click' 'button' 'Home - dismiss_alert' target=analytics)
     }}
-        <p>{{t 'home.alert_logged_out'}} </p>
+        <p>{{t 'home.alert_logged_out'}}</p>
     {{/bs-alert}}
 {{/if}}
 {{#bs-modal
@@ -28,9 +28,7 @@
         <div class="network-bg"></div>
         <h1 class="hero-brand">{{t 'home.brand'}}</h1>
         <h3 class="hero-tagline">{{t 'home.tagline'}}</h3>
-        <div class="logo-hero">
-            <img src="/static/img/osf_white-400.png" alt="{{t 'general.osf'}}" role="graphics-symbol" height="200px">
-        </div>
+        {{osf-logo animate=true}}
         <div id="hero-signup" class="container">
             <div class="row">
                 <div class="col-sm-6 hidden-xs">
@@ -236,7 +234,8 @@
                 <h4>{{t 'home.free_title2'}}</h4>
                 <a href="#signUp" class="btn btn-info btn-lg" onclick={{action 'click' 'link' 'Home - goto_signup' target=analytics}}>{{t 'home.free_link'}}</a>
             </div>
-            <div class="col-md-4 hidden-xs hidden-sm logo-image logo-div-bottom">
+            <div class="col-md-4 hidden-xs hidden-sm">
+                {{osf-logo double=true}}
             </div>
         </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "ember-browserify": "^1.2.0",
     "ember-cli": "~3.1.0",
     "ember-cli-app-version": "^3.0.0",
+    "ember-cli-autoprefixer": "^0.8.1",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-clipboard": "0.9.0",
     "ember-cli-code-coverage": "https://github.com/kategengler/ember-cli-code-coverage#77b5b9201060d634d281f64a5bb7b412773a8b89",

--- a/yarn.lock
+++ b/yarn.lock
@@ -870,6 +870,17 @@ atob@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.0.tgz#ab2b150e51d7b122b9efc8d7340c06b6c41076bc"
 
+autoprefixer@^7.0.0:
+  version "7.2.6"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-7.2.6.tgz#256672f86f7c735da849c4f07d008abb056067dc"
+  dependencies:
+    browserslist "^2.11.3"
+    caniuse-lite "^1.0.30000805"
+    normalize-range "^0.1.2"
+    num2fraction "^1.2.2"
+    postcss "^6.0.17"
+    postcss-value-parser "^3.2.3"
+
 autoprefixer@^8.0.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-8.2.0.tgz#1e49b611b31a5259b86b7a6b2b1b8faf091abe2a"
@@ -1811,6 +1822,14 @@ broccoli-asset-rewrite@^1.1.0:
   dependencies:
     broccoli-filter "^1.2.3"
 
+broccoli-autoprefixer@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-autoprefixer/-/broccoli-autoprefixer-5.0.0.tgz#68c9f3bfdfff9df2d39e46545b9cf9d4443d6a16"
+  dependencies:
+    autoprefixer "^7.0.0"
+    broccoli-persistent-filter "^1.1.6"
+    postcss "^6.0.1"
+
 broccoli-babel-transpiler@^5.6.2:
   version "5.7.4"
   resolved "https://registry.yarnpkg.com/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz#2b0611ce9e5d98b8d8d2b49ae1219af2f52767e3"
@@ -2373,7 +2392,7 @@ browserify@^13.0.0:
     vm-browserify "~0.0.1"
     xtend "^4.0.0"
 
-browserslist@^2.1.2, browserslist@^2.2.2:
+browserslist@^2.1.2, browserslist@^2.11.3, browserslist@^2.2.2:
   version "2.11.3"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.3.tgz#fe36167aed1bbcde4827ebfe71347a2cc70b99b2"
   dependencies:
@@ -2535,6 +2554,10 @@ caniuse-lite@^1.0.30000792:
   version "1.0.30000830"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000830.tgz#cb96b8a2dd3cbfe04acea2af3c4e894249095328"
 
+caniuse-lite@^1.0.30000805:
+  version "1.0.30000833"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000833.tgz#98e84fcdb4399c6fa0b0fd41490d3217ac7802b4"
+
 caniuse-lite@^1.0.30000809:
   version "1.0.30000810"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000810.tgz#47585fffce0e9f3593a6feea4673b945424351d9"
@@ -2625,6 +2648,14 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1:
 chalk@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
+chalk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
@@ -3749,6 +3780,13 @@ ember-cli-app-version@^3.0.0:
   dependencies:
     ember-cli-babel "^6.8.0"
     git-repo-version "^1.0.0"
+
+ember-cli-autoprefixer@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-autoprefixer/-/ember-cli-autoprefixer-0.8.1.tgz#071dd9574451057b03dcc03b71f5bd9cb07ef332"
+  dependencies:
+    broccoli-autoprefixer "^5.0.0"
+    lodash "^4.0.0"
 
 ember-cli-babel@6.12.0, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.0, ember-cli-babel@^6.7.2, ember-cli-babel@^6.8, ember-cli-babel@^6.8.1, ember-cli-babel@^6.9.2:
   version "6.12.0"
@@ -9421,6 +9459,14 @@ postcss@^5.2.16:
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
+postcss@^6.0.1, postcss@^6.0.17:
+  version "6.0.22"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.22.tgz#e23b78314905c3b90cbd61702121e7a78848f2a3"
+  dependencies:
+    chalk "^2.4.1"
+    source-map "^0.6.1"
+    supports-color "^5.4.0"
+
 postcss@^6.0.13, postcss@^6.0.14, postcss@^6.0.15, postcss@^6.0.6, postcss@^6.0.8:
   version "6.0.19"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.19.tgz#76a78386f670b9d9494a655bf23ac012effd1555"
@@ -11036,7 +11082,7 @@ supports-color@^3.1.2, supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^5.1.0, supports-color@^5.2.0:
+supports-color@^5.1.0, supports-color@^5.2.0, supports-color@^5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   dependencies:


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

FIx home logo + animation for IE and Edge

## Summary of Changes

* Reverts #249 and #251
* Add autoprefixer for CSS
* IE and Edge don't respect the `calc` function inside transform: rotate (possibly other places), so just use sass for that.

## Side Effects / Testing Notes

<img width="1748" alt="screen shot 2018-05-02 at 15 23 49" src="https://user-images.githubusercontent.com/3374510/39544768-1fe28d16-4e1d-11e8-8ed6-1f641d614fbf.png">
<img width="1804" alt="screen shot 2018-05-02 at 15 26 21" src="https://user-images.githubusercontent.com/3374510/39544794-375a823c-4e1d-11e8-98a2-884dfb1fb837.png">


## Ticket

https://openscience.atlassian.net/browse/EMB-261

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
