### PR TITLE
[EMB-298] Fix Quick Files alignment/style issues

### DIFF
--- a/lib/osf-components/addon/components/file-browser-item/component.ts
+++ b/lib/osf-components/addon/components/file-browser-item/component.ts
@@ -1,3 +1,4 @@
+import { classNames } from '@ember-decorators/component';
 import { action, computed } from '@ember-decorators/object';
 import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
@@ -35,6 +36,7 @@ import layout from './template';
  * ```
  * @class file-icon
  */
+@classNames('container')
 @localClassNames('file-browser-item')
 export default class FileBrowserItem extends Component.extend({ styles }) {
     layout = layout;

--- a/lib/osf-components/addon/components/file-browser-item/styles.scss
+++ b/lib/osf-components/addon/components/file-browser-item/styles.scss
@@ -6,10 +6,15 @@
     border-bottom: 1px solid $color-border-gray-dark;
     line-height: 27px;
 
+    &:global(.container) {
+        padding-left: 0;
+        padding-right: 32px;
+    }
+
     &:hover {
         background-color: $color-text-gray-cool;
         color: $color-text-black;
-    
+
         a {
             color: inherit;
         }
@@ -30,7 +35,7 @@
     }
 
     .file-row-col {
-        padding-top: 2px;
+        padding-top: 3px;
         padding-left: 6px;
         margin-left: 0;
 

--- a/lib/osf-components/addon/components/file-browser/component.ts
+++ b/lib/osf-components/addon/components/file-browser/component.ts
@@ -137,6 +137,7 @@ export default class FileBrowser extends Component {
     @filterBy('items', 'isSelected', true) selectedItems!: File[];
     @notEmpty('filter') showFilterInput!: boolean;
     @or('showFilterClicked', 'showFilterInput') showFilter!: boolean;
+    @or('items.length', 'filter', 'isUploading') showItems!: boolean;
 
     @computed('selectedItems.firstObject.guid')
     get link(): string | undefined {

--- a/lib/osf-components/addon/components/file-browser/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/styles.scss
@@ -84,26 +84,12 @@ a {
     }
 }
 
-.column-labels-wrapper {
-    position: relative;
-
-    .column-labels-header::after {
-        position: absolute;
-        background-color: #f5f5f5;
-        width: 20px;
-        height: 33px;
-        top: 1px;
-        right: 1px;
-    }
-}
-
 .column-labels-header {
     margin: 0;
     display: block;
     height: 35px;
     background: #f5f5f5;
     border: 1px solid #eee;
-    overflow-y: scroll;
 }
 
 .file-browser-list {
@@ -174,14 +160,17 @@ a {
 .file-row-item {
     margin-left: 0;
     margin-right: 0;
+    height: 35px;
+    border-bottom: 1px solid $color-border-gray-dark;
+    line-height: 27px;
 
-    :global(.file-row-col) {
-        padding-top: 2px;
+    .file-row-col {
+        padding-top: 3px;
         padding-left: 21px;
         margin-left: 0;
     }
 
-    :global(.upload-file-header) {
+    .upload-file-header {
         color: #000;
     }
 

--- a/lib/osf-components/addon/components/file-browser/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/template.hbs
@@ -112,25 +112,23 @@
         </div>
     {{/if}}
 </div>
-<div local-class="column-labels-wrapper">
-    <div local-class="column-labels-header">
-        <div class="col-lg-7 col-md-9 col-sm-9 col-xs-12" local-class="file-browser-header header">
-            <span local-class="sortable-column">{{t 'general.name'}}</span>
-            {{sort-button sortAction=(action (mut sort)) sort=sort sortBy='name'}}
-        </div>
-        <div class="col-lg-1 col-md-1 hidden-sm hidden-xs" local-class="file-browser-header header">
-            <span local-class="sortable-column">{{t 'general.size'}}</span>
-        </div>
-        <div class="col-lg-1 hidden-md hidden-sm hidden-xs" local-class="file-browser-header header">
-            <span local-class="sortable-column">{{t 'general.version'}}</span>
-        </div>
-        <div class="col-lg-1 hidden-md hidden-sm hidden-xs" local-class="file-browser-header header">
-            <span local-class="sortable-column">{{t 'general.downloads'}}</span>
-        </div>
-        <div class="col-lg-2 col-md-2 col-sm-3 hidden-xs" local-class="file-browser-header header">
-            <span local-class="sortable-column">{{t 'general.modified'}}</span>
-            {{sort-button sortAction=(action (mut sort)) sort=sort sortBy='modified'}}
-        </div>
+<div local-class="column-labels column-labels-header">
+    <div class="col-lg-7 col-md-9 col-sm-9 col-xs-12" local-class="file-browser-header header">
+        <span local-class="sortable-column">{{t 'general.name'}}</span>
+        {{sort-button sortAction=(action (mut sort)) sort=sort sortBy='name'}}
+    </div>
+    <div class="col-lg-1 col-md-1 hidden-sm hidden-xs" local-class="file-browser-header header">
+        <span local-class="sortable-column">{{t 'general.size'}}</span>
+    </div>
+    <div class="col-lg-1 hidden-md hidden-sm hidden-xs" local-class="file-browser-header header">
+        <span local-class="sortable-column">{{t 'general.version'}}</span>
+    </div>
+    <div class="col-lg-1 hidden-md hidden-sm hidden-xs" local-class="file-browser-header header">
+        <span local-class="sortable-column">{{t 'general.downloads'}}</span>
+    </div>
+    <div class="col-lg-2 col-md-2 col-sm-3 hidden-xs" local-class="file-browser-header header">
+        <span local-class="sortable-column">{{t 'general.modified'}}</span>
+        {{sort-button sortAction=(action (mut sort)) sort=sort sortBy='modified'}}
     </div>
 </div>
 {{#bs-modal onHide=(action (mut currentModal) '') open=(eq currentModal 'info') as |modal|}}
@@ -289,41 +287,13 @@
             <div class="ball-scale ball-dark" style="text-align: center">
                 <div></div>
             </div>
-        {{else if (not (or items.length filter))}}
-            {{#if isUploading}}
-                {{#each uploading as |file|}}
-                    <div class="row">
-                        <div class="col-xs-5" local-class="file-browser-header">
-                            {{file-icon item=file}}
-                            {{file.name}}
-                        </div>
-                        <div class="col-xs-5">
-                            <div local-class="progress">
-                                <div id="uploading-{{file.size}}" class="progress-bar" role="progressbar"></div>
-                            </div>
-                        </div>
-                        <div class="col-xs-2" local-class="file-browser-header"></div>
-                    </div>
-                {{/each}}
-            {{else}}
-                <div local-class="file-placeholder">
-                    {{#if canEdit}}
-                        <div local-class="file-placeholder-content">
-                            <div>{{fa-icon 'upload' size=5}}</div>
-                            <div local-class="file-placeholder-text">{{t 'file_browser.drop_placeholder'}}</div>
-                        </div>
-                    {{else}}
-                        <div local-class="file-placeholder-text file-placeholder-content">{{t 'file_browser.no_files'}}</div>
-                    {{/if}}
-                </div>
-            {{/if}}
-        {{else}}
+        {{else if showItems}}
             <div local-class="items">
                 {{#each uploading as |file|}}
                     <div class="row" local-class="file-row-item">
-                        <div class="col-xs-5 file-row-col" local-class="file-browser-header">
+                        <div class="col-xs-5" local-class="file-browser-header file-row-col">
                             {{file-icon item=file}}
-                            <span class="upload-file-header">{{file.name}}</span>
+                            <span local-class="upload-file-header">{{file.name}}</span>
                         </div>
                         <div class="col-xs-5">
                             <div class="progress">
@@ -342,6 +312,17 @@
                         openItem=(action 'openItem')
                     }}
                 {{/each}}
+            </div>
+        {{else}}
+            <div local-class="file-placeholder">
+                {{#if canEdit}}
+                    <div local-class="file-placeholder-content">
+                        <div>{{fa-icon 'upload' size=5}}</div>
+                        <div local-class="file-placeholder-text">{{t 'file_browser.drop_placeholder'}}</div>
+                    </div>
+                {{else}}
+                    <div local-class="file-placeholder-text file-placeholder-content">{{t 'file_browser.no_files'}}</div>
+                {{/if}}
             </div>
         {{/if}}
     </div>


### PR DESCRIPTION
## Purpose

QA found a couple of style issues when there are no existing items:
* progress indicator not showing for first uploaded file
* mis-alignment of first file while uploading

This PR also fixes an issue with alignment of Quick Files header columns with item columns and vertical centering of item text.

## Summary of Changes

* Refactor file-browser template to use the same "uploading" section whether or not there existing items
* Apply bootstrap container class to file-browser items to keep them at a fixed width regardless of the presence of a scrollbar
* Increase top padding to better vertically center text.
* Localize some local classes.

## Side Effects / Testing Notes

Check first file upload with no existing items and upload with existing items. Also check file list with more items than will fit vertically so that a scrollbar appears.

## Ticket

https://openscience.atlassian.net/browse/EMB-298

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
