### PR TITLE
Mark controller properties inited in setupController as inited

### DIFF
--- a/app/dashboard/controller.ts
+++ b/app/dashboard/controller.ts
@@ -28,7 +28,8 @@ export default class Dashboard extends Controller {
     loadingSearch: boolean = false;
     loadingMore: boolean = false;
     initialLoad: boolean = true;
-    filter: string | null = '';
+    // Initialized in setupController.
+    filter!: string | null;
     sort: string = '-last_logged';
     modalOpen: boolean = false;
     newNode: Node | null = null;

--- a/app/guid-user/quickfiles/controller.ts
+++ b/app/guid-user/quickfiles/controller.ts
@@ -19,7 +19,8 @@ export default class UserQuickfiles extends Controller {
     pageName = 'QuickFiles';
 
     filter: string = this.filter || '';
-    newProject?: Node;
+    // Initialized in setupController.
+    newProject!: Node;
     sort: string = this.sort || 'name';
 
     @alias('model.taskInstance.value.user') user!: User;

--- a/app/home/controller.ts
+++ b/app/home/controller.ts
@@ -34,7 +34,8 @@ export default class Home extends Controller.extend({
 }) {
     @service analytics!: Analytics;
 
-    didValidate?: boolean;
+    // Initialized in setupController.
+    didValidate!: boolean;
     goodbye = null;
     hasSubmitted = false;
     modalOpen: boolean = this.modalOpen || false;


### PR DESCRIPTION
## Purpose

These properties are all initialized in setupController, so they should be marked as such instead. In the case `filter` in the dashboard controller. It is initialized to `null` in setupController, so it does not not need to be initialized here.

## Summary of Changes

Mark controller properties inited in setupController as inited

## Side Effects / Testing Notes

n/a

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
