### PR TITLE
[No Ticket] Fix handbook search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         - Non-relationship links
         - Guid files
         - Root user
+    - Mirage: pass through all requests on current domain
 
 ### Removed
 - Models:

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -7,7 +7,7 @@ import { userFileList, userNodeList } from './views/user';
 const { OSF: { apiUrl } } = config;
 
 export default function(this: Server) {
-    this.passthrough('/write-coverage'); // for ember-cli-code-coverage
+    this.passthrough(); // pass through all requests on currrent domain
 
     this.urlPrefix = apiUrl;
     this.namespace = '/v2';


### PR DESCRIPTION
## Purpose

Handbook search is currently non-functional because mirage is intercepting the request for the search index JSON file. This configures to Mirage to pass through all requests on the current domain, allowing dynamic load of any file in `dist`.

## Summary of Changes

Mirage: pass through all requests on current domain

## Side Effects

Shouldn't be any.

## Feature Flags

n/a

## QA Notes

No QA needed.

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
