### PR TITLE
[EMB-382] hide wiki link in project navbar if wiki is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased']
+### Changed
+- Models:
+    - `node` - add `wikiEnabled` boolean attribute
+- Components:
+    - `node-navbar` - only display the Wiki link when `node.wikiEnabled`
+- Tests:
+    - `node-navbar` integration test - added checks for Wiki link presence/omission based on `node.wikiEnabled`
+
 ## [Unreleased]
 ### Added
 - Models:

--- a/app/models/node.ts
+++ b/app/models/node.ts
@@ -99,6 +99,7 @@ export default class Node extends BaseFileItem.extend(Validations, CollectableVa
     @attr('boolean') preprint!: boolean;
     @attr('array') subjects!: string[];
     @attr('boolean') currentUserCanComment!: boolean;
+    @attr('boolean') wikiEnabled!: boolean;
 
     @hasMany('contributor', { inverse: 'node' })
     contributors!: DS.PromiseManyArray<Contributor>;

--- a/lib/osf-components/addon/components/node-navbar/template.hbs
+++ b/lib/osf-components/addon/components/node-navbar/template.hbs
@@ -19,7 +19,7 @@
                     {{/node-navbar/link}}
                     {{node-navbar/link nodeId=@node.id useLinkTo=false destination='files'}}
                     {{#if @node.wikiEnabled}}
-                        {{node-navbar/link nodeId=@node.id useLinkTo=false destination='wiki'}}
+                        {{node-navbar/link data-test-node-navbar-link-wiki nodeId=@node.id useLinkTo=false destination='wiki'}}
                     {{/if}}
                     {{node-navbar/link nodeId=@node.id useLinkTo=true destination='analytics'}}
                     {{#unless @node.isRegistration}}

--- a/lib/osf-components/addon/components/node-navbar/template.hbs
+++ b/lib/osf-components/addon/components/node-navbar/template.hbs
@@ -18,7 +18,9 @@
                         {{@node.title}}
                     {{/node-navbar/link}}
                     {{node-navbar/link nodeId=@node.id useLinkTo=false destination='files'}}
-                    {{node-navbar/link nodeId=@node.id useLinkTo=false destination='wiki'}}
+                    {{#if @node.wikiEnabled}}
+                        {{node-navbar/link nodeId=@node.id useLinkTo=false destination='wiki'}}
+                    {{/if}}
                     {{node-navbar/link nodeId=@node.id useLinkTo=true destination='analytics'}}
                     {{#unless @node.isRegistration}}
                         {{node-navbar/link nodeId=@node.id useLinkTo=true destination='registrations'}}

--- a/tests/integration/components/node-navbar/component-test.ts
+++ b/tests/integration/components/node-navbar/component-test.ts
@@ -15,14 +15,14 @@ module('Integration | Component | node-navbar', hooks => {
 
     test('it renders active tab when in proper route', async function(assert) {
         const routerStub = Service.extend({
-            currentRouteName: 'guid-node.wiki',
+            currentRouteName: 'guid-node.files',
         });
 
         this.owner.register('service:router', routerStub);
         await render(hbs`{{node-navbar renderInPlace=true}}`);
 
         assert.ok(findAll('li.active').length);
-        assert.ok(findAll('li.active')[0].innerHTML.includes('wiki'));
+        assert.ok(findAll('li.active')[0].innerHTML.includes('files'));
     });
 
     test('it renders no active tabs', async function(assert) {
@@ -34,5 +34,21 @@ module('Integration | Component | node-navbar', hooks => {
         await render(hbs`{{node-navbar renderInPlace=true}}`);
 
         assert.ok(!findAll('li.active').length);
+    });
+
+    test('it includes the wiki link when the wiki is enabled', async function(assert) {
+        this.set('node', { wikiEnabled: true });
+
+        await render(hbs`<NodeNavbar @renderInPlace={{true}} @node={{this.node}} />`);
+
+        assert.dom('[data-test-node-navbar-link-wiki]').exists('Wiki link exists');
+    });
+
+    test('it omits the wiki link when the wiki is disabled', async function(assert) {
+        this.set('node', { wikiEnabled: false });
+
+        await render(hbs`<NodeNavbar @renderInPlace={{true}} @node={{this.node}} />`);
+
+        assert.dom('[data-test-node-navbar-link-wiki]').doesNotExist('Wiki link does not exist');
     });
 });


### PR DESCRIPTION
## Purpose

This PR is to modify the node navbar so that the wiki link is omitted when a node has its wiki disabled. It depends on https://github.com/CenterForOpenScience/osf.io/pull/8736.

## Summary of Changes

### Changed
- Models:
    - `node` - add `wikiEnabled` boolean attribute
- Components:
    - `node-navbar` - only display the Wiki link when `node.wikiEnabled`
- Tests:
    - `node-navbar` integration test - added checks for Wiki link presence/omission based on `node.wikiEnabled`

## Side Effects

Should not be any.

## Feature Flags

n/a

## QA Notes

Embosfed guid-node and guid-registration pages should be tested to make sure the Wiki link appears for nodes/registrations that have their wiki enabled and does not for nodes/registrations that have their wiki disabled. Cross browser testing should not be necessary. There are no known edge cases. This should be low risk.

## Ticket

https://openscience.atlassian.net/browse/EMB-382

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
