### PR TITLE
[EMB-374] Make join-osf-banner stay dead in safari

### DIFF
--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -95,6 +95,7 @@ declare const config: {
         };
         localStorageKeys: {
             authSession: string;
+            joinBannerDismissed: string;
         };
         orcidClientId?: string;
         casUrl: string;

--- a/config/environment.js
+++ b/config/environment.js
@@ -169,6 +169,7 @@ module.exports = function(environment) {
             },
             localStorageKeys: {
                 authSession: 'embosf-auth-session',
+                joinBannerDismissed: 'slide', // TODO: update legacy UI to use a more unique key
             },
             orcidClientId,
             casUrl,

--- a/lib/osf-components/addon/components/join-osf-banner/component.ts
+++ b/lib/osf-components/addon/components/join-osf-banner/component.ts
@@ -1,29 +1,39 @@
-import { action, computed } from '@ember-decorators/object';
+import { layout } from '@ember-decorators/component';
+import { action } from '@ember-decorators/object';
+import { or } from '@ember-decorators/object/computed';
 import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
+import config from 'ember-get-config';
 import Analytics from 'ember-osf-web/services/analytics';
 import Session from 'ember-simple-auth/services/session';
 import styles from './styles';
-import layout from './template';
+import template from './template';
 
+const {
+    OSF: {
+        localStorageKeys: {
+            joinBannerDismissed: dismissedKey,
+        },
+    },
+} = config;
+
+@layout(template)
 export default class JoinOsfBanner extends Component {
-    layout = layout;
     styles = styles;
 
     @service analytics!: Analytics;
     @service session!: Session;
 
+    dismissed: boolean = false;
     storage = window.localStorage;
-    dismissedBanner = this.storage.getItem('slide') !== null;
+    previouslyDismissed = this.storage.getItem(dismissedKey) !== null;
+
+    @or('session.isAuthenticated', 'previouslyDismissed')
+    hideBanner!: boolean;
 
     @action
-    dismiss(this: JoinOsfBanner) {
-        this.set('dismissedBanner', true);
-        this.storage.setItem('slide', '0');
-    }
-
-    @computed('session.isAuthenticated', 'dismissedBanner')
-    get collapsed(): string {
-        return this.dismissedBanner || this.session.isAuthenticated ? 'collapse' : 'expand';
+    dismiss() {
+        this.set('dismissed', true);
+        this.storage.setItem(dismissedKey, '0');
     }
 }

--- a/lib/osf-components/addon/components/join-osf-banner/styles.scss
+++ b/lib/osf-components/addon/components/join-osf-banner/styles.scss
@@ -4,19 +4,17 @@
     z-index: 9;
     background-color: $color-bg-white;
     border-top: 2px solid $color-text-black;
-    animation-name: slideInFromBottom;
     width: 100%;
-    animation-fill-mode: both;
-}
 
-.JoinOsfBanner--expand {
-    animation-duration: 1s;
+    animation-name: slideUp;
     animation-delay: 2s;
-    transform: translateY(100%);
+    animation-fill-mode: both;
+    animation-duration: 1s;
 }
 
