### PR TITLE
Add flag to enable mirage in development mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [ember-css-modules-stylelint](https://github.com/dfreeman/ember-css-modules-stylelint)
 - [ember-css-modules-reporter](https://github.com/dfreeman/ember-css-modules-reporter)
 - developer handbook as in-repo engine
+- flag for enabling mirage in development mode
 
 ### Changed
 - contributor-list component, to accept lists with links

--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -135,6 +135,9 @@ declare const config: {
             turnAuditOff: boolean,
         },
     };
+    'ember-cli-mirage'?: {
+        enabled: boolean;
+    };
     engines: {
         collections: {
             enabled: boolean;

--- a/config/environment.js
+++ b/config/environment.js
@@ -20,6 +20,7 @@ const {
     GIT_COMMIT: release,
     GOOGLE_ANALYTICS_ID,
     LINT_ON_BUILD_DISABLED = false,
+    MIRAGE_ENABLED = false,
     OAUTH_SCOPES: scope,
     OSF_STATUS_COOKIE: statusCookie = 'osf_status',
     OSF_COOKIE_DOMAIN: cookieDomain = 'localhost',
@@ -220,6 +221,9 @@ module.exports = function(environment) {
                 componentOptions: {
                     turnAuditOff: A11Y_AUDIT !== 'true',
                 },
+            },
+            'ember-cli-mirage': {
+                enabled: Boolean(MIRAGE_ENABLED),
             },
         });
     }


### PR DESCRIPTION
## Purpose

By default, `ember-cli-mirage` enables mirage in development mode (it's always enabled in testing mode and never enabled in production). This can be useful for developing without needing to start the backend or before a back-end feature has been implemented, but not something we want on by default. This adds a flag to enable mirage in development (disabled by default) that can be set via an environment variable or `config/local.js`.

## Summary of Changes

Add a flag to enable mirage in development environment.

## Side Effects / Testing Notes

n/a

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
