### PR TITLE
Feature/collections fixes

### DIFF
--- a/app/services/theme.ts
+++ b/app/services/theme.ts
@@ -114,7 +114,10 @@ export default class Theme extends Service {
     }
 
     reset(this: Theme) {
-        this.set('id', defaultProvider);
+        this.setProperties({
+            id: defaultProvider,
+            providerType: undefined,
+        });
     }
 
     prefixRoute(route: string): string {

--- a/lib/app-components/addon/components/error-page/template.hbs
+++ b/lib/app-components/addon/components/error-page/template.hbs
@@ -17,15 +17,21 @@
                     </a>
                 </span>
             </p>
-            <a
-                class="btn btn-primary m-t-md"
-                href={{theme.pathPrefix}}
-                onclick={{action 'click' 'link' (concat label ' - Go to Index') target=analytics}}
-            >
-                {{t 'app_components.error_page.go_to'
-                    brand=(t @brandKey name=(if theme.isProvider theme.provider.name 'general.osf'))
-                }}
-            </a>
+            {{#if theme.isProvider}}
+                <a
+                    class="btn btn-primary m-t-md"
+                    href={{theme.pathPrefix}}
+                    onclick={{action 'click' 'link' (concat label ' - Go to Index') target=analytics}}
+                >
+                    {{t 'app_components.error_page.go_to'
+                        brand=(t @brandKey name=theme.provider.name)
+                    }}
+                </a>
+            {{else}}
+                {{#link-to-external 'home' class="btn btn-primary m-t-md"}}
+                    {{t 'app_components.error_page.go_to' brand=(t 'general.OSF')}}
+                {{/link-to-external}}
+            {{/if}}
         </div>
     </div>
 </div>

--- a/lib/collections/addon/application/controller.ts
+++ b/lib/collections/addon/application/controller.ts
@@ -3,11 +3,13 @@ import { service } from '@ember-decorators/service';
 import Controller from '@ember/controller';
 import config from 'ember-get-config';
 import CurrentUser from 'ember-osf-web/services/current-user';
+import Theme from 'ember-osf-web/services/theme';
 import pathJoin from 'ember-osf-web/utils/path-join';
 import $ from 'jquery';
 
 export default class Application extends Controller {
     @service currentUser!: CurrentUser;
+    @service theme!: Theme;
 
     signupUrl = `${pathJoin(config.OSF.url, 'register')}?${$.param({ next: window.location.href })}`;
 

--- a/lib/collections/addon/application/route.ts
+++ b/lib/collections/addon/application/route.ts
@@ -1,13 +1,18 @@
+import { service } from '@ember-decorators/service';
 import Route from '@ember/routing/route';
+import Theme from 'ember-osf-web/services/theme';
 
 export default class Application extends Route.extend({
-    beforeModel(transition: any) {
+    beforeModel(this: Application, transition: any) {
         this._super(transition);
 
+        this.theme.set('providerType', 'collection');
+
         // If we're not on a provider, redirect
-        if (!/^collections\.provider/.test(transition.targetName)) {
-            this.transitionToExternal('home');
+        if (!/^collections\.(provider|page-not-found)/.test(transition.targetName)) {
+            return this.transitionToExternal('home');
         }
     },
 }) {
+    @service theme!: Theme;
 }

--- a/lib/collections/addon/application/route.ts
+++ b/lib/collections/addon/application/route.ts
@@ -6,7 +6,6 @@ export default class Application extends Route.extend({
 
         // If we're not on a provider, redirect
         if (!/^collections\.provider/.test(transition.targetName)) {
-            // @ts-ignore
             this.transitionToExternal('home');
         }
     },

--- a/lib/collections/addon/application/template.hbs
+++ b/lib/collections/addon/application/template.hbs
@@ -1,9 +1,11 @@
 {{theme-styles}}
-{{branded-navbar
-    translateKey='collections.general.brand'
-    brandRoute='provider.discover'
-    signupUrl=signupUrl
-    loginAction=(action 'login')
-    addLinkKey='collections.navbar.add'
-}}
+{{#if theme.isProvider}}
+    {{branded-navbar
+        translateKey='collections.general.brand'
+        brandRoute='provider.discover'
+        signupUrl=signupUrl
+        loginAction=(action 'login')
+        addLinkKey='collections.navbar.add'
+    }}
+{{/if}}
 {{outlet}}

--- a/lib/collections/addon/components/discover-page/component.ts
+++ b/lib/collections/addon/components/discover-page/component.ts
@@ -307,6 +307,9 @@ export default class DiscoverPage extends Component.extend({
 
             // If issue with search query, for example, invalid lucene search syntax
             this.set(errorResponse.status === 400 ? 'queryError' : 'shareDown', true);
+
+            // re-throw for error monitoring
+            throw errorResponse;
         }
     }).keepLatest();
 

--- a/types/ember-engines/route.d.ts
+++ b/types/ember-engines/route.d.ts
@@ -1,0 +1,14 @@
+/**
+ * This functionality is only available in ember-engines
+ * http://ember-engines.com/guide/linking-and-external-links
+ * https://github.com/ember-engines/ember-engines/blob/85ac004478f357fbdec34110613f7569c7dccece/addon/
+ * -private/route-ext.js
+ */
+declare module '@ember/routing/route' {
+    class EngineRoute extends Route {
+        replaceWithExternal(name: string, ...args: any[]): Transition;
+        transitionToExternal(name: string, ...args: any[]): Transition;
+    }
+
+    export = EngineRoute;
+}


### PR DESCRIPTION
## Purpose

* Need to re-throw errors on the discover-page component so it gets logged to Sentry
* Get rid of some `// @ts-ignore` for engine-specific route methods
* Don't show `branded-navbar` in collections if a provider is not set

## Summary of Changes

* Adds types for routes with Engines
  * `replaceWithExternal`
  * `transitionToExternal`

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## Feature Flags

None

## QA Notes

* `/collections/page-not-found` should work correctly now
* Going to a provider route `/collections/unknown/discover` should redirect to page-not-found without error

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
None

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
