### PR TITLE
[EMB-314] Display a banner from the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Models:
+    - `banner` - used to fetch `/_/banners/current/` from the API
+- Components:
+    - `scheduled-banner` - display the "current" banner on the landing page(s)
+
 ## [0.5.0] - 2018-06-29
 ### Added
 - Routes:

--- a/app/adapters/banner.ts
+++ b/app/adapters/banner.ts
@@ -1,0 +1,11 @@
+import OsfAdapter from './osf-adapter';
+
+export default class BannerAdapter extends OsfAdapter {
+    namespace = '_';
+}
+
+declare module 'ember-data' {
+    interface AdapterRegistry {
+        'banner': BannerAdapter;
+    }
+}

--- a/app/dashboard/template.hbs
+++ b/app/dashboard/template.hbs
@@ -14,6 +14,7 @@
         create=(perform createNode)
     }}
 {{/if}}
+{{scheduled-banner}}
 <div local-class="quickSearch">
     <div class="container p-t-lg">
         <div class="row m-t-lg {{if (or (gt nodes.length 9) loading) (local-class 'quick-search-contents')}}">

--- a/app/home/template.hbs
+++ b/app/home/template.hbs
@@ -25,6 +25,7 @@
         }}
     {{/modal.body}}
 {{/bs-modal}}
+{{scheduled-banner}}
 <div id="home-hero">
     <div class="container text-center">
         <div local-class="network-bg"></div>

--- a/app/models/banner.ts
+++ b/app/models/banner.ts
@@ -1,0 +1,20 @@
+import { attr } from '@ember-decorators/data';
+
+import OsfModel from './osf-model';
+
+export default class BannerModel extends OsfModel {
+    @attr('date') startDate!: Date;
+    @attr('date') endDate!: Date;
+    @attr('string') name!: string; // eslint-disable-line no-restricted-globals
+    @attr('string') link!: string;
+    @attr('string') mobileAltText!: string;
+    @attr('string') defaultAltText!: string;
+    @attr('string') license!: string;
+    @attr('string') color!: string;
+}
+
+declare module 'ember-data' {
+  interface ModelRegistry {
+    'banner': BannerModel;
+  }
+}

--- a/app/serializers/banner.ts
+++ b/app/serializers/banner.ts
@@ -1,0 +1,25 @@
+import DS from 'ember-data';
+
+import OsfSerializer from './osf-serializer';
+
+export default class BannerAdapter extends OsfSerializer {
+    normalizeSingleResponse(
+        store: DS.Store,
+        primaryModelClass: any,
+        payload: any,
+        id: string,
+        requestType: string,
+    ): any {
+        // The banner payload currently has an empty ID
+        if (payload.data && payload.data.id === '') {
+            payload.data.id = id; // eslint-disable-line no-param-reassign
+        }
+        return super.normalizeSingleResponse(store, primaryModelClass, payload, id, requestType);
+    }
+}
+
+declare module 'ember-data' {
+    interface SerializerRegistry {
+        'banner': BannerAdapter;
+    }
+}

--- a/lib/osf-components/addon/components/scheduled-banner/component.ts
+++ b/lib/osf-components/addon/components/scheduled-banner/component.ts
@@ -1,0 +1,36 @@
+import { computed } from '@ember-decorators/object';
+import { readOnly } from '@ember-decorators/object/computed';
+import { service } from '@ember-decorators/service';
+import Component from '@ember/component';
+import { htmlSafe } from '@ember/string';
+import { task } from 'ember-concurrency';
+import DS from 'ember-data';
+
+import Banner from 'ember-osf-web/models/banner';
+import Analytics from 'ember-osf-web/services/analytics';
+import styles from './styles';
+import layout from './template';
+
+export default class ScheduledBanners extends Component.extend({
+    loadBanner: task(function *(this: ScheduledBanners) {
+        const banner = yield this.store.findRecord('banner', 'current');
+        return banner.name ? banner : null;
+    }).on('init'),
+}) {
+    @service store!: DS.Store;
+    @service analytics!: Analytics;
+
+    layout = layout;
+    styles = styles;
+
+    @readOnly('loadBanner.last.value')
+    banner?: Banner;
+
+    @computed('banner.color')
+    get bannerWrapperStyle() {
+        if (!this.banner) {
+            return null;
+        }
+        return htmlSafe(`background-color: ${this.banner.color};`);
+    }
+}

