### PR TITLE
[EMB-322] Refactor to load active feature flags from /v2 on auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - only show captcha when all other form fields are valid
 - disable lint-on-build by default (enable with `LINT_ON_BUILD`)
 - disable sourcemap generation by default (enable with `SOURCEMAPS_ENABLED`)
+- refactorted feature flags to be loaded from /v2 base
 
 ### Fixed
 - Max length validation of full name on the user-registration model

--- a/app/authenticators/osf-cookie.ts
+++ b/app/authenticators/osf-cookie.ts
@@ -6,6 +6,7 @@ import Base from 'ember-simple-auth/authenticators/base';
 import Session from 'ember-simple-auth/services/session';
 
 import { NotLoggedIn } from 'ember-osf-web/errors';
+import CurrentUser from 'ember-osf-web/services/current-user';
 import authenticatedAJAX from 'ember-osf-web/utils/ajax-helpers';
 
 const {
@@ -21,10 +22,12 @@ interface ApiRootResponse {
     meta: {
         version: string,
         current_user: { data: { id: string } } | null, // eslint-disable-line camelcase
+        active_flags: string[], // eslint-disable-line camelcase
     };
 }
 
 export default class OsfCookie extends Base {
+    @service currentUser!: CurrentUser;
     @service session!: Session;
     @service store!: DS.Store;
 
@@ -36,6 +39,8 @@ export default class OsfCookie extends Base {
         const res: ApiRootResponse = await authenticatedAJAX({
             url: `${apiUrl}/${apiNamespace}/`,
         });
+
+        this.currentUser.setFeatures(res.meta.active_flags);
 
         const userData = res.meta.current_user;
         if (!userData) {

--- a/app/router.ts
+++ b/app/router.ts
@@ -11,6 +11,7 @@ const {
 
 const Router = EmberRouter.extend({
     currentUser: service('current-user'),
+    features: service('features'),
     statusMessages: service('status-messages'),
     ready: service('ready'),
 
@@ -22,9 +23,8 @@ const Router = EmberRouter.extend({
         const flag = routes[transition.targetName];
 
         if (flag) {
-            const enabled = await this.get('currentUser').getWaffle(flag);
-
-            if (!enabled) {
+            await this.get('currentUser').featuresAreLoaded();
+            if (!this.get('features').isEnabled(flag)) {
                 window.location.reload();
             }
         }

--- a/lib/osf-components/addon/components/osf-navbar/component.ts
+++ b/lib/osf-components/addon/components/osf-navbar/component.ts
@@ -3,7 +3,7 @@ import { equal } from '@ember-decorators/object/computed';
 import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
 import { camelize } from '@ember/string';
-import Features from 'ember-feature-flags';
+import Features from 'ember-feature-flags/services/features';
 import config from 'ember-get-config';
 import { osfServices } from 'ember-osf-web/const/service-links';
 import Analytics from 'ember-osf-web/services/analytics';

--- a/types/ember-concurrency/index.d.ts
+++ b/types/ember-concurrency/index.d.ts
@@ -69,6 +69,7 @@ interface Task<T, P> extends TaskProperty<T> {
 
 export function allSettled(promiseLikeObjects: any[]): Promise<any>;
 export function task(generator: any): Task;
+export function waitForProperty(object: object, key: string, callbackOrValue?: any): Promise<any>;
 export function waitForQueue(queue: string): Promise<any>;
 export function timeout(seconds: number): Promise<any>;
 export function all(...args: any[]): Promise<any>;

--- a/types/ember-feature-flags/services/features.d.ts
+++ b/types/ember-feature-flags/services/features.d.ts
@@ -1,0 +1,11 @@
+import Features from 'ember-feature-flags';
+
+declare module 'ember-feature-flags/services/features' {
+    export = Features;
+}
+
+declare module '@ember/service' {
+    interface Registry {
+        'features': Features;
+    }
+}


### PR DESCRIPTION
## Purpose

Load active feature flags from /v2 during auth check instead of separate check to /v2/_waffle

## Summary of Changes

* Add method in current-user service for:
  * enabling features from a list of active flags
  * awaiting features to be loaded
* Pass `active_flags` from /v2 to `currentUser.setFeatures` during auth check.
* In `router.willTransition`, if the target route is flagged, await features to be loaded then check if feature is enabled for the route flag.

## Side Effects / Testing Notes

Make sure this works for routes that require auth (e.g. dashboard) and routes that don't (e.g. support). Make sure flags load correctly whether logged-in or logged-out.

## Ticket

https://openscience.atlassian.net/browse/EMB-322

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
