### PR TITLE
[EMB-329] Fix alt-text after refactor

### DIFF
--- a/app/home/template.hbs
+++ b/app/home/template.hbs
@@ -119,30 +119,30 @@
         </div>
         <div class="row" local-class="integrations">
             <div class="col-sm-3 col-xs-6">
-                <img src="/assets/images/home/dropbox.png" class="img-responsive" alt="{{t (concat 'home.integrations_alt_' integration)}}">
+                <img src="/assets/images/home/dropbox.png" class="img-responsive" alt="{{t 'home.integrations_alt_dropbox'}}">
             </div>
             <div class="col-sm-3 col-xs-6">
-                <img src="/assets/images/home/github.png" class="img-responsive" alt="{{t (concat 'home.integrations_alt_' integration)}}">
+                <img src="/assets/images/home/github.png" class="img-responsive" alt="{{t 'home.integrations_alt_github'}}">
             </div>
             <div class="col-sm-3 col-xs-6">
-                <img src="/assets/images/home/amazon.png" class="img-responsive" alt="{{t (concat 'home.integrations_alt_' integration)}}">
+                <img src="/assets/images/home/amazon.png" class="img-responsive" alt="{{t 'home.integrations_alt_amazon'}}">
             </div>
             <div class="col-sm-3 col-xs-6">
-                <img src="/assets/images/home/box.png" class="img-responsive" alt="{{t (concat 'home.integrations_alt_' integration)}}">
+                <img src="/assets/images/home/box.png" class="img-responsive" alt="{{t 'home.integrations_alt_box'}}">
             </div>
         </div>
         <div class="row" local-class="integrations">
             <div class="col-sm-3 col-xs-6">
-                <img src="/assets/images/home/google.png" class="img-responsive" alt="{{t (concat 'home.integrations_alt_' integration)}}">
+                <img src="/assets/images/home/google.png" class="img-responsive" alt="{{t 'home.integrations_alt_google'}}">
             </div>
             <div class="col-sm-3 col-xs-6">
-                <img src="/assets/images/home/figshare.png" class="img-responsive" alt="{{t (concat 'home.integrations_alt_' integration)}}">
+                <img src="/assets/images/home/figshare.png" class="img-responsive" alt="{{t 'home.integrations_alt_figshare'}}">
             </div>
             <div class="col-sm-3 col-xs-6">
-                <img src="/assets/images/home/dataverse.png" class="img-responsive" alt="{{t (concat 'home.integrations_alt_' integration)}}">
+                <img src="/assets/images/home/dataverse.png" class="img-responsive" alt="{{t 'home.integrations_alt_dataverse'}}">
             </div>
             <div class="col-sm-3 col-xs-6">
-                <img src="/assets/images/home/mendeley.png" class="img-responsive" alt="{{t (concat 'home.integrations_alt_' integration)}}">
+                <img src="/assets/images/home/mendeley.png" class="img-responsive" alt="{{t 'home.integrations_alt_mendeley'}}">
             </div>
         </div>
     </div>

--- a/tests/acceptance/logged-out-home-page-test.ts
+++ b/tests/acceptance/logged-out-home-page-test.ts
@@ -37,5 +37,7 @@ module('Acceptance | logged-out home page', hooks => {
         assert.notFound('[class*="SignUpForm"] iframe', 'Invalidate form: captcha disappears.');
         await click('#acceptedTermsOfService');
         assert.found('[class*="SignUpForm"] iframe', 'Revalidate form: captcha reappears.');
+        assert.found('[class*="_integrations"] img[alt*="Dropbox logo"]');
+        assert.notFound('[class*="_integrations"] img[alt*="Missing translation"]');
     });
 });

--- a/tests/assertions/not-found.ts
+++ b/tests/assertions/not-found.ts
@@ -9,7 +9,7 @@ export default function notFound<Context extends TestContext>(
 ) {
     const result = !(typeof subject === 'string' ? context.element.querySelector(subject) : subject);
     const actual = result ? 'not found' : 'found';
-    const expected = 'found';
+    const expected = 'not found';
     this.pushResult({ result, actual, expected, message, negative: true });
 }
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Alt text was broken when I refactored the list of logos to be static. 

## Summary of Changes

1. Remove concat composition
2. Build strings by hand

## Side Effects / Testing Notes

Should be straightforward to test. The `notFound` assert, when it failed, had an expected state of `found` so I fixed that while I was there.


## Ticket

https://openscience.atlassian.net/browse/EMB-329

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
