### PR TITLE
[EMB-326] Set `anonymizeIp` true for google analytics

### DIFF
--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -39,6 +39,7 @@ declare const config: {
         config: {
             id?: string;
             cookieDomain?: string;
+            setFields?: { [k: string]: any };
         };
         dimensions: {
             authenticated: string;

--- a/config/environment.js
+++ b/config/environment.js
@@ -93,6 +93,9 @@ module.exports = function(environment) {
                 environments: ['all'],
                 config: {
                     id: GOOGLE_ANALYTICS_ID,
+                    setFields: {
+                        anonymizeIp: true,
+                    },
                 },
                 dimensions: {
                     authenticated: 'dimension1',

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "ember-i18n-inject": "^0.0.2",
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-metrics": "^0.12.1",
+    "ember-metrics": "https://github.com/cos-forks/ember-metrics#v0.12.1+cos0",
     "ember-moment": "^7.6.0",
     "ember-page-title": "4.0.3",
     "ember-power-select": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5540,9 +5540,9 @@ ember-maybe-in-element@^0.1.3:
   dependencies:
     ember-cli-babel "^6.11.0"
 
-ember-metrics@^0.12.1:
+"ember-metrics@https://github.com/cos-forks/ember-metrics#v0.12.1+cos0":
   version "0.12.1"
-  resolved "https://registry.yarnpkg.com/ember-metrics/-/ember-metrics-0.12.1.tgz#8659343bf7b8bda403e70d482ff59cc9714d89f6"
+  resolved "https://github.com/cos-forks/ember-metrics#32fcc6eec0c4bc1974c854435401f94f660c6e74"
   dependencies:
     broccoli-funnel "^1.0.1"
     ember-cli-babel "^6.1.0"


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Anonymize IPs sent to google analytics


## Summary of Changes
Switch ember-metrics to a cos-fork that allows setting fields, and configure it to add anonymizeIp: true


## Side Effects / Testing Notes
Main visible effect: Requests sent to google analytics now have the query param `aip=1`.


## Ticket

https://openscience.atlassian.net/browse/EMB-326

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
