### PR TITLE
[EMB-296] Add explictly making modalOpen false when hiding modal

### DIFF
--- a/app/home/template.hbs
+++ b/app/home/template.hbs
@@ -11,6 +11,7 @@
 {{#bs-modal
     open=modalOpen
     backdrop=true
+    onHidden=(action (mut modalOpen) false)
     as | modal |
 }}
     {{#modal.header}}


### PR DESCRIPTION
## Purpose
Fix bug with youtube modal:
 - On the logged out home page, click on the youtube link, a modal will pop up. Close the modal using the `x` 
 - Click on the support page on the toolbar
 -  Click back on the home page using the toolbar
 - The modal pops back up (it shouldn't)


## Ticket

https://openscience.atlassian.net/browse/EMB-296

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
