### PR TITLE
[EMB-304] Unset acceptedTermsOfService when falsy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [hotfix]
+### Fixed
+- Unset acceptedTermsOfService when falsy to avoid premature validation of consent checkbox
+
 ## [0.3.5] - 2018-05-29
 ### Fixed
 - Allow acceptedTermsOfService to be null to avoid premature validation of consent checkbox

--- a/app/services/current-user.ts
+++ b/app/services/current-user.ts
@@ -117,6 +117,8 @@ export default class CurrentUserService extends Service {
     async checkShowTosConsentBanner(this: CurrentUserService) {
         const user = await this.user;
         if (user && !user.acceptedTermsOfService) {
+            // Unset to avoid premature validation.
+            user.set('acceptedTermsOfService', undefined);
             this.set('showTosConsentBanner', true);
         }
     }


### PR DESCRIPTION
## Purpose

Don't prematurely validate `user.acceptedTermsOfService`

## Summary of Changes

* Unset `user.acceptedTermsOfService` when falsy

## Side Effects / Testing Notes

n/a

## Ticket

https://openscience.atlassian.net/browse/EMB-304

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
