### PR TITLE
[EMB-304] GDPR ToS consent banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [hotfix]
+### Added
+- DGPR ToS banner (for existing users)
+
 ## [0.3.3] - 2018-05-24
 ### Added
 - GDPR ToS consent checkbox

--- a/app/adapters/osf-adapter.ts
+++ b/app/adapters/osf-adapter.ts
@@ -79,13 +79,13 @@ export default class OsfAdapter extends JSONAPIAdapter.extend(GenericDataAdapter
         const opts: AdapterOptions = adapterOptions || {};
 
         if (requestType === 'deleteRecord') {
-            if (record.get('links.delete')) {
+            if (record && record.get('links.delete')) {
                 url = record.get('links.delete');
-            } else if (record.get('links.self')) {
+            } else if (record && record.get('links.self')) {
                 url = record.get('links.self');
             }
         } else if (requestType === 'updateRecord' || requestType === 'findRecord') {
-            if (record.get('links.self')) {
+            if (record && record.get('links.self')) {
                 url = record.get('links.self');
             }
         } else if (opts.url) {

--- a/app/application/template.hbs
+++ b/app/application/template.hbs
@@ -5,6 +5,7 @@
     <div id="{{secondaryNavbarId}}"></div>
     {{maintenance-banner}}
     {{status-banner}}
+    {{tos-consent-banner}}
     <div class="{{routeStyleNamespaceClassSet}} Application__page">
         {{outlet}}
     </div>

--- a/app/components/tos-consent-banner/component.ts
+++ b/app/components/tos-consent-banner/component.ts
@@ -32,7 +32,7 @@ export default class TosConsentBanner extends Component {
         Object.assign(this, config.signUpPolicy);
     }
 
-    async init(this: TosConsentBanner) {
+    init(this: TosConsentBanner) {
         super.init();
         this.currentUser.checkShowTosConsentBanner();
     }

--- a/app/components/tos-consent-banner/component.ts
+++ b/app/components/tos-consent-banner/component.ts
@@ -1,0 +1,46 @@
+import { action } from '@ember-decorators/object';
+import { service } from '@ember-decorators/service';
+import Component from '@ember/component';
+import { task } from 'ember-concurrency';
+import config from 'ember-get-config';
+import Analytics from 'ember-osf-web/services/analytics';
+import CurrentUser from 'ember-osf-web/services/current-user';
+
+export default class TosConsentBanner extends Component {
+    @service analytics!: Analytics;
+    @service currentUser!: CurrentUser;
+
+    show = false;
+    didValidate?: boolean;
+    hasSubmitted = false;
+
+    saveUser = task(function* (this: TosConsentBanner) {
+        const user = yield this.currentUser.user;
+        const { validations } = yield user.validate();
+        this.set('didValidate', true);
+
+        if (!validations.isValid) {
+            return;
+        }
+
+        yield user.save();
+        this.currentUser.set('showTosConsentBanner', false);
+    }).drop();
+
+    constructor(properties: object) {
+        super(properties);
+        Object.assign(this, config.signUpPolicy);
+    }
+
+    async init(this: TosConsentBanner) {
+        super.init();
+        this.currentUser.checkShowTosConsentBanner();
+    }
+
+    @action
+    dismiss() {
+        this.analytics.click('button', 'ToS Consent Banner - dismiss');
+        this.currentUser.set('showTosConsentBanner', false);
+        return false;
+    }
+}

--- a/app/components/tos-consent-banner/styles.scss
+++ b/app/components/tos-consent-banner/styles.scss
@@ -1,0 +1,30 @@
+/* stylelint-disable selector-class-pattern */
+.TosConsentBanner {
+    &__jumbo {
+        padding-right: 15px;
+
+        .close {
+            top: 0;
+            right: 2px;
+        }
+    }
+
+    &__jumbotron {
+        padding: 10px 40px;
+        margin-bottom: 0;
+        text-align: center;
+
+        a {
+            color: #2d6a9f;
+        }
+
+        label {
+            font-weight: normal;
+            margin-bottom: 0;
+        }
+
+        .form-group {
+            margin-bottom: 0;
+        }
+    }
+}

--- a/app/components/tos-consent-banner/template.hbs
+++ b/app/components/tos-consent-banner/template.hbs
@@ -1,0 +1,36 @@
+<div class="container">
+    {{#bs-alert
+        type='default'
+        dismissible=true
+        visible=currentUser.showTosConsentBanner
+        onDismiss=(action 'dismiss')
+        classNames='TosConsentBanner__jumbo'
+    }}
+        <div class="TosConsentBanner__jumbotron jumbotron">
+            <p></p>
+            <div>
+                <h4>
+                    {{t 'tos_consent.paragraph'
+                        link1=termsLink
+                        link2=privacyPolicyLink
+                    }}
+                </h4>
+                <h5>
+                    {{#validated-input
+                        type='checkbox'
+                        model=currentUser.user
+                        didValidate=didValidate
+                        disabled=hasSubmitted
+                        valuePath='acceptedTermsOfService'
+                    }}
+                        {{t 'tos_consent.have_read_and_agree'}}
+                    {{/validated-input}}
+                </h5>
+            </div>
+            <button type="submit" class="btn btn-primary" {{action (perform saveUser)}} {{action 'click' 'button' 'ToS Consent Banner - continue' target=analytics}}>
+                {{t 'tos_consent.continue'}}
+            </button>
+            <p></p>
+        </div>
+    {{/bs-alert}}
+</div>

--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -405,6 +405,11 @@ export default {
     sign_up_policy: {
         paragraph: 'I have read and agree to the <a href="{{link1}}">Terms of Use</a> and <a href="{{link2}}">Privacy Policy</a>.',
     },
+    tos_consent: {
+        paragraph: 'We\'ve updated our <a href="{{link1}}">Terms of Use</a> and <a href="{{link2}}">Privacy Policy</a>. Please read them carefully.',
+        have_read_and_agree: 'I have read and agree to these terms.',
+        continue: 'Continue',
+    },
     validationErrors: {
         description: 'This field',
         inclusion: '{{description}} is not included in the list.',

--- a/app/locales/ja/translations.ts
+++ b/app/locales/ja/translations.ts
@@ -405,6 +405,11 @@ export default {
     sign_up_policy: {
         paragraph: '「無料で登録」をクリックすると、<a href="{{link1}}">利用規約</a>に同意し、<a href="{{link3}}">Cookieの使用</a>に関する情報を含む<a href="{{link2}}">プライバシーポリシー</a>を読んだことになります。', // TODO: update this based on en translation
     },
+    tos_consent: {
+        paragraph: 'We\'ve updated our <a href="{{link1}}">Terms of Use</a> and <a href="{{link2}}">Privacy Policy</a>. Please read them carefully.',
+        have_read_and_agree: 'I have read and agree to these terms.',
+        continue: 'Continue',
+    },
     validationErrors: {
         description: 'このフィールド',
         inclusion: '{{description}}はリストに含まれていません。',

--- a/app/locales/zh/translations.ts
+++ b/app/locales/zh/translations.ts
@@ -405,6 +405,11 @@ export default {
     sign_up_policy: {
         paragraph: 'I have read and agree to the <a href="{{link1}}">Terms of Use</a> and <a href="{{link2}}">Privacy Policy</a>.',
     },
+    tos_consent: {
+        paragraph: 'We\'ve updated our <a href="{{link1}}">Terms of Use</a> and <a href="{{link2}}">Privacy Policy</a>. Please read them carefully.',
+        have_read_and_agree: 'I have read and agree to these terms.',
+        continue: 'Continue',
+    },
     validationErrors: {
         description: 'This field',
         inclusion: '{{description}} is not included in the list.',

--- a/app/models/user.ts
+++ b/app/models/user.ts
@@ -1,5 +1,6 @@
 import { attr, hasMany } from '@ember-decorators/data';
 import { alias } from '@ember-decorators/object/computed';
+import { buildValidations, validator } from 'ember-cp-validations';
 import DS from 'ember-data';
 import File from './file';
 import Institution from './institution';
@@ -12,13 +13,21 @@ import Registration from './registration';
  * @submodule models
  */
 
+const Validations = buildValidations({
+    acceptedTermsOfService: [
+        validator('affirmation', {
+            messageKey: 'affirm_terms',
+        }),
+    ],
+});
+
 /**
  * Model for OSF APIv2 users. This model may be used with one of several API endpoints. It may be queried directly,
  *  or accessed via relationship fields.
  *
  * @class User
  */
-export default class User extends OsfModel {
+export default class User extends OsfModel.extend(Validations) {
     @attr('fixstring') fullName!: string;
     @attr('fixstring') givenName!: string;
     @attr('array') middleNames!: string[];
@@ -29,6 +38,8 @@ export default class User extends OsfModel {
     @attr('fixstring') username!: string;
 
     @attr('boolean', { defaultValue: false }) canViewReviews!: boolean;
+
+    @attr('boolean') acceptedTermsOfService?: boolean;
 
     @hasMany('node') nodes!: DS.PromiseManyArray<Node>;
     @hasMany('registration') registrations!: DS.PromiseManyArray<Registration>;

--- a/app/router.ts
+++ b/app/router.ts
@@ -24,6 +24,8 @@ const Router = EmberRouter.extend({
             }
         }
 
+        this.get('currentUser').checkShowTosConsentBanner();
+
         if (!this.readyBlocker || this.readyBlocker.isDone()) {
             this.readyBlocker = this.get('ready').getBlocker();
         }

--- a/app/serializers/osf-serializer.ts
+++ b/app/serializers/osf-serializer.ts
@@ -123,16 +123,17 @@ export default class OsfSerializer extends JSONAPISerializer.extend({
                     delete serialized.data.attributes[attribute];
                 }
             }
-
             // HACK: There's no public-API way to tell whether a relationship has been changed.
             const relationships = (snapshot as any)._internalModel._relationships.initializedRelationships;
-            for (const key of Object.keys(serialized.data.relationships)) {
-                const rel = relationships[camelize(key)];
-                if (rel
-                    && rel.members.length === rel.canonicalMembers.length
-                    && rel.members.list.every((v: any, i: any) => v === rel.canonicalMembers.list[i])
-                ) {
-                    delete serialized.data.relationships[key];
+            if (serialized.data.relationships) {
+                for (const key of Object.keys(serialized.data.relationships)) {
+                    const rel = relationships[camelize(key)];
+                    if (rel
+                        && rel.members.length === rel.canonicalMembers.length
+                        && rel.members.list.every((v: any, i: any) => v === rel.canonicalMembers.list[i])
+                    ) {
+                        delete serialized.data.relationships[key];
+                    }
                 }
             }
         }

--- a/app/services/current-user.ts
+++ b/app/services/current-user.ts
@@ -31,6 +31,7 @@ export default class CurrentUserService extends Service {
     @service features!: Features;
 
     waffleLoaded = false;
+    showTosConsentBanner = false;
 
     /**
      * If logged in, return the ID of the current user, else return null.
@@ -111,6 +112,13 @@ export default class CurrentUserService extends Service {
         }
 
         return this.get('features').isEnabled(feature);
+    }
+
+    async checkShowTosConsentBanner(this: CurrentUserService) {
+        const user = await this.user;
+        if (user && !user.acceptedTermsOfService) {
+            this.set('showTosConsentBanner', true);
+        }
     }
 }
 

--- a/tests/integration/components/tos-consent-banner/component-test.ts
+++ b/tests/integration/components/tos-consent-banner/component-test.ts
@@ -1,0 +1,42 @@
+import { run } from '@ember/runloop';
+import { render } from '@ember/test-helpers';
+import { make, mockFindRecord, setupFactoryGuy } from 'ember-data-factory-guy';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+
+module('Integration | Component | tos-consent-banner', hooks => {
+    setupRenderingTest(hooks);
+    setupFactoryGuy(hooks);
+
+    test('hidden when no user is logged in', async function(assert) {
+        await render(hbs`{{tos-consent-banner}}`);
+        assert.equal(this.$().text().trim(), '');
+    });
+
+    test('shown when current user has not accepted ToS', async function(assert) {
+        await run(async () => {
+            const session = this.owner.lookup('service:session');
+            session.set('isAuthenticated', true);
+            session.set('data', { authenticated: { id: '1' } });
+            const user = make('user', { id: '1', fullName: 'test', acceptedTermsOfService: false });
+            mockFindRecord('user').returns({ model: user });
+            await render(hbs`{{tos-consent-banner}}`);
+            assert.ok(this.$().text().trim().includes(
+                'We\'ve updated our Terms of Use and Privacy Policy. Please read them carefully.',
+            ));
+        });
+    });
+
+    test('hidden when current user has accepted ToS', async function(assert) {
+        await run(async () => {
+            const session = this.owner.lookup('service:session');
+            session.set('isAuthenticated', true);
+            session.set('data', { authenticated: { id: '1' } });
+            const user = make('user', { id: '1', acceptedTermsOfService: true });
+            mockFindRecord('user').returns({ model: user });
+            await render(hbs`{{tos-consent-banner}}`);
+            assert.equal(this.$().text().trim(), '');
+        });
+    });
+});

--- a/types/ember-data-factory-guy/index.d.ts
+++ b/types/ember-data-factory-guy/index.d.ts
@@ -1,2 +1,8 @@
-export function make(factory: string);
+export function make(factory: string, data?: object);
 export function setupFactoryGuy(hooks: any);
+
+class Mock {
+    returns(object): void;
+}
+
+export function mockFindRecord(model: string): Mock;


### PR DESCRIPTION
## Purpose

Add a banner to ask users to consent to Terms of Service.

## Summary of Changes

* add `acceptedTermsOfService` to `user` model
* add Terms of Service consent banner
  * added `tos-consent-banner` component
  * added tracking of when to show it to currentUser service
  * added `tos-consent-banner` to application template
  * added check that relationships exist before iterating on them (osf-serializer)
  * make sure record snapshot exists before getting links (for mocked models)
  * more ember-data-factory-guy types
  * added integration tests for `tos-consent-banner` component

## Side Effects / Testing Notes

Make sure it does not display for logged out users, displays for existing users that have not consented, and does not display for users that have consented.

## Ticket

https://openscience.atlassian.net/browse/EMB-304

# Reviewer Checklist

- [x] meets requirements
- [x] easy to understand
- [x] DRY
- [x] testable and includes test(s)
- [x] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
