### PR TITLE
Remove mirage fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - Update ember-cli-addon-docs dependency
 - Misc:
     - upgrade to ember(-(cli|data))@~3.3.0
+- DX:
+    - No more mirage fixtures
 
 ## [0.7.0] - 2018-08-07
 ### Added

--- a/mirage/fixtures/nodes.js
+++ b/mirage/fixtures/nodes.js
@@ -1,4 +1,0 @@
-export default [
-    { id: 'z3sg2', linkedNodeIds: ['1', '2', '3', '4', '5'], title: 'NNW' },
-    { id: '57tnq', linkedNodeIds: ['6', '7', '8', '9', '10'], title: 'Popular' },
-];

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -3,7 +3,8 @@ export default function (server) {
     const firstNode = server.create('node', {});
     server.create('contributor', { node: firstNode, users: currentUser, index: 0 });
     const nodes = server.createList('node', 10, {}, 'withContributors');
-    server.loadFixtures('nodes');
+    server.create('node', { id: 'z3sg2', linkedNodeIds: ['1', '2', '3', '4', '5'], title: 'NNW' });
+    server.create('node', { id: '57tnq', linkedNodeIds: ['6', '7', '8', '9', '10'], title: 'Popular' });
     for (let i = 4; i < 10; i++) {
         server.create('contributor', { node: nodes[i], users: currentUser, index: 11 });
     }

--- a/tests/acceptance/dashboard-test.ts
+++ b/tests/acceptance/dashboard-test.ts
@@ -12,7 +12,8 @@ module('Acceptance | dashboard', hooks => {
         // A fully loaded dashboard should have no major troubles
         const currentUser = server.create('user');
         const nodes = server.createList('node', 10, {}, 'withContributors');
-        server.loadFixtures('nodes');
+        server.create('node', { id: 'z3sg2', linkedNodeIds: ['1', '2', '3', '4', '5'], title: 'NNW' });
+        server.create('node', { id: '57tnq', linkedNodeIds: ['6', '7', '8', '9', '10'], title: 'Popular' });
         for (let i = 4; i < 10; i++) {
             server.create('contributor', { node: nodes[i], users: currentUser, index: 11 });
         }
@@ -53,7 +54,8 @@ module('Acceptance | dashboard', hooks => {
         const currentUser = server.create('user');
         server.create('root', { currentUser });
         const nodes = server.createList('node', 10, {}, 'withContributors');
-        server.loadFixtures('nodes');
+        server.create('node', { id: 'z3sg2', linkedNodeIds: ['1', '2', '3', '4', '5'], title: 'NNW' });
+        server.create('node', { id: '57tnq', linkedNodeIds: ['6', '7', '8', '9', '10'], title: 'Popular' });
         await visit('/dashboard');
         assert.dom('img[alt*="Missing translation"]').doesNotExist();
         for (const node of nodes) {
@@ -95,7 +97,8 @@ module('Acceptance | dashboard', hooks => {
     test('user has many projects', async function(assert) {
         const currentUser = server.create('user');
         const nodes = server.createList('node', 30, {}, 'withContributors');
-        server.loadFixtures('nodes');
+        server.create('node', { id: 'z3sg2', linkedNodeIds: ['1', '2', '3', '4', '5'], title: 'NNW' });
+        server.create('node', { id: '57tnq', linkedNodeIds: ['6', '7', '8', '9', '10'], title: 'Popular' });
         for (const node of nodes) {
             server.create('contributor', { node, users: currentUser, index: 11 });
         }


### PR DESCRIPTION
## Purpose

No more icky Fixtures. Only Factories.

## Summary of Changes

1. Delete fixtures directory
2. Update default scenario to use node factory instead of fixtures for NNW and Popular nodes
3. Update tests to use node factory instead of fixtures for NNW and Popular nodes

## QA Notes

No need to test. Developer-only changes

## Ticket

N/A

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->