### PR TITLE
Add #bs-alert to handbook

### DIFF
--- a/lib/handbook/addon/docs/components/bs-alert/demo-danger-hidden/template.hbs
+++ b/lib/handbook/addon/docs/components/bs-alert/demo-danger-hidden/template.hbs
@@ -1,0 +1,13 @@
+{{#docs-demo as |demo|}}
+    {{#demo.example name='bs-alert.danger-hidden.hbs'}}
+            {{#bs-alert type='danger' dismissible=false hidden=hideAlert}}
+                    <strong>Danger, Will Robinson!</strong>
+            {{/bs-alert}}
+        {{/demo.example}}
+
+        {{#bs-button class='center-block m-b-lg' onClick=(action (mut hideAlert) (not hideAlert))}}
+            set: hideAlert = {{not hideAlert}}
+        {{/bs-button}}
+
+    {{demo.snippet 'bs-alert.danger-hidden.hbs'}}
+{{/docs-demo}}

--- a/lib/handbook/addon/docs/components/bs-alert/demo-info/template.hbs
+++ b/lib/handbook/addon/docs/components/bs-alert/demo-info/template.hbs
@@ -1,0 +1,10 @@
+{{#docs-demo as |demo|}}
+    {{#demo.example name='bs-alert.info.hbs'}}
+            {{#bs-alert type='info'}}
+                    <strong>Hey! You like info?</strong>
+                    This is some fine info
+            {{/bs-alert}}
+    {{/demo.example}}
+
+    {{demo.snippet 'bs-alert.info.hbs'}}
+{{/docs-demo}}

--- a/lib/handbook/addon/docs/components/bs-alert/demo-warn-no-dismiss/template.hbs
+++ b/lib/handbook/addon/docs/components/bs-alert/demo-warn-no-dismiss/template.hbs
@@ -1,0 +1,10 @@
+{{#docs-demo as |demo|}}
+    {{#demo.example name='bs-alert.warn-no-dismiss.hbs'}}
+            {{#bs-alert type='warning' dismissible=false}}
+                    <strong>Uh oh.</strong>
+                    I've got a bad feeling about this.
+            {{/bs-alert}}
+    {{/demo.example}}
+
+    {{demo.snippet 'bs-alert.warn-no-dismiss.hbs'}}
+{{/docs-demo}}

--- a/lib/handbook/addon/docs/components/bs-alert/template.md
+++ b/lib/handbook/addon/docs/components/bs-alert/template.md
@@ -4,7 +4,7 @@ Generates what is mostly a [boostrap alert](https://www.ember-bootstrap.com/api/
 
 In addition to the standard look and functionality, we:
  - Have a font-awesome close icon to match OSF styling;
- - Have the ability to hide and show the alert.
+ - Gave the close button an aria-label to work well with i18n.
 
 ## info
 {{docs/components/bs-alert/demo-info}}

--- a/lib/handbook/addon/docs/components/bs-alert/template.md
+++ b/lib/handbook/addon/docs/components/bs-alert/template.md
@@ -1,0 +1,9 @@
+# bs-alert
+
+Generates a [boostrap alert](https://www.ember-bootstrap.com/api/classes/Components.Alert.html).
+
+## info
+{{docs/components/bs-alert/demo-info}}
+
+## warning (not dismissible)
+{{docs/components/bs-alert/demo-warn-no-dismiss}}

--- a/lib/handbook/addon/docs/components/bs-alert/template.md
+++ b/lib/handbook/addon/docs/components/bs-alert/template.md
@@ -1,9 +1,16 @@
 # bs-alert
 
-Generates a [boostrap alert](https://www.ember-bootstrap.com/api/classes/Components.Alert.html).
+Generates what is mostly a [boostrap alert](https://www.ember-bootstrap.com/api/classes/Components.Alert.html). 
+
+In addition to the standard look and functionality, we:
+ - Have a font-awesome close icon to match OSF styling;
+ - Have the ability to hide and show the alert.
 
 ## info
 {{docs/components/bs-alert/demo-info}}
 
 ## warning (not dismissible)
 {{docs/components/bs-alert/demo-warn-no-dismiss}}
+
+## danger (hidden)
+{{docs/components/bs-alert/demo-danger-hidden}}

--- a/lib/handbook/addon/docs/template.hbs
+++ b/lib/handbook/addon/docs/template.hbs
@@ -15,6 +15,7 @@
 
         {{nav.section 'Component gallery'}}
         {{nav.item 'loading-indicator' 'docs.components.loading-indicator'}}
+        {{nav.item 'bs-alert' 'docs.components.bs-alert'}}
     {{/viewer.nav}}
 
     {{#viewer.main}}

--- a/lib/handbook/addon/routes.js
+++ b/lib/handbook/addon/routes.js
@@ -22,6 +22,7 @@ export default buildRoutes(function() {
 
         this.route('components', function() {
             this.route('loading-indicator');
+            this.route('bs-alert');
         });
 
         this.route('api', function() {

--- a/lib/handbook/index.js
+++ b/lib/handbook/index.js
@@ -4,6 +4,9 @@ const EngineAddon = require('ember-engines/lib/engine-addon');
 
 module.exports = EngineAddon.extend({
     name: 'handbook',
+    'ember-font-awesome': {
+        includeFontAwesomeAssets: false,
+    },
 
     lazyLoading: {
         enabled: true,

--- a/lib/handbook/package.json
+++ b/lib/handbook/package.json
@@ -5,6 +5,7 @@
     "ember-engine"
   ],
   "dependencies": {
+    "ember-bootstrap": "*",
     "ember-cli-addon-docs": "*",
     "ember-cli-addon-docs-typedoc": "*",
     "ember-cli-babel": "*",
@@ -12,7 +13,8 @@
     "ember-cli-sass": "*",
     "ember-code-snippet": "*",
     "ember-css-modules": "*",
-    "ember-css-modules-sass": "*"
+    "ember-css-modules-sass": "*",
+    "ember-font-awesome": "*"
   },
   "ember-addon": {
     "paths": [


### PR DESCRIPTION
## Purpose

Make our docs slightly more complete with the `#bs-alert` component.

## Summary of Changes

Add a bs-alert component with a couple of examples and a link to the docs

![bs-alert-more-truthful](https://user-images.githubusercontent.com/6599111/43730620-ed475654-9979-11e8-98f4-b852ee41e65f.png)


## Side Effects / Testing Notes

Shouldn't have too many side effects, really. Test with the handbook enabled on localhost:4200/handbook/docs/

## Ticket

https://openscience.atlassian.net/browse/EMB-

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~
- [ ] ~~changes described in `CHANGELOG.md`~~

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