--- a/lib/osf-components/addon/components/scheduled-banner/styles.scss
+++ b/lib/osf-components/addon/components/scheduled-banner/styles.scss
@@ -1,0 +1,4 @@
+.Image {
+    margin: auto;
+    max-height: 300px;
+}

--- a/lib/osf-components/addon/components/scheduled-banner/template.hbs
+++ b/lib/osf-components/addon/components/scheduled-banner/template.hbs
@@ -1,0 +1,26 @@
+{{#if banner}}
+    {{#scheduled-banner/x-maybe-link href=banner.link}}
+        <div style={{bannerWrapperStyle}}>
+            <div class="container">
+                <div class="row">
+                    <div class="col-sm-10 col-sm-offset-1 col-lg-8 col-lg-offset-2 hidden-xs">
+                        <img
+                            src={{banner.links.default_photo}}
+                            alt={{banner.defaultAltText}}
+                            local-class="Image"
+                            class="img-responsive"
+                        >
+                    </div>
+                    <div class="col-xs-12 hidden-sm hidden-md hidden-lg hidden-xl">
+                        <img
+                            src={{banner.links.mobile_photo}}
+                            alt={{banner.mobileAltText}}
+                            local-class="Image"
+                            class="img-responsive"
+                        >
+                    </div>
+                </div>
+            </div>
+        </div>
+    {{/scheduled-banner/x-maybe-link}}
+{{/if}}

--- a/lib/osf-components/addon/components/scheduled-banner/x-maybe-link/component.ts
+++ b/lib/osf-components/addon/components/scheduled-banner/x-maybe-link/component.ts
@@ -1,0 +1,13 @@
+import { service } from '@ember-decorators/service';
+import Component from '@ember/component';
+
+import Analytics from 'ember-osf-web/services/analytics';
+import layout from './template';
+
+export default class BannerMaybeLink extends Component {
+    @service analytics!: Analytics;
+    layout = layout;
+
+    // Required argument
+    href!: string;
+}

--- a/lib/osf-components/addon/components/scheduled-banner/x-maybe-link/template.hbs
+++ b/lib/osf-components/addon/components/scheduled-banner/x-maybe-link/template.hbs
@@ -1,0 +1,13 @@
+{{#if href}}
+    <a
+        href={{href}}
+        onclick={{action 'click' 'link' (concat 'Banner - ' banner.name) target=analytics}}
+        target="_blank"
+        rel="noopener"
+    >
+        {{yield}}
+    </a>
+{{else}}
+    {{yield}}
+{{/if}}
+

--- a/lib/osf-components/app/components/scheduled-banner/component.ts
+++ b/lib/osf-components/app/components/scheduled-banner/component.ts
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/scheduled-banner/component';

--- a/lib/osf-components/app/components/scheduled-banner/x-maybe-link/component.ts
+++ b/lib/osf-components/app/components/scheduled-banner/x-maybe-link/component.ts
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/scheduled-banner/x-maybe-link/component';

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -123,4 +123,18 @@ export default function() {
         }));
         return { data: waffles };
     });
+
+    // Private namespace
+    this.namespace = '/_';
+
+    this.get('/banners/current/', () => {
+        return {
+            data: {
+                attributes: {
+                },
+                type: 'banners',
+                id: '',
+            },
+        };
+    });
 }

--- a/tests/unit/models/banner-test.ts
+++ b/tests/unit/models/banner-test.ts
@@ -1,0 +1,12 @@
+import { run } from '@ember/runloop';
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Model | banner', hooks => {
+    setupTest(hooks);
+
+    test('it exists', function(assert) {
+        const model = run(() => this.owner.lookup('service:store').createRecord('banner'));
+        assert.ok(model);
+    });
+});


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
When a banner is created in the admin, display it on the landing page (home/dashboard).


## Summary of Changes
* Add `banner` model/adapter/serializer, for fetching `/_/banners/current/`
* Add `scheduled-banner` component, to display that banner on the dashboard and home page


## Side Effects / Testing Notes
* Should have exactly the same behavior as the banner in registries and preprints


## Ticket

https://openscience.atlassian.net/browse/EMB-314

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
