### PR TITLE
Disable no-restricted-globals for declaration files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,7 @@ module.exports = {
             files: ['**/*.d.ts'],
             rules: {
                 'no-unused-vars': 'off',
+                'no-restricted-globals': 'off',
             },
         },
         {

--- a/types/ember-simple-auth/mixins/data-adapter-mixin.d.ts
+++ b/types/ember-simple-auth/mixins/data-adapter-mixin.d.ts
@@ -6,10 +6,8 @@ declare module 'ember-simple-auth/mixins/data-adapter-mixin' {
         authorizer: string | null;
 
         ajaxOptions(...args: any[]): object;
-        /* eslint-disable no-restricted-globals */
         ensureResponseAuthorized(status: number, headers?: object, payload?: any, requestData?: object): void;
         handleResponse(status: number, headers: object, payload: any, requestData: object);
-        /* eslint-enable no-restricted-globals */
         headersForRequest();
     }
 

--- a/types/ember-sinon-qunit/test-support/test.d.ts
+++ b/types/ember-sinon-qunit/test-support/test.d.ts
@@ -5,7 +5,6 @@ declare module 'ember-sinon-qunit/test-support/test' {
         stub(...args: any[]): any;
     }
 
-    // eslint-disable-next-line no-restricted-globals
     function test(name: string, callback: (this: SinonTestContext, assert: Assert) => void): void;
 
     export default test;


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

The `no-restricted-globals` rule really doesn't apply with regard to TypeScript declaration files, so disable it for them.

## Summary of Changes

Disable no-restricted-globals for declaration files

## Side Effects / Testing Notes

n/a

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
