### PR TITLE
[EMB-298] fix css regressions

### DIFF
--- a/app/home/styles.scss
+++ b/app/home/styles.scss
@@ -519,3 +519,7 @@ footer {
         clear: left;
     }
 }
+
+.goodbye:global(.alert) {
+    margin-bottom: 0;
+}

--- a/app/home/template.hbs
+++ b/app/home/template.hbs
@@ -31,6 +31,7 @@
         <h1 local-class="hero-brand">{{t 'home.brand'}}</h1>
         <h3 local-class="hero-tagline">{{t 'home.tagline'}}</h3>
         {{osf-logo animate=true}}
+        <div id="signUp" class="anchor"></div>
         <div id="hero-signup" class="container">
             <div class="row">
                 <div class="col-sm-6 hidden-xs">
@@ -41,7 +42,6 @@
                 </div>
                 <div class="col-sm-6" local-class="sign-up-div">
                     <h2>{{t 'home.signup_title'}}</h2>
-                    <div id="signUp" class="anchor"></div>
                     <div id="signUpScope">
                         {{sign-up-form model=model didValidate=didValidate submit=(perform submit) hasSubmitted=hasSubmitted}}
                     </div>

--- a/app/home/template.hbs
+++ b/app/home/template.hbs
@@ -3,6 +3,7 @@
     {{#bs-alert
         type='success'
         classNames='text-center'
+        local-class='goodbye'
         onDismiss=(action 'click' 'button' 'Home - dismiss_alert' target=analytics)
     }}
         <p>{{t 'home.alert_logged_out'}}</p>

--- a/lib/osf-components/addon/components/file-browser-item/styles.scss
+++ b/lib/osf-components/addon/components/file-browser-item/styles.scss
@@ -28,6 +28,18 @@
             color: $color-text-white;
         }
     }
