### PR TITLE
Enable i18n locales with config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Hotfix]
+### Changed
+- i18n locales are now enabled with `ENABLED_LOCALES` env variable
+
 ## [0.3.0] - 2018-05-03
 ### Added
 - Node navbar: to accompany all node pages

--- a/app/application/route.ts
+++ b/app/application/route.ts
@@ -1,8 +1,15 @@
 import { service } from '@ember-decorators/service';
 import Route from '@ember/routing/route';
 import DS from 'ember-data';
+import config from 'ember-get-config';
 import I18N from 'ember-i18n/services/i18n';
 import OsfAuthenticatedRouteMixin from 'ember-osf-web/mixins/osf-authenticated-route';
+
+const {
+    i18n: {
+        enabledLocales,
+    },
+} = config;
 
 export default class Application extends Route.extend(OsfAuthenticatedRouteMixin) {
     @service i18n!: I18N;
@@ -26,7 +33,7 @@ export default class Application extends Route.extend(OsfAuthenticatedRouteMixin
             locale = navigator.language;
         }
 
-        if (locale) {
+        if (locale && enabledLocales.includes(locale)) {
             i18n.setProperties({ locale });
         }
     }

--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -29,6 +29,7 @@ declare const config: {
     APP: {};
     i18n: {
         defaultLocale: string;
+        enabledLocales: string[];
     };
     moment: {
         includeTimezone: string;

--- a/config/environment.js
+++ b/config/environment.js
@@ -12,6 +12,7 @@ const {
     A11Y_AUDIT = 'true',
     BACKEND: backend = 'local',
     CLIENT_ID: clientId,
+    ENABLED_LOCALES = 'en, en-US',
     FB_APP_ID,
     GIT_COMMIT: release,
     GOOGLE_ANALYTICS_ID,
@@ -77,6 +78,7 @@ module.exports = function(environment) {
         },
         i18n: {
             defaultLocale: 'en-US',
+            enabledLocales: ENABLED_LOCALES.split(/[, ]+/),
         },
         moment: {
             includeTimezone: 'all',


### PR DESCRIPTION
## Purpose

Enable i18n locales with config

## Summary of Changes

* get `i18n.enabledLocales` config by splitting `ENABLED_LOCALES` env variable on comma and space.
* check that detected browser locale is in `i18n.enabledLocales` before setting it

## Side Effects / Testing Notes

Only `en` and `en-US` locales are enabled by default.

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
