### PR TITLE
Disable lint-on-build and sourcemap generation by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - refactored tos-consent-banner component to use ember-css-modules
 - access assets at `/` for development/testing builds (but retain `/ember_osf_web/` for production builds)
 - only show captcha when all other form fields are valid
+- disable lint-on-build by default (enable with `LINT_ON_BUILD`)
+- disable sourcemap generation by default (enable with `SOURCEMAPS_ENABLED`)
 
 ### Fixed
 - Max length validation of full name on the user-registration model

--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -7,6 +7,8 @@
  */
 declare const config: {
     environment: any;
+    lintOnBuild: boolean;
+    sourcemapsEnabled: boolean;
     modulePrefix: string;
     locationType: string;
     rootURL: string;
@@ -149,7 +151,6 @@ declare const config: {
             docGenerationEnabled: boolean;
         };
     };
-    lintOnBuild: boolean;
     'ember-cli-tailwind'?: {
         shouldIncludeStyleguide: boolean,
     };

--- a/config/environment.js
+++ b/config/environment.js
@@ -20,7 +20,7 @@ const {
     FB_APP_ID,
     GIT_COMMIT: release,
     GOOGLE_ANALYTICS_ID,
-    LINT_ON_BUILD_DISABLED = false,
+    LINT_ON_BUILD: lintOnBuild = false,
     MIRAGE_ENABLED = false,
     OAUTH_SCOPES: scope,
     OSF_STATUS_COOKIE: statusCookie = 'osf_status',
@@ -43,6 +43,7 @@ const {
     SHARE_BASE_URL: shareBaseUrl = 'https://staging-share.osf.io/',
     SHARE_API_URL: shareApiUrl = 'https://staging-share.osf.io/api/v2',
     SHARE_SEARCH_URL: shareSearchUrl = 'https://staging-share.osf.io/api/v2/search/creativeworks/_search',
+    SOURCEMAPS_ENABLED: sourcemapsEnabled = false,
 } = { ...process.env, ...localConfig };
 
 module.exports = function(environment) {
@@ -51,6 +52,8 @@ module.exports = function(environment) {
     const ENV = {
         modulePrefix: 'ember-osf-web',
         environment,
+        lintOnBuild,
+        sourcemapsEnabled,
         rootURL: '/',
         assetsPrefix: ASSETS_PREFIX || '/',
         locationType: 'auto',
@@ -204,7 +207,6 @@ module.exports = function(environment) {
                 docGenerationEnabled: HANDBOOK_DOC_GENERATION_ENABLED,
             },
         },
-        lintOnBuild: !LINT_ON_BUILD_DISABLED,
         'ember-cli-tailwind': {
             shouldIncludeStyleguide: false,
         },

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -73,7 +73,7 @@ module.exports = function(defaults) {
             sourceMaps: 'inline',
         },
         sourcemaps: {
-            enabled: true,
+            enabled: config.sourcemapsEnabled,
             extensions: ['js'],
         },
         inlineContent: {


### PR DESCRIPTION
## Purpose

Disable lint-on-build and sourcemap generation by default to speed up build times in default config. Devs can enable each locally by setting `LINT_ON_BUILD` and/or `SOURCEMAPS_ENABLED` to a truthy value.

## Summary of Changes

* Made `config.lintOnBuild` false by default and changed ENV var name to `LINT_ON_BUILD`
* Added `SOURCEMAPS_ENABLED` ENV var to control sourcemap generation (disabled by default)

## Side Effects / Testing Notes

Faster builds!

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
