### PR TITLE
Tidy up development settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,13 @@
 {
-    "typescript.format.insertSpaceAfterFunctionKeywordForAnonymousFunctions": false
+    "typescript.format.insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
+    "files.exclude": {
+        "**/.git": true,
+        "**/.DS_Store": true,
+        "tmp/**": true,
+    },
+    "search.exclude": {
+        "**/node_modules": true,
+        "**/bower_components": true,
+        "tmp/**": true,
+    },
 }

--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,3 +1,3 @@
 {
-  "ignore_dirs": ["tmp", "dist"]
+  "ignore_dirs": ["tmp", "dist", "node_modules"]
 }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ You will need the following things properly installed on your computer.
 * [Git](https://git-scm.com/)
 * [Node.js](https://nodejs.org/) (with NPM)
 * [Ember CLI](https://ember-cli.com/)
+* [Watchman](https://facebook.github.io/watchman/)
 
 ## Installation
 
@@ -26,6 +27,19 @@ You will need the following things properly installed on your computer.
 * `yarn --frozen-lockfile`
 
 ## Running / Development
+
+### Mac OS File Descriptor Limits
+
+Watchman states "*Only applicable on OS X 10.6 and earlier*". Though it's been observed this setting can remain incorrect on systems where the operation system was upgraded from a legacy version.
+
+> Putting the following into a file named /etc/sysctl.conf on OS X will cause these values to persist across reboots:
+
+```bash
+kern.maxfiles=10485760
+kern.maxfilesperproc=1048576
+```
+
+### Development
 
 Configure the application for local development, add the following to your `config/local.js`:
 ```ts


### PR DESCRIPTION
Changes based on Visual Studio Code [settings.json](https://github.com/Microsoft/vscode/blob/master/.vscode/settings.json) file.

Exclude `node_modules` from watchman, *cough* 1.3 GB or 1.5 million files... [discussion](https://facebook.github.io/watchman/docs/install.html#mac-os-file-descriptor-limits)

Document OSX [kernel file limitations](https://facebook.github.io/watchman/docs/install.html#mac-os-file-descriptor-limits) and a fix since I personally got bit by this one... and I'm running OSX 10.13.5...
