### PR TITLE
Don't strip ember-test-selectors from production builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Misc:
     - install `@cos-forks/ember-content-placeholders`
     - upgrade to ember(-(cli|data))@~3.3.0
+    - don't strip ember-test-selectors from production builds
 - DX:
     - No more mirage fixtures
     - Have guid-like IDs for mirage factories (nodes and users to start)

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -117,6 +117,9 @@ module.exports = function(defaults) {
                 return config.assetsPrefix.replace(/\/$/, '') + filePath;
             },
         },
+        'ember-test-selectors': {
+            strip: false,
+        },
     });
 
     app.import('node_modules/dropzone/dist/dropzone.css');


### PR DESCRIPTION
## Purpose

Never strip ember-test-selectors (even in production builds), because we want to use them for Selenium tests.

## Summary of Changes

Add
```js
'ember-test-selectors': {
    strip: false,
},
```
to `ember-cli-build.js`

## Side Effects

Slightly larger bundle.

## Feature Flags

N/A

## QA Notes

Should start seeing `data-test-*` attributes on elements that have been marked with them.

Try:
```js
document.querySelector('[data-test-quick-search-input]');
```
on the dashboard.

## Ticket

N/A

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
