### PR TITLE
[EMB-351] Change local storage key used by ember-simple-auth

### DIFF
--- a/app/session-stores/application.ts
+++ b/app/session-stores/application.ts
@@ -1,0 +1,20 @@
+import config from 'ember-get-config';
+import AdaptiveStore from 'ember-simple-auth/session-stores/adaptive';
+
+const {
+    OSF: {
+        cookieDomain,
+        cookies: {
+            authSession: cookieName,
+        },
+        localStorageKeys: {
+            authSession: localStorageKey,
+        },
+    },
+} = config;
+
+export default AdaptiveStore.extend({
+    cookieDomain,
+    cookieName,
+    localStorageKey,
+});

--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -78,6 +78,12 @@ declare const config: {
         authenticator: string;
         keenProjectId?: string;
         analyticsDismissAdblockCookie: string;
+        cookies: {
+            authSession: string;
+        };
+        localStorageKeys: {
+            authSession: string;
+        };
     };
     social: {
         twitter: {

--- a/config/environment.js
+++ b/config/environment.js
@@ -146,6 +146,12 @@ module.exports = function(environment) {
             authenticator: `authenticator:${osfAuthenticator}`,
             keenProjectId,
             analyticsDismissAdblockCookie: 'adBlockDismiss',
+            cookies: {
+                authSession: 'embosf-auth-session',
+            },
+            localStorageKeys: {
+                authSession: 'embosf-auth-session',
+            },
         },
         social: {
             twitter: {

--- a/types/ember-simple-auth/session-stores/adaptive.d.ts
+++ b/types/ember-simple-auth/session-stores/adaptive.d.ts
@@ -1,0 +1,5 @@
+import EmberObject from '@ember/object';
+
+declare class AdaptiveStore extends EmberObject {}
+
+export default AdaptiveStore;


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
When an embosf page is open in one tab and preprints (or maybe reviews?) in another tab, they try to store different auth data in local storage, using the same key. This causes an infinite loop of each app clobbering the other's data and making API requests, until one of the tabs is closed.

This might have been causing subtle, strange bugs in preprints, but it's hard to say what they might have looked like.


## Summary of Changes
Configure ember-simple-auth's AdaptiveStore, changing the local storage key used.


## Side Effects / Testing Notes
- Open the dashboard and preprints in separate tabs (same environment, same browser)
- Open the devtools network tab in either/both tabs
- Previously, there would be repeated requests to `/v2/` (in embosf) or `/v2/users/me` (in preprints). Now, all should be calm.


## Ticket

https://openscience.atlassian.net/browse/EMB-351

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
