### PR TITLE
[no ticket] Fix up template-lint rules

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -7,8 +7,13 @@ module.exports = {
 
     rules: {
         'block-indentation': 4,
-        'bare-strings': true,
-        'nested-interactive': false,
+        'attribute-indentation': {
+            indentation: 4,
+            'open-invocation-max-len': 120,
+            'process-elements': true,
+        },
+        'no-bare-strings': true,
+        'no-nested-interactive': false,
     },
 
     ignore: [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         - Guid files
         - Root user
     - Mirage: pass through all requests on current domain
+    - Fix up template-lint rules for `ember-cli-template-lint` 1.0
+        - Configure the `attribute-indentation` rule to use 4 spaces and prevent lines > 120 chars
+        - Enable `no-bare-strings` in place of the deprecated `bare-strings` rule
+        - Disable `no-nested-interactive` which has replaced `nested-interactive` in the recommended ruleset
 
 ### Removed
 - Models:


### PR DESCRIPTION
## Purpose

The upgrade to ember* 3.4 included upgrading ember-cli-template-lint to [1.0.0-beta.1](https://github.com/ember-template-lint/ember-cli-template-lint/blob/master/CHANGELOG.md#v100-beta1) (which ember-new-output [shows us](https://github.com/ember-cli/ember-new-output/blob/v3.4.3/package.json#L35) we would get with `ember new` using ember-cli 3.4). This version depends on [ember-template-lint 1.0.0-beta.2](https://github.com/ember-template-lint/ember-template-lint/blob/master/CHANGELOG.md#v100-beta2), which, along with [ember-template-lint 1.0.0-beta.1](https://github.com/ember-template-lint/ember-template-lint/blob/master/CHANGELOG.md#v100-beta1), includes quite a few new rules in the recommended set. This PR adds a bit of configuration for this new ruleset.

## Summary of Changes

- Configure the `attribute-indentation` rule to use 4 spaces and prevent lines > 120 chars
- Enable `no-bare-strings` in place of the deprecated `bare-strings` rule
- Disable `no-nested-interactive` which has replaced `nested-interactive` in the recommended ruleset

## Side Effects

n/a

## Feature Flags

n/a

## QA Notes

n/a

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
