### PR TITLE
Auto-deploy handbook to GitHub pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
         - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
 
     - stage: "deploy handbook"
-      if: branch = develop
+      if: branch = develop AND type != pull_request
       before_install:
         - curl -o- -L https://yarnpkg.com/install.sh | bash
         - export PATH=$HOME/.yarn/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
       deploy:
         provider: pages
         skip-cleanup: true
-        github-token: $GITHUB_TOKEN
+        github-token: $GH_TOKEN
         local-dir: dist
         on:
           branch: develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ language: node_js
 sudo: false
 dist: trusty
 
-addons:
-  chrome: stable
-  firefox: latest
-
 env:
   global:
     - SUPPRESS_NO_CONFIG_WARNING=true
@@ -17,20 +13,44 @@ cache:
   directories:
     - node_modules
 
-before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
-  - export PATH=$HOME/.yarn/bin:$PATH
-  - yarn global add greenkeeper-lockfile@1
+jobs:
+  include:
+    - stage: "test"
+      addons:
+        chrome: stable
+        firefox: latest
+      before_install:
+        - curl -o- -L https://yarnpkg.com/install.sh | bash
+        - export PATH=$HOME/.yarn/bin:$PATH
+        - yarn global add greenkeeper-lockfile@1
+      install:
+        - yarn --prefer-offline --frozen-lockfile --ignore-engines
+        - greenkeeper-lockfile-update
+      script:
+        - yarn lint && yarn test:node-tests && yarn test:cover
+      after_script:
+        - greenkeeper-lockfile-upload
+      after_success:
+        - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
 
-install:
-  - greenkeeper-lockfile-update
-  - yarn --prefer-offline --frozen-lockfile --ignore-engines
-
-script:
-  - yarn lint && yarn test:node-tests && yarn test:cover
-
-after_script:
-  - greenkeeper-lockfile-upload
-
-after_success:
-  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+    - stage: "deploy handbook"
+      if: branch = develop
+      before_install:
+        - curl -o- -L https://yarnpkg.com/install.sh | bash
+        - export PATH=$HOME/.yarn/bin:$PATH
+      install:
+        - yarn --prefer-offline --frozen-lockfile --ignore-engines
+      env:
+        - HANDBOOK_ENABLED=1
+        - MIRAGE_ENABLED=1
+        - ROOT_URL=/ember-osf-web/
+        - ASSETS_PREFIX=/ember-osf-web/
+      script:
+        - ember build --environment=production && cp dist/index.html dist/404.html
+      deploy:
+        provider: pages
+        skip-cleanup: true
+        github-token: $GITHUB_TOKEN
+        local-dir: dist
+        on:
+          branch: develop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- DX:
+  - Auto-deployment of handbook to GitHub pages on Travis `develop` branch builds
+
+### Changed
+- DX:
+  - `rootURL` is now configurable via `ROOT_URL` environment variable
+  - production builds will respect `MIRAGE_ENABLED`
+  - `ember-cli-addon-docs` in handbook will use `ASSETS_PREFIX` to find assets
+
 ### Fixed
 - Components:
     - `node-navbar` - banner overlapping

