### PR TITLE
[EMB-368] Add mirage support for files, user files, and root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - Improved osf-api types
     - Fixed up types for `faker.list.cycle`/`faker.list.random`
     - Disable `max-classes-per-file` tslint rule globally
+    - Increase mirage support for:
+        - Non-relationship links
+        - Guid files
+        - Root user
 
 ### Removed
 - Models:

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -1,8 +1,9 @@
 import { Server } from 'ember-cli-mirage';
 import config from 'ember-get-config';
 import { relationshipList } from './views';
+import { rootDetail } from './views/root';
 import { tokenList } from './views/token';
-import { userList, userNodeList } from './views/user';
+import { userFileList, userList, userNodeList } from './views/user';
 
 const { OSF: { apiUrl } } = config;
 
@@ -13,10 +14,11 @@ export default function(this: Server) {
     this.namespace = '/v2';
     this.apiBaseUrl = `${this.urlPrefix}${this.namespace}`;
 
-    this.get('/', schema => {
-        return schema.roots.first();
+    this.get('/', function(schema) {
+        return rootDetail(schema, this);
     });
 
+    this.get('/files/:id');
     this.get('/institutions');
 
     this.resource('node', { path: '/nodes' });
@@ -46,6 +48,13 @@ export default function(this: Server) {
     this.get('/users/:id');
     this.get('/users/:id/nodes', function(schema, request) {
         return userNodeList(schema, request, this);
+    });
+    this.get('/users/:id/quickfiles', function(schema, request) {
+        return userFileList(schema, request, this);
+    });
+    this.get('/users/:userid/quickfiles/:id', (schema, request) => {
+        const { id } = request.params;
+        return schema.files.find(id);
     });
 
     this.get('tokens', function(schema, request) {

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -46,6 +46,9 @@ export default function(this: Server) {
     });
 
     this.get('/users/:id');
+    this.get('/users/:id/institutions', function(schema, request) {
+        return relationshipList('users', 'institutions', schema, request, this);
+    });
     this.get('/users/:id/nodes', function(schema, request) {
         return userNodeList(schema, request, this);
     });

--- a/mirage/factories/file.ts
+++ b/mirage/factories/file.ts
@@ -1,0 +1,62 @@
+import { Factory, faker } from 'ember-cli-mirage';
+import config from 'ember-get-config';
+
+import { guid } from './utils';
+
+const { OSF: { apiUrl } } = config;
+
+export default Factory.extend({
+    id(i: number) {
+        return guid(i, 'file');
+    },
+    name() {
+        return faker.system.commonFileName(faker.system.commonFileExt(), faker.system.commonFileType());
+    },
+    extra: {
+        hashes: {
+            md5: `${faker.random.uuid().replace(/-/g, '')}`,
+            sha256: `${faker.random.uuid().replace(/-/g, '')}`,
+        },
+        downloads: faker.random.number(1000),
+    },
+    kind: 'file',
+    last_touched() {
+        return faker.date.past(5);
+    },
+    materialized_path: `/${faker.system.commonFileName(faker.system.commonFileExt(), faker.system.commonFileType())}`,
+    date_modified() {
+        return faker.date.recent();
+    },
+    date_created() {
+        return faker.date.past(5);
+    },
+    guid(i: number) {
+        return guid(i, 'file');
+    },
+    currentVersion() {
+        return faker.random.number(200);
+    },
+    provider: 'osfstorage',
+    path(i: number) {
+        return `/${i}`;
+    },
+    currentUserCanComment: true,
+    checkout: null,
+    tags() {
+        return faker.lorem.words(5).split(' ');
+    },
+    size() {
+        return faker.random.number(1000000000);
+    },
+    normalLinks(i: number) {
+        const id = guid(i, 'file');
+        return {
+            upload: `${apiUrl}/wb/files/${id}/upload/`,
+            download: `${apiUrl}/wb/files/${id}/download/`,
+            move: `${apiUrl}/wb/files/${id}/move/`,
+            delete: `${apiUrl}/wb/files/${id}/download/`,
+            self: `${apiUrl}/v2/files/${id}/`,
+            info: `${apiUrl}/v2/files/${id}/`,
+        };
+    },
+});

--- a/mirage/factories/file.ts
+++ b/mirage/factories/file.ts
@@ -1,11 +1,9 @@
 import { Factory, faker } from 'ember-cli-mirage';
-import config from 'ember-get-config';
+import File from 'ember-osf-web/models/file';
 
 import { guid } from './utils';
 
-const { OSF: { apiUrl } } = config;
-
-export default Factory.extend({
+export default Factory.extend<File>({
     id(i: number) {
         return guid(i, 'file');
     },
@@ -19,15 +17,18 @@ export default Factory.extend({
         },
         downloads: faker.random.number(1000),
     },
-    kind: 'file',
-    last_touched() {
+    // kind: 'file',
+    // currentUserCanComment: true,
+    lastTouched() {
         return faker.date.past(5);
     },
-    materialized_path: `/${faker.system.commonFileName(faker.system.commonFileExt(), faker.system.commonFileType())}`,
-    date_modified() {
+    materializedPath(): string {
+        return `/${faker.system.commonFileName(faker.system.commonFileExt(), faker.system.commonFileType())}`;
+    },
+    dateModified() {
         return faker.date.recent();
     },
-    date_created() {
+    dateCreated() {
         return faker.date.past(5);
     },
     guid(i: number) {
@@ -40,23 +41,11 @@ export default Factory.extend({
     path(i: number) {
         return `/${i}`;
     },
-    currentUserCanComment: true,
-    checkout: null,
+    checkout: 'null',
     tags() {
         return faker.lorem.words(5).split(' ');
     },
     size() {
         return faker.random.number(1000000000);
-    },
-    normalLinks(i: number) {
-        const id = guid(i, 'file');
-        return {
-            upload: `${apiUrl}/wb/files/${id}/upload/`,
-            download: `${apiUrl}/wb/files/${id}/download/`,
-            move: `${apiUrl}/wb/files/${id}/move/`,
-            delete: `${apiUrl}/wb/files/${id}/download/`,
-            self: `${apiUrl}/v2/files/${id}/`,
-            info: `${apiUrl}/v2/files/${id}/`,
-        };
     },
 });

--- a/mirage/factories/user.ts
+++ b/mirage/factories/user.ts
@@ -6,7 +6,6 @@ import { guid } from './utils';
 
 export interface UserTraits {
     withNodes: Trait;
-    withFiles: Trait;
     loggedIn: Trait;
 }
 

--- a/mirage/factories/user.ts
+++ b/mirage/factories/user.ts
@@ -1,17 +1,13 @@
 import { Factory, faker, trait, Trait } from 'ember-cli-mirage';
 
-import config from 'ember-get-config';
 import User from 'ember-osf-web/models/user';
-import { NormalLinks } from 'osf-api';
 
 import { guid } from './utils';
 
-const { OSF: { apiUrl } } = config;
 export interface UserTraits {
     withNodes: Trait;
     withFiles: Trait;
     loggedIn: Trait;
-    normalLinks: NormalLinks;
 }
 
 export default Factory.extend<User & UserTraits>({
@@ -46,13 +42,6 @@ export default Factory.extend<User & UserTraits>({
     dateRegistered() {
         return faker.date.past();
     },
-    normalLinks(i: number) {
-        return {
-            self: `${apiUrl}/v2/users/${guid(i, 'user')}/`,
-            profile_image: `https://www.gravatar.com/avatar/${faker.random.uuid().replace(/-/g, '')}?d=identicon`,
-        };
-    },
-
     withNodes: trait({
         afterCreate(user, server) {
             server.createList('node', 5, { user }, 'withContributors');

--- a/mirage/models/user.js
+++ b/mirage/models/user.js
@@ -4,7 +4,7 @@ export default Model.extend({
     nodes: hasMany('node'),
     contributors: hasMany('contributor'),
     // reigstrations: hasMany('registration'),
-    // files: hasMany('file'),
+    quickfiles: hasMany('file'),
     institutions: hasMany('institution', { inverse: 'users' }),
     root: belongsTo('root', { inverse: 'currentUser' }),
 });

--- a/mirage/serializers/application.ts
+++ b/mirage/serializers/application.ts
@@ -1,7 +1,10 @@
 import { underscore } from '@ember/string';
 import { JSONAPISerializer, ModelInstance, Request } from 'ember-cli-mirage';
 import { ModelRegistry, RelationshipsFor } from 'ember-data';
+import config from 'ember-get-config';
 import { RelatedLinkMeta, RelationshipLinks } from 'osf-api';
+
+const { OSF: { apiUrl } } = config;
 
 // eslint-disable-next-line space-infix-ops
 export type SerializedLinks<T extends ModelRegistry[keyof ModelRegistry]> = {
@@ -30,26 +33,26 @@ export default class ApplicationSerializer extends JSONAPISerializer {
         return relatedCounts.includes(this.keyForRelationship(relationship)) ? { count } : {};
     }
 
-    serialize(_: ModelInstance, __: Request) {
-        // eslint-disable-next-line prefer-rest-params
-        const json = JSONAPISerializer.prototype.serialize.apply(this, arguments);
-        if ('data' in json) {
-            if ('attributes' in json.data && 'normal_links' in json.data.attributes) {
-                const links = json.data.attributes.normal_links;
-                json.data.links = links;
-                delete json.data.attributes.normal_links;
-            }
-            if ('relationships' in json.data) {
-                const { relationships } = json.data;
-                for (const key of Object.keys(relationships)) {
-                    const relationship = relationships[key].links;
-                    if ('data' in relationship) {
-                        json.data.relationships[key].data = relationship.data;
-                        delete json.data.relationships[key].links.data;
-                    }
+    buildNormalLinks(model: ModelInstance) {
+        return {
+            self: `${apiUrl}/v2/${model.type}/${model.id}/`,
+        };
+    }
+
+    serialize(model: ModelInstance, request: Request) {
+        const json = super.serialize(model, request);
+        json.data.links = this.buildNormalLinks(model);
+        if ('relationships' in json.data && json.data.relationships !== undefined) {
+            const { relationships } = json.data;
+            for (const key of Object.keys(relationships)) {
+                const relationship = relationships[key].links;
+                if ('data' in relationship) {
+                    json.data.relationships[key].data = relationship.data;
+                    delete json.data.relationships[key].links.data;
                 }
             }
         }
+
         return json;
     }
 }

--- a/mirage/serializers/application.ts
+++ b/mirage/serializers/application.ts
@@ -1,5 +1,5 @@
 import { underscore } from '@ember/string';
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import { JSONAPISerializer, ModelInstance, Request } from 'ember-cli-mirage';
 import { ModelRegistry, RelationshipsFor } from 'ember-data';
 import { RelatedLinkMeta, RelationshipLinks } from 'osf-api';
 
@@ -28,5 +28,28 @@ export default class ApplicationSerializer extends JSONAPISerializer {
         const related = model[relationship];
         const count = Array.isArray(related) ? related.length : 0;
         return relatedCounts.includes(this.keyForRelationship(relationship)) ? { count } : {};
+    }
+
+    serialize(_: ModelInstance, __: Request) {
+        // eslint-disable-next-line prefer-rest-params
+        const json = JSONAPISerializer.prototype.serialize.apply(this, arguments);
+        if ('data' in json) {
+            if ('attributes' in json.data && 'normal_links' in json.data.attributes) {
+                const links = json.data.attributes.normal_links;
+                json.data.links = links;
+                delete json.data.attributes.normal_links;
+            }
+            if ('relationships' in json.data) {
+                const { relationships } = json.data;
+                for (const key of Object.keys(relationships)) {
+                    const relationship = relationships[key].links;
+                    if ('data' in relationship) {
+                        json.data.relationships[key].data = relationship.data;
+                        delete json.data.relationships[key].links.data;
+                    }
+                }
+            }
+        }
+        return json;
     }
 }

--- a/mirage/serializers/file.ts
+++ b/mirage/serializers/file.ts
@@ -1,0 +1,30 @@
+import config from 'ember-get-config';
+import File from 'ember-osf-web/models/file';
+
+import ApplicationSerializer from './application';
+
+const { OSF: { apiUrl } } = config;
+
+export default class FileSerializer extends ApplicationSerializer {
+    links(model: File & { attrs: any }) {
+        const returnValue = {
+            user: {
+                data: {
+                    type: 'users',
+                    id: model.user.id,
+                },
+                related: {
+                    href: `${apiUrl}/v2/users/${model.user.id}/`,
+                    meta: this.buildRelatedLinkMeta(model, 'user'),
+                },
+            },
+            versions: {
+                related: {
+                    href: `${apiUrl}/v2/files/${model.id}/versions/`,
+                    meta: this.buildRelatedLinkMeta(model, 'versions'),
+                },
+            },
+        };
+        return returnValue;
+    }
+}

--- a/mirage/serializers/file.ts
+++ b/mirage/serializers/file.ts
@@ -1,3 +1,4 @@
+import { ModelInstance } from 'ember-cli-mirage';
 import config from 'ember-get-config';
 import File from 'ember-osf-web/models/file';
 
@@ -7,7 +8,7 @@ const { OSF: { apiUrl } } = config;
 
 export default class FileSerializer extends ApplicationSerializer {
     links(model: File & { attrs: any }) {
-        const returnValue = {
+        return {
             user: {
                 data: {
                     type: 'users',
@@ -25,6 +26,17 @@ export default class FileSerializer extends ApplicationSerializer {
                 },
             },
         };
-        return returnValue;
+    }
+
+    buildNormalLinks(model: ModelInstance<File>) {
+        const { id } = model;
+        return {
+            upload: `${apiUrl}/wb/files/${id}/upload/`,
+            download: `${apiUrl}/wb/files/${id}/download/`,
+            move: `${apiUrl}/wb/files/${id}/move/`,
+            delete: `${apiUrl}/wb/files/${id}/download/`,
+            self: `${apiUrl}/v2/files/${id}/`,
+            info: `${apiUrl}/v2/files/${id}/`,
+        };
     }
 }

--- a/mirage/serializers/file.ts
+++ b/mirage/serializers/file.ts
@@ -34,7 +34,7 @@ export default class FileSerializer extends ApplicationSerializer {
             upload: `${apiUrl}/wb/files/${id}/upload/`,
             download: `${apiUrl}/wb/files/${id}/download/`,
             move: `${apiUrl}/wb/files/${id}/move/`,
-            delete: `${apiUrl}/wb/files/${id}/download/`,
+            delete: `${apiUrl}/wb/files/${id}/delete/`,
             self: `${apiUrl}/v2/files/${id}/`,
             info: `${apiUrl}/v2/files/${id}/`,
         };

--- a/mirage/serializers/node.ts
+++ b/mirage/serializers/node.ts
@@ -1,3 +1,4 @@
+import { ModelInstance } from 'ember-cli-mirage';
 import config from 'ember-get-config';
 import Node from 'ember-osf-web/models/registration';
 import ApplicationSerializer, { SerializedLinks } from './application';
@@ -59,5 +60,11 @@ export default class NodeSerializer extends ApplicationSerializer {
             };
         }
         return returnValue;
+    }
+    buildNormalLinks(model: ModelInstance<Node>) {
+        return {
+            self: `${apiUrl}/v2/nodes/${model.id}/`,
+            html: `/${model.id}/`,
+        };
     }
 }

--- a/mirage/serializers/root.ts
+++ b/mirage/serializers/root.ts
@@ -1,23 +1,21 @@
-import config from 'ember-get-config';
+import { ModelInstance } from 'ember-cli-mirage';
 import { Links } from 'jsonapi-typescript';
-import { RootDocument } from 'osf-api';
+import { RootDocument } from 'osf-api'; // UserResource
 
 import User from 'ember-osf-web/models/user';
 
 import ApplicationSerializer from './application';
-
-const { OSF: { apiUrl } } = config;
 
 interface RootObject {
     activeFlags: string[];
     message: string;
     version: string;
     links: Links;
-    currentUser: User;
+    currentUser: ModelInstance<User>;
 }
 
 export default class RootSerializer extends ApplicationSerializer {
-    serialize(object: RootObject) {
+    serialize(object: ModelInstance<RootObject>) {
         const data: RootDocument = {
             meta: {
                 activeFlags: object.activeFlags,
@@ -26,42 +24,6 @@ export default class RootSerializer extends ApplicationSerializer {
             },
             links: object.links,
         };
-        if (object.currentUser) {
-            // When we fix links in the application serializer, replace this with a serialization of the user
-            data.meta.current_user = {
-                data: {
-                    relationships: {
-                        nodes: {
-                            links: {
-                                related: {
-                                    href: `${apiUrl}/v2/users/${object.currentUser.id}/nodes/`,
-                                    meta: this.buildRelatedLinkMeta(object.currentUser, 'nodes'),
-                                },
-                            },
-                        },
-                    },
-                    attributes: {
-                        accepted_terms_of_service: object.currentUser.acceptedTermsOfService ?
-                            object.currentUser.acceptedTermsOfService : false,
-                        full_name: object.currentUser.fullName,
-                        given_name: object.currentUser.givenName,
-                        family_name: object.currentUser.familyName,
-                        suffix: object.currentUser.suffix,
-                        locale: object.currentUser.locale,
-                        middle_names: object.currentUser.middleNames,
-                        social: object.currentUser.social,
-                        active: object.currentUser.active,
-                        timezone: object.currentUser.timezone,
-                    },
-                    links: {
-                        self: `/v2/users/${object.currentUser.id}/`,
-                        profile_image: object.currentUser.profileImage,
-                    },
-                    type: 'users',
-                    id: object.currentUser.id,
-                },
-            };
-        }
         return data;
     }
 }

--- a/mirage/serializers/user.ts
+++ b/mirage/serializers/user.ts
@@ -13,6 +13,18 @@ export default class UserSerializer extends ApplicationSerializer {
                     meta: this.buildRelatedLinkMeta(model, 'nodes'),
                 },
             },
+            quickfiles: {
+                related: {
+                    href: `${apiUrl}/v2/users/${model.id}/quickfiles/`,
+                    meta: this.buildRelatedLinkMeta(model, 'quickfiles'),
+                },
+            },
+            institutions: {
+                related: {
+                    href: `${apiUrl}/v2/users/${model.id}/institutions/`,
+                    meta: this.buildRelatedLinkMeta(model, 'institutions'),
+                },
+            },
         };
     }
 }

--- a/mirage/serializers/user.ts
+++ b/mirage/serializers/user.ts
@@ -1,3 +1,4 @@
+import { faker, ModelInstance } from 'ember-cli-mirage';
 import config from 'ember-get-config';
 import User from 'ember-osf-web/models/user';
 import ApplicationSerializer, { SerializedLinks } from './application';
@@ -25,6 +26,13 @@ export default class UserSerializer extends ApplicationSerializer {
                     meta: this.buildRelatedLinkMeta(model, 'institutions'),
                 },
             },
+        };
+    }
+
+    buildNormalLinks(model: ModelInstance<User>) {
+        return {
+            self: `${apiUrl}/v2/users/${model.id}/`,
+            profile_image: `https://www.gravatar.com/avatar/${faker.random.uuid().replace(/-/g, '')}?d=identicon`,
         };
     }
 }

--- a/mirage/views/root.ts
+++ b/mirage/views/root.ts
@@ -1,0 +1,10 @@
+import { HandlerContext, Schema } from 'ember-cli-mirage';
+
+export function rootDetail(schema: Schema, handlerContext: HandlerContext) {
+    const root = schema.roots.first();
+    const json = handlerContext.serialize(root);
+    if (root.currentUser && 'meta' in json) {
+        json.meta.current_user = handlerContext.serialize(root.currentUser);
+    }
+    return json;
+}

--- a/mirage/views/user.ts
+++ b/mirage/views/user.ts
@@ -15,6 +15,13 @@ export function userNodeList(schema: Schema, request: Request, handlerContext: H
     return json;
 }
 
+export function userFileList(schema: Schema, request: Request, handlerContext: HandlerContext) {
+    const user = schema.users.find(request.params.id);
+    const files = user.schema.files.all().models.map((file: any) => handlerContext.serialize(file).data);
+    const json = process(schema, request, handlerContext, files, { defaultSortKey: 'date_modified' });
+    return json;
+}
+
 export function userList(schema: Schema, request: Request) {
     return schema.users.where(user => filter(user, request));
 }

--- a/types/ember-cli-mirage/index.d.ts
+++ b/types/ember-cli-mirage/index.d.ts
@@ -42,7 +42,7 @@ interface ModelInstanceShared<T> {
     toString(): string;
 }
 
-export type ModelInstance<T> = ModelInstanceShared<T> & Model<T>;
+export type ModelInstance<T = AnyAttrs> = ModelInstanceShared<T> & Model<T>;
 
 interface Collection<T> {
     models: Array<ModelInstance<T>>;
@@ -208,4 +208,6 @@ export class JSONAPISerializer {
     keyForAttribute(attr: string): string;
 
     keyForRelationship(relationship: string): string;
+
+    serialize(object: ModelInstance, request: Request): Document;
 }

--- a/types/ember-cli-mirage/index.d.ts
+++ b/types/ember-cli-mirage/index.d.ts
@@ -1,3 +1,5 @@
+import { Document } from 'osf-api';
+
 export { default as faker } from 'faker';
 
 type ID = number | string;
@@ -209,5 +211,5 @@ export class JSONAPISerializer {
 
     keyForRelationship(relationship: string): string;
 
-    serialize(object: ModelInstance, request: Request): Document;
+    serialize(object: ModelInstance, request: Request): SingleResourceDocument;
 }

--- a/types/osf-api.d.ts
+++ b/types/osf-api.d.ts
@@ -81,4 +81,14 @@ export interface RelatedLinkMeta {
     count?: number;
 }
 
+export interface NormalLinks extends JSONAPI.Links {
+    info?: Link | null;
+    self?: Link | null;
+    move?: Link | null;
+    upload?: Link | null;
+    download?: Link | null;
+    delete?: Link | null;
+    self?: Link | null;
+    html?: Link | null;
+}
 /* eslint-enable no-use-before-define,camelcase */

--- a/types/osf-api.d.ts
+++ b/types/osf-api.d.ts
@@ -47,6 +47,7 @@ export interface Resource extends JSONAPI.ResourceObject {
     id: string | number;
     relationships?: Relationships;
     embeds?: Embeds;
+    links?: NormalLinks;
 }
 
 export interface UserResource extends Resource {
@@ -90,5 +91,6 @@ export interface NormalLinks extends JSONAPI.Links {
     delete?: Link | null;
     self?: Link | null;
     html?: Link | null;
+    profile_image?: Link | null;
 }
 /* eslint-enable no-use-before-define,camelcase */


### PR DESCRIPTION
## Purpose

Make mirage for ember-osf-web more complete. Note: you cannot go directly to a file detail page because the guid resolver could use a little extra work to handle that properly (and probably other guid situations). The details for that are available at 
https://openscience.atlassian.net/browse/EMB-379

## Summary of Changes

1. Add support for non-relationship links
2. Add support for files
3. Replace user serialization on root with call to user serializer
4. Allow `type` and `id` on relationships to serialize correctly

![dashboard gravatar](https://user-images.githubusercontent.com/6599111/45580907-97ee0900-b864-11e8-8738-130f711f04c5.png)
![guid user files](https://user-images.githubusercontent.com/6599111/45580913-a4726180-b864-11e8-96aa-0692a9ab43fb.png)
![guid files](https://user-images.githubusercontent.com/6599111/45580915-aa684280-b864-11e8-9e2e-ba533cbeede8.png)


## QA Notes

No QA; this is all developer-facing

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
https://openscience.atlassian.net/browse/EMB-3368

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~testable and includes test(s)~ But will allow for testing on quickfiles
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