-.JoinOsfBanner--collapse {
-    animation-direction: reverse;
+.JoinOsfBanner--collapsed {
+    animation-name: slideDown;
+    animation-delay: 0s;
 }
 
 .JoinOsfBanner__banner {
@@ -33,12 +31,22 @@
     height: 120px;
 }
 
-@keyframes slideInFromBottom {
-    0% {
+@keyframes slideUp {
+    from {
         transform: translateY(100%);
     }
 
-    100% {
+    to {
         transform: translateY(0%);
+    }
+}
+
+@keyframes slideDown {
+    from {
+        transform: translateY(0%);
+    }
+
+    to {
+        transform: translateY(100%);
     }
 }

--- a/lib/osf-components/addon/components/join-osf-banner/template.hbs
+++ b/lib/osf-components/addon/components/join-osf-banner/template.hbs
@@ -1,36 +1,53 @@
-<div local-class="JoinOsfBanner JoinOsfBanner--{{collapsed}}">
-    <div class="container" local-class="JoinOsfBanner__banner">
-        <div class="row">
-            <div class='col-sm-2 hidden-xs'>
-                <img src='/static/img/circle_logo.png'
-                     alt={{t 'general.osf'}}
-                     aria-role="image"
-                     local-class="JoinOsfBanner__img"
-                >
-            </div>
-            <div class='col-sm-10 col-xs-12'>
-                <div class="row">
-                    <div class='col-xs-11'>
-                        <h2 local-class="JoinOsfBanner__heading">{{t 'join_osf.header'}}</h2>
-                        <p>
-                            {{t 'join_osf.pitch'}}
-                            <a aria_role="link" onclick={{action 'click' 'button' 'Join OSF Banner - sign_up' target=analytics}} href="/register/">
-                                {{t 'join_osf.create_account'}}
-                            </a>
-                            {{t 'general.or'}}
-                            <a aria_role="link" onclick={{action 'click' 'button' 'Join OSF Banner - learn_more' target=analytics}} href="http://help.osf.io" target="_blank" rel="noreferrer">
-                                {{t 'join_osf.learn_more'}}
-                            </a>
-                            {{t 'general.period'}}
-                        </p>
-                    </div>
-                    <div class='col-xs-1'>
-                        <button type="button" class="close" aria-label="Close" {{action 'click' 'button' 'Join OSF Banner - dismiss' target=analytics}} {{action dismiss}}>
-                            {{fa-icon 'times'}}
-                        </button>
+{{#unless this.hideBanner}}
+    <div local-class="JoinOsfBanner {{if this.dismissed 'JoinOsfBanner--collapsed'}}">
+        <div class="container" local-class="JoinOsfBanner__banner">
+            <div class="row">
+                <div class='col-sm-2 hidden-xs'>
+                    <img src='/static/img/circle_logo.png'
+                         alt={{t 'general.osf'}}
+                         local-class="JoinOsfBanner__img"
+                    >
+                </div>
+                <div class='col-sm-10 col-xs-12'>
+                    <div class="row">
+                        <div class='col-xs-11'>
+                            <h2 local-class="JoinOsfBanner__heading">
+                                {{t 'join_osf.header'}}
+                            </h2>
+                            <p>
+                                {{t 'join_osf.pitch'}}
+                                <a
+                                    href="/register/"
+                                    onclick={{action 'click' 'button' 'Join OSF Banner - sign_up' target=analytics}}
+                                >
+                                    {{t 'join_osf.create_account'}}
+                                </a>
+                                {{t 'general.or'}}
+                                <a
+                                    href="http://help.osf.io"
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    onclick={{action 'click' 'button' 'Join OSF Banner - learn_more' target=analytics}}
+                                >
+                                    {{t 'join_osf.learn_more'}}
+                                </a>
+                                {{t 'general.period'}}
+                            </p>
+                        </div>
+                        <div class='col-xs-1'>
+                            <button
+                                type="button"
+                                class="close"
+                                aria-label={{t 'general.close'}}
+                                {{action 'click' 'button' 'Join OSF Banner - dismiss' target=analytics}}
+                                {{action dismiss}}
+                            >
+                                {{fa-icon 'times'}}
+                            </button>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
+{{/unless}}


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[EMB-123] some really great stuff`
-->

## Purpose
In safari, you can dismiss the "join OSF" banner once, but then it comes back and is unkillable.
<!-- Describe the purpose of your changes. -->

## Summary of Changes
- Wrap the banner in an `{{#unless}}` block, so it's not even in the DOM if it's been previously dismissed.
- Make the dismissal a nice animated slide down, like on legacy.
- Move the local storage key into the config, rather than a hardcoded string.
<!-- Briefly describe or list your changes. -->
![kapture 2018-10-05 at 12 50 43](https://user-images.githubusercontent.com/6776190/46550279-9aabaf00-c8a2-11e8-9f55-b94f9de66f98.gif)


## Side Effects
n/a
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## Feature Flags
n/a
<!--
  Please list any feature flags that need to be enabled for these changes to go into effect.
  For each flag, what is the expected behavior with the flag enabled vs disabled?
-->

## QA Notes
Of course test in safari, and probably worth checking the new downward animation works in at least one other browser too.

- Open a private/incognito window
- Go to an embosf project page, like forks or analytics
- The "join osf" banner should slide up gracefully
- Isn't it sad that our first impression to most people has the cookie banner obscuring our pitch?
- Dismiss the "join osf" banner, it should slide down just as gracefully
- Refresh the page, and it should not come back
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
-->

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
https://openscience.atlassian.net/browse/EMB-374

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
