### PR TITLE
Enable more ember linting rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,6 @@ module.exports = {
         'class-methods-use-this': 'off',
         'max-len': ['error', { code: 120 }],
         strict: 'off',
-        'ember/named-functions-in-promises': 'off',
         'function-paren-newline': ['error', 'consistent'],
         'prefer-rest-params': 'error',
         'generator-star-spacing': ['error', 'before'],
@@ -31,6 +30,10 @@ module.exports = {
             ImportDeclaration: { multiline: true, consistent: true },
             ExportDeclaration: { multiline: true, consistent: true },
         }],
+        'ember/named-functions-in-promises': 'off',
+        'ember/new-module-imports': 'error',
+        'ember/no-attrs-in-components': 'error',
+        'ember/no-old-shims': 'error',
     },
     overrides: [
         {

--- a/app/serializers/review-action.ts
+++ b/app/serializers/review-action.ts
@@ -3,6 +3,7 @@ import OsfSerializer from './osf-serializer';
 export default class ReviewAction extends OsfSerializer {
     // Because `trigger` is a private method on DS.Model
     attrs: any = {
+        // eslint-disable-next-line ember/no-attrs-in-components
         ...this.attrs, // from OsfSerializer
         actionTrigger: 'trigger',
     };


### PR DESCRIPTION
## Purpose

Enable all the ember linting rules we can because...we can.

## Summary of Changes

Enable the following linting rules:
* [ember/new-module-imports](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/new-module-imports.md)
* [ember/no-attrs-in-components](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-attrs-in-components.md)
* [ember/no-old-shims](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-old-shims.md)

Add one "exception" for `ember/no-attrs-in-components` because it apparently doesn't know what a component is.

## Side Effects

Better code?

## Testing Notes

N/A

## Ticket

N/A

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(no code change)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
