### PR TITLE
Remove unnecessary and overzealous wrapping

### DIFF
--- a/lib/analytics-page/addon/application/styles.scss
+++ b/lib/analytics-page/addon/application/styles.scss
@@ -1,7 +1,6 @@
 @media (min-width: 768px) {
     .Counts {
         display: flex;
-        flex-wrap: wrap;
     }
 }
 


### PR DESCRIPTION
## Purpose

The analytics tab has three bootstrap columns that are also flexwrapped. That causes them to do this:

![screen shot 2018-06-28 at 10 04 05 am](https://user-images.githubusercontent.com/6599111/42039963-9938f44a-7abc-11e8-9c95-ace598b9d490.png)


## Summary of Changes

Remove the wrap so that it looks like

![screen shot 2018-06-28 at 10 03 53 am](https://user-images.githubusercontent.com/6599111/42039984-a3b6e828-7abc-11e8-9d42-318f24634b1d.png)



## Side Effects / Testing Notes

Tested in the browser by modifying the CSS, not yet tested locally because docker. Should be _fine_.


# Reviewer Checklist

- [x] meets requirements
- [x] easy to understand
- [x] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
