### PR TITLE
Sort collection-metadata choices

### DIFF
--- a/lib/app-components/addon/helpers/sort.ts
+++ b/lib/app-components/addon/helpers/sort.ts
@@ -1,0 +1,7 @@
+import Helper from '@ember/component/helper';
+
+export default class Sort extends Helper {
+    compute<T>([arr]: [T[]]) {
+        return arr.sort();
+    }
+}

--- a/lib/app-components/app/helpers/sort.js
+++ b/lib/app-components/app/helpers/sort.js
@@ -1,0 +1,1 @@
+export { default } from 'app-components/helpers/sort';

--- a/lib/collections/addon/components/collection-metadata/template.hbs
+++ b/lib/collections/addon/components/collection-metadata/template.hbs
@@ -7,7 +7,7 @@
                     {{#validated-input/power-select
                         model=this.collectedMetadatum
                         valuePath=field.valuePath
-                        options=(get this.collection field.optionsKey)
+                        options=(sort (get this.collection field.optionsKey))
                         showMessages=this.didValidate
                         as |option|
                     }}

--- a/lib/collections/addon/components/discover-page/facets/checklist/component.ts
+++ b/lib/collections/addon/components/discover-page/facets/checklist/component.ts
@@ -60,6 +60,7 @@ export default abstract class SearchFacetChecklist extends Base.extend({
                 (acc, val) => [...acc, ...(val[this.modelAttribute] as string[])],
                 [],
             )
+            .sort()
             .map(key => ({ key }));
 
         this.allItems.pushObjects(allItems);

--- a/tests/engines/app-components/integration/helpers/sort-test.ts
+++ b/tests/engines/app-components/integration/helpers/sort-test.ts
@@ -1,0 +1,23 @@
+import { render } from '@ember/test-helpers';
+import { setupEngineRenderingTest } from 'ember-osf-web/tests/helpers/engines';
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+
+module('Integration | Helper | sort', hooks => {
+    setupEngineRenderingTest(hooks, 'collections');
+
+    test('it renders', async function(assert) {
+        const options = [
+            'Charlie',
+            'Delta',
+            'Bravo',
+            'Alpha',
+        ];
+
+        this.setProperties({ options });
+
+        await render(hbs`{{#each (sort options) as |option|}} {{option}} {{/each}}`);
+
+        assert.dom(this.element).hasText(' Alpha Bravo Charlie Delta ');
+    });
+});


### PR DESCRIPTION
## Purpose

Product wants collection-metadata choices (alpha) sorted

## Summary of Changes

* Add a sort helper, for the submit/edit page collection-metadata component
* Sort options on the discover page

## Side Effects

None

## Feature Flags

None

## QA Notes

Choices will be sorted in alphabetical order (e.g. status, collected type, etc)

## Ticket

None

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
