### PR TITLE
Use stable version of ember-power-select

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "ember-metrics": "^0.12.1",
     "ember-moment": "^7.6.0",
     "ember-page-title": "4.0.3",
-    "ember-power-select": "^2.0.0-beta.0",
+    "ember-power-select": "^2.0.0",
     "ember-promise-helpers": "^1.0.4",
     "ember-resolver": "^4.0.0",
     "ember-simple-auth": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3703,14 +3703,13 @@ ember-assign-polyfill@^2.0.1:
     ember-cli-babel "^6.8.2"
     ember-cli-version-checker "^2.0.0"
 
-ember-basic-dropdown@^1.0.0-beta.3:
-  version "1.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-1.0.0-beta.3.tgz#c6fb53d4cc8e4ddc1ec9f09e23207f15be7b1f04"
+ember-basic-dropdown@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-1.0.0.tgz#bbafcaab986ba86dfe8d02b0f8529984229bd738"
   dependencies:
-    ember-cli-babel "^6.11.0"
+    ember-cli-babel "^6.12.0"
     ember-cli-htmlbars "^2.0.3"
-    ember-maybe-in-element "^0.1.0"
-    ember-native-dom-helpers "^0.5.10"
+    ember-maybe-in-element "^0.1.3"
 
 ember-bootstrap-datepicker@^2.0.8:
   version "2.0.8"
@@ -3788,7 +3787,7 @@ ember-cli-autoprefixer@^0.8.1:
     broccoli-autoprefixer "^5.0.0"
     lodash "^4.0.0"
 
-ember-cli-babel@6.12.0, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.0, ember-cli-babel@^6.7.2, ember-cli-babel@^6.8, ember-cli-babel@^6.8.1, ember-cli-babel@^6.9.2:
+ember-cli-babel@6.12.0, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.12.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.0, ember-cli-babel@^6.7.2, ember-cli-babel@^6.8, ember-cli-babel@^6.8.1, ember-cli-babel@^6.9.2:
   version "6.12.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.12.0.tgz#3adcdbe1278da1fcd0b9038f1360cb4ac5d4414c"
   dependencies:
@@ -4455,9 +4454,9 @@ ember-component-css@^0.6.3:
     rsvp "^4.8.1"
     walk-sync "^0.3.2"
 
-ember-concurrency@^0.8.12, ember-concurrency@^0.8.7:
-  version "0.8.14"
-  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.8.14.tgz#4017133e5fbb9d088082ef6ab5b91839ed33107b"
+ember-concurrency@^0.8.12, ember-concurrency@^0.8.7, ember-concurrency@^0.8.18:
+  version "0.8.19"
+  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.8.19.tgz#71b9c175ba077865310029cb4bdb880e17d5155e"
   dependencies:
     babel-core "^6.24.1"
     ember-cli-babel "^6.8.2"
@@ -4700,7 +4699,7 @@ ember-maybe-import-regenerator@^0.1.5, ember-maybe-import-regenerator@^0.1.6:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
-ember-maybe-in-element@^0.1.0, ember-maybe-in-element@^0.1.3:
+ember-maybe-in-element@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/ember-maybe-in-element/-/ember-maybe-in-element-0.1.3.tgz#1c89be49246e580c1090336ad8be31e373f71b60"
   dependencies:
@@ -4722,13 +4721,6 @@ ember-moment@^7.6.0:
     ember-cli-babel "^6.7.2"
     ember-getowner-polyfill "^2.0.1"
     ember-macro-helpers "^0.17.0"
-
-ember-native-dom-helpers@^0.5.10:
-  version "0.5.10"
-  resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.5.10.tgz#9c7172e4ddfa5dd86830c46a936e2f8eca3e5896"
-  dependencies:
-    broccoli-funnel "^1.1.0"
-    ember-cli-babel "^6.6.0"
 
 ember-page-title@4.0.3:
   version "4.0.3"
@@ -4758,14 +4750,14 @@ ember-popper@^0.9.0:
     fastboot-transform "^0.1.0"
     popper.js "^1.14.1"
 
-ember-power-select@^2.0.0-beta.0:
-  version "2.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/ember-power-select/-/ember-power-select-2.0.0-beta.2.tgz#18064a309fa43d43b3c92c0d2647652ee7ac5884"
+ember-power-select@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-power-select/-/ember-power-select-2.0.0.tgz#f36e113f77006a939a62a2c6e4bcff83aebfe6c3"
   dependencies:
-    ember-basic-dropdown "^1.0.0-beta.3"
+    ember-basic-dropdown "^1.0.0"
     ember-cli-babel "^6.11.0"
     ember-cli-htmlbars "^2.0.1"
-    ember-concurrency "^0.8.12"
+    ember-concurrency "^0.8.18"
     ember-text-measurer "^0.4.0"
     ember-truth-helpers "^2.0.0"
 


### PR DESCRIPTION
## Purpose

ember-power-select 2.0.0 has been released, so we should use it.

## Summary of Changes

Upgrade to ember-power-select 2.0.0

## Side Effects / Testing Notes

n/a

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
