### PR TITLE
[EMB-346] No IP address tracking

### DIFF
--- a/app/metrics-adapters/keen.ts
+++ b/app/metrics-adapters/keen.ts
@@ -241,6 +241,7 @@ export default class KeenAdapter extends BaseAdapter {
             name: 'keen:ip_to_geo',
             input: {
                 ip: 'tech.ip',
+                remove_ip_property: true,
             },
             output: 'geo',
         });


### PR DESCRIPTION
## Purpose

Stop keen from saving IP Addresses

## Summary of Changes

Added the line to the keen adapter per https://keen.io/docs/streams/ip-to-geo-enrichment/#ip-anonymization

## Side Effects / Testing Notes

You should notice in the staging public keen bucket, new page view counts from embosf pages will not have IP Addresses after this is merged.

## Ticket

https://openscience.atlassian.net/browse/EMB-346

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~ All integration with 3rd-party services
- [ ] ~~changes described in `CHANGELOG.md`~~ This should go out with the keen adapter, preferably

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->