### PR TITLE
Remove empty handbook pages from the side nav

### DIFF
--- a/lib/handbook/addon/docs/template.hbs
+++ b/lib/handbook/addon/docs/template.hbs
@@ -6,10 +6,6 @@
 
         {{nav.section 'Development'}}
         {{nav.item 'Quickstart' 'docs.quickstart'}}
-        {{nav.item 'Dev environment' 'docs.dev-env'}}
-        {{nav.item 'Coding conventions' 'docs.conventions'}}
-        {{nav.item 'Testing' 'docs.testing'}}
-        {{nav.item 'Additional resources' 'docs.resources'}}
         {{nav.item 'Troubleshooting' 'docs.troubleshooting'}}
 
         {{nav.section 'Component gallery'}}


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

No point linking to handbook pages that just say "TODO"