### PR TITLE
[EMB-307] Only show captcha when form is valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - update OSF API version to 2.8
 - refactored tos-consent-banner component to use ember-css-modules
 - access assets at / instead of /ember_osf_web/
+- only show captcha when all other form fields are valid
 
 ### Fixed
 - Max length validation of full name on the user-registration model

--- a/lib/osf-components/addon/components/sign-up-form/component.ts
+++ b/lib/osf-components/addon/components/sign-up-form/component.ts
@@ -1,4 +1,5 @@
 import { computed } from '@ember-decorators/object';
+import { alias, and } from '@ember-decorators/object/computed';
 import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
 import PasswordStrength from 'ember-cli-password-strength/services/password-strength';
@@ -52,4 +53,14 @@ export default class SignUpForm extends Component {
             return 'none';
         }
     }
+
+    @alias('model.validations.attrs') a!: object;
+
+    @and(
+        'a.fullName.isValid',
+        'a.email1.isValid',
+        'a.email2.isValid',
+        'a.password.isValid',
+        'a.acceptedTermsOfService.isValid',
+    ) formIsValid!: boolean;
 }

--- a/lib/osf-components/addon/components/sign-up-form/template.hbs
+++ b/lib/osf-components/addon/components/sign-up-form/template.hbs
@@ -54,7 +54,7 @@
     {{/validated-input}}
     {{#if (and
         (not hasSubmitted)
-        model.password
+        formIsValid
     )}}
         <div class="col-md-12 m-t-sm" local-class="RecaptchaParent">
             {{validated-input

--- a/tests/acceptance/logged-out-home-page-test.ts
+++ b/tests/acceptance/logged-out-home-page-test.ts
@@ -25,8 +25,8 @@ module('Acceptance | logged-out home page', hooks => {
         await fillIn('#fullName', 'Test User');
         await fillIn('#email1', 'test@user.com');
         await fillIn('#email2', 'test@user.com');
-        await fillIn('#password', '12345');
-        assert.found('[class*="SignUpForm"] iframe', 'Captcha iframe appears.');
+        await fillIn('#password', 'correct horse battery staple');
         await click('#acceptedTermsOfService');
+        assert.found('[class*="SignUpForm"] iframe', 'Captcha iframe appears.');
     });
 });

--- a/tests/acceptance/logged-out-home-page-test.ts
+++ b/tests/acceptance/logged-out-home-page-test.ts
@@ -22,11 +22,20 @@ module('Acceptance | logged-out home page', hooks => {
         assert.found('footer');
 
         // Check sign-up form.
+        assert.notFound('[class*="SignUpForm"] iframe', 'Empty form: no captcha appears.');
         await fillIn('#fullName', 'Test User');
+        assert.notFound('[class*="SignUpForm"] iframe', 'Filled in fullName: no captcha appears.');
         await fillIn('#email1', 'test@user.com');
+        assert.notFound('[class*="SignUpForm"] iframe', 'Filled in email1: no captcha appears.');
         await fillIn('#email2', 'test@user.com');
+        assert.notFound('[class*="SignUpForm"] iframe', 'Filled in email2: no captcha appears.');
         await fillIn('#password', 'correct horse battery staple');
+        assert.notFound('[class*="SignUpForm"] iframe', 'Filled in password: no captcha appears.');
         await click('#acceptedTermsOfService');
-        assert.found('[class*="SignUpForm"] iframe', 'Captcha iframe appears.');
+        assert.found('[class*="SignUpForm"] iframe', 'All fields valid: captcha appears.');
+        await click('#acceptedTermsOfService');
+        assert.notFound('[class*="SignUpForm"] iframe', 'Invalidate form: captcha disappears.');
+        await click('#acceptedTermsOfService');
+        assert.found('[class*="SignUpForm"] iframe', 'Revalidate form: captcha reappears.');
     });
 });


### PR DESCRIPTION
## Purpose

Only show captcha when form is valid to avoid submission of captcha with invalid data and reset captcha if server invalidates.

## Summary of Changes

* Only show captcha when form is valid
* Adjust logged out home page acceptance test to expect this

## Side Effects

The captcha won't appear until all fields are valid and ToS consent box is checked (e.g. form is ready to submit). Invalidating the form at this point will cause the captcha to disappear (regardless of if it has been completed). Once the form is valid again, the captcha is reset.

## Testing Notes

Double check there is no case where user is unable to submit when they should or able to submit when they shouldn't.

## Ticket

https://openscience.atlassian.net/browse/EMB-307

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
