### PR TITLE
[EMB-334] Analytics title, pagination controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- `simple-paginator` component: Use &gt; and &lt; instead of font-awesome chevrons
+- Analytics engine: Set page title to "OSF | [node title] Analytics"
+- Test assertions: Collapse all whitespace characters to a single space
+
 ## [0.5.0] - 2018-06-29
 ### Added
 - Routes:

--- a/app/app.ts
+++ b/app/app.ts
@@ -36,6 +36,8 @@ const App = Application.extend({
                     'store',
                     'analytics',
                     'ready',
+                    'page-title-list',
+                    'head-data',
                 ],
                 externalRoutes: {
                     nodeForks: 'guid-node.forks',

--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -575,6 +575,7 @@ export default {
         },
     },
     analytics: {
+        pageTitle: '{{nodeTitle}} Analytics',
         forks: 'Forks',
         viewForks: 'View forks',
         links: 'Links to this project',

--- a/app/locales/ja/translations.ts
+++ b/app/locales/ja/translations.ts
@@ -575,6 +575,7 @@ export default {
         },
     },
     analytics: {
+        pageTitle: '{{nodeTitle}} Analytics',
         forks: 'Forks',
         viewForks: 'View forks',
         links: 'Links to this project',

--- a/app/locales/zh/translations.ts
+++ b/app/locales/zh/translations.ts
@@ -575,6 +575,7 @@ export default {
         },
     },
     analytics: {
+        pageTitle: '{{nodeTitle}} Analytics',
         forks: 'Forks',
         viewForks: 'View forks',
         links: 'Links to this project',

--- a/lib/analytics-page/addon/application/template.hbs
+++ b/lib/analytics-page/addon/application/template.hbs
@@ -1,3 +1,4 @@
+{{title (t 'analytics.pageTitle' nodeTitle=node.title)}}
 <div class="container">
     <div local-class='Counts' class='row'>
         <div class='col-sm-4 panel panel-default' local-class='CountBox'>

--- a/lib/analytics-page/addon/engine.js
+++ b/lib/analytics-page/addon/engine.js
@@ -16,6 +16,8 @@ const Eng = Engine.extend({
             'store',
             'analytics',
             'ready',
+            'page-title-list',
+            'head-data',
         ],
         externalRoutes: [
             'nodeForks',

--- a/lib/analytics-page/package.json
+++ b/lib/analytics-page/package.json
@@ -18,7 +18,8 @@
     "ember-css-modules-sass": "*",
     "ember-i18n": "*",
     "ember-i18n-inject": "*",
-    "ember-font-awesome": "*"
+    "ember-font-awesome": "*",
+    "ember-page-title": "*"
   },
   "ember-addon": {
     "paths": [

--- a/lib/osf-components/addon/components/simple-paginator/template.hbs
+++ b/lib/osf-components/addon/components/simple-paginator/template.hbs
@@ -2,7 +2,7 @@
     <span local-class='SimplePaginator__element'>
         {{#bs-button disabled=(not hasPrev) onClick=(action previousPage)}}
             <span aria-label="{{t 'paginator.previous'}}">
-                {{fa-icon 'chevron-left'}}
+                &lt;
             </span>
         {{/bs-button}}
     </span>
@@ -12,7 +12,7 @@
     <span local-class='SimplePaginator__element'>
         {{#bs-button disabled=(not hasNext) onClick=(action nextPage)}}
             <span aria-label="{{t 'paginator.previous'}}">
-                {{fa-icon 'chevron-right'}}
+                &gt;
             </span>
         {{/bs-button}}
     </span>

--- a/tests/assertions/has-text.ts
+++ b/tests/assertions/has-text.ts
@@ -8,7 +8,9 @@ export default function hasText<Context extends TestContext>(
     expected: string,
     message: string = makeMessage(subject, 'has text', expected),
 ) {
-    const actual = getElement(context, subject).innerText.trim();
+    const actual = getElement(context, subject).innerText
+        .trim()
+        .replace(/\s+/g, ' ');
     const result = actual === expected;
     this.pushResult({ result, actual, expected, message });
 }

--- a/tests/assertions/includes-text.ts
+++ b/tests/assertions/includes-text.ts
@@ -8,7 +8,9 @@ export default function includesText<Context extends TestContext>(
     expected: string,
     message: string = makeMessage(subject, 'includes text', expected),
 ) {
-    const actual = getElement(context, subject).innerText.trim();
+    const actual = getElement(context, subject).innerText
+        .trim()
+        .replace(/\s+/g, ' ');
     const result = actual.includes(expected);
     this.pushResult({ result, actual, expected, message });
 }

--- a/tests/assertions/not-has-text.ts
+++ b/tests/assertions/not-has-text.ts
@@ -7,7 +7,9 @@ export default function notHasText<Context extends TestContext>(
     subject: ElemOrSelector,
     message: string = makeMessage(subject, 'does not have text'),
 ) {
-    const actual = getElement(context, subject).innerText.trim();
+    const actual = getElement(context, subject).innerText
+        .trim()
+        .replace(/\s+/g, ' ');
     const expected = '';
     const result = actual === expected;
     this.pushResult({ result, actual, expected, message });

--- a/tests/assertions/not-includes-text.ts
+++ b/tests/assertions/not-includes-text.ts
@@ -8,7 +8,9 @@ export default function notIncludesText<Context extends TestContext>(
     expected: string,
     message: string = makeMessage(subject, 'does not include text', expected),
 ) {
-    const actual = getElement(context, subject).innerText.trim();
+    const actual = getElement(context, subject).innerText
+        .trim()
+        .replace(/\s+/g, ' ');
     const result = !actual.includes(expected);
     this.pushResult({ result, actual, expected, message, negative: true });
 }

--- a/tests/integration/components/simple-paginator/component-test.ts
+++ b/tests/integration/components/simple-paginator/component-test.ts
@@ -14,7 +14,7 @@ module('Integration | Component | simple-paginator', hooks => {
 
     test('it renders', async function(assert) {
         await render(hbs`{{simple-paginator nextPage=stubAction previousPage=stubAction maxPage=3 curPage=2}}`);
-        assert.hasText(this.element, 'Page 2 of 3');
+        assert.hasText(this.element, '< Page 2 of 3 >');
     });
 
     test('if no more than 1 page, don\'t show paginator at all', async function(assert) {


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Set `<title>` on the analytics page, and make pagination controls more old-browser-friendly.


## Summary of Changes
Pass everything needed for the `{{title}}` helper to work into the `analytics-page` engine, then use `{{title}}`.

Use `&gt;` and `&lt;` instead of font-awesome chevrons:
![screen shot 2018-06-29 at 17 00 51](https://user-images.githubusercontent.com/6776190/42114814-76d1a1b0-7bbe-11e8-97b6-be1a9f4225f9.png)



## Side Effects / Testing Notes
Pagination controls on the forks page and analytics links popup are affected.

The title on the analytics page should now be "OSF | [node title] Analytics" instead of just "OSF".

## Ticket

https://openscience.atlassian.net/browse/EMB-334

# Reviewer Checklist

- [x] meets requirements
- [x] easy to understand
- [x] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
