### PR TITLE
Get new & noteworth + popular node IDs from config

### DIFF
--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -1,10 +1,19 @@
+import config from 'ember-get-config';
+
+const {
+    dashboard: {
+        noteworthyNode,
+        popularNode,
+    },
+} = config;
+
 export default function (server) {
     const currentUser = server.create('user');
     const firstNode = server.create('node', {});
     server.create('contributor', { node: firstNode, users: currentUser, index: 0 });
     const nodes = server.createList('node', 10, {}, 'withContributors');
-    server.create('node', { id: 'z3sg2', linkedNodeIds: ['1', '2', '3', '4', '5'], title: 'NNW' });
-    server.create('node', { id: '57tnq', linkedNodeIds: ['6', '7', '8', '9', '10'], title: 'Popular' });
+    server.create('node', { id: noteworthyNode, linkedNodeIds: ['1', '2', '3', '4', '5'], title: 'NNW' });
+    server.create('node', { id: popularNode, linkedNodeIds: ['6', '7', '8', '9', '10'], title: 'Popular' });
     for (let i = 4; i < 10; i++) {
         server.create('contributor', { node: nodes[i], users: currentUser, index: 11 });
     }


### PR DESCRIPTION
## Purpose

Tests break if you set `POPULAR_LINKS_NODE` and/or `NEW_AND_NOTEWORTHY_LINKS_NODE` locally

## Summary of Changes

Use the values from the ember config, which has the proper defaults in it

## Side Effects

N/A

## Feature Flags

N/A

## QA Notes

No QA needed

## Ticket

None

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
