### PR TITLE
[EMB-379] Resolve guids in mirage

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -132,6 +132,10 @@ module.exports = function(defaults) {
     app.import('node_modules/dropzone/dist/dropzone.css');
     app.import('node_modules/dropzone/dist/dropzone.js');
 
+    app.import('node_modules/seedrandom/seedrandom.min.js', {
+        using: [{ transformation: 'amd', as: 'seedrandom' }],
+    });
+
     app.import({
         test: 'vendor/ember/ember-template-compiler.js',
     });

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -6,6 +6,12 @@ import { userFileList, userNodeList } from './views/user';
 
 const { OSF: { apiUrl } } = config;
 
+function queryParamIsTruthy(value?: string) {
+    return Boolean(
+        value && ['true', '1'].includes(value.toString().toLowerCase()),
+    );
+}
+
 export default function(this: Server) {
     this.passthrough(); // pass through all requests on currrent domain
 
@@ -18,6 +24,17 @@ export default function(this: Server) {
     });
 
     this.get('/files/:id');
+
+    this.get('/guids/:id', (schema, request) => {
+        const { id } = request.params;
+        const { resolve } = request.queryParams;
+        const guid = schema.guids.find(id);
+        if (queryParamIsTruthy(resolve)) {
+            return schema[guid.referentType].find(id);
+        }
+        return guid;
+    });
+
     this.get('/institutions');
 
     osfResource(this, 'nodes');

--- a/mirage/factories/file.ts
+++ b/mirage/factories/file.ts
@@ -1,12 +1,13 @@
 import { Factory, faker } from 'ember-cli-mirage';
 import File from 'ember-osf-web/models/file';
 
-import { guid } from './utils';
+import { guid, guidAfterCreate } from './utils';
 
 export default Factory.extend<File>({
-    id(i: number) {
-        return guid(i, 'file');
-    },
+    id: guid('file'),
+    guid: guid('file'),
+    afterCreate: guidAfterCreate,
+
     name() {
         return faker.system.commonFileName(faker.system.commonFileExt(), faker.system.commonFileType());
     },
@@ -30,9 +31,6 @@ export default Factory.extend<File>({
     },
     dateCreated() {
         return faker.date.past(5);
-    },
-    guid(i: number) {
-        return guid(i, 'file');
     },
     currentVersion() {
         return faker.random.number(200);

--- a/mirage/factories/node.ts
+++ b/mirage/factories/node.ts
@@ -2,7 +2,7 @@ import { Factory, faker, trait, Trait } from 'ember-cli-mirage';
 
 import Node from 'ember-osf-web/models/node';
 
-import { guid } from './utils';
+import { guid, guidAfterCreate } from './utils';
 
 export interface NodeTraits {
     withContributors: Trait;
@@ -11,6 +11,9 @@ export interface NodeTraits {
 }
 
 export default Factory.extend<Node & NodeTraits>({
+    id: guid('node'),
+    afterCreate: guidAfterCreate,
+
     category: faker.list.cycle(
         'project',
         'analysis',
@@ -24,9 +27,6 @@ export default Factory.extend<Node & NodeTraits>({
         'software',
         'other',
     ),
-    id(i: number) {
-        return guid(i, 'node');
-    },
     fork: false,
     currentUserIsContributor: false,
     preprint: false,
@@ -50,6 +50,7 @@ export default Factory.extend<Node & NodeTraits>({
     nodeLicense: null,
     public: true,
     tags: faker.lorem.words(5).split(' '),
+
     withContributors: trait({
         afterCreate(node: any, server: any) {
             const contributorCount = faker.random.number({ min: 1, max: 5 });
@@ -65,6 +66,7 @@ export default Factory.extend<Node & NodeTraits>({
             }
         },
     }),
+
     withRegistrations: trait({
         afterCreate(node: any, server: any) {
             const registrationCount = faker.random.number({ min: 5, max: 15 });
@@ -80,6 +82,7 @@ export default Factory.extend<Node & NodeTraits>({
             }
         },
     }),
+
     withDraftRegistrations: trait({
         afterCreate(node: any, server: any) {
             const draftRegistrationCount = faker.random.number({ min: 5, max: 15 });

--- a/mirage/factories/registration.ts
+++ b/mirage/factories/registration.ts
@@ -3,16 +3,16 @@ import { association, faker, trait, Trait } from 'ember-cli-mirage';
 import Registration from 'ember-osf-web/models/registration';
 
 import NodeFactory from './node';
-import { createRegistrationMetadata, guid } from './utils';
+import { createRegistrationMetadata, guid, guidAfterCreate } from './utils';
 
 export interface RegistrationTraits {
     withRegisteredMeta: Trait;
 }
 
 export default NodeFactory.extend<Registration & RegistrationTraits>({
-    id(i: number) {
-        return guid(i, 'registration');
-    },
+    id: guid('registration'),
+    afterCreate: guidAfterCreate,
+
     registration: true,
     dateRegistered() {
         return faker.date.recent(5);

--- a/mirage/factories/user.ts
+++ b/mirage/factories/user.ts
@@ -2,7 +2,7 @@ import { Factory, faker, trait, Trait } from 'ember-cli-mirage';
 
 import User from 'ember-osf-web/models/user';
 
-import { guid } from './utils';
+import { guid, guidAfterCreate } from './utils';
 
 export interface UserTraits {
     withNodes: Trait;
@@ -10,9 +10,9 @@ export interface UserTraits {
 }
 
 export default Factory.extend<User & UserTraits>({
-    id(i: number) {
-        return guid(i, 'user');
-    },
+    id: guid('user'),
+    afterCreate: guidAfterCreate,
+
     fullName() {
         return `${faker.name.firstName()} ${faker.name.lastName()}`;
     },

--- a/mirage/factories/utils.ts
+++ b/mirage/factories/utils.ts
@@ -1,12 +1,27 @@
-import { faker } from 'ember-cli-mirage';
+import { faker, ModelInstance, Server } from 'ember-cli-mirage';
+import SeedRandom from 'seedrandom';
 
 import { RegistrationMetadata, Schema } from 'ember-osf-web/models/registration-schema';
 
-export const guid = (id: number, type: string): string => {
-    const numPart = String(id);
-    const typPart = type.substr(0, 5 - numPart.length);
-    return `${typPart}${numPart}`;
-};
+const GUID_CHARS = 'abcdefghijklmnopqrstuvwxyz0123456789';
+
+export function guid(referentType: string) {
+    return (id: number) => {
+        // Generate a pseudo-random guid
+        const prng = new SeedRandom(`${referentType}-${id}`);
+        const chars = new Array(5).fill(undefined).map(
+            () => GUID_CHARS[Math.floor(prng() * GUID_CHARS.length)],
+        );
+        return ''.concat(...chars);
+    };
+}
+
+export function guidAfterCreate(newObj: ModelInstance, server: Server) {
+    server.schema.guids.create({
+        id: newObj.id,
+        referentType: newObj.modelName,
+    });
+}
 
 /**
  * Create registration metadata with a random number of questions answered.

--- a/mirage/serializers/contributor.ts
+++ b/mirage/serializers/contributor.ts
@@ -3,23 +3,27 @@ import config from 'ember-get-config';
 
 import Contributor from 'ember-osf-web/models/contributor';
 
-import ApplicationSerializer, { SerializedLinks } from './application';
+import ApplicationSerializer from './application';
 
 const { OSF: { apiUrl } } = config;
 
-export default class ContributorSerializer extends ApplicationSerializer {
-    links(model: ModelInstance<Contributor>): SerializedLinks<Contributor> {
+export default class ContributorSerializer extends ApplicationSerializer<Contributor> {
+    buildRelationships(model: ModelInstance<Contributor>) {
         return {
             users: {
-                related: {
-                    href: `${apiUrl}/v2/users/${model.users.id}/`,
-                    meta: this.buildRelatedLinkMeta(model, 'users'),
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/users/${model.users.id}/`,
+                        meta: this.buildRelatedLinkMeta(model, 'users'),
+                    },
                 },
             },
             node: {
-                related: {
-                    href: `${apiUrl}/v2/nodes/${model.node.id}`,
-                    meta: this.buildRelatedLinkMeta(model, 'node'),
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/nodes/${model.node.id}`,
+                        meta: this.buildRelatedLinkMeta(model, 'node'),
+                    },
                 },
             },
         };

--- a/mirage/serializers/draft-registration.ts
+++ b/mirage/serializers/draft-registration.ts
@@ -1,28 +1,34 @@
 import config from 'ember-get-config';
 import DraftRegistration from 'ember-osf-web/models/draft-registration';
-import ApplicationSerializer, { SerializedLinks } from './application';
+import ApplicationSerializer from './application';
 
 const { OSF: { apiUrl } } = config;
 
-export default class DraftRegistrationSerializer extends ApplicationSerializer {
-    links(model: DraftRegistration): SerializedLinks<DraftRegistration> {
+export default class DraftRegistrationSerializer extends ApplicationSerializer<DraftRegistration> {
+    buildRelationships(model: DraftRegistration) {
         return {
             branchedFrom: {
-                related: {
-                    href: `${apiUrl}/v2/nodes/${model.branchedFrom.id}`,
-                    meta: {},
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/nodes/${model.branchedFrom.id}`,
+                        meta: {},
+                    },
                 },
             },
             initiator: {
-                related: {
-                    href: `${apiUrl}/v2/users/${model.initiator.id}`,
-                    meta: {},
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/users/${model.initiator.id}`,
+                        meta: {},
+                    },
                 },
             },
             registrationSchema: {
-                related: {
-                    href: `${apiUrl}/v2/schemas/registrations/${model.registrationSchema.id}`,
-                    meta: {},
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/schemas/registrations/${model.registrationSchema.id}`,
+                        meta: {},
+                    },
                 },
             },
         };

--- a/mirage/serializers/file.ts
+++ b/mirage/serializers/file.ts
@@ -6,23 +6,27 @@ import ApplicationSerializer from './application';
 
 const { OSF: { apiUrl } } = config;
 
-export default class FileSerializer extends ApplicationSerializer {
-    links(model: ModelInstance<File>) {
+export default class FileSerializer extends ApplicationSerializer<File> {
+    buildRelationships(model: ModelInstance<File>) {
         return {
             user: {
                 data: {
                     type: 'users',
                     id: model.user.id,
                 },
-                related: {
-                    href: `${apiUrl}/v2/users/${model.user.id}/`,
-                    meta: this.buildRelatedLinkMeta(model, 'user'),
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/users/${model.user.id}/`,
+                        meta: this.buildRelatedLinkMeta(model, 'user'),
+                    },
                 },
             },
             versions: {
-                related: {
-                    href: `${apiUrl}/v2/files/${model.id}/versions/`,
-                    meta: this.buildRelatedLinkMeta(model, 'versions'),
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/files/${model.id}/versions/`,
+                        meta: this.buildRelatedLinkMeta(model, 'versions'),
+                    },
                 },
             },
         };

--- a/mirage/serializers/guid.ts
+++ b/mirage/serializers/guid.ts
@@ -1,0 +1,32 @@
+import { ModelInstance } from 'ember-cli-mirage';
+import config from 'ember-get-config';
+
+import Guid from 'ember-osf-web/models/guid';
+import ApplicationSerializer from './application';
+
+const { OSF: { apiUrl } } = config;
+
+type SerializedGuid = Guid & { referent: ModelInstance };
+
+export default class GuidSerializer extends ApplicationSerializer<SerializedGuid> {
+    buildRelationships(guid: ModelInstance<SerializedGuid>) {
+        const referent = server.schema[guid.referentType].find(guid.id);
+        const referentType = this.typeKeyForModel(referent);
+        return {
+            referent: {
+                data: {
+                    id: referent.id,
+                    type: referentType,
+                },
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/${referentType}/${referent.id}/`,
+                        meta: {
+                            type: referentType,
+                        },
+                    },
+                },
+            },
+        };
+    }
+}

--- a/mirage/serializers/guid.ts
+++ b/mirage/serializers/guid.ts
@@ -1,5 +1,6 @@
 import { ModelInstance } from 'ember-cli-mirage';
 import config from 'ember-get-config';
+import { pluralize } from 'ember-inflector';
 
 import Guid from 'ember-osf-web/models/guid';
 import ApplicationSerializer from './application';
@@ -9,20 +10,23 @@ const { OSF: { apiUrl } } = config;
 type SerializedGuid = Guid & { referent: ModelInstance };
 
 export default class GuidSerializer extends ApplicationSerializer<SerializedGuid> {
+    attrs = [];
+
     buildRelationships(guid: ModelInstance<SerializedGuid>) {
-        const referent = server.schema[guid.referentType].find(guid.id);
-        const referentType = this.typeKeyForModel(referent);
+        const pluralizedType = pluralize(guid.referentType);
+        const referent = guid.schema[pluralizedType].find(guid.id);
+        const typeKey = this.typeKeyForModel(referent);
         return {
             referent: {
                 data: {
                     id: referent.id,
-                    type: referentType,
+                    type: typeKey,
                 },
                 links: {
                     related: {
-                        href: `${apiUrl}/v2/${referentType}/${referent.id}/`,
+                        href: `${apiUrl}/v2/${typeKey}/${referent.id}/`,
                         meta: {
-                            type: referentType,
+                            type: typeKey,
                         },
                     },
                 },

--- a/mirage/serializers/node.ts
+++ b/mirage/serializers/node.ts
@@ -1,7 +1,7 @@
 import { ID, ModelInstance } from 'ember-cli-mirage';
 import config from 'ember-get-config';
 import Node from 'ember-osf-web/models/registration';
-import ApplicationSerializer, { SerializedLinks } from './application';
+import ApplicationSerializer, { SerializedRelationships } from './application';
 
 const { OSF: { apiUrl } } = config;
 
@@ -10,65 +10,92 @@ export interface Attrs {
     rootId: ID | null;
 }
 
-export default class NodeSerializer extends ApplicationSerializer {
-    links(model: ModelInstance<Node & { attrs: Attrs }>) {
-        const returnValue: SerializedLinks<Node> = {
+type MirageNode = Node & { attrs: Attrs };
+
+export default class NodeSerializer extends ApplicationSerializer<MirageNode> {
+    buildRelationships(model: ModelInstance<MirageNode>) {
+        const relationships: SerializedRelationships<Node> = {
             linkedNodes: {
-                related: {
-                    href: `${apiUrl}/v2/nodes/${model.id}/linked_nodes/`,
-                    meta: this.buildRelatedLinkMeta(model, 'linkedNodes'),
-                },
-                self: {
-                    href: `${apiUrl}/v2/nodes/${model.id}/relationships/linked_nodes/`,
-                    meta: {},
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/nodes/${model.id}/linked_nodes/`,
+                        meta: this.buildRelatedLinkMeta(model, 'linkedNodes'),
+                    },
+                    self: {
+                        href: `${apiUrl}/v2/nodes/${model.id}/relationships/linked_nodes/`,
+                        meta: {},
+                    },
                 },
             },
             contributors: {
-                related: {
-                    href: `${apiUrl}/v2/nodes/${model.id}/contributors/`,
-                    meta: this.buildRelatedLinkMeta(model, 'contributors'),
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/nodes/${model.id}/contributors/`,
+                        meta: this.buildRelatedLinkMeta(model, 'contributors'),
+                    },
                 },
             },
             forks: {
-                related: {
-                    href: `${apiUrl}/v2/nodes/${model.id}/forks/`,
-                    meta: this.buildRelatedLinkMeta(model, 'forks'),
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/nodes/${model.id}/forks/`,
+                        meta: this.buildRelatedLinkMeta(model, 'forks'),
+                    },
                 },
             },
             registrations: {
-                related: {
-                    href: `${apiUrl}/v2/nodes/${model.id}/registrations/`,
-                    meta: this.buildRelatedLinkMeta(model, 'registrations'),
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/nodes/${model.id}/registrations/`,
+                        meta: this.buildRelatedLinkMeta(model, 'registrations'),
+                    },
                 },
             },
             draftRegistrations: {
-                related: {
-                    href: `${apiUrl}/v2/nodes/${model.id}/draft_registrations/`,
-                    meta: this.buildRelatedLinkMeta(model, 'draftRegistrations'),
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/nodes/${model.id}/draft_registrations/`,
+                        meta: this.buildRelatedLinkMeta(model, 'draftRegistrations'),
+                    },
                 },
             },
         };
         if (model.attrs.parentId !== null) {
-            returnValue.parent = {
-                related: {
-                    href: `${apiUrl}/v2/nodes/${model.attrs.parentId}`,
-                    meta: {},
+            const { parentId } = model.attrs;
+            relationships.parent = {
+                data: {
+                    id: parentId,
+                    type: this.typeKeyForModel(model),
+                },
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/nodes/${parentId}`,
+                        meta: {},
+                    },
                 },
             };
         }
         if (model.attrs.rootId !== null) {
-            returnValue.root = {
-                related: {
-                    href: `${apiUrl}/v2/nodes/${model.attrs.rootId}`,
-                    meta: {},
+            const { rootId } = model.attrs;
+            relationships.root = {
+                data: {
+                    id: rootId,
+                    type: this.typeKeyForModel(model),
+                },
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/nodes/${rootId}`,
+                        meta: {},
+                    },
                 },
             };
         }
-        return returnValue;
+        return relationships;
     }
-    buildNormalLinks(model: ModelInstance<Node>) {
+
+    buildNormalLinks(model: ModelInstance<MirageNode>) {
         return {
-            self: `${apiUrl}/v2/nodes/${model.id}/`,
+            ...super.buildNormalLinks(model),
             html: `/${model.id}/`,
         };
     }

--- a/mirage/serializers/registration-schema.ts
+++ b/mirage/serializers/registration-schema.ts
@@ -1,6 +1,7 @@
+import RegistrationSchema from 'ember-osf-web/models/registration-schema';
 import ApplicationSerializer from './application';
 
-export default class RegistrationSchemaSerializer extends ApplicationSerializer {
+export default class RegistrationSchemaSerializer extends ApplicationSerializer<RegistrationSchema> {
     keyForAttribute(attr: string) {
         if (attr === 'schemaNoConflict') {
             return 'schema';

--- a/mirage/serializers/registration.ts
+++ b/mirage/serializers/registration.ts
@@ -3,59 +3,83 @@ import config from 'ember-get-config';
 
 import Registration from 'ember-osf-web/models/registration';
 
-import ApplicationSerializer, { SerializedLinks } from './application';
+import ApplicationSerializer, { SerializedRelationships } from './application';
 import { Attrs } from './node';
 
 const { OSF: { apiUrl } } = config;
 
-export default class RegistrationSerializer extends ApplicationSerializer {
-    links(model: ModelInstance<Registration & { attrs: Attrs }>) {
-        const returnValue: SerializedLinks<Registration> = {
+type MirageRegistration = Registration & { attrs: Attrs };
+
+export default class RegistrationSerializer extends ApplicationSerializer<MirageRegistration> {
+    buildRelationships(model: ModelInstance<MirageRegistration>) {
+        const relationships: SerializedRelationships<MirageRegistration> = {
             linkedNodes: {
-                related: {
-                    href: `${apiUrl}/v2/nodes/${model.id}/linked_nodes/`,
-                    meta: this.buildRelatedLinkMeta(model, 'linkedNodes'),
-                },
-                self: {
-                    href: `${apiUrl}/v2/nodes/${model.id}/relationships/linked_nodes/`,
-                    meta: {},
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/nodes/${model.id}/linked_nodes/`,
+                        meta: this.buildRelatedLinkMeta(model, 'linkedNodes'),
+                    },
+                    self: {
+                        href: `${apiUrl}/v2/nodes/${model.id}/relationships/linked_nodes/`,
+                        meta: {},
+                    },
                 },
             },
             contributors: {
-                related: {
-                    href: `${apiUrl}/v2/nodes/${model.id}/contributors/`,
-                    meta: this.buildRelatedLinkMeta(model, 'contributors'),
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/nodes/${model.id}/contributors/`,
+                        meta: this.buildRelatedLinkMeta(model, 'contributors'),
+                    },
                 },
             },
             forks: {
-                related: {
-                    href: `${apiUrl}/v2/nodes/${model.id}/forks/`,
-                    meta: this.buildRelatedLinkMeta(model, 'forks'),
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/nodes/${model.id}/forks/`,
+                        meta: this.buildRelatedLinkMeta(model, 'forks'),
+                    },
                 },
             },
             registrationSchema: {
-                related: {
-                    href: `${apiUrl}/v2/schemas/registrations/${model.registrationSchema.id}`,
-                    meta: {},
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/schemas/registrations/${model.registrationSchema.id}`,
+                        meta: {},
+                    },
                 },
             },
         };
         if (model.attrs.parentId !== null) {
-            returnValue.parent = {
-                related: {
-                    href: `${apiUrl}/v2/nodes/${model.attrs.parentId}`,
-                    meta: {},
+            const { parentId } = model.attrs;
+            relationships.parent = {
+                data: {
+                    id: parentId,
+                    type: this.typeKeyForModel(model),
+                },
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/nodes/${parentId}`,
+                        meta: {},
+                    },
                 },
             };
         }
         if (model.attrs.rootId !== null) {
-            returnValue.root = {
-                related: {
-                    href: `${apiUrl}/v2/nodes/${model.attrs.rootId}`,
-                    meta: {},
+            const { rootId } = model.attrs;
+            relationships.root = {
+                data: {
+                    id: rootId,
+                    type: this.typeKeyForModel(model),
+                },
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/nodes/${rootId}`,
+                        meta: {},
+                    },
                 },
             };
         }
-        return returnValue;
+        return relationships;
     }
 }

--- a/mirage/serializers/root.ts
+++ b/mirage/serializers/root.ts
@@ -14,7 +14,7 @@ interface RootObject {
     currentUser: ModelInstance<User>;
 }
 
-export default class RootSerializer extends ApplicationSerializer {
+export default class RootSerializer extends ApplicationSerializer<RootObject> {
     serialize(object: ModelInstance<RootObject>) {
         const data: RootDocument = {
             meta: {

--- a/mirage/serializers/token.ts
+++ b/mirage/serializers/token.ts
@@ -1,7 +1,9 @@
 import { SingleResourceDocument } from 'osf-api';
+
+import Token from 'ember-osf-web/models/token';
 import ApplicationSerializer from './application';
 
-export default class TokenSerializer extends ApplicationSerializer {
+export default class TokenSerializer extends ApplicationSerializer<Token> {
     normalize(json: SingleResourceDocument) {
         if (json.data.attributes && json.data.attributes.scopes) {
             const { scopes } = json.data.attributes;

--- a/mirage/serializers/user.ts
+++ b/mirage/serializers/user.ts
@@ -1,29 +1,35 @@
 import { faker, ModelInstance } from 'ember-cli-mirage';
 import config from 'ember-get-config';
 import User from 'ember-osf-web/models/user';
-import ApplicationSerializer, { SerializedLinks } from './application';
+import ApplicationSerializer from './application';
 
 const { OSF: { apiUrl } } = config;
 
-export default class UserSerializer extends ApplicationSerializer {
-    links(model: ModelInstance<User>): SerializedLinks<User> {
+export default class UserSerializer extends ApplicationSerializer<User> {
+    buildRelationships(model: ModelInstance<User>) {
         return {
             nodes: {
-                related: {
-                    href: `${apiUrl}/v2/users/${model.id}/nodes/`,
-                    meta: this.buildRelatedLinkMeta(model, 'nodes'),
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/users/${model.id}/nodes/`,
+                        meta: this.buildRelatedLinkMeta(model, 'nodes'),
+                    },
                 },
             },
             quickfiles: {
-                related: {
-                    href: `${apiUrl}/v2/users/${model.id}/quickfiles/`,
-                    meta: this.buildRelatedLinkMeta(model, 'quickfiles'),
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/users/${model.id}/quickfiles/`,
+                        meta: this.buildRelatedLinkMeta(model, 'quickfiles'),
+                    },
                 },
             },
             institutions: {
-                related: {
-                    href: `${apiUrl}/v2/users/${model.id}/institutions/`,
-                    meta: this.buildRelatedLinkMeta(model, 'institutions'),
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/users/${model.id}/institutions/`,
+                        meta: this.buildRelatedLinkMeta(model, 'institutions'),
+                    },
                 },
             },
         };

--- a/mirage/views/guid.ts
+++ b/mirage/views/guid.ts
@@ -1,0 +1,17 @@
+import { HandlerContext, Request, Schema } from 'ember-cli-mirage';
+
+function queryParamIsTruthy(value?: string) {
+    return Boolean(
+        value && ['true', '1'].includes(value.toString().toLowerCase()),
+    );
+}
+
+export function guidDetail(this: HandlerContext, schema: Schema, request: Request) {
+    const { id } = request.params;
+    const { resolve } = request.queryParams;
+    const guid = schema.guids.find(id);
+    if (queryParamIsTruthy(resolve)) {
+        return schema[guid.referentType].find(id);
+    }
+    return guid;
+}

--- a/mirage/views/osf-resource.ts
+++ b/mirage/views/osf-resource.ts
@@ -1,5 +1,6 @@
 import { underscore } from '@ember/string';
 import { resourceAction, Server } from 'ember-cli-mirage';
+
 import { filter, process } from './utils';
 
 interface ResourceOptions {
@@ -77,6 +78,7 @@ export function osfNestedResource(
         relatedModelName: relationshipName,
         defaultSortKey: '-id',
     }, options);
+    const detailPath = `${opts.path}/:id`;
     const actions = gatherActions(opts);
 
     if (actions.includes('index')) {
@@ -88,7 +90,20 @@ export function osfNestedResource(
         });
     }
 
+    if (actions.includes('show')) {
+        server.get(detailPath, opts.relatedModelName);
+    }
+
     if (actions.includes('create')) {
         server.post(opts.path, opts.relatedModelName);
+    }
+
+    if (actions.includes('update')) {
+        server.put(opts.path, opts.relatedModelName);
+        server.patch(opts.path, opts.relatedModelName);
+    }
+
+    if (actions.includes('delete')) {
+        server.del(opts.path, opts.relatedModelName);
     }
 }

--- a/mirage/views/root.ts
+++ b/mirage/views/root.ts
@@ -1,10 +1,10 @@
 import { HandlerContext, Schema } from 'ember-cli-mirage';
 
-export function rootDetail(schema: Schema, handlerContext: HandlerContext) {
+export function rootDetail(this: HandlerContext, schema: Schema) {
     const root = schema.roots.first();
-    const json = handlerContext.serialize(root);
+    const json = this.serialize(root);
     if (root.currentUser && 'meta' in json) {
-        json.meta.current_user = handlerContext.serialize(root.currentUser);
+        json.meta.current_user = this.serialize(root.currentUser);
     }
     return json;
 }

--- a/mirage/views/token.ts
+++ b/mirage/views/token.ts
@@ -1,0 +1,8 @@
+import { HandlerContext, Schema } from 'ember-cli-mirage';
+
+export function createToken(this: HandlerContext, schema: Schema) {
+    const attrs = this.normalizedRequestAttrs();
+    const token = schema.tokens.create(attrs);
+    token.attrs.tokenId = 'blahblah';
+    return token;
+}

--- a/mirage/views/user.ts
+++ b/mirage/views/user.ts
@@ -1,23 +1,17 @@
 import { HandlerContext, Request, Schema } from 'ember-cli-mirage';
+
 import { filter, process } from './utils';
 
-export function userNodeList(schema: Schema, request: Request, handlerContext: HandlerContext) {
+export function userNodeList(this: HandlerContext, schema: Schema, request: Request) {
     const user = schema.users.find(request.params.id);
     const nodes = [];
     const { contributorIds } = user;
     for (const contributorId of contributorIds as string[]) {
         const { node } = schema.contributors.find(contributorId);
         if (filter(node, request)) {
-            nodes.push(handlerContext.serialize(node).data);
+            nodes.push(this.serialize(node).data);
         }
     }
-    const json = process(schema, request, handlerContext, nodes, { defaultSortKey: 'last_logged' });
-    return json;
-}
-
-export function userFileList(schema: Schema, request: Request, handlerContext: HandlerContext) {
-    const user = schema.users.find(request.params.id);
-    const files = user.schema.files.all().models.map((file: any) => handlerContext.serialize(file).data);
-    const json = process(schema, request, handlerContext, files, { defaultSortKey: 'date_modified' });
+    const json = process(schema, request, this, nodes, { defaultSortKey: 'last_logged' });
     return json;
 }

--- a/package.json
+++ b/package.json
@@ -195,5 +195,8 @@
       "lib/osf-components",
       "lib/registries"
     ]
+  },
+  "dependencies": {
+    "seedrandom": "^2.4.4"
   }
 }

--- a/tests/unit/mirage/factories/utils-test.ts
+++ b/tests/unit/mirage/factories/utils-test.ts
@@ -6,10 +6,18 @@ module('Unit | Mirage | Factories | Utils | guid generation', hooks => {
     setupTest(hooks);
 
     test('it can create guids', assert => {
-        assert.equal(guid(1, 'node'), 'node1');
-        assert.equal(guid(10, 'node'), 'nod10');
-        assert.equal(guid(100, 'node'), 'no100');
-        assert.equal(guid(1000, 'node'), 'n1000');
-        assert.equal(guid(10000, 'node'), '10000');
+        const guidFactory = guid('node');
+        const generatedGuids: Record<string, true> = {};
+
+        // https://oeis.org/A028355
+        for (const i of [1, 2, 3, 4, 32, 123, 43, 2123, 432, 1234, 32123, 43212]) {
+            // Should generate the same guid for the same input
+            const newGuid = guidFactory(i);
+            assert.equal(newGuid, guidFactory(i));
+
+            // Shouldn't repeat itself
+            assert.notOk(generatedGuids[newGuid]);
+            generatedGuids[newGuid] = true;
+        }
     });
 });

--- a/types/ember-cli-mirage/index.d.ts
+++ b/types/ember-cli-mirage/index.d.ts
@@ -131,6 +131,8 @@ function handlerDefinition(
 ): void;
 /* tslint:enable unified-signatures */
 
+export type resourceAction = 'index' | 'show' | 'create' | 'update' | 'delete';
+
 export interface Server {
     schema: Schema;
     db: Database;
@@ -148,7 +150,10 @@ export interface Server {
     patch: typeof handlerDefinition;
     del: typeof handlerDefinition;
 
-    resource(resourceName: string, options?: { only?: string[], except?: string[], path?: string }): void;
+    resource(
+        resourceName: string,
+        options?: { only?: resourceAction[], except?: resourceAction[], path?: string },
+    ): void;
 
     loadFixtures(...fixtures: string[]): void;
 

--- a/types/ember-cli-mirage/index.d.ts
+++ b/types/ember-cli-mirage/index.d.ts
@@ -37,6 +37,7 @@ export type Model<T> = {
 interface ModelInstanceShared<T> {
     id: ID;
     attrs: T;
+    schema: Schema;
 
     save(): void;
     update<K extends keyof T>(key: K, val: T[K]): void;

--- a/types/osf-api.d.ts
+++ b/types/osf-api.d.ts
@@ -81,6 +81,7 @@ export type RelatedLink = string | { href: string; meta?: RelatedLinkMeta };
 
 export interface RelatedLinkMeta {
     count?: number;
+    type?: string;
 }
 
 export interface NormalLinks extends JSONAPI.Links {

--- a/types/seedrandom/index.d.ts
+++ b/types/seedrandom/index.d.ts
@@ -1,0 +1,9 @@
+class SeedRandom {
+    constructor(seed: string | number);
+}
+
+interface SeedRandom {
+    (): number; // tslint:disable-line callable-types
+}
+
+export default SeedRandom;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3965,6 +3965,7 @@ commander@^2.12.1, commander@^2.9.0:
 commander@^2.16.0:
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.18.0.tgz#2bf063ddee7c7891176981a2cc798e5754bc6970"
+  integrity sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ==
 
 commander@~2.17.1:
   version "2.17.1"
@@ -10350,6 +10351,7 @@ just-extend@^1.1.27:
 katex@^0.10.0-rc.1:
   version "0.10.0-rc.1"
   resolved "https://registry.yarnpkg.com/katex/-/katex-0.10.0-rc.1.tgz#bd46155281f61c4855a064e2b7a89d137ee04b41"
+  integrity sha512-JmnreLp0lWPA1z1krzO5drN1qBrkhqzMg5qv0l5y+Fr97sqgOuh37k9ky7VD1k/Ec+yvOe2BptiYSR9OoShkFg==
   dependencies:
     commander "^2.16.0"
 
@@ -14358,6 +14360,11 @@ scss-tokenizer@^0.2.3:
   dependencies:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
+
+seedrandom@^2.4.4:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-2.4.4.tgz#b25ea98632c73e45f58b77cfaa931678df01f9ba"
+  integrity sha512-9A+PDmgm+2du77B5i0Ip2cxOqqHjgNxnBgglxLcX78A2D6c2rTo61z4jnVABpF4cKeDMDG+cmXXvdnqse2VqMA==
 
 select@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[EMB-123] some really great stuff`
-->

## Purpose
Allow resolving guids in mirage, so we can write acceptance tests for pages that depend on that (e.g. file detail page)
<!-- Describe the purpose of your changes. -->

## Summary of Changes
- Generate pseudo-random guids in mirage for users, files, nodes, and registrations
  - Same sequence of guids for each type, so if an object is created in the default scenario, the guid will stay valid across reloads
- Add shorthands for configuring route handlers for our API, inspired by mirage's shorthands
  - `osfResource` -- similar to [`this.resource`](http://www.ember-cli-mirage.com/docs/v0.4.x/shorthands/#resource-helper), adds handlers for a list of objects, detail view, create, update, delete
  - `osfNestedResource` -- for adding nested routes that correspond to a relationship
- Add `ApplicationSerializer.buildRelationships()` as a more flexible way of serializing relationships than relying on mirage's unintuitive use of `links()`
  - Model serializers should override to build their relationships hash
  - Required for the weird format of guids' `referent` relationship
<!-- Briefly describe or list your changes. -->

## Side Effects
n/a
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## Feature Flags
n/a
<!--
  Please list any feature flags that need to be enabled for these changes to go into effect.
  For each flag, what is the expected behavior with the flag enabled vs disabled?
-->

## QA Notes
No testing by QA, but the reviewer could run it locally and check that browsing around with mirage works. Especially check going directly to the file detail page (http://localhost:4200/mxxdb/ ) to see the guid resolve.
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
-->

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
https://openscience.atlassian.net/browse/EMB-379

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
