### PR TITLE
Enforce consistent spacing before function parens

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
         'function-paren-newline': ['error', 'consistent'],
         'ember/no-attrs-snapshot': 'off',
         'prefer-rest-params': 'error',
+        'generator-star-spacing': ['error', 'before'],
     },
     overrides: [
         {

--- a/app/components/dashboard-item/component.ts
+++ b/app/components/dashboard-item/component.ts
@@ -11,7 +11,7 @@ import Node from 'ember-osf-web/models/node';
 import Analytics from 'ember-osf-web/services/analytics';
 
 export default class DashboardItem extends Component.extend({
-    getAncestorTitles: task(function* (this: DashboardItem) {
+    getAncestorTitles: task(function *(this: DashboardItem) {
         if (!this.node) {
             return [];
         }

--- a/app/components/file-browser/component.ts
+++ b/app/components/file-browser/component.ts
@@ -86,7 +86,7 @@ export default class FileBrowser extends Component {
         acceptDirectories: false,
     };
 
-    moveToProject = task(function* (this: FileBrowser) {
+    moveToProject = task(function *(this: FileBrowser) {
         if (!this.node) {
             return;
         }
@@ -342,7 +342,7 @@ export default class FileBrowser extends Component {
             currentItem.set('isSelected', true);
         }
 
-        next(this, function () {
+        next(this, function() {
             if (this.selectedItems.length === 1) {
                 this.set('shiftAnchor', currentItem);
             }

--- a/app/components/maintenance-banner/component.ts
+++ b/app/components/maintenance-banner/component.ts
@@ -15,7 +15,7 @@ interface MaintenanceData {
 }
 
 export default class MaintenanceBanner extends Component.extend({
-    getMaintenanceStatus: task(function* (this: MaintenanceBanner): IterableIterator<any> {
+    getMaintenanceStatus: task(function *(this: MaintenanceBanner): IterableIterator<any> {
         const url: string = `${config.OSF.apiUrl}/v2/status/`;
         const data = yield $.ajax(url, { type: 'GET' });
         this.set('maintenance', data.maintenance);

--- a/app/components/osf-navbar/auth-dropdown/component.ts
+++ b/app/components/osf-navbar/auth-dropdown/component.ts
@@ -71,7 +71,7 @@ export default class NavbarAuthDropdown extends Component {
         return imgLink ? `${imgLink}&s=25` : '';
     }
 
-    logout = task(function* (this: NavbarAuthDropdown) {
+    logout = task(function *(this: NavbarAuthDropdown) {
         const query = this.redirectUrl ? `?${$.param({ next_url: this.redirectUrl })}` : '';
         yield this.session.invalidate();
         window.location.href = `${config.OSF.url}logout/${query}`;

--- a/app/components/project-selector/component.ts
+++ b/app/components/project-selector/component.ts
@@ -37,7 +37,7 @@ export enum ProjectSelectState {
  * @class project-selector
  */
 export default class ProjectSelector extends Component.extend({
-    initialLoad: task(function* (this: ProjectSelector) {
+    initialLoad: task(function *(this: ProjectSelector) {
         this.setProperties({
             didValidate: false,
             selected: null,
@@ -45,7 +45,7 @@ export default class ProjectSelector extends Component.extend({
         });
     }),
 
-    findNodes: task(function* (this: ProjectSelector, filter?: string) {
+    findNodes: task(function *(this: ProjectSelector, filter?: string) {
         if (filter) {
             yield timeout(250);
         }

--- a/app/components/sign-up-form/component.ts
+++ b/app/components/sign-up-form/component.ts
@@ -13,7 +13,7 @@ export default class SignUpForm extends Component {
     @service passwordStrength!: PasswordStrength;
     @service analytics!: Analytics;
 
-    strength = task(function* (this: SignUpForm, value: string) {
+    strength = task(function *(this: SignUpForm, value: string) {
         if (!value) {
             return 0;
         }

--- a/app/dashboard/controller.ts
+++ b/app/dashboard/controller.ts
@@ -40,17 +40,17 @@ export default class Dashboard extends Controller {
     noteworthy = A([]);
     popular = A([]);
 
-    getInstitutions = task(function* (this: Dashboard) {
+    getInstitutions = task(function *(this: Dashboard) {
         this.set('institutions', yield this.get('store').findAll('institution'));
     }).restartable();
 
-    filterNodes = task(function* (this: Dashboard, filter: string) {
+    filterNodes = task(function *(this: Dashboard, filter: string) {
         yield timeout(500);
         this.setProperties({ filter });
         yield this.get('findNodes').perform();
     }).restartable();
 
-    findNodes = task(function* (this: Dashboard, more?: boolean) {
+    findNodes = task(function *(this: Dashboard, more?: boolean) {
         const indicatorProperty = more ? 'loadingMore' : 'loading';
         this.set(indicatorProperty, true);
 
@@ -74,7 +74,7 @@ export default class Dashboard extends Controller {
         this.set('initialLoad', false);
     }).restartable();
 
-    getPopularAndNoteworthy = task(function* (this: Dashboard, id: string, dest: 'noteworthy' | 'popular') {
+    getPopularAndNoteworthy = task(function *(this: Dashboard, id: string, dest: 'noteworthy' | 'popular') {
         try {
             const node = yield this.get('store').findRecord('node', id);
             const linkedNodes = yield node.queryHasMany('linkedNodes', {
@@ -88,13 +88,13 @@ export default class Dashboard extends Controller {
         }
     });
 
-    searchNodes = task(function* (this: Dashboard, title: string) {
+    searchNodes = task(function *(this: Dashboard, title: string) {
         yield timeout(500);
         const user = yield this.get('user');
         return yield user.queryHasMany('nodes', { filter: { title } });
     }).restartable();
 
-    createNode = task(function* (this: Dashboard, title: string, description: string, templateFrom: Node) {
+    createNode = task(function *(this: Dashboard, title: string, description: string, templateFrom: Node) {
         if (!title) {
             return;
         }

--- a/app/guid-file/controller.ts
+++ b/app/guid-file/controller.ts
@@ -96,7 +96,7 @@ export default class GuidFile extends Controller {
         return !!file && file.getContents();
     }
 
-    updateFilter = task(function* (this: GuidFile, filter: string) {
+    updateFilter = task(function *(this: GuidFile, filter: string) {
         yield timeout(250);
         this.setProperties({ filter });
     }).drop();

--- a/app/guid-file/route.ts
+++ b/app/guid-file/route.ts
@@ -23,7 +23,7 @@ export default class GuidFile extends Route {
 
     headTags?: HeadTagDef[];
 
-    setHeadTags = task(function* (this: GuidFile, model: any) {
+    setHeadTags = task(function *(this: GuidFile, model: any) {
         const blocker = this.get('ready').getBlocker();
         const dateCreated = model.file.get('dateCreated');
         const dateModified = model.file.get('dateModified');

--- a/app/guid-user/quickfiles/controller.ts
+++ b/app/guid-user/quickfiles/controller.ts
@@ -25,12 +25,12 @@ export default class UserQuickfiles extends Controller {
     @alias('model.taskInstance.value.user') user!: User;
     @alias('model.taskInstance.value.files') allFiles!: File[];
 
-    updateFilter = task(function* (this: UserQuickfiles, filter: string) {
+    updateFilter = task(function *(this: UserQuickfiles, filter: string) {
         yield timeout(250);
         this.setProperties({ filter });
     }).restartable();
 
-    createProject = task(function* (this: UserQuickfiles, node: Node) {
+    createProject = task(function *(this: UserQuickfiles, node: Node) {
         try {
             return yield node.save();
         } catch (ex) {
@@ -38,13 +38,13 @@ export default class UserQuickfiles extends Controller {
         }
     });
 
-    flash = task(function* (item: File, message: string, type = 'success', duration = 2000) {
+    flash = task(function *(item: File, message: string, type = 'success', duration = 2000) {
         item.set('flash', { message, type });
         yield timeout(duration);
         item.set('flash', null);
     });
 
-    addFile = task(function* (this: UserQuickfiles, id: string) {
+    addFile = task(function *(this: UserQuickfiles, id: string) {
         const allFiles = this.get('allFiles');
         const duplicate = allFiles.findBy('id', id);
 
@@ -66,7 +66,7 @@ export default class UserQuickfiles extends Controller {
         this.get('flash').perform(file, i18n.t('file_browser.file_added'));
     });
 
-    deleteFile = task(function* (this: UserQuickfiles, file: File) {
+    deleteFile = task(function *(this: UserQuickfiles, file: File) {
         try {
             yield file.destroyRecord();
             yield this.get('flash').perform(file, this.get('i18n').t('file_browser.file_deleted'), 'danger');
@@ -76,13 +76,13 @@ export default class UserQuickfiles extends Controller {
         }
     });
 
-    deleteFiles = task(function* (this: UserQuickfiles, files: File[]) {
+    deleteFiles = task(function *(this: UserQuickfiles, files: File[]) {
         const deleteFile = this.get('deleteFile');
 
         yield all(files.map(file => deleteFile.perform(file)));
     });
 
-    moveFile = task(function* (this: UserQuickfiles, file: File, node: Node): IterableIterator<any> {
+    moveFile = task(function *(this: UserQuickfiles, file: File, node: Node): IterableIterator<any> {
         try {
             if (node.get('isNew')) {
                 yield this.get('createProject').perform(node);
@@ -106,7 +106,7 @@ export default class UserQuickfiles extends Controller {
         return false;
     });
 
-    renameFile = task(function* (
+    renameFile = task(function *(
         this: UserQuickfiles,
         file: File,
         name: string,

--- a/app/guid-user/quickfiles/route.ts
+++ b/app/guid-user/quickfiles/route.ts
@@ -35,7 +35,7 @@ export default class UserQuickfiles extends Route.extend({
     @service ready!: Ready;
     @service router!: any;
 
-    loadModel = task(function* (this: UserQuickfiles, userModel: any) {
+    loadModel = task(function *(this: UserQuickfiles, userModel: any) {
         const blocker = this.get('ready').getBlocker();
         try {
             const user = yield userModel.taskInstance;

--- a/app/home/controller.ts
+++ b/app/home/controller.ts
@@ -8,7 +8,7 @@ import Analytics from 'ember-osf-web/services/analytics';
 import chunkArray from 'ember-osf-web/utils/chunk-array';
 
 export default class Home extends Controller.extend({
-    submit: task(function* (this: Home) {
+    submit: task(function *(this: Home) {
         const model = this.get('model');
         const { validations } = yield model.validate();
         this.set('didValidate', true);

--- a/app/models/osf-model.ts
+++ b/app/models/osf-model.ts
@@ -27,7 +27,7 @@ interface QueryHasManyResult extends Array<any> {
  */
 
 export default class OsfModel extends Model.extend({
-    queryHasManyTask: task(function* (
+    queryHasManyTask: task(function *(
         this: OsfModel,
         propertyName: any,
         queryParams?: object,

--- a/app/resolve-guid/resolved-guid-route.ts
+++ b/app/resolve-guid/resolved-guid-route.ts
@@ -12,7 +12,7 @@ export default class ResolveGuidRoute extends Route {
     @service ready!: Ready;
     @service router!: any;
 
-    loadModel = task(function* (this: ResolveGuidRoute, typeName: GuidRecord, id: string) {
+    loadModel = task(function *(this: ResolveGuidRoute, typeName: GuidRecord, id: string) {
         const blocker = this.get('ready').getBlocker();
 
         try {

--- a/app/router.ts
+++ b/app/router.ts
@@ -42,7 +42,7 @@ const Router = EmberRouter.extend({
 
 /* eslint-disable array-callback-return */
 
-Router.map(function () {
+Router.map(function() {
     // All non-guid routes (except `not-found`) belong above "Guid Routing"
     this.route('home', { path: '/' });
     this.route('goodbye');
@@ -64,7 +64,7 @@ Router.map(function () {
     this.route('guid-node', { path: '/:node_guid' });
     this.route('guid-preprint', { path: '/:preprint_guid' });
     this.route('guid-registration', { path: '/:registration_guid' });
-    this.route('guid-user', { path: '/:user_guid' }, function () {
+    this.route('guid-user', { path: '/:user_guid' }, function() {
         this.route('quickfiles');
     });
 

--- a/app/services/analytics.ts
+++ b/app/services/analytics.ts
@@ -17,7 +17,7 @@ export default class Analytics extends Service {
     @service session!: Session;
     @service router!: any;
 
-    trackPageTask = task(function* (
+    trackPageTask = task(function *(
         this: Analytics,
         publicPrivate: analyticPrivacy,
         resourceType: string,

--- a/app/services/current-user.ts
+++ b/app/services/current-user.ts
@@ -67,7 +67,7 @@ export default class CurrentUserService extends Service {
         });
     }
 
-    setWaffle = task(function* (this: CurrentUserService) {
+    setWaffle = task(function *(this: CurrentUserService) {
         const { data } = yield authenticatedAJAX({
             url: `${config.OSF.apiUrl}/v2/_waffle/`,
         });

--- a/app/services/ready.ts
+++ b/app/services/ready.ts
@@ -24,7 +24,7 @@ export default class Ready extends Service.extend(Evented) {
     lastId = 0;
     blockers = A();
 
-    tryReady = task(function* (this: Ready) {
+    tryReady = task(function *(this: Ready) {
         // Waiting until `destroy` makes sure that everyone in `render` and `afterRender`
         // (e.g. components, jQuery plugins, etc.) has a chance to call `getBlocker`, and that
         // all DOM manipulation has settled.

--- a/app/utils/i18n/missing-message.ts
+++ b/app/utils/i18n/missing-message.ts
@@ -6,7 +6,7 @@ import Locale from 'ember-i18n/utils/locale';
 
 const fallbackLocale = config.i18n.defaultLocale;
 
-export default function (this: any, locale: string, key: string, data: any) {
+export default function(this: any, locale: string, key: string, data: any) {
     if (locale === fallbackLocale) {
         return `Missing translation: ${key}`;
     }

--- a/tests/integration/components/file-list-item/component-test.ts
+++ b/tests/integration/components/file-list-item/component-test.ts
@@ -7,7 +7,7 @@ import { module, test } from 'qunit';
 module('Integration | Component | file-list-item', hooks => {
     setupRenderingTest(hooks);
 
-    test('it renders', async function (assert) {
+    test('it renders', async function(assert) {
         // Set any properties with this.set('myProperty', 'value');
         // Handle any actions with this.set('myAction', function(val) { ... });
 

--- a/tests/integration/components/file-list/component-test.ts
+++ b/tests/integration/components/file-list/component-test.ts
@@ -6,7 +6,7 @@ import { module, test } from 'qunit';
 module('Integration | Component | file-list', hooks => {
     setupRenderingTest(hooks);
 
-    test('it renders', async function (assert) {
+    test('it renders', async function(assert) {
         await render(hbs`
             {{#file-list}}
                 template block text

--- a/tests/integration/components/file-renderer/component-test.ts
+++ b/tests/integration/components/file-renderer/component-test.ts
@@ -9,7 +9,7 @@ const { OSF: { renderUrl } } = config;
 module('Integration | Component | file-renderer', hooks => {
     setupRenderingTest(hooks);
 
-    test('file rendering defaults', async function (assert) {
+    test('file rendering defaults', async function(assert) {
         const download = this.set('download', 'someTruthyValue');
 
         await render(hbs`
@@ -30,7 +30,7 @@ module('Integration | Component | file-renderer', hooks => {
         );
     });
 
-    test('specify file rendering parameters', async function (assert) {
+    test('specify file rendering parameters', async function(assert) {
         this.setProperties({
             download: 'http://cos.io/',
             height: 500,

--- a/tests/integration/components/new-project-modal/component-test.ts
+++ b/tests/integration/components/new-project-modal/component-test.ts
@@ -23,7 +23,7 @@ moduleForComponent('new-project-modal', 'Integration | Component | new project m
     },
 });
 
-test('it renders', function (assert) {
+test('it renders', function(assert) {
     this.render(hbs`{{new-project-modal
         newNode=newNode
         institutions=institutions

--- a/tests/integration/components/sort-button/component-test.ts
+++ b/tests/integration/components/sort-button/component-test.ts
@@ -9,7 +9,7 @@ moduleForComponent('sort-button', 'Integration | Component | sort button', {
     },
 });
 
-test('selected works with sortBy', function (assert) {
+test('selected works with sortBy', function(assert) {
     this.render(hbs`{{sort-button sortAction=sortAction sortBy='kindness' sort='-kindndess'}}`);
 
     assert.equal(this.$('button').length, 2);

--- a/tests/integration/components/validated-input/component-test.ts
+++ b/tests/integration/components/validated-input/component-test.ts
@@ -6,7 +6,7 @@ import { module, skip, test } from 'qunit';
 module('Integration | Component | validated input', hooks => {
     setupRenderingTest(hooks);
 
-    test('it renders', async function (assert) {
+    test('it renders', async function(assert) {
         await render(hbs`{{validated-input
             valuePath='fullName'
             placeholder='Full Name'
@@ -19,7 +19,7 @@ module('Integration | Component | validated input', hooks => {
         assert.equal(this.$('.warning').length, 0);
     });
 
-    test('render valid', async function (assert) {
+    test('render valid', async function(assert) {
         // simulates that the success element renders on success
         await render(hbs`{{validated-input
             valuePath='fullName'
@@ -33,7 +33,7 @@ module('Integration | Component | validated input', hooks => {
         assert.equal(this.$('.warning').length, 0);
     });
 
-    test('render error message', async function (assert) {
+    test('render error message', async function(assert) {
         // checks that the error message renders
         await render(hbs`{{validated-input
             valuePath='fullName'
@@ -48,7 +48,7 @@ module('Integration | Component | validated input', hooks => {
         assert.equal(this.$('.warning').length, 0);
     });
 
-    test('render to text by default', async function (assert) {
+    test('render to text by default', async function(assert) {
         await render(hbs`{{validated-input
             valuePath='fullName'
             placeholder='Full Name'
@@ -58,7 +58,7 @@ module('Integration | Component | validated input', hooks => {
         assert.equal(this.$('input[type="text"]').length, 1);
     });
 
-    test('render to text when explicitly specified', async function (assert) {
+    test('render to text when explicitly specified', async function(assert) {
         await render(hbs`{{validated-input
             valuePath='fullName'
             placeholder='Full Name'
@@ -69,7 +69,7 @@ module('Integration | Component | validated input', hooks => {
         assert.equal(this.$('input[type="text"]').length, 1);
     });
 
-    test('render to password when explicitly specified', async function (assert) {
+    test('render to password when explicitly specified', async function(assert) {
         await render(hbs`{{validated-input
             valuePath='password'
             placeholder='Password'
@@ -80,7 +80,7 @@ module('Integration | Component | validated input', hooks => {
         assert.equal(this.$('input[type="password"]').length, 1);
     });
 
-    test('render to textarea when explicitly speficied', async function (assert) {
+    test('render to textarea when explicitly speficied', async function(assert) {
         await render(hbs`{{validated-input
             valuePath='fullName'
             placeholder='Full Name'
@@ -91,7 +91,7 @@ module('Integration | Component | validated input', hooks => {
         assert.equal(this.$('textarea').length, 1);
     });
 
-    test('render to date when explicitly speficied', async function (assert) {
+    test('render to date when explicitly speficied', async function(assert) {
         // TODO: Needs improvement as there are no obvious ways to distinguish a dateField from a text.
         await render(hbs`{{validated-input
             valuePath='fullName'

--- a/tests/unit/models/user-registration.ts
+++ b/tests/unit/models/user-registration.ts
@@ -6,7 +6,7 @@ module('Unit | Model | user registration', hooks => {
     setupTest(hooks);
 
     // Replace this with your real tests.
-    test('it exists', function (assert) {
+    test('it exists', function(assert) {
         const store = this.owner.lookup('service:store');
         const model = run(() => store.createRecord('user-registration', {}));
         assert.ok(model);

--- a/tests/unit/serializers/user-registration-test.ts
+++ b/tests/unit/serializers/user-registration-test.ts
@@ -6,14 +6,14 @@ module('Unit | Serializer | user registration', hooks => {
     setupTest(hooks);
 
     // Replace this with your real tests.
-    test('it exists', function (assert) {
+    test('it exists', function(assert) {
         const store = this.owner.lookup('service:store');
         const serializer = store.serializerFor('user-registration');
 
         assert.ok(serializer);
     });
 
-    test('it serializes records', function (assert) {
+    test('it serializes records', function(assert) {
         const store = this.owner.lookup('service:store');
         const record = run(() => store.createRecord('user-registration', {}));
 

--- a/tests/unit/services/analytics-test.ts
+++ b/tests/unit/services/analytics-test.ts
@@ -5,7 +5,7 @@ module('Unit | Service | analytics', hooks => {
     setupTest(hooks);
 
     // Replace this with your real tests.
-    test('it exists', function (assert) {
+    test('it exists', function(assert) {
         const service = this.owner.lookup('service:analytics');
         assert.ok(service);
     });

--- a/tslint.json
+++ b/tslint.json
@@ -16,7 +16,7 @@
     "member-access": false,
     "no-namespace": [true, "allow-declarations"],
     "interface-name": [true, "never-prefix"],
-    "space-before-function-paren": [true, { "anonymous": false }],
+    "space-before-function-paren": [true, { "anonymous": "never" }],
     "object-literal-sort-keys": false,
     "object-literal-key-quotes": [true, "as-needed"]
   },


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Anonymous functions should be consistent with their spacing. `function()`, not `function ()`.


## Summary of Changes
Lint it up.


## Side Effects / Testing Notes
There wasn't a rule enabled for this before because eslint and tslint rules conflicted on generator functions. If they're changed to expect `function *(` instead of `function* (`, they can live in harmony.


## Ticket
n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
