### PR TITLE
Make assets prefix configurable and set to /ember_osf_web/ for prod builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - contributor-list component, to accept lists with links
 - update OSF API version to 2.8
 - refactored tos-consent-banner component to use ember-css-modules
-- access assets at / instead of /ember_osf_web/
+- access assets at `/` for development/testing builds (but retain `/ember_osf_web/` for production builds)
 - only show captcha when all other form fields are valid
 
 ### Fixed

--- a/app/index.html
+++ b/app/index.html
@@ -7,8 +7,8 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600,300,700' rel='stylesheet' type='text/css'>
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css" class="notranslate">
-    <link rel="stylesheet" href="{{rootURL}}assets/ember-osf-web.css" class="notranslate">
+    <link rel="stylesheet" href="{{content-for "assetsPrefix"}}assets/vendor.css" class="notranslate">
+    <link rel="stylesheet" href="{{content-for "assetsPrefix"}}assets/ember-osf-web.css" class="notranslate">
     {{content-for "head"}}
     {{content-for "head-footer"}}
   </head>
@@ -24,8 +24,8 @@
     <script> window.prerenderReady = false; </script>
     {{content-for "body"}}
 
-    <script src="{{rootURL}}assets/vendor.js"></script>
-    <script src="{{rootURL}}assets/ember-osf-web.js"></script>
+    <script src="{{content-for "assetsPrefix"}}assets/vendor.js"></script>
+    <script src="{{content-for "assetsPrefix"}}assets/ember-osf-web.js"></script>
 
     {{content-for "raven"}}
     {{content-for "zxcvbn"}}

--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -10,6 +10,7 @@ declare const config: {
     modulePrefix: string;
     locationType: string;
     rootURL: string;
+    assetsPrefix: string;
     sentryDSN: string | null;
     sentryOptions: {
         release?: string;

--- a/config/environment.js
+++ b/config/environment.js
@@ -51,6 +51,7 @@ module.exports = function(environment) {
         modulePrefix: 'ember-osf-web',
         environment,
         rootURL: '/',
+        assetsPrefix: '/',
         locationType: 'auto',
         sentryDSN: null,
         sentryOptions: {
@@ -207,6 +208,10 @@ module.exports = function(environment) {
             shouldIncludeStyleguide: false,
         },
     };
+
+    if (environment === 'production') {
+        ENV.assetsPrefix = '/ember_osf_web/';
+    }
 
     if (environment === 'development') {
         // ENV.APP.LOG_RESOLVER = true;

--- a/config/environment.js
+++ b/config/environment.js
@@ -10,6 +10,7 @@ try {
 
 const {
     A11Y_AUDIT = 'true',
+    ASSETS_PREFIX,
     BACKEND: backend = 'local',
     CLIENT_ID: clientId,
     ENABLED_LOCALES = 'en, en-US',
@@ -51,7 +52,7 @@ module.exports = function(environment) {
         modulePrefix: 'ember-osf-web',
         environment,
         rootURL: '/',
-        assetsPrefix: '/',
+        assetsPrefix: ASSETS_PREFIX || '/',
         locationType: 'auto',
         sentryDSN: null,
         sentryOptions: {
@@ -210,7 +211,7 @@ module.exports = function(environment) {
     };
 
     if (environment === 'production') {
-        ENV.assetsPrefix = '/ember_osf_web/';
+        ENV.assetsPrefix = ASSETS_PREFIX || '/ember_osf_web/';
     }
 
     if (environment === 'development') {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -112,7 +112,11 @@ module.exports = function(defaults) {
         'ember-cli-babel': {
             includePolyfill: true,
         },
-
+        assetLoader: {
+            generateURI(filePath) {
+                return config.assetsPrefix.replace(/\/$/, '') + filePath;
+            },
+        },
     });
 
     app.import('node_modules/dropzone/dist/dropzone.css');

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -57,6 +57,7 @@ module.exports = function(defaults) {
             exclude: [
                 'zxcvbn.js',
             ],
+            prepend: config.assetsPrefix,
         },
         sassOptions: {
             includePaths: [
@@ -76,6 +77,9 @@ module.exports = function(defaults) {
             extensions: ['js'],
         },
         inlineContent: {
+            assetsPrefix: {
+                content: config.assetsPrefix,
+            },
             raven: {
                 enabled: useCdn,
                 content: `


### PR DESCRIPTION
## Purpose

Serve assets for production builds from `/ember_osf_web/` while serving from `/` in development.

## Summary of Changes

* make assets prefix configurable
* set to /ember_osf_web/ for prod builds
* use assets prefix for finding lazy-loaded engines assets

## Side Effects / Testing Notes

n/a

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
