### PR TITLE
[EMB-304] Unset acceptedTermsOfService when falsy

### DIFF
--- a/app/models/user.ts
+++ b/app/models/user.ts
@@ -39,7 +39,7 @@ export default class User extends OsfModel.extend(Validations) {
 
     @attr('boolean', { defaultValue: false }) canViewReviews!: boolean;
 
-    @attr('boolean', { allowNull: true }) acceptedTermsOfService?: boolean;
+    @attr('boolean') acceptedTermsOfService?: boolean;
 
     @hasMany('node') nodes!: DS.PromiseManyArray<Node>;
     @hasMany('registration') registrations!: DS.PromiseManyArray<Registration>;

--- a/app/services/current-user.ts
+++ b/app/services/current-user.ts
@@ -134,6 +134,8 @@ export default class CurrentUserService extends Service {
     async checkShowTosConsentBanner(this: CurrentUserService) {
         const user = await this.user;
         if (user && !user.acceptedTermsOfService) {
+            // Unset to avoid premature validation.
+            user.set('acceptedTermsOfService', undefined);
             this.set('showTosConsentBanner', true);
         }
     }


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

https://github.com/CenterForOpenScience/osf.io/commit/3a0227d0dc3b67460e4ae5e1661ff8d09334ca8c changed accepted_terms_of_service to be more correct (always a boolean), but caused the TOS Consent Banner to prematurely show a validation error. This unsets the property if falsy to avoid premature validation.

## Summary of Changes

* Unset acceptedTermsOfService when falsy
* No longer allow null for user.acceptedTermsOfService

## Side Effects / Testing Notes

Make sure consent banner does not prematurely validate.

## Ticket

https://openscience.atlassian.net/browse/EMB-304

# Reviewer Checklist

- [x] meets requirements
- [x] easy to understand
- [x] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
