### PR TITLE
Enable sourcemaps by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Services:
     - `analytics` - support multiple metrics adapters
 - Add `join-osf-banner` to `guid-node` pages.
+- DX:
+  - enable sourcemap generation by default
 
 ## [0.6.1] - 2018-07-31
 ### Changed

--- a/config/environment.js
+++ b/config/environment.js
@@ -45,7 +45,7 @@ const {
     SHARE_BASE_URL: shareBaseUrl = 'https://staging-share.osf.io/',
     SHARE_API_URL: shareApiUrl = 'https://staging-share.osf.io/api/v2',
     SHARE_SEARCH_URL: shareSearchUrl = 'https://staging-share.osf.io/api/v2/search/creativeworks/_search',
-    SOURCEMAPS_ENABLED: sourcemapsEnabled = false,
+    SOURCEMAPS_ENABLED: sourcemapsEnabled = true,
 } = { ...process.env, ...localConfig };
 
 module.exports = function(environment) {


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Enable sourcemaps by default. It turns out the babel config setting of `sourceMaps: 'inline'` [just means adding the sourceMappingURL comment to the bottom of the outputted JS](https://babeljs.io/docs/en/babel-core.html#options), so this is safe to do in all environments. The TypeScript compiler is configured to inline sourcemaps (and sources), but Babel uses these to generate and external `.map` file. Sourcemaps in prod/test/stagings are needed for Sentry grouping as well as aid in debugging.

Babel sourcemap generation can be disabled locally, if so desired, to speed up build times, by setting `SOURCEMAPS_ENABLED: false` in `config/local.js`, but the speed-up is fairly negligible (see build time table below). 

You may also wish to set `inlineSourceMap` and `inlineSources` to `false` in `tsconfig.json` (see [Compiler Options](https://www.typescriptlang.org/docs/handbook/compiler-options.html)) to disable TypeScript sourcemap generation, but additional speed-up is quite negligible (see build time table below). Note that, for `ember-cli-typescript`, it only makes sense to have `inlineSourceMap` and `inlineSources` both be `true` or both be `false` because the original TypeScript source does not end up in `dist/`.

| inlineSourceMap | inlineSources | SOURCEMAPS_ENABLED | average build time<br>(three local builds) |
| --- | --- | --- | --- |
| true | true | true |  50 sec |
| true | true | false | 47 sec |
| false | false | false | 46 sec |

## Summary of Changes

Default `sourcemapsEnabled` to `true`

## Side Effects / Testing Notes

N/A

## Ticket

N/A

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
