### PR TITLE
Feature/mirage guids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - upgrade to ember(-(cli|data))@~3.3.0
 - DX:
     - No more mirage fixtures
+    - Have guid-like IDs for mirage factories (nodes and users to start)
 
 ## [0.7.0] - 2018-08-07
 ### Added

--- a/mirage/factories/node.js
+++ b/mirage/factories/node.js
@@ -1,4 +1,5 @@
 import { Factory, faker, trait } from 'ember-cli-mirage';
+import { guid } from './utils';
 
 export default Factory.extend({
     category() {
@@ -15,6 +16,9 @@ export default Factory.extend({
             'software',
             'other',
         ]);
+    },
+    id(i) {
+        return guid(i, 'node');
     },
     fork: false,
     currentUserIsContributor: false,

--- a/mirage/factories/user.js
+++ b/mirage/factories/user.js
@@ -1,6 +1,10 @@
 import { Factory, faker, trait } from 'ember-cli-mirage';
+import { guid } from './utils';
 
 export default Factory.extend({
+    id(i) {
+        return guid(i, 'user');
+    },
     fullName() {
         return `${faker.name.firstName()} ${faker.name.lastName()}`;
     },

--- a/mirage/factories/utils.ts
+++ b/mirage/factories/utils.ts
@@ -1,0 +1,5 @@
+export const guid = (id: number, type: string): string => { // eslint-disable-line import/prefer-default-export
+    const numPart = String(id);
+    const typPart = type.substr(0, 5 - numPart.length);
+    return `${typPart}${numPart}`;
+};

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -3,8 +3,16 @@ export default function (server) {
     const firstNode = server.create('node', {});
     server.create('contributor', { node: firstNode, users: currentUser, index: 0 });
     const nodes = server.createList('node', 10, {}, 'withContributors');
-    server.create('node', { id: 'z3sg2', linkedNodeIds: ['1', '2', '3', '4', '5'], title: 'NNW' });
-    server.create('node', { id: '57tnq', linkedNodeIds: ['6', '7', '8', '9', '10'], title: 'Popular' });
+    server.create('node', {
+        id: 'z3sg2',
+        linkedNodeIds: ['node1', 'node2', 'node3', 'node4', 'node5'],
+        title: 'NNW',
+    });
+    server.create('node', {
+        id: '57tnq',
+        linkedNodeIds: ['node6', 'node7', 'node8', 'node9', 'nod10'],
+        title: 'Popular',
+    });
     for (let i = 4; i < 10; i++) {
         server.create('contributor', { node: nodes[i], users: currentUser, index: 11 });
     }

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -14,16 +14,16 @@ export default function (server) {
     const nodes = server.createList('node', 10, {}, 'withContributors');
     server.create('node', {
         id: noteworthyNode,
-        linkedNodeIds: ['node1', 'node2', 'node3', 'node4', 'node5'],
+        linkedNodes: nodes.slice(0, 5),
         title: 'NNW',
     });
     server.create('node', {
         id: popularNode,
-        linkedNodeIds: ['node6', 'node7', 'node8', 'node9', 'nod10'],
+        linkedNodes: nodes.slice(5, 10),
         title: 'Popular',
     });
-    for (let i = 4; i < 10; i++) {
-        server.create('contributor', { node: nodes[i], users: currentUser, index: 11 });
+    for (const node of nodes.slice(4, 10)) {
+        server.create('contributor', { node, users: currentUser, index: 11 });
     }
     server.create('root', { currentUser });
     server.createList('institution', 20);

--- a/mirage/serializers/root.js
+++ b/mirage/serializers/root.js
@@ -21,7 +21,7 @@ export default ApplicationSerializer.extend({
                         nodes: {
                             links: {
                                 related: {
-                                    href: `${apiUrl}/v2/users/${object.id}/nodes/`,
+                                    href: `${apiUrl}/v2/users/${object.currentUser.id}/nodes/`,
                                     meta: {},
                                 },
                             },
@@ -40,7 +40,7 @@ export default ApplicationSerializer.extend({
                         timezone: object.currentUser.timezone,
                     },
                     links: {
-                        self: `/v2/users/${object.currentUser.id}/`,
+                        self: `/v2/users/${object.currentUser.attrs.id}/`,
                         profile_image: object.currentUser.profileImage,
                     },
                     type: 'users',

--- a/tests/acceptance/dashboard-test.ts
+++ b/tests/acceptance/dashboard-test.ts
@@ -12,8 +12,16 @@ module('Acceptance | dashboard', hooks => {
         // A fully loaded dashboard should have no major troubles
         const currentUser = server.create('user');
         const nodes = server.createList('node', 10, {}, 'withContributors');
-        server.create('node', { id: 'z3sg2', linkedNodeIds: ['1', '2', '3', '4', '5'], title: 'NNW' });
-        server.create('node', { id: '57tnq', linkedNodeIds: ['6', '7', '8', '9', '10'], title: 'Popular' });
+        server.create('node', {
+            id: 'z3sg2',
+            linkedNodeIds: ['node1', 'node2', 'node3', 'node4', 'node5'],
+            title: 'NNW',
+        });
+        server.create('node', {
+            id: '57tnq',
+            linkedNodeIds: ['node6', 'node7', 'node8', 'node9', 'nod10'],
+            title: 'Popular',
+        });
         for (let i = 4; i < 10; i++) {
             server.create('contributor', { node: nodes[i], users: currentUser, index: 11 });
         }
@@ -54,8 +62,16 @@ module('Acceptance | dashboard', hooks => {
         const currentUser = server.create('user');
         server.create('root', { currentUser });
         const nodes = server.createList('node', 10, {}, 'withContributors');
-        server.create('node', { id: 'z3sg2', linkedNodeIds: ['1', '2', '3', '4', '5'], title: 'NNW' });
-        server.create('node', { id: '57tnq', linkedNodeIds: ['6', '7', '8', '9', '10'], title: 'Popular' });
+        server.create('node', {
+            id: 'z3sg2',
+            linkedNodeIds: ['node1', 'node2', 'node3', 'node4', 'node5'],
+            title: 'NNW',
+        });
+        server.create('node', {
+            id: '57tnq',
+            linkedNodeIds: ['node6', 'node7', 'node8', 'node9', 'nod10'],
+            title: 'Popular',
+        });
         await visit('/dashboard');
         assert.dom('img[alt*="Missing translation"]').doesNotExist();
         for (const node of nodes) {
@@ -97,8 +113,16 @@ module('Acceptance | dashboard', hooks => {
     test('user has many projects', async function(assert) {
         const currentUser = server.create('user');
         const nodes = server.createList('node', 30, {}, 'withContributors');
-        server.create('node', { id: 'z3sg2', linkedNodeIds: ['1', '2', '3', '4', '5'], title: 'NNW' });
-        server.create('node', { id: '57tnq', linkedNodeIds: ['6', '7', '8', '9', '10'], title: 'Popular' });
+        server.create('node', {
+            id: 'z3sg2',
+            linkedNodeIds: ['node1', 'node2', 'node3', 'node4', 'node5'],
+            title: 'NNW',
+        });
+        server.create('node', {
+            id: '57tnq',
+            linkedNodeIds: ['node6', 'node7', 'node8', 'node9', 'nod10'],
+            title: 'Popular',
+        });
         for (const node of nodes) {
             server.create('contributor', { node, users: currentUser, index: 11 });
         }

--- a/tests/acceptance/dashboard-test.ts
+++ b/tests/acceptance/dashboard-test.ts
@@ -23,16 +23,16 @@ module('Acceptance | dashboard', hooks => {
         const nodes = server.createList('node', 10, {}, 'withContributors');
         server.create('node', {
             id: noteworthyNode,
-            linkedNodeIds: ['node0', 'node1', 'node2', 'node3', 'node4'],
+            linkedNodes: nodes.slice(0, 5),
             title: 'NNW',
         });
         server.create('node', {
             id: popularNode,
-            linkedNodeIds: ['node5', 'node6', 'node7', 'node8', 'node9'],
+            linkedNodes: nodes.slice(5, 10),
             title: 'Popular',
         });
-        for (let i = 4; i < 10; i++) {
-            server.create('contributor', { node: nodes[i], users: currentUser, index: 11 });
+        for (const node of nodes.slice(4, 10)) {
+            server.create('contributor', { node, users: currentUser, index: 11 });
         }
         server.create('root', { currentUser });
         server.createList('institution', 20);
@@ -73,12 +73,12 @@ module('Acceptance | dashboard', hooks => {
         const nodes = server.createList('node', 10, {}, 'withContributors');
         server.create('node', {
             id: noteworthyNode,
-            linkedNodeIds: ['node0', 'node1', 'node2', 'node3', 'node4'],
+            linkedNodes: nodes.slice(0, 5),
             title: 'NNW',
         });
         server.create('node', {
             id: popularNode,
-            linkedNodeIds: ['node5', 'node6', 'node7', 'node8', 'node9'],
+            linkedNodes: nodes.slice(5, 10),
             title: 'Popular',
         });
         await visit('/dashboard');
@@ -126,12 +126,12 @@ module('Acceptance | dashboard', hooks => {
         const nodes = server.createList('node', 30, {}, 'withContributors');
         server.create('node', {
             id: noteworthyNode,
-            linkedNodeIds: ['node0', 'node1', 'node2', 'node3', 'node4'],
+            linkedNodes: nodes.slice(0, 5),
             title: 'NNW',
         });
         server.create('node', {
             id: popularNode,
-            linkedNodeIds: ['node5', 'node6', 'node7', 'node8', 'node9'],
+            linkedNodes: nodes.slice(5, 10),
             title: 'Popular',
         });
         for (const node of nodes) {

--- a/tests/acceptance/dashboard-test.ts
+++ b/tests/acceptance/dashboard-test.ts
@@ -4,6 +4,15 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
+import config from 'ember-get-config';
+
+const {
+    dashboard: {
+        noteworthyNode,
+        popularNode,
+    },
+} = config;
+
 module('Acceptance | dashboard', hooks => {
     setupApplicationTest(hooks);
     setupMirage(hooks);
@@ -13,13 +22,13 @@ module('Acceptance | dashboard', hooks => {
         const currentUser = server.create('user');
         const nodes = server.createList('node', 10, {}, 'withContributors');
         server.create('node', {
-            id: 'z3sg2',
-            linkedNodeIds: ['node1', 'node2', 'node3', 'node4', 'node5'],
+            id: noteworthyNode,
+            linkedNodeIds: ['node0', 'node1', 'node2', 'node3', 'node4'],
             title: 'NNW',
         });
         server.create('node', {
-            id: '57tnq',
-            linkedNodeIds: ['node6', 'node7', 'node8', 'node9', 'nod10'],
+            id: popularNode,
+            linkedNodeIds: ['node5', 'node6', 'node7', 'node8', 'node9'],
             title: 'Popular',
         });
         for (let i = 4; i < 10; i++) {
@@ -63,23 +72,25 @@ module('Acceptance | dashboard', hooks => {
         server.create('root', { currentUser });
         const nodes = server.createList('node', 10, {}, 'withContributors');
         server.create('node', {
-            id: 'z3sg2',
-            linkedNodeIds: ['node1', 'node2', 'node3', 'node4', 'node5'],
+            id: noteworthyNode,
+            linkedNodeIds: ['node0', 'node1', 'node2', 'node3', 'node4'],
             title: 'NNW',
         });
         server.create('node', {
-            id: '57tnq',
-            linkedNodeIds: ['node6', 'node7', 'node8', 'node9', 'nod10'],
+            id: popularNode,
+            linkedNodeIds: ['node5', 'node6', 'node7', 'node8', 'node9'],
             title: 'Popular',
         });
         await visit('/dashboard');
         assert.dom('img[alt*="Missing translation"]').doesNotExist();
+        let i = 0;
         for (const node of nodes) {
             const { id, title, description } = node.attrs;
             let projectType = 'noteworthy';
-            if (id > 5) {
+            if (i > 4) {
                 projectType = 'popular';
             }
+            i++;
             assert.dom(`[data-test-${projectType}-project="${id}"]`)
                 .exists(`The ${projectType} project ${id} exists`);
             assert.dom(`[data-test-${projectType}-project="${id}"] [data-test-nnwp-project-title]`)
@@ -114,13 +125,13 @@ module('Acceptance | dashboard', hooks => {
         const currentUser = server.create('user');
         const nodes = server.createList('node', 30, {}, 'withContributors');
         server.create('node', {
-            id: 'z3sg2',
-            linkedNodeIds: ['node1', 'node2', 'node3', 'node4', 'node5'],
+            id: noteworthyNode,
+            linkedNodeIds: ['node0', 'node1', 'node2', 'node3', 'node4'],
             title: 'NNW',
         });
         server.create('node', {
-            id: '57tnq',
-            linkedNodeIds: ['node6', 'node7', 'node8', 'node9', 'nod10'],
+            id: popularNode,
+            linkedNodeIds: ['node5', 'node6', 'node7', 'node8', 'node9'],
             title: 'Popular',
         });
         for (const node of nodes) {

--- a/tests/unit/mirage/factories/utils-test.ts
+++ b/tests/unit/mirage/factories/utils-test.ts
@@ -1,0 +1,15 @@
+import { guid } from 'ember-osf-web/mirage/factories/utils';
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Mirage | Factories | Utils | guid generation', hooks => {
+    setupTest(hooks);
+
+    test('it can create guids', assert => {
+        assert.equal(guid(1, 'node'), 'node1');
+        assert.equal(guid(10, 'node'), 'nod10');
+        assert.equal(guid(100, 'node'), 'no100');
+        assert.equal(guid(1000, 'node'), 'n1000');
+        assert.equal(guid(10000, 'node'), '10000');
+    });
+});

--- a/tests/unit/models/osf-model-test.ts
+++ b/tests/unit/models/osf-model-test.ts
@@ -17,7 +17,7 @@ module('Unit | Model | osf-model', hooks => {
         const userId = '1';
 
         await run(async () => {
-            const userOne = server.create('user');
+            const userOne = server.create('user', { id: userId });
             const nodeList = server.createList('node', 3, {});
             for (let i = 0; i < 3; i++) {
                 server.create('contributor', { node: nodeList[i], users: userOne });
@@ -26,7 +26,7 @@ module('Unit | Model | osf-model', hooks => {
             assert.ok(!!user);
             assert.equal(user.get('id'), userId, 'Checking user id.');
 
-            const nodeIds = ['1', '2', '3'];
+            const nodeIds = ['node0', 'node1', 'node2'];
 
             const nodes = await user.queryHasMany('nodes');
 

--- a/tests/unit/models/osf-model-test.ts
+++ b/tests/unit/models/osf-model-test.ts
@@ -19,18 +19,18 @@ module('Unit | Model | osf-model', hooks => {
         await run(async () => {
             const userOne = server.create('user', { id: userId });
             const nodeList = server.createList('node', 3, {});
-            for (let i = 0; i < 3; i++) {
-                server.create('contributor', { node: nodeList[i], users: userOne });
+            for (const node of nodeList) {
+                server.create('contributor', { node, users: userOne });
             }
             const user = await store.findRecord('user', userId);
             assert.ok(!!user);
             assert.equal(user.get('id'), userId, 'Checking user id.');
-
-            const nodeIds = ['node0', 'node1', 'node2'];
+            const nodeIds = nodeList.map(node => node.id);
 
             const nodes = await user.queryHasMany('nodes');
 
             assert.equal(nodes.length, nodeIds.length);
+            assert.notEqual(nodes.length, 0);
             for (const node of nodes) {
                 assert.ok((nodeIds.indexOf(node.id) !== -1),
                     `All the node ids should be in the array, but ${node.id} isn't in nodeIds.`);


### PR DESCRIPTION
## Purpose

Make mirage work better with guid-like ids for factories that can take advantage of them.

## Summary of Changes

1. Add `guid()` helper for factories that let you pass in the index and the type and get back something that's 5 characters and unique
2. Update `nodes` and `users` factories to use this helper
3. Fix all the broken tests
4. Upgrade the tests for NNW/Popular nodes to use the settings (h/t @binoculars)
5. Update the root serializer to use the user's id and not the root's id
6. Tests for the `guid()` helper

## Side Effects

Anything relying on ids being stable for nodes and users should will break (though everything that was in `develop` at the time of this PR should be fixed).


## QA Notes

No testing required; this is exclusively for local development and testing

## Ticket

N/A

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
