### PR TITLE
[EMB-377] Fix premature ToU checkbox validation and add tests for validation behavior

### DIFF
--- a/app/home/template.hbs
+++ b/app/home/template.hbs
@@ -43,7 +43,7 @@
                 <div class="col-sm-6" local-class="sign-up-div">
                     <h2>{{t 'home.signup_title'}}</h2>
                     <div id="signUpScope">
-                        {{sign-up-form}}
+                        {{sign-up-form data-test-sign-up-form}}
                     </div>
                 </div>
             </div>

--- a/lib/osf-components/addon/components/sign-up-form/template.hbs
+++ b/lib/osf-components/addon/components/sign-up-form/template.hbs
@@ -51,7 +51,7 @@
         data-test-sign-up-tos
         model=this.userRegistration
         valuePath='acceptedTermsOfService'
-        messagesShown=this.didValidate
+        showMessages=this.didValidate
         disabled=this.hasSubmitted
         local-class='tos-checkbox'
     }}
@@ -72,7 +72,12 @@
             }}
         </div>
         <div>
-            <button type="submit" class="btn btn-success" {{action submit}} {{action 'click' 'button' 'Home - sign_up' target=analytics}}>
+            <button data-test-sign-up-button
+                type="submit"
+                class="btn btn-success"
+                {{action submit}}
+                {{action 'click' 'button' 'Home - sign_up' target=analytics}}
+            >
                 {{t 'osf-components.sign-up-form.sign_up_button_label'}}
             </button>
         </div>

--- a/tests/acceptance/logged-out-home-page-test.ts
+++ b/tests/acceptance/logged-out-home-page-test.ts
@@ -1,4 +1,4 @@
-import { currentURL, visit } from '@ember/test-helpers';
+import { click, currentURL, visit } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -25,7 +25,11 @@ module('Acceptance | logged-out home page', hooks => {
         assert.dom('footer').exists();
 
         // Check sign-up form.
-        assert.dom('[data-test-sign-up-full-name]').exists();
+        assert.dom('[data-test-sign-up-form] .has-error').doesNotExist('Sign up form: no premature validation');
+        assert.dom('[data-test-sign-up-form] .help-block').doesNotExist('Sign up form: no validation messages shown');
+        await click('[data-test-sign-up-form] [data-test-sign-up-button]');
+        assert.dom('[data-test-sign-up-form] .has-error').exists('Sign up form: validation errors present');
+        assert.dom('[data-test-sign-up-form] .help-block').exists('Sign up form: validation messages shown');
 
         // Alt text for integration logos
         assert.dom('[class*="_integrations"] img[alt*="Dropbox logo"]').exists();


### PR DESCRIPTION
## Purpose

Fix premature Terms of Use checkbox validation on sign up form.

## Summary of Changes

* `s/messagesShown/showMessages/` in `validated-input/checkbox` invocation in `sign-up-form` component
* expand logged-out-home-page acceptance test to check for premature validation (and that validation errors appear after clicking sign up without filling in any fields)

## Side Effects

Shouldn't be.

## Feature Flags

n/a

## QA Notes

Should make sure there is no premature validation on the sign up form.

## Ticket

https://openscience.atlassian.net/browse/EMB-377

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
