### PR TITLE
[EMB-308] fix username length validation on landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [ember-css-modules-reporter](https://github.com/dfreeman/ember-css-modules-reporter)
 - developer handbook as in-repo engine
 - flag for enabling mirage in development mode
+- Max length validation for email on the user-registration model
 
 ### Changed
 - contributor-list component, to accept lists with links
 - update OSF API version to 2.8
 - refactored tos-consent-banner component to use ember-css-modules
+
+### Fixed
+- Max length validation of full name on the user-registration model
 
 ## [0.3.5] - 2018-05-29
 ### Fixed

--- a/app/models/user-registration.ts
+++ b/app/models/user-registration.ts
@@ -15,6 +15,9 @@ const Validations = buildValidations({
                 return [...this.get('model').get('existingEmails')];
             }).volatile(),
         }),
+        validator('length', {
+            max: 255,
+        }),
     ],
     email2: [
         validator('presence', true),

--- a/app/models/user-registration.ts
+++ b/app/models/user-registration.ts
@@ -26,7 +26,7 @@ const Validations = buildValidations({
     fullName: [
         validator('presence', true),
         validator('length', {
-            max: 255,
+            max: 200,
             min: 3,
         }),
     ],


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

The fullName field length validation was set to 255 when it should have been 200. Also, email was not being validated for length at all.

## Summary of Changes

* Adjust max length for fullName on user-registration validation
* Add max length validation to email1 field

## Side Effects / Testing Notes

Double-check length validations.

## Ticket

https://openscience.atlassian.net/browse/EMB-308

# Reviewer Checklist

- [x] meets requirements
- [x] easy to understand
- [x] DRY
- [ ] testable and includes test(s)
- [x] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
