### PR TITLE
Remove prepend from fingerprint

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -57,7 +57,6 @@ module.exports = function(defaults) {
             exclude: [
                 'zxcvbn.js',
             ],
-            prepend: config.assetsPrefix,
         },
         sassOptions: {
             includePaths: [


### PR DESCRIPTION
## Purpose

`assetLoader` seems to prefix everything properly. However, the sourcemaps are double prefixed, so opening the console makes a bunch of errors show up. Since sourcemaps only need to be relative, this is fine.

## Summary of Changes

Just removed the one line

## Side Effects

Hopefully none. I checked the build with --production and it looks good

## Feature Flags

<!--
  Please list any feature flags that need to be enabled for these changes to go into effect.
  For each flag, what is the expected behavior with the flag enabled vs disabled?
-->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
-->

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
https://openscience.atlassian.net/browse/EMB-

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
