### PR TITLE
[no-ticket] Fix creating registrations and forks

### DIFF
--- a/app/guid-node/forks/controller.ts
+++ b/app/guid-node/forks/controller.ts
@@ -20,7 +20,7 @@ export default class GuidNodeForks extends Controller {
     loadingNew = false;
     newModal = false;
 
-    reloadList!: (page?: number) => void; // bound by paginated-list
+    reloadList?: (page?: number) => void; // bound by paginated-list
 
     forksQueryParams = { embed: 'contributors' };
 
@@ -67,7 +67,9 @@ export default class GuidNodeForks extends Controller {
                 timeOut: 0,
                 extendedTimeOut: 0,
             });
-            this.reloadList();
+            if (this.reloadList) {
+                this.reloadList();
+            }
         }).catch(() => {
             this.set('loadingNew', false);
             this.toast.error(this.i18n.t('forks.new_fork_failed'));
@@ -86,7 +88,9 @@ export default class GuidNodeForks extends Controller {
         node.deleteRecord();
         node.save().then(() => {
             this.toast.success(this.i18n.t('status.project_deleted'));
-            this.reloadList();
+            if (this.reloadList) {
+                this.reloadList();
+            }
         }).catch(() => {
             this.toast.error(this.i18n.t('forks.delete_fork_failed'));
         });

--- a/app/guid-node/forks/template.hbs
+++ b/app/guid-node/forks/template.hbs
@@ -31,7 +31,7 @@
         {{#paginated-list/has-many
             modelTaskInstance=model.taskInstance
             relationshipName='forks'
-            doReload=(mut reloadList)
+            bindReload=(action (mut reloadList))
             query=forksQueryParams
             analyticsScope='Project Forks'
             as |list|

--- a/app/guid-node/registrations/controller.ts
+++ b/app/guid-node/registrations/controller.ts
@@ -27,7 +27,7 @@ export default class GuidNodeRegistrations extends Controller {
     preregModalOpen = false;
     preregConsented = false;
 
-    reloadDrafts!: (page?: number) => void; // bound by paginated-list
+    reloadDrafts?: (page?: number) => void; // bound by paginated-list
 
     preregLinks = {
         approvedJournal: 'http://cos.io/our-services/prereg-more-information/',
@@ -112,7 +112,6 @@ export default class GuidNodeRegistrations extends Controller {
         await draftRegistration.save();
         this.set('newModalOpen', false);
         this.set('selectedSchema', this.defaultSchema);
-        this.reloadDrafts();
         window.location.assign(
             pathJoin(baseURL, draftRegistration.branchedFrom.get('id'), 'drafts', draftRegistration.id),
         );

--- a/app/guid-node/registrations/template.hbs
+++ b/app/guid-node/registrations/template.hbs
@@ -27,7 +27,7 @@
                                 {{#paginated-list/has-many
                                     modelTaskInstance=this.model.taskInstance
                                     relationshipName='draftRegistrations'
-                                    doReload=(mut this.reloadDrafts)
+                                    bindReload=(action (mut this.reloadDrafts))
                                     query=this.draftsQueryParams
                                     analyticsScope='Project Draft Registrations'
                                     as |list|

--- a/app/guid-registration/forks/controller.ts
+++ b/app/guid-registration/forks/controller.ts
@@ -20,7 +20,7 @@ export default class GuidRegistrationForks extends Controller {
     loadingNew = false;
     newModal = false;
 
-    reloadList!: (page?: number) => void;
+    reloadList?: (page?: number) => void;
 
     forksQueryParams = { embed: 'contributors' };
 
@@ -67,7 +67,9 @@ export default class GuidRegistrationForks extends Controller {
                 timeOut: 0,
                 extendedTimeOut: 0,
             });
-            this.reloadList();
+            if (this.reloadList) {
+                this.reloadList();
+            }
         }).catch(() => {
             this.set('loadingNew', false);
             this.toast.error(this.i18n.t('forks.new_fork_failed'));
@@ -86,7 +88,9 @@ export default class GuidRegistrationForks extends Controller {
         node.deleteRecord();
         node.save().then(() => {
             this.toast.success(this.i18n.t('status.project_deleted'));
-            this.reloadList();
+            if (this.reloadList) {
+                this.reloadList();
+            }
         }).catch(() => {
             this.toast.error(this.i18n.t('forks.delete_fork_failed'));
         });

--- a/app/guid-registration/forks/template.hbs
+++ b/app/guid-registration/forks/template.hbs
@@ -31,7 +31,7 @@
         {{#paginated-list/has-many
             modelTaskInstance=model.taskInstance
             relationshipName='forks'
-            doReload=(mut reloadList)
+            bindReload=(action (mut reloadList))
             query=forksQueryParams
             analyticsScope='Registration Forks'
             as |list|

--- a/lib/osf-components/addon/components/node-list/component.ts
+++ b/lib/osf-components/addon/components/node-list/component.ts
@@ -15,6 +15,7 @@ export default class NodeList extends Component {
 
     // Optional parameters
     analyticsScope?: string;
+    bindReload?: (action: (page?: number) => void) => void;
 
     @computed('relationshipName')
     get queryParams() {

--- a/lib/osf-components/addon/components/node-list/template.hbs
+++ b/lib/osf-components/addon/components/node-list/template.hbs
@@ -3,6 +3,7 @@
         modelTaskInstance=@modelTaskInstance
         relationshipName=@relationshipName
         query=this.queryParams
+        bindReload=this.bindReload
         analyticsScope=@analyticsScope
         as |pr|
     }}

--- a/lib/osf-components/addon/components/paginated-list/base-data-component.ts
+++ b/lib/osf-components/addon/components/paginated-list/base-data-component.ts
@@ -39,9 +39,10 @@ export default abstract class BaseDataComponent extends Component.extend({
     analyticsScope?: string;
 
     // Exposes a reload action the the parent scope.
-    // Invoke this component with `doReload=(mut this.reload)`, then call `this.reload()` to trigger a reload
-    // TODO: Don't use this pattern again; it's messy.
-    doReload?: (action: (page?: number) => void) => void;
+    // Usage: `bindReload=(action (mut this.reload))`, then call `this.reload()` to trigger a reload
+    // NOTE: Don't use this pattern too often, it could get messy. Try to reserve it for telling
+    // data-loading components to refresh themselves.
+    bindReload?: (action: (page?: number) => void) => void;
 
     // Private properties
     @service ready!: Ready;
@@ -56,8 +57,8 @@ export default abstract class BaseDataComponent extends Component.extend({
 
     constructor(...args: any[]) {
         super(...args);
-        if (this.doReload) {
-            this.doReload(this._doReload.bind(this));
+        if (this.bindReload) {
+            this.bindReload(this._doReload.bind(this));
         }
         this.loadItemsWrapperTask.perform({ reloading: false });
     }


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[EMB-123] some really great stuff`
-->

## Purpose
Fix a bug introduced in #387 that broke reloading paginated lists.

Alternative fix to #393 
<!-- Describe the purpose of your changes. -->

## Summary of Changes
The problem is we want `paginated-list/*` to own their data and be in charge of loading logic, to avoid duplication, but also want to trigger a reload from the parent scope. The solution used here is calling an action to send a bound function upward:

```hbs
{{paginated-list/... bindReload=(action (mut this.reload))}}
```
From the parent scope, `this.reload()` will trigger a reload.

This pattern of passing component actions upward could get messy if used more generally, though. We should probably avoid it in most circumstances. It seems acceptable in this specific situation: Telling a data-loading component to refresh itself.
<!-- Briefly describe or list your changes. -->

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
