### PR TITLE
Use ember osf web asset prefix for all builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - contributor-list component, to accept lists with links
 - update OSF API version to 2.8
 - refactored tos-consent-banner component to use ember-css-modules
-- access assets at `/` for development/testing builds (but retain `/ember_osf_web/` for production builds)
+- Make assets prefix configurable (defaults to `/ember_osf_web/`)
 - only show captcha when all other form fields are valid
 - disable lint-on-build by default (enable with `LINT_ON_BUILD`)
 - disable sourcemap generation by default (enable with `SOURCEMAPS_ENABLED`)

--- a/config/environment.js
+++ b/config/environment.js
@@ -10,7 +10,7 @@ try {
 
 const {
     A11Y_AUDIT = 'true',
-    ASSETS_PREFIX,
+    ASSETS_PREFIX: assetsPrefix = '/ember_osf_web/',
     BACKEND: backend = 'local',
     CLIENT_ID: clientId,
     ENABLED_LOCALES = 'en, en-US',
@@ -55,7 +55,7 @@ module.exports = function(environment) {
         lintOnBuild,
         sourcemapsEnabled,
         rootURL: '/',
-        assetsPrefix: ASSETS_PREFIX || '/',
+        assetsPrefix,
         locationType: 'auto',
         sentryDSN: null,
         sentryOptions: {
@@ -211,10 +211,6 @@ module.exports = function(environment) {
             shouldIncludeStyleguide: false,
         },
     };
-
-    if (environment === 'production') {
-        ENV.assetsPrefix = ASSETS_PREFIX || '/ember_osf_web/';
-    }
 
     if (environment === 'development') {
         // ENV.APP.LOG_RESOLVER = true;

--- a/config/environment.js
+++ b/config/environment.js
@@ -237,6 +237,9 @@ module.exports = function(environment) {
         // Testem prefers this...
         ENV.locationType = 'none';
 
+        // Test environment needs to find assets in the "regular" location.
+        ENV.assetsPrefix = '/';
+
         // keep test console output quieter
         ENV.APP.LOG_ACTIVE_GENERATION = false;
         ENV.APP.LOG_VIEW_LOOKUPS = false;

--- a/lib/assets-prefix-middleware/index.js
+++ b/lib/assets-prefix-middleware/index.js
@@ -1,0 +1,16 @@
+/* eslint-env node */
+
+'use strict';
+
+const express = require('express');
+const path = require('path');
+const config = require('../../config/environment')('development');
+
+module.exports = {
+    name: 'assets-prefix-middleware',
+
+    serverMiddleware({ app }) {
+        // Serve dist directory at config.assetsPrefix.
+        app.use(config.assetsPrefix, express.static(path.join(__dirname, '../../dist')));
+    },
+};

--- a/lib/assets-prefix-middleware/package.json
+++ b/lib/assets-prefix-middleware/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "assets-prefix-middleware",
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -164,9 +164,10 @@
   "homepage": "https://github.com/CenterForOpenScience/ember-osf-web#readme",
   "ember-addon": {
     "paths": [
+      "lib/assets-prefix-middleware",
       "lib/collections",
-      "lib/osf-components",
-      "lib/handbook"
+      "lib/handbook",
+      "lib/osf-components"
     ]
   }
 }

--- a/tests/test-helper.ts
+++ b/tests/test-helper.ts
@@ -8,13 +8,6 @@ import { start } from 'ember-qunit';
 setApplication(Application.create(config.APP) as any);
 
 (async () => {
-    // Remove /ember_osf_web prefix from manifest URIs.
-    Object.values(manifest.bundles).forEach(bundle => {
-        for (const asset of bundle.assets) {
-            asset.uri = asset.uri.replace(/^\/ember_osf_web/, '');
-        }
-    });
-
     // This ensures all engine resources are loaded before the tests
     await preloadAssets(manifest);
 

--- a/tests/test-helper.ts
+++ b/tests/test-helper.ts
@@ -8,6 +8,13 @@ import { start } from 'ember-qunit';
 setApplication(Application.create(config.APP) as any);
 
 (async () => {
+    // Remove /ember_osf_web prefix from manifest URIs.
+    Object.values(manifest.bundles).forEach(bundle => {
+        for (const asset of bundle.assets) {
+            asset.uri = asset.uri.replace(/^\/ember_osf_web/, '');
+        }
+    });
+
     // This ensures all engine resources are loaded before the tests
     await preloadAssets(manifest);
 


### PR DESCRIPTION
## Purpose

Because of https://github.com/CenterForOpenScience/osf.io/pull/8371/files#diff-758f58f82207e3674b3105d2b3d4ce7aR1679 we can't server Ember assets from `/assets/` (even in development) when serving through Flask, so this sets the default to `/ember_osf_web/` for all builds (not just production). The `ASSETS_PREFIX` remains configurable and can be set to `'/'` locally for directly serving on 4200. Additionally, this PR strips the `/ember_osf_web` prefix from the asset manifest so that test will continue to run, whether run in the development environment with `localhost:4200/tests` or in the test environment via `ember test`.

## Summary of Changes

* Set default assets prefix to /ember_osf_web/ for all environments
* Add express middleware to serve assets from assets prefix
* Set assets prefix to `/` in test environment

## Side Effects / Testing Notes

n/a

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
