### PR TITLE
Move node-navbar buffer inside wormhole and adjust to height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Components:
+    - `node-navbar` - banner overlapping
 
 ## [0.4.1] - 2018-06-26
 ### Changed

--- a/lib/osf-components/addon/components/node-navbar/component.ts
+++ b/lib/osf-components/addon/components/node-navbar/component.ts
@@ -2,7 +2,6 @@ import { action, computed } from '@ember-decorators/object';
 import Component from '@ember/component';
 import config from 'ember-get-config';
 import Node from 'ember-osf-web/models/node';
-import defaultTo from 'ember-osf-web/utils/default-to';
 import styles from './styles';
 import layout from './template';
 
@@ -12,7 +11,6 @@ export default class NodeNavbar extends Component {
 
     node?: Node;
     allowComments?: boolean;
-    renderInPlace: boolean = defaultTo(this.renderInPlace, false);
     secondaryNavbarId = config.secondaryNavbarId;
     collapsedNav = true;
 

--- a/lib/osf-components/addon/components/node-navbar/styles.scss
+++ b/lib/osf-components/addon/components/node-navbar/styles.scss
@@ -4,5 +4,5 @@
 }
 
 .NodeNavbar__navbar-buffer {
-    padding-top: 50px;
+    padding-top: 42px;
 }

--- a/lib/osf-components/addon/components/node-navbar/template.hbs
+++ b/lib/osf-components/addon/components/node-navbar/template.hbs
@@ -35,7 +35,5 @@
             {{/bs-collapse}}
         </div>
     </nav>
-{{/ember-wormhole}}
-{{#unless renderInPlace}}
     <div local-class='NodeNavbar__navbar-buffer'></div>
-{{/unless}}
+{{/ember-wormhole}}


### PR DESCRIPTION
## Purpose

Prevent node-navbar from overlapping banners.

## Summary of Changes

* Move node-navbar buffer inside wormhole and adjust to height

## Side Effects / Testing Notes

Make sure it works with various (and no) banners enabled.

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
