### PR TITLE
[EMB-229] Update API version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - contributor-list component, to accept lists with links
+- update OSF API version to 2.8
 
 ## [0.3.2] - 2018-05-17
 ### Fixed

--- a/config/environment.js
+++ b/config/environment.js
@@ -22,7 +22,7 @@ const {
     OSF_COOKIE_DOMAIN: cookieDomain = 'localhost',
     OSF_URL: url = 'http://localhost:5000/',
     OSF_API_URL: apiUrl = 'http://localhost:8000',
-    OSF_API_VERSION: apiVersion = '2.4',
+    OSF_API_VERSION: apiVersion = '2.8',
     OSF_RENDER_URL: renderUrl = 'http://localhost:7778/render',
     OSF_FILE_URL: waterbutlerUrl = 'http://localhost:7777/',
     OSF_HELP_URL: helpUrl = 'http://localhost:4200/help',


### PR DESCRIPTION
## Purpose

We need the latest version of the API for the Forks page, and we should keep up with versions anyways

## Summary of Changes

Increase the version

## Side Effects / Testing Notes

Everything that might go wrong would be caught in the regression test. The only likely scenario was that PATCHing might break, because that's the only thing that was in-between 2.4 and 2.8 that we were using and didn't explicitly request. 

## Ticket

https://openscience.atlassian.net/browse/EMB-229

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
