### PR TITLE
Use native getters in BaseFileItem

### DIFF
--- a/app/models/base-file-item.ts
+++ b/app/models/base-file-item.ts
@@ -1,7 +1,6 @@
 import { attr } from '@ember-decorators/data';
 import { computed } from '@ember-decorators/object';
 import { or } from '@ember-decorators/object/computed';
-import { get } from '@ember/object';
 import OsfModel from './osf-model';
 
 /**
@@ -34,12 +33,12 @@ export default class BaseFileItem extends OsfModel {
     @or('isNode', 'isProvider', 'isFolder') canHaveChildren!: boolean;
 
     @computed('isFileModel', 'kind')
-    get isFolder(this: BaseFileItem): boolean {
-        return get(this, 'isFileModel') && get(this, 'kind') === FileItemKinds.Folder;
+    get isFolder() {
+        return this.isFileModel && this.kind === FileItemKinds.Folder;
     }
 
     @computed('isFileModel', 'kind')
-    get isFile(this: BaseFileItem) {
-        return get(this, 'isFileModel') && get(this, 'kind') === FileItemKinds.File;
+    get isFile() {
+        return this.isFileModel && this.kind === FileItemKinds.File;
     }
 }


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

`tsc --watch` (but not just `tsc` or `ember build`) is giving:
```
app/models/base-file-item.ts(42,9): error TS7022: 'isFile' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
app/models/base-file-item.ts(42,9): error TS7023: 'isFile' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
```
Refactoring to use native getters here prevents this.

## Summary of Changes

Use native getters instead of `get` from `@ember/object`.

## Side Effects / Testing Notes

Should be no change, but maybe double-check that quick files functions properly?

## Ticket

N/A

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(minor refactor)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
