### PR TITLE
[EMB-377] Check file.tags instead of tags and calculate showAdd correctly

### DIFF
--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -83,20 +83,20 @@
                 updateFilter=(perform updateFilter)
                 openFile=(action 'openFile')
             }}
-            {{#if (or canEdit tags)}}
+            {{#if (or this.canEdit this.file.tags)}}
                 <div class='panel panel-default' local-class="TagsPanel">
                     <div class='panel-heading clearfix' local-class="TagsPanel__heading">
                         <h3 class='panel-title'>{{t "file_detail.tags"}}</h3>
                     </div>
                     <div class='panel-body'>
-                        {{tags-widget
-                            tags=this.file.tags
-                            addTag=(action this.addTag)
-                            removeTag=(action this.removeTag)
-                            readOnly=(not this.canEdit)
-                            showAdd=true
-                            analyticsScope='Quick Files'
-                        }}
+                        <TagsWidget
+                            @tags={{this.file.tags}}
+                            @addTag={{action this.addTag}}
+                            @removeTag={{action this.removeTag}}
+                            @readOnly={{not this.canEdit}}
+                            @showAdd={{this.canEdit}}
+                            @analyticsScope='Quick Files'
+                        />
                         <div class="tags_clear"></div>
                     </div>
                 </div>


### PR DESCRIPTION
## Purpose

The tags widget was being completely hidden (instead of just read only) on quick files file detail when the current user did not have edit permissions.

## Summary of Changes

* check `file.tags` instead of `tags` when determining if tags widget should render
* change `showAdd` to be based on `canEdit` rather than always `true`
* use angle bracket invocation for the tags widget

## Side Effects

Unlikely.

## Feature Flags

n/a

## QA Notes

The tags widget on quick file file detail pages should be tested. It should always appear for the owner of the quick file, appear in read-only mode for non-owners when a quick file has tags, and not appear at all for non-owners when a quick file has no tags. Cross browser testing is not necessary. This should be low risk.

## Ticket

https://openscience.atlassian.net/browse/EMB-377

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(bugfix)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
