### PR TITLE
[no-ticket] Fix creating registrations and forks

### DIFF
--- a/app/guid-node/forks/controller.ts
+++ b/app/guid-node/forks/controller.ts
@@ -19,8 +19,7 @@ export default class GuidNodeForks extends Controller {
     deleteModal = false;
     loadingNew = false;
     newModal = false;
-
-    reloadList!: (page?: number) => void; // bound by paginated-list
+    reloadList = false;
 
     forksQueryParams = { embed: 'contributors' };
 
@@ -67,7 +66,7 @@ export default class GuidNodeForks extends Controller {
                 timeOut: 0,
                 extendedTimeOut: 0,
             });
-            this.reloadList();
+            this.set('reloadList', true);
         }).catch(() => {
             this.set('loadingNew', false);
             this.toast.error(this.i18n.t('forks.new_fork_failed'));
@@ -86,7 +85,7 @@ export default class GuidNodeForks extends Controller {
         node.deleteRecord();
         node.save().then(() => {
             this.toast.success(this.i18n.t('status.project_deleted'));
-            this.reloadList();
+            this.set('reloadList', true);
         }).catch(() => {
             this.toast.error(this.i18n.t('forks.delete_fork_failed'));
         });

--- a/app/guid-node/forks/template.hbs
+++ b/app/guid-node/forks/template.hbs
@@ -31,7 +31,7 @@
         {{#paginated-list/has-many
             modelTaskInstance=model.taskInstance
             relationshipName='forks'
-            doReload=(mut reloadList)
+            reload=reloadList
             query=forksQueryParams
             analyticsScope='Project Forks'
             as |list|

--- a/app/guid-node/registrations/controller.ts
+++ b/app/guid-node/registrations/controller.ts
@@ -26,8 +26,7 @@ export default class GuidNodeRegistrations extends Controller {
     newModalOpen = false;
     preregModalOpen = false;
     preregConsented = false;
-
-    reloadDrafts!: (page?: number) => void; // bound by paginated-list
+    reloadDrafts = false;
 
     preregLinks = {
         approvedJournal: 'http://cos.io/our-services/prereg-more-information/',
@@ -111,8 +110,8 @@ export default class GuidNodeRegistrations extends Controller {
         });
         await draftRegistration.save();
         this.set('newModalOpen', false);
+        this.set('reloadDrafts', true);
         this.set('selectedSchema', this.defaultSchema);
-        this.reloadDrafts();
         window.location.assign(
             pathJoin(baseURL, draftRegistration.branchedFrom.get('id'), 'drafts', draftRegistration.id),
         );

--- a/app/guid-node/registrations/template.hbs
+++ b/app/guid-node/registrations/template.hbs
@@ -27,7 +27,7 @@
                                 {{#paginated-list/has-many
                                     modelTaskInstance=this.model.taskInstance
                                     relationshipName='draftRegistrations'
-                                    doReload=(mut this.reloadDrafts)
+                                    reload=this.reloadDrafts
                                     query=this.draftsQueryParams
                                     analyticsScope='Project Draft Registrations'
                                     as |list|

--- a/app/guid-registration/forks/controller.ts
+++ b/app/guid-registration/forks/controller.ts
@@ -19,8 +19,7 @@ export default class GuidRegistrationForks extends Controller {
     deleteModal = false;
     loadingNew = false;
     newModal = false;
-
-    reloadList!: (page?: number) => void;
+    reloadList = false;
 
     forksQueryParams = { embed: 'contributors' };
 
@@ -67,7 +66,7 @@ export default class GuidRegistrationForks extends Controller {
                 timeOut: 0,
                 extendedTimeOut: 0,
             });
-            this.reloadList();
+            this.set('reloadList', true);
         }).catch(() => {
             this.set('loadingNew', false);
             this.toast.error(this.i18n.t('forks.new_fork_failed'));
@@ -86,7 +85,7 @@ export default class GuidRegistrationForks extends Controller {
         node.deleteRecord();
         node.save().then(() => {
             this.toast.success(this.i18n.t('status.project_deleted'));
-            this.reloadList();
+            this.set('reloadList', true);
         }).catch(() => {
             this.toast.error(this.i18n.t('forks.delete_fork_failed'));
         });

--- a/app/guid-registration/forks/template.hbs
+++ b/app/guid-registration/forks/template.hbs
@@ -31,7 +31,7 @@
         {{#paginated-list/has-many
             modelTaskInstance=model.taskInstance
             relationshipName='forks'
-            doReload=(mut reloadList)
+            reload=reloadList
             query=forksQueryParams
             analyticsScope='Registration Forks'
             as |list|


### PR DESCRIPTION

<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[EMB-123] some really great stuff`
-->

## Purpose
Revert a part of #387 that broke reloading paginated lists. 
<!-- Describe the purpose of your changes. -->

## Summary of Changes
The problem is we want `paginated-list/*` to own their data and be in charge of loading logic, to avoid duplication, but also want to trigger a reload from the parent scope. I thought passing a bound action upward might be a good idea. It was not.

For now, going back to the old pattern of a bound boolean flag:
```hbs
{{paginated-list/... reload=this.reloadList}}
```
From the parent scope, `this.set('reloadList', true)` will trigger a reload, and `reloadList` will be set `false` when that reload is complete.
<!-- Briefly describe or list your changes. -->

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
