### PR TITLE
[EMB-333] Add missing analytics events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Missing analytics events:
-    - Quick files detail page actions
+    - User quick files page
+    - Quick files detail page
     - Institutions landing page
     - Dashboard filtering
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Analytics engine: Set page title to "OSF | [node title] Analytics"
 - Test assertions: Collapse all whitespace characters to a single space
 
+### Added
+- Missing analytics events:
+    - Quick files detail page actions
+    - Institutions landing page
+    - Dashboard filtering
+
 ## [0.5.0] - 2018-06-29
 ### Added
 - Routes:

--- a/app/dashboard/controller.ts
+++ b/app/dashboard/controller.ts
@@ -48,6 +48,7 @@ export default class Dashboard extends Controller {
     filterNodes = task(function *(this: Dashboard, filter: string) {
         yield timeout(500);
         this.setProperties({ filter });
+        this.analytics.track('list', 'filter', 'Dashboard - Search projects');
         yield this.get('findNodes').perform();
     }).restartable();
 

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -55,14 +55,14 @@
         </div>
     </div>
     {{#bs-modal open=deleteModalOpen onSubmit=(action 'delete') onHidden=(action 'closeDeleteModal') as |modal|}}
-        {{#modal.header onClose=(action 'closeDeleteModal')}}
+        {{#modal.header}}
             <h4 class="modal-title">{{t "file_detail.delete_file.question"}}</h4>
         {{/modal.header}}
         {{#modal.body}}
             <p>{{t 'file_detail.delete_file.confirm' file-name=model.file.name}}</p>
         {{/modal.body}}
         {{#modal.footer}}
-            {{#bs-button onClick=(action 'closeDeleteModal') type='default'}}
+            {{#bs-button onClick=(action modal.close) type='default'}}
                 {{t 'general.cancel'}}
             {{/bs-button}}
             {{#bs-button onClick=(action modal.submit) type='danger'}}

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -100,7 +100,12 @@
                             readOnly=(unless canEdit true false)
                             as |tag|
                         }}
-                            <a href='{{searchUrl}}?q=(tags:"{{tag}}")'>{{tag}}</a>
+                            <a
+                                href='{{searchUrl}}?q=(tags:"{{tag}}")'
+                                onclick={{action 'click' 'link' 'Quick Files - Search by tag' target=analytics}}
+                            >
+                                {{tag}}
+                            </a>
                         {{/tag-input}}
                         <div class="tags_clear"></div>
                     </div>

--- a/app/guid-user/quickfiles/controller.ts
+++ b/app/guid-user/quickfiles/controller.ts
@@ -5,13 +5,16 @@ import { A } from '@ember/array';
 import Controller from '@ember/controller';
 import { all, task, timeout } from 'ember-concurrency';
 import I18N from 'ember-i18n/services/i18n';
+import Toast from 'ember-toastr/services/toast';
+
 import File from 'ember-osf-web/models/file';
 import Node from 'ember-osf-web/models/node';
 import User from 'ember-osf-web/models/user';
+import Analytics from 'ember-osf-web/services/analytics';
 import CurrentUser from 'ember-osf-web/services/current-user';
-import Toast from 'ember-toastr/services/toast';
 
 export default class UserQuickfiles extends Controller {
+    @service analytics!: Analytics;
     @service currentUser!: CurrentUser;
     @service i18n!: I18N;
     @service toast!: Toast;
@@ -29,6 +32,7 @@ export default class UserQuickfiles extends Controller {
     updateFilter = task(function *(this: UserQuickfiles, filter: string) {
         yield timeout(250);
         this.setProperties({ filter });
+        this.analytics.track('list', 'filter', 'Quick Files - Filter files');
     }).restartable();
 
     createProject = task(function *(this: UserQuickfiles, node: Node) {
@@ -169,6 +173,8 @@ export default class UserQuickfiles extends Controller {
     @action
     async openFile(this: UserQuickfiles, file: File, show: string) {
         const guid = file.get('guid') || await file.getGuid();
+
+        this.analytics.click('link', 'Quick Files - Open file');
         this.transitionToRoute('guid-file', guid, { queryParams: { show } });
     }
 }

--- a/app/institutions/controller.ts
+++ b/app/institutions/controller.ts
@@ -1,15 +1,24 @@
 import { action, computed } from '@ember-decorators/object';
 import { service } from '@ember-decorators/service';
 import Controller from '@ember/controller';
-
+import { task, timeout } from 'ember-concurrency';
 import DS from 'ember-data';
+
 import Institution from 'ember-osf-web/models/institution';
+import Analytics from 'ember-osf-web/services/analytics';
 
 export default class Institutions extends Controller {
     @service store!: DS.Store;
+    @service analytics!: Analytics;
+
     sortOrder: 'title' | '-title' = 'title';
     page = 1;
     textValue: string = '';
+
+    trackFilter = task(function *(this: Institutions) {
+        yield timeout(1000);
+        this.analytics.track('list', 'filter', 'Institutions - Search');
+    }).restartable();
 
     @computed('model', 'textValue')
     get filtered(): Institution[] {
@@ -39,6 +48,7 @@ export default class Institutions extends Controller {
     @action
     next() {
         this.incrementProperty('page');
+        this.analytics.click('button', 'Institutions - Next page');
     }
 
     @action

--- a/app/institutions/route.ts
+++ b/app/institutions/route.ts
@@ -1,3 +1,4 @@
+import { action } from '@ember-decorators/object';
 import { service } from '@ember-decorators/service';
 import Route from '@ember/routing/route';
 import DS from 'ember-data';
@@ -12,7 +13,8 @@ export default class Institutions extends Route {
         return this.store.findAll('institution');
     }
 
+    @action
     didTransition(this: Institutions) {
-        this.get('analytics').trackPage();
+        this.analytics.trackPage();
     }
 }

--- a/app/institutions/route.ts
+++ b/app/institutions/route.ts
@@ -2,10 +2,17 @@ import { service } from '@ember-decorators/service';
 import Route from '@ember/routing/route';
 import DS from 'ember-data';
 
+import Analytics from 'ember-osf-web/services/analytics';
+
 export default class Institutions extends Route {
+    @service analytics!: Analytics;
     @service store!: DS.Store;
 
     model() {
         return this.store.findAll('institution');
+    }
+
+    didTransition(this: Institutions) {
+        this.get('analytics').trackPage();
     }
 }

--- a/app/institutions/template.hbs
+++ b/app/institutions/template.hbs
@@ -7,7 +7,13 @@
                     <div local-class="Institutions__header-logo"></div>
                     <p class="lead">
                         {{t 'institutions.description'}}
-                        <a local-class='Institutions__block__link' href='https://cos.io/our-products/osf-institutions/'>{{t 'institutions.read_more'}}</a>
+                        <a
+                            local-class='Institutions__block__link'
+                            href='https://cos.io/our-products/osf-institutions/'
+                            onclick={{action 'click' 'link' 'Institutions - Header - Read more' target=analytics}}
+                        >
+                            {{t 'institutions.read_more'}}
+                        </a>
                     </p>
                 </div>
             </div>
@@ -23,14 +29,26 @@
                                 <div class='row'>
                                     <div class='col-xs-3' local-class='Institutions__sorting'>
                                         {{t 'institutions.title'}}
-                                        {{sort-button sortAction=(action sort) sort=sortOrder sortBy='title'}}
+                                        {{sort-button sortAction=(action 'sort') sort=sortOrder sortBy='title'}}
                                     </div>
                                     <div class="col-xs-9 filter-input">
-                                        {{input (html-attributes aria-label=(t 'institutions.search_placeholder')) placeholder=(t 'institutions.search_placeholder') class='form-control' value=textValue type="text"}}
+                                        {{input
+                                            (html-attributes aria-label=(t 'institutions.search_placeholder'))
+                                            value=textValue
+                                            type='text'
+                                            class='form-control'
+                                            placeholder=(t 'institutions.search_placeholder')
+                                            keyPress=(perform trackFilter)
+                                        }}
                                     </div>
                                 </div>
                                 {{#each institutions as |institution|}}
-                                    <a class="m-v-sm row" local-class='Institutions__table__item' href='{{institution.id}}'>
+                                    <a
+                                        class="m-v-sm row"
+                                        local-class='Institutions__table__item'
+                                        href='{{institution.id}}'
+                                        onclick={{action 'click' 'link' 'Institutions - Visit institution' target=analytics}}
+                                    >
                                         <div class='col-xs-3'>
                                             <img local-class='Institutions__logo' alt='{{institution.name}}' src='{{institution.logoPath}}'>
                                         </div>
@@ -55,6 +73,12 @@
                 <div class="text-center col-xs-12">
                     <p class="lead">
                         {{t 'institutions.footer'}}
+                        <a
+                            href='https://cos.io/contact'
+                            onclick={{action 'click' 'link' 'Institutions - Footer - Contact us' target=analytics}}
+                        >
+                            {{t 'institutions.contact_us'}}
+                        </a>
                     </p>
                 </div>
             </div>

--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -540,7 +540,8 @@ export default {
     institutions: {
         description: 'OSF Institutions is a free scholarly web tool that enhances transparency, fosters collaboration, and increases the visibility of research outputs at the institutional level.',
         read_more: 'Read more',
-        footer: 'Interested in setting up an OSF Institutions page for your research institution? <a href=\'https://cos.io/contact\'>Contact us</a>',
+        footer: 'Interested in setting up an OSF Institutions page for your research institution?',
+        contact_us: 'Contact us',
         title: 'Institutions',
         search_placeholder: 'Search institutions',
     },

--- a/app/locales/ja/translations.ts
+++ b/app/locales/ja/translations.ts
@@ -540,7 +540,8 @@ export default {
     institutions: {
         description: 'OSF Institutions is a free scholarly web tool that enhances transparency, fosters collaboration, and increases the visibility of research outputs at the institutional level.',
         read_more: 'Read more',
-        footer: 'Interested in setting up an OSF Institutions page for your research institution? <a href=\'https://cos.io/contact\'>Contact us</a>',
+        footer: 'Interested in setting up an OSF Institutions page for your research institution?',
+        contact_us: 'Contact us',
         title: 'Institutions',
         search_placeholder: 'Search institutions',
     },

--- a/app/locales/zh/translations.ts
+++ b/app/locales/zh/translations.ts
@@ -540,7 +540,8 @@ export default {
     institutions: {
         description: 'OSF Institutions is a free scholarly web tool that enhances transparency, fosters collaboration, and increases the visibility of research outputs at the institutional level.',
         read_more: 'Read more',
-        footer: 'Interested in setting up an OSF Institutions page for your research institution? <a href=\'https://cos.io/contact\'>Contact us</a>',
+        footer: 'Interested in setting up an OSF Institutions page for your research institution?',
+        contact_us: 'Contact us',
         title: 'Institutions',
         search_placeholder: 'Search institutions',
     },

--- a/app/services/analytics.ts
+++ b/app/services/analytics.ts
@@ -77,7 +77,7 @@ export default class Analytics extends Service {
         this.get('metrics')
             .trackEvent({
                 category,
-                actionName,
+                action: actionName,
                 label,
                 extra,
             });

--- a/lib/osf-components/addon/components/file-browser/component.ts
+++ b/lib/osf-components/addon/components/file-browser/component.ts
@@ -97,6 +97,7 @@ export default class FileBrowser extends Component {
         if (!this.node) {
             return;
         }
+        this.analytics.track('file', 'move', 'Quick Files - Move to project');
 
         this.setProperties({
             isMoving: true,
@@ -107,7 +108,6 @@ export default class FileBrowser extends Component {
         const isChildNode = !!this.node && !!this.node.links && !!this.node.links.relationships.parent;
 
         const moveSuccess: boolean = yield this.moveFile(selectedItem as File, this.node);
-        this.analytics.track('file', 'move', 'Quick Files - Move to project');
 
         let successPropertyUpdates = {};
 
@@ -249,6 +249,7 @@ export default class FileBrowser extends Component {
             renameValue: '',
             showRename: false,
         });
+        this.analytics.click('button', 'Quick Files - Cancel file rename');
     }
 
     @action
@@ -257,6 +258,7 @@ export default class FileBrowser extends Component {
             showFilterClicked: false,
             filter: '',
         });
+        this.analytics.click('button', 'Quick Files - Close filter');
     }
 
     // dropzone listeners
@@ -293,6 +295,8 @@ export default class FileBrowser extends Component {
 
     @action
     selectItem(this: FileBrowser, currentItem: File) {
+        this.analytics.track('file', 'select', 'Quick Files - Select file');
+
         if (this.openOnSelect) {
             this.openFile(currentItem, 'view');
         }
@@ -355,6 +359,8 @@ export default class FileBrowser extends Component {
                 this.set('shiftAnchor', currentItem);
             }
         });
+
+        this.analytics.track('file', 'select', 'Quick Files - Select multiple files');
     }
 
     @action
@@ -380,6 +386,7 @@ export default class FileBrowser extends Component {
 
     @action
     deleteItems(this: FileBrowser, multiple: boolean = false) {
+        this.analytics.track('file', 'delete', 'Quick Files - Delete files');
         this.deleteFiles(multiple ? this.selectedItems.slice() : this.selectedItems.slice(0, 1));
         this.set('currentModal', modals.None);
     }
@@ -403,10 +410,13 @@ export default class FileBrowser extends Component {
             renameValue: '',
             showRename: false,
         });
+        this.analytics.click('button', `Quick Files - Resolve rename conflict - ${conflict}`);
     }
 
     @action
     rename(this: FileBrowser): void {
+        this.analytics.track('file', 'rename', 'Quick Files - Rename file');
+
         const { renameValue } = this;
         const selectedItem = this.selectedItems.get('firstObject') as File;
         const conflictingItem = this.items ? this.items
@@ -440,29 +450,16 @@ export default class FileBrowser extends Component {
     }
 
     @action
-    cancelRename(this: FileBrowser) {
-        this.setProperties({
-            renameValue: '',
-            currentModal: modals.None,
-        });
-    }
-
-    @action
     copyLink(this: FileBrowser) {
         this.set('popupOpen', true);
+
+        this.analytics.click('button', 'Quick Files - Copy share link');
 
         if (this.link) {
             return;
         }
 
         (this.selectedItems.get('firstObject') as File).getGuid();
-    }
-
-    @action
-    setSelectedNode(this: FileBrowser, node: Node) {
-        this.setProperties({
-            node,
-        });
     }
 
     @action

--- a/lib/osf-components/addon/components/file-list-item/component.ts
+++ b/lib/osf-components/addon/components/file-list-item/component.ts
@@ -56,7 +56,10 @@ export default class FileListItem extends Component.extend({ styles }) {
     }
 
     @action
-    open() {
+    open(ev?: Event) {
+        if (ev) {
+            ev.stopPropagation();
+        }
         this.openItem(this.item);
     }
 }

--- a/lib/osf-components/addon/components/file-list-item/template.hbs
+++ b/lib/osf-components/addon/components/file-list-item/template.hbs
@@ -1,7 +1,7 @@
-<div class="row" local-class="file-row-item" onclick={{action 'open' preventDefault='true'}} role="option">
+<div class="row" local-class="file-row-item" onclick={{action 'open'}} role="option">
     <div class="col-lg-12 col-md-9 col-sm-9 col-xs-12" local-class="file-row-col">
         {{file-icon item=item}}
-        <a {{action 'open' preventDefault='true'}} role="link" href={{link}}>
+        <a {{action 'open'}} role="link" href={{link}}>
             {{item.itemName}}
         </a>
     </div>

--- a/lib/osf-components/addon/components/file-version/component.ts
+++ b/lib/osf-components/addon/components/file-version/component.ts
@@ -1,7 +1,10 @@
 import { classNames, tagName } from '@ember-decorators/component';
 import { action, computed } from '@ember-decorators/object';
+import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
 import { assert } from '@ember/debug';
+
+import Analytics from 'ember-osf-web/services/analytics';
 import eatArgs from 'ember-osf-web/utils/eat-args';
 import styles from './styles';
 import layout from './template';
@@ -38,6 +41,8 @@ export interface Version {
 @tagName('tr')
 @classNames('file-version')
 export default class FileVersion extends Component {
+    @service analytics!: Analytics;
+
     layout = layout;
     styles = styles;
 
@@ -68,10 +73,12 @@ export default class FileVersion extends Component {
     @action
     downloadVersion(version: Version): void {
         this.download(version);
+        this.analytics.click('button', 'File version - Download');
     }
 
     @action
     changeVersion(version: Version): void {
         this.versionChange(version);
+        this.analytics.click('button', 'File version - Change version');
     }
 }


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Send analytics events for page views and user actions that should have been tracked all along


## Summary of Changes
New events:
* Dashboard page:
  * `Dashboard - Search projects`
* Quick files detail page:
  * `Quick Files - Filter file browser`
  * `Quick Files - Delete file`
  * `Quick Files - Open delete modal`
  * `Quick Files - Close delete modal`
  * `Quick Files - Change view - edit`
  * `Quick Files - Change view - revision`
  * `Quick Files - Change view - view`
  * `Quick Files - Change view - view_edit`
  * `Quick Files - Save`
  * `Quick Files - Open file`
  * `Quick Files - Add tag`
  * `Quick Files - Remove tag`
  * `Quick Files - Search by tag`
  * `File version - Download`
  * `File version - Change version`
* Institutions landing page
  * Page view
  * `Institutions - Search`
  * `Institutions - Next page`
  * `Institutions - Header - Read more`
  * `Institutions - Visit institution`
  * `Institutions - Footer - Contact us`
* User quick files page
  * `Quick Files - Filter files`
  * `Quick Files - Close filter`
  * `Quick Files - Select file`
  * `Quick Files - Select multiple files`
  * `Quick Files - Open file`
  * `Quick Files - Move to project`
  * `Quick Files - Delete files`
  * `Quick Files - Rename file`
  * `Quick Files - Cancel file rename`
  * `Quick Files - Resolve rename conflict - keep`
  * `Quick Files - Resolve rename conflict - replace`
  * `Quick Files - Copy share link`

Also I fixed a bug that got in the way of manual testing: Clicking an item's name in the file browser would trigger the `open` action twice (`preventDefault` is not the same as `stopPropagation`).

## Side Effects / Testing Notes
I guess the best way to test would be checking the devtools network tab to see google analytics events being sent when you navigate to each page and take various actions. You can filter for `Img` requests that contain `google-analytics` to see just the GA requests.


## Ticket

https://openscience.atlassian.net/browse/EMB-333

# Reviewer Checklist

- [x] meets requirements
- [x] easy to understand
- [x] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
