### PR TITLE
[EMB-196] When logging out, only bother CAS once.

### DIFF
--- a/lib/osf-components/addon/components/osf-navbar/auth-dropdown/component.ts
+++ b/lib/osf-components/addon/components/osf-navbar/auth-dropdown/component.ts
@@ -3,7 +3,6 @@ import { action, computed } from '@ember-decorators/object';
 import { alias } from '@ember-decorators/object/computed';
 import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
-import { task } from 'ember-concurrency';
 import config from 'ember-get-config';
 import I18N from 'ember-i18n/services/i18n';
 import { serviceLinks } from 'ember-osf-web/const/service-links';
@@ -74,11 +73,12 @@ export default class NavbarAuthDropdown extends Component {
         return imgLink ? `${imgLink}&s=25` : '';
     }
 
-    logout = task(function *(this: NavbarAuthDropdown) {
+    @action
+    logout(this: NavbarAuthDropdown) {
+        // Assuming `redirectUrl` comes back to this app, the session will be invalidated then.
         const query = this.redirectUrl ? `?${$.param({ next_url: this.redirectUrl })}` : '';
-        yield this.session.invalidate();
         window.location.href = `${config.OSF.url}logout/${query}`;
-    });
+    }
 
     @action
     clicked(category: string, label: string) {

--- a/lib/osf-components/addon/components/osf-navbar/auth-dropdown/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/auth-dropdown/template.hbs
@@ -32,7 +32,7 @@
                 </a>
             {{/ddm.item}}
             {{#ddm.item (html-attributes role='menuitem')}}
-                <a class="logoutLink" {{action (perform logout)}} onclick={{action 'clicked' 'button' 'Navbar - Logout'}} role="button">
+                <a class="logoutLink" {{action 'logout'}} onclick={{action 'clicked' 'button' 'Navbar - Logout'}} role="button">
                     <i class="fa fa-sign-out fa-lg p-r-xs"></i>
                     {{t 'auth_dropdown.log_out'}}
                 </a>


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Avoid a [CAS error](https://openscience.atlassian.net/browse/SVCS-821) when multiple tabs try to log out at the same time.


## Summary of Changes
When the user clicks the logout button, navigate to `/logout` **without** first invalidating the ember-simple-auth session. When CAS redirects back to the app, the session will [fail to restore and be invalidated](https://github.com/CenterForOpenScience/ember-osf-web/blob/develop/app/authenticators/osf-cookie.ts#L56). Then, all other open tabs will log themselves out.


## Side Effects / Testing Notes
If the browser doesn't get back to the ember app after logging out, other tabs might still think they're logged in. This is unlikely to happen.


## Ticket

https://openscience.atlassian.net/browse/EMB-196

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