--- a/app/application/controller.ts
+++ b/app/application/controller.ts
@@ -15,6 +15,7 @@ export default class Application extends Controller {
     secondaryNavbarId = config.secondaryNavbarId;
     signupUrl = `${pathJoin(config.OSF.url, 'register')}?${$.param({ next: window.location.href })}`;
 
+    // This is a hack until we refactor the nav bar/page headers to be customizable by routes.
     @match('router.currentRouteName', /^handbook/) disableHeaders!: boolean;
 
     @action

--- a/app/application/controller.ts
+++ b/app/application/controller.ts
@@ -1,6 +1,8 @@
 import { action } from '@ember-decorators/object';
+import { match } from '@ember-decorators/object/computed';
 import { service } from '@ember-decorators/service';
 import Controller from '@ember/controller';
+import { Registry as Services } from '@ember/service';
 import config from 'ember-get-config';
 import CurrentUser from 'ember-osf-web/services/current-user';
 import pathJoin from 'ember-osf-web/utils/path-join';
@@ -8,9 +10,12 @@ import $ from 'jquery';
 
 export default class Application extends Controller {
     @service currentUser!: CurrentUser;
+    @service router!: Services['router'];
 
     secondaryNavbarId = config.secondaryNavbarId;
     signupUrl = `${pathJoin(config.OSF.url, 'register')}?${$.param({ next: window.location.href })}`;
+
+    @match('router.currentRouteName', /^handbook/) disableHeaders!: boolean;
 
     @action
     login() {

--- a/app/application/template.hbs
+++ b/app/application/template.hbs
@@ -1,11 +1,13 @@
 {{head-layout}}
 {{title (t 'general.OSF')}}
 <div local-class="Application">
-    {{osf-navbar signupUrl=signupUrl loginAction=(action 'login')}}
-    <div id="{{secondaryNavbarId}}"></div>
-    {{maintenance-banner}}
-    {{status-banner}}
-    {{tos-consent-banner}}
+    {{#unless disableHeaders}}
+        {{osf-navbar signupUrl=signupUrl loginAction=(action 'login')}}
+        <div id="{{secondaryNavbarId}}"></div>
+        {{maintenance-banner}}
+        {{status-banner}}
+        {{tos-consent-banner}}
+    {{/unless}}
     <div local-class="Application__page">
         {{outlet}}
     </div>

--- a/config/environment.js
+++ b/config/environment.js
@@ -41,6 +41,7 @@ const {
     // https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha-v2-what-should-i-do
     RECAPTCHA_SITE_KEY = '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI',
     REDIRECT_URI: redirectUri,
+    ROOT_URL: rootURL = '/',
     SHARE_BASE_URL: shareBaseUrl = 'https://staging-share.osf.io/',
     SHARE_API_URL: shareApiUrl = 'https://staging-share.osf.io/api/v2',
     SHARE_SEARCH_URL: shareSearchUrl = 'https://staging-share.osf.io/api/v2/search/creativeworks/_search',
@@ -55,7 +56,7 @@ module.exports = function(environment) {
         environment,
         lintOnBuild,
         sourcemapsEnabled,
-        rootURL: '/',
+        rootURL,
         assetsPrefix,
         locationType: 'auto',
         sentryDSN: null,
@@ -218,6 +219,9 @@ module.exports = function(environment) {
         'ember-cli-tailwind': {
             shouldIncludeStyleguide: false,
         },
+        'ember-cli-mirage': {
+            enabled: Boolean(MIRAGE_ENABLED),
+        },
     };
 
     if (environment === 'development') {
@@ -235,9 +239,6 @@ module.exports = function(environment) {
                     turnAuditOff: A11Y_AUDIT !== 'true',
                 },
             },
-            'ember-cli-mirage': {
-                enabled: Boolean(MIRAGE_ENABLED),
-            },
         });
     }
 
@@ -247,6 +248,9 @@ module.exports = function(environment) {
 
         // Test environment needs to find assets in the "regular" location.
         ENV.assetsPrefix = '/';
+
+        // Always enable mirage for tests.
+        ENV['ember-cli-mirage'].enabled = true;
 
         // keep test console output quieter
         ENV.APP.LOG_ACTIVE_GENERATION = false;

--- a/lib/handbook/config/environment.js
+++ b/lib/handbook/config/environment.js
@@ -4,7 +4,9 @@
 const projectConfig = require('../../../config/environment');
 
 module.exports = function(environment) {
-    const { docGenerationEnabled } = projectConfig(environment).engines.handbook;
+    const config = projectConfig(environment);
+
+    const { docGenerationEnabled } = config.engines.handbook;
 
     const ENV = {
         modulePrefix: 'handbook',
@@ -14,6 +16,7 @@ module.exports = function(environment) {
         docGenerationEnabled,
 
         'ember-cli-addon-docs': {
+            assetsUrlPath: config.assetsPrefix,
             docsApp: 'handbook',
             docsAppPath: 'lib/handbook/addon/',
             editDocPath: '/edit/develop/lib/handbook/addon/',

--- a/lib/handbook/config/environment.js
+++ b/lib/handbook/config/environment.js
@@ -16,7 +16,7 @@ module.exports = function(environment) {
         docGenerationEnabled,
 
         'ember-cli-addon-docs': {
-            assetsUrlPath: config.assetsPrefix,
+            assetsUrlPath: `${config.assetsPrefix}engines-dist/handbook/`,
             docsApp: 'handbook',
             docsAppPath: 'lib/handbook/addon/',
             editDocPath: '/edit/develop/lib/handbook/addon/',

--- a/lib/handbook/index.js
+++ b/lib/handbook/index.js
@@ -6,7 +6,7 @@ module.exports = EngineAddon.extend({
     name: 'handbook',
 
     lazyLoading: {
-        enabled: false,
+        enabled: true,
     },
 
     isDevelopingAddon() {


### PR DESCRIPTION
## Purpose

Auto-deploy handbook to GitHub pages when travis runs for the `develop` branch

## Summary of Changes

* make `rootURL` configurable via environment variable
* make `MIRAGE_ENABLED` environment variable apply to all build environments except `test`
* use `assetsPrefix` for handbook `assetsUrlPath`
* enable lazy loading for handbook engine
* configure Travis to build and deploy the handbook to GitHub pages as a separate build stage that is only run for the `develop` branch

## Side Effects / Testing Notes

Example build with deploy: https://travis-ci.org/jamescdavis/ember-osf-web/builds/397410596
(when this build ran, was configured to deploy for `deploy_github_pages` branch, since changed to `develop`)

Deployed to: https://jamescdavis.github.io/ember-osf-web/handbook

Example build on branch that shouldn't deploy: https://travis-ci.org/jamescdavis/ember-osf-web/builds/397429550
(When this build ran, was configured to deploy for `develop` branch. Note the lack of `Deploy handbook` stage.)

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
