### PR TITLE
[EMB-319]Remove google plus from the footer

### DIFF
--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -535,7 +535,6 @@ export default {
         facebook: 'Facebook',
         google_group: 'Google Group',
         github: 'GitHub',
-        google_plus: 'Google Plus',
         linkedin: 'LinkedIn',
     },
     institutions: {

--- a/app/locales/ja/translations.ts
+++ b/app/locales/ja/translations.ts
@@ -535,7 +535,6 @@ export default {
         facebook: 'Facebook',
         google_group: 'Google Group',
         github: 'GitHub',
-        google_plus: 'Google Plus',
         linkedin: 'LinkedIn',
     },
     institutions: {

--- a/app/locales/zh/translations.ts
+++ b/app/locales/zh/translations.ts
@@ -535,7 +535,6 @@ export default {
         facebook: 'Facebook',
         google_group: 'Google Group',
         github: 'GitHub',
-        google_plus: 'Google Plus',
         linkedin: 'LinkedIn',
     },
     institutions: {

--- a/lib/osf-components/addon/components/osf-footer/template.hbs
+++ b/lib/osf-components/addon/components/osf-footer/template.hbs
@@ -55,7 +55,6 @@
                     <a href="{{facebook}}" aria-label={{t 'social.facebook'}} onclick={{action 'click' 'link' 'Footer - social_facebook' target=analytics}}><i class="fa fa-facebook fa-2x"></i></a>
                     <a href="{{googleGroup}}" aria-label={{t 'social.google_group'}} onclick={{action 'click' 'link' 'Footer - social_google_group' target=analytics}}><i class="fa fa-group fa-2x"></i></a>
                     <a href="{{github}}" aria-label={{t 'social.github'}} onclick={{action 'click' 'link' 'Footer - social_github' target=analytics}}><i class="fa fa-github fa-2x"></i></a>
-                    <a href="{{googlePlus}}" aria-label={{t 'social.google_plus'}} rel="publisher" onclick={{action 'click' 'link' 'Footer - social_google_plus' target=analytics}}><i class="fa fa-google-plus fa-2x"></i></a>
                 </p>
             </div>
         </div>


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Remove the google plus footer from the footer

## Summary of Changes

1. Remove from footer
2. Remove translations strings related to google plus

Before
![footer before](https://user-images.githubusercontent.com/6599111/43287518-493a9852-90f3-11e8-9a7b-fbb0accafd55.png)

After
![footer after](https://user-images.githubusercontent.com/6599111/43287528-4dd7a198-90f3-11e8-99c3-4a846c9046a5.png)


## Side Effects / Testing Notes
Nobody may go to our google plus site any more.


## Ticket

https://openscience.atlassian.net/browse/EMB-319

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~
- [ ] ~~changes described in `CHANGELOG.md`~~

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
