### PR TITLE
Remove asset prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - contributor-list component, to accept lists with links
 - update OSF API version to 2.8
 - refactored tos-consent-banner component to use ember-css-modules
+- access assets at / instead of /ember_osf_web/
 
 ## [0.3.5] - 2018-05-29
 ### Fixed

--- a/app/index.html
+++ b/app/index.html
@@ -7,8 +7,8 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600,300,700' rel='stylesheet' type='text/css'>
-    <link rel="stylesheet" href="{{rootURL}}ember_osf_web/assets/vendor.css" class="notranslate">
-    <link rel="stylesheet" href="{{rootURL}}ember_osf_web/assets/ember-osf-web.css" class="notranslate">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css" class="notranslate">
+    <link rel="stylesheet" href="{{rootURL}}assets/ember-osf-web.css" class="notranslate">
     {{content-for "head"}}
     {{content-for "head-footer"}}
   </head>
@@ -24,8 +24,8 @@
     <script> window.prerenderReady = false; </script>
     {{content-for "body"}}
 
-    <script src="{{rootURL}}ember_osf_web/assets/vendor.js"></script>
-    <script src="{{rootURL}}ember_osf_web/assets/ember-osf-web.js"></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/ember-osf-web.js"></script>
 
     {{content-for "raven"}}
     {{content-for "zxcvbn"}}

--- a/lib/handbook/config/environment.js
+++ b/lib/handbook/config/environment.js
@@ -16,7 +16,6 @@ module.exports = function(environment) {
         'ember-cli-addon-docs': {
             docsApp: 'handbook',
             docsAppPath: 'lib/handbook/addon/',
-            assetsUrlPath: '/ember_osf_web/',
             editDocPath: '/edit/develop/lib/handbook/addon/',
             // editSourcePath: '/edit/develop/something/',
             documentedAddons: docGenerationEnabled ? ['osf-components'] : [],


### PR DESCRIPTION
## Purpose

Now that https://github.com/CenterForOpenScience/osf.io/pull/8365 has been merged, we can remove the `ember_osf_web` asset prefix.

## Summary of Changes

* Remove asset prefix from `index.html`
* Remove assetsUrlPath customization for handbook engine

## Side Effects / Testing Notes

Make sure everything still works!

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
