### PR TITLE
[EMB-298] Fix up styles for status banners

### DIFF
--- a/lib/osf-components/addon/components/status-banner/styles.scss
+++ b/lib/osf-components/addon/components/status-banner/styles.scss
@@ -1,16 +1,25 @@
 .StatusBanner {
     margin: 0;
 
-    :global(.StatusBanner__jumbotron) {
+    .StatusBanner__jumbo {
+        padding: 0;
+
+        :global(.close) {
+            top: 8px;
+            right: 14px;
+        }
+    }
+
+    :global(.alert) {
+        margin-bottom: 0;
+    }
+
+    :global(.jumbotron) {
         padding: 10px 40px;
         margin-bottom: 0;
 
         a {
             color: #2d6a9f;
         }
-    }
-
-    :global(.StatusBanner__jumbo) {
-        padding: 0;
     }
 }

--- a/lib/osf-components/addon/components/status-banner/template.hbs
+++ b/lib/osf-components/addon/components/status-banner/template.hbs
@@ -1,7 +1,7 @@
 {{#each messages as |stat|}}
     {{#bs-alert
         type=stat.class
-        dismissable=stat.dismiss
+        dismissible=stat.dismiss
         classNames=(if stat.jumbo (local-class 'StatusBanner__jumbo'))
     }}
         <div class="{{if stat.jumbo 'jumbotron'}}">

--- a/lib/osf-components/addon/components/status-banner/template.hbs
+++ b/lib/osf-components/addon/components/status-banner/template.hbs
@@ -2,9 +2,9 @@
     {{#bs-alert
         type=stat.class
         dismissable=stat.dismiss
-        classNames=(if stat.jumbo 'StatusBanner__jumbo')
+        classNames=(if stat.jumbo (local-class 'StatusBanner__jumbo'))
     }}
-        <div class="{{if stat.jumbo 'StatusBanner__jumbotron jumbotron'}}">
+        <div class="{{if stat.jumbo 'jumbotron'}}">
             <p>{{t stat.id extra=stat.extra}}</p>
         </div>
     {{/bs-alert}}


### PR DESCRIPTION
## Purpose

Status banners had bottom margin.

Also:
* close button for dismissible jumbo status banners was being rendered off screen
* banners were always dismissible due to misspelling

## Summary of Changes

* Refactor styles to use `ember-css-modules` more appropriately
* Remove bottom margin for `.alert`
* Adjust position of close button for jumbo banners so it is rendered on screen and aligns with non-jumbo banners' close buttons.
* Fix spelling of dismissible

## Side Effects / Testing Notes

Make sure style changes work for all types of banners (dismissible and non-dismissible, jumbo and regular).

## Ticket

https://openscience.atlassian.net/browse/EMB-298

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