+
+    .file-row-col {
+        padding-top: 2px;
+        padding-left: 6px;
+        margin-left: 0;
+
+        display: inline-block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        height: 100%;
+    }
 }
 
 .file-row-item {
@@ -41,18 +53,6 @@
 .version-link {
     color: $color-text-blue-dark;
     font-weight: 600;
-}
-
-.file-row-col {
-    padding-top: 2px;
-    padding-left: 6px;
-    margin-left: 0;
-
-    display: inline-block;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    height: 100%;
 }
 
 .flash-message-alert {

--- a/lib/osf-components/addon/components/file-browser/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/styles.scss
@@ -174,19 +174,19 @@ a {
 .file-row-item {
     margin-left: 0;
     margin-right: 0;
-}
 
-.file-row-col {
-    padding-top: 2px;
-    padding-left: 6px;
-    margin-left: 0;
-}
+    :global(.file-row-col) {
+        padding-top: 2px;
+        padding-left: 21px;
+        margin-left: 0;
+    }
 
-.upload-file-header {
-    color: #000;
-}
+    :global(.upload-file-header) {
+        color: #000;
+    }
 
-.progress {
-    margin-bottom: 0;
-    margin-top: 7px;
+    :global(.progress) {
+        margin-bottom: 0;
+        margin-top: 7px;
+    }
 }

--- a/lib/osf-components/addon/components/file-list-item/styles.scss
+++ b/lib/osf-components/addon/components/file-list-item/styles.scss
@@ -35,16 +35,16 @@
     padding: 2px 0 4px;
     margin-left: 0;
     margin-right: 0;
-}
 
-.file-row-col {
-    padding-top: 2px;
-    padding-left: 6px;
-    margin-left: 0;
+    .file-row-col {
+        padding-top: 2px;
+        padding-left: 21px;
+        margin-left: 0;
 
-    display: inline-block;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    height: 100%;
+        display: inline-block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        height: 100%;
+    }
 }

--- a/lib/osf-components/addon/components/file-version/styles.scss
+++ b/lib/osf-components/addon/components/file-version/styles.scss
@@ -1,4 +1,4 @@
-.FileVersion__button {
+.FileVersion__button:global(.btn) {
     padding: 0;
 }
 

--- a/lib/osf-components/addon/components/inline-list/component.ts
+++ b/lib/osf-components/addon/components/inline-list/component.ts
@@ -1,9 +1,11 @@
+import { tagName } from '@ember-decorators/component';
 import { computed } from '@ember-decorators/object';
 import { alias } from '@ember-decorators/object/computed';
 import Component from '@ember/component';
 import defaultTo from 'ember-osf-web/utils/default-to';
 import layout from './template';
 
+@tagName('')
 export default class InlineList extends Component {
     layout = layout;
 

--- a/lib/osf-components/addon/components/maintenance-banner/component.ts
+++ b/lib/osf-components/addon/components/maintenance-banner/component.ts
@@ -3,9 +3,11 @@ import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
 import { task } from 'ember-concurrency';
 import config from 'ember-get-config';
+import { localClassNames } from 'ember-osf-web/decorators/css-modules';
 import Analytics from 'ember-osf-web/services/analytics';
 import $ from 'jquery';
 import moment from 'moment';
+import styles from './styles';
 import layout from './template';
 
 interface MaintenanceData {
@@ -15,6 +17,7 @@ interface MaintenanceData {
     end?: string;
 }
 
+@localClassNames('MaintenanceBanner')
 export default class MaintenanceBanner extends Component.extend({
     getMaintenanceStatus: task(function *(this: MaintenanceBanner): IterableIterator<any> {
         const url: string = `${config.OSF.apiUrl}/v2/status/`;
@@ -23,6 +26,7 @@ export default class MaintenanceBanner extends Component.extend({
     }).restartable(),
 }) {
     layout = layout;
+    styles = styles;
 
     @service analytics!: Analytics;
 

--- a/lib/osf-components/addon/components/maintenance-banner/styles.scss
+++ b/lib/osf-components/addon/components/maintenance-banner/styles.scss
@@ -1,0 +1,3 @@
+.MaintenanceBanner :global(.alert) {
+    margin-bottom: 0;
+}

--- a/lib/osf-components/addon/components/sign-up-form/styles.scss
+++ b/lib/osf-components/addon/components/sign-up-form/styles.scss
@@ -1,6 +1,10 @@
 /* stylelint-disable selector-class-pattern */
 
 .SignUpForm {
+    :global(.form-group) {
+        margin-bottom: 0;
+    }
+
     :global(.has-error) input:not(:placeholder-shown) {
         border: 1px solid #a94442;
     }
@@ -16,6 +20,10 @@
         position: relative;
     }
 
+    .tos-checkbox {
+        margin-top: 20px;
+    }
+
     @for $i from 0 through 5 {
         :global(.progress-bar-#{$i}) {
             width: #{$i * 20%};
@@ -29,9 +37,8 @@
     }
 }
 
-.CreatePassword {
-    margin-top: 5px;
-    margin-bottom: 5px;
+.CreatePassword:global(.progress) {
+    margin-bottom: 0;
     height: inherit;
 }
 

--- a/lib/osf-components/addon/components/sign-up-form/template.hbs
+++ b/lib/osf-components/addon/components/sign-up-form/template.hbs
@@ -49,6 +49,7 @@
         didValidate=didValidate
         disabled=hasSubmitted
         valuePath='acceptedTermsOfService'
+        local-class='tos-checkbox'
     }}
         {{sign-up-policy}}
     {{/validated-input}}
@@ -56,7 +57,7 @@
         (not hasSubmitted)
         formIsValid
     )}}
-        <div class="col-md-12 m-t-sm" local-class="RecaptchaParent">
+        <div class="col-md-12" local-class="RecaptchaParent">
             {{validated-input
                 type='reCaptcha'
                 model=model
@@ -71,7 +72,7 @@
         </div>
     {{else}}
         <div>
-            <button type="submit" class="btn btn-success m-t-sm" {{action submit}} {{action 'click' 'button' 'Home - sign_up' target=analytics}}>
+            <button type="submit" class="btn btn-success" {{action submit}} {{action 'click' 'button' 'Home - sign_up' target=analytics}}>
                 {{t 'sign_up_form.sign_up_free'}}
             </button>
         </div>

--- a/tests/integration/components/contributor-list/component-test.ts
+++ b/tests/integration/components/contributor-list/component-test.ts
@@ -91,7 +91,7 @@ module('Integration | Component | contributor-list', hooks => {
             };
             this.set('contributors', contributors);
             await render(hbs`{{contributor-list contributors=contributors}}`);
-            assert.hasText('div', expected);
+            assert.hasText(this.element, expected);
         }
     });
 });


### PR DESCRIPTION
## Purpose

Fix CSS regressions

## Summary of Changes

* Remove maintenance banner bottom margin
* Remove goodbye banner bottom margin
* Fix password strength indicator and other sign-up form CSS tweaks
* Move signUp anchor up
* Kill wrapper div for inline-list component
* Fix left padding on QF detail file list
* Fix padding for QF file-version buttons
* Fix file browser padding issues

## Side Effects / Testing Notes

I did some additional CSS tweaking to get things looking like production.

## Ticket

https://openscience.atlassian.net/browse/EMB-298

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(fixes for unreleased regressions)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
