### PR TITLE
[EMB-327] Keep maintenance banner dismissed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Models:
     - `node` - add `region` relationship
     - `user` - add `defaultRegion` relationship
+- Components:
+    - `maintenance-banner` - Set cookie on dismiss and check cookie before showing
 - Services:
     - `analytics` - support multiple metrics adapters
 

--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -88,6 +88,7 @@ declare const config: {
             keenUserId: string;
             keenSessionId: string;
             analyticsDismissAdblock: string;
+            maintenance: string;
         },
     };
     social: {

--- a/config/environment.js
+++ b/config/environment.js
@@ -155,6 +155,7 @@ module.exports = function(environment) {
                 keenUserId: 'keenUserId',
                 keenSessionId: 'keenSessionId',
                 analyticsDismissAdblock: 'adBlockDismiss',
+                maintenance: 'maintenance',
             },
         },
         social: {

--- a/lib/osf-components/addon/components/maintenance-banner/component.ts
+++ b/lib/osf-components/addon/components/maintenance-banner/component.ts
@@ -74,6 +74,7 @@ export default class MaintenanceBanner extends Component.extend({
 
     @action
     dismiss(this: MaintenanceBanner) {
+        this.analytics.click('button', 'Maintenance Banner - dismiss');
         this.cookies.write(maintenanceCookie, 0, {
             expires: moment().add(24, 'hours').toDate(),
             path: '/',

--- a/lib/osf-components/addon/components/maintenance-banner/template.hbs
+++ b/lib/osf-components/addon/components/maintenance-banner/template.hbs
@@ -2,6 +2,7 @@
     {{#bs-alert
         type=alertType
         onDismiss=(action 'click' 'button' 'Maintenance Banner - dismiss' target=analytics)
+        onDismiss=(action 'dismiss')
     }}
         <strong>{{t 'maintenance.title'}}</strong>
         {{#if maintenance.message.length}}

--- a/lib/osf-components/addon/components/maintenance-banner/template.hbs
+++ b/lib/osf-components/addon/components/maintenance-banner/template.hbs
@@ -1,7 +1,6 @@
 {{#if maintenance}}
     {{#bs-alert
         type=alertType
-        onDismiss=(action 'click' 'button' 'Maintenance Banner - dismiss' target=analytics)
         onDismiss=(action 'dismiss')
     }}
         <strong>{{t 'maintenance.title'}}</strong>


### PR DESCRIPTION
## Purpose

Ensure that the maintenance banner respects the cookies that the OSF sets and also sets those cookies. This will let people dismiss the maintenance banner from either place and not see it pop back up again for a day.

## Summary of Changes

1. Add a cookie to the settings
2. Modify the `maintenance-banner` component to like and use cookies
3. Modify the `maintenance-banner` template to send an action to set the cookie

## Side Effects / Testing Notes

Should be fairly side-effect free. Dismissing the status banner of legacy OSF should be reflected in ember-osf-web pages and vice-versa.

## Ticket

https://openscience.atlassian.net/browse/EMB-

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
