### PR TITLE
Re-enable show ToS Consent banner test

### DIFF
--- a/tests/integration/components/tos-consent-banner/component-test.ts
+++ b/tests/integration/components/tos-consent-banner/component-test.ts
@@ -3,7 +3,7 @@ import { click, render } from '@ember/test-helpers';
 import { make, mockFindRecord, setupFactoryGuy } from 'ember-data-factory-guy';
 import { setupRenderingTest } from 'ember-osf-web/tests/helpers/osf-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { module, skip, test } from 'qunit';
+import { module, test } from 'qunit';
 
 module('Integration | Component | tos-consent-banner', hooks => {
     setupRenderingTest(hooks);
@@ -14,7 +14,7 @@ module('Integration | Component | tos-consent-banner', hooks => {
         assert.notHasText(this.element);
     });
 
-    skip('shown when current user has not accepted ToS', async function(assert) {
+    test('shown when current user has not accepted ToS', async function(assert) {
         await run(async () => {
             const session = this.owner.lookup('service:session');
             session.set('isAuthenticated', true);


### PR DESCRIPTION
## Purpose

Re-enable test disabled in hotfix to master.

## Summary of Changes

* Re-enable show ToS Consent banner test

## Side Effects / Testing Notes

n/a

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
