### PR TITLE
[EMB-369] panel component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased']
+### Added
+- Components:
+    - `panel` - a general-use abstraction of bootstrap panels
+- Tests:
+    - `panel` component integration test
+- Handbook:
+    - `panel` component
 ### Removed
 - Flags:
     - `ember_project_forks_page` - `guid-node.forks` and `guid-registration.forks` now always on

--- a/lib/handbook/addon/docs/components/panel/demo-args/template.hbs
+++ b/lib/handbook/addon/docs/components/panel/demo-args/template.hbs
@@ -1,0 +1,11 @@
+{{#docs-demo as |demo|}}
+    {{#demo.example name='panel.demo-args.hbs'}}
+        <Panel as |panel|>
+            <panel.heading @title="I'm a panel" />
+            <panel.body @text="This is my body" />
+            <panel.footer @text="This is my footer" />
+        </Panel>
+    {{/demo.example}}
+
+    {{demo.snippet 'panel.demo-args.hbs'}}
+{{/docs-demo}}

--- a/lib/handbook/addon/docs/components/panel/demo-blocks/template.hbs
+++ b/lib/handbook/addon/docs/components/panel/demo-blocks/template.hbs
@@ -1,0 +1,17 @@
+{{#docs-demo as |demo|}}
+    {{#demo.example name='panel.demo-blocks.hbs'}}
+        <Panel as |panel|>
+            <panel.heading>
+                <h2>I'm a panel</h2>
+            </panel.heading>
+            <panel.body>
+                <strong>This is my body</strong>
+            </panel.body>
+            <panel.footer>
+                <h3>This is my footer</h3>
+            </panel.footer>
+        </Panel>
+    {{/demo.example}}
+
+    {{demo.snippet 'panel.demo-blocks.hbs'}}
+{{/docs-demo}}

--- a/lib/handbook/addon/docs/components/panel/demo-mix/template.hbs
+++ b/lib/handbook/addon/docs/components/panel/demo-mix/template.hbs
@@ -1,0 +1,14 @@
+{{#docs-demo as |demo|}}
+    {{#demo.example name='panel.demo-mix.hbs'}}
+        <Panel as |panel|>
+            <panel.heading @title="I'm a panel">
+                <span class="pull-right">Here's some other stuff in the heading</span>
+            </panel.heading>
+            <panel.body @text="This is my body">
+                <button class="btn btn-default">This is something additional</button>
+            </panel.body>
+        </Panel>
+    {{/demo.example}}
+
+    {{demo.snippet 'panel.demo-mix.hbs'}}
+{{/docs-demo}}

--- a/lib/handbook/addon/docs/components/panel/template.md
+++ b/lib/handbook/addon/docs/components/panel/template.md
@@ -1,0 +1,12 @@
+# panel
+
+Render content in a panel.
+
+## Using arguments
+{{docs/components/panel/demo-args}}
+
+## Using blocks
+{{docs/components/panel/demo-blocks}}
+
+## Using both
+{{docs/components/panel/demo-mix}}

--- a/lib/handbook/addon/docs/template.hbs
+++ b/lib/handbook/addon/docs/template.hbs
@@ -20,6 +20,7 @@
         {{nav.item 'copyable-text' 'docs.components.copyable-text'}}
         {{nav.item 'delete-button' 'docs.components.delete-button'}}
         {{nav.item 'loading-indicator' 'docs.components.loading-indicator'}}
+        {{nav.item 'panel' 'docs.components.panel'}}
         {{nav.item 'tags-widget' 'docs.components.tags-widget'}}
     {{/viewer.nav}}
 

--- a/lib/handbook/addon/routes.js
+++ b/lib/handbook/addon/routes.js
@@ -25,6 +25,7 @@ export default buildRoutes(function() {
             this.route('copyable-text');
             this.route('delete-button');
             this.route('loading-indicator');
+            this.route('panel');
             this.route('tags-widget');
         });
 

--- a/lib/osf-components/addon/components/panel/component.ts
+++ b/lib/osf-components/addon/components/panel/component.ts
@@ -1,0 +1,8 @@
+import { layout } from '@ember-decorators/component';
+import Component from '@ember/component';
+
+import template from './template';
+
+@layout(template)
+export default class Panel extends Component {
+}

--- a/lib/osf-components/addon/components/panel/template.hbs
+++ b/lib/osf-components/addon/components/panel/template.hbs
@@ -1,0 +1,5 @@
+<div data-test-panel class="panel panel-default">
+    {{yield (hash heading=(component 'panel/x-heading'))}}
+    {{yield (hash body=(component 'panel/x-body'))}}
+    {{yield (hash footer=(component 'panel/x-footer'))}}
+</div>

--- a/lib/osf-components/addon/components/panel/x-body/component.ts
+++ b/lib/osf-components/addon/components/panel/x-body/component.ts
@@ -1,0 +1,9 @@
+import { layout, tagName } from '@ember-decorators/component';
+import Component from '@ember/component';
+
+import template from './template';
+
+@layout(template)
+@tagName('')
+export default class PanelBody extends Component {
+}

--- a/lib/osf-components/addon/components/panel/x-body/template.hbs
+++ b/lib/osf-components/addon/components/panel/x-body/template.hbs
@@ -1,0 +1,8 @@
+<div data-test-panel-body class="panel-body">
+    {{#if @text}}
+        {{@text}}
+    {{/if}}
+    {{#if (has-block)}}
+        {{yield}}
+    {{/if}}
+</div>

--- a/lib/osf-components/addon/components/panel/x-footer/component.ts
+++ b/lib/osf-components/addon/components/panel/x-footer/component.ts
@@ -1,0 +1,9 @@
+import { layout, tagName } from '@ember-decorators/component';
+import Component from '@ember/component';
+
+import template from './template';
+
+@layout(template)
+@tagName('')
+export default class PanelFooter extends Component {
+}

--- a/lib/osf-components/addon/components/panel/x-footer/template.hbs
+++ b/lib/osf-components/addon/components/panel/x-footer/template.hbs
@@ -1,0 +1,8 @@
+<div data-test-panel-footer class="panel-footer clearfix">
+    {{#if @text}}
+        {{@text}}
+    {{/if}}
+    {{#if (has-block)}}
+        {{yield}}
+    {{/if}}
+</div>

--- a/lib/osf-components/addon/components/panel/x-heading/component.ts
+++ b/lib/osf-components/addon/components/panel/x-heading/component.ts
@@ -1,0 +1,9 @@
+import { layout, tagName } from '@ember-decorators/component';
+import Component from '@ember/component';
+
+import template from './template';
+
+@layout(template)
+@tagName('')
+export default class PanelHeading extends Component {
+}

--- a/lib/osf-components/addon/components/panel/x-heading/template.hbs
+++ b/lib/osf-components/addon/components/panel/x-heading/template.hbs
@@ -1,0 +1,8 @@
+<div data-test-panel-heading class="panel-heading clearfix">
+    {{#if @title}}
+        <h3 data-test-panel-title class="panel-title">{{@title}}</h3>
+    {{/if}}
+    {{#if (has-block)}}
+        {{yield}}
+    {{/if}}
+</div>

--- a/lib/osf-components/app/components/panel/component.js
+++ b/lib/osf-components/app/components/panel/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/panel/component';

--- a/lib/osf-components/app/components/panel/x-body/component.js
+++ b/lib/osf-components/app/components/panel/x-body/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/panel/x-body/component';

--- a/lib/osf-components/app/components/panel/x-footer/component.js
+++ b/lib/osf-components/app/components/panel/x-footer/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/panel/x-footer/component';

--- a/lib/osf-components/app/components/panel/x-heading/component.js
+++ b/lib/osf-components/app/components/panel/x-heading/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/panel/x-heading/component';

--- a/tests/integration/components/panel/component-test.ts
+++ b/tests/integration/components/panel/component-test.ts
@@ -1,0 +1,162 @@
+import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+
+const attrTitle = 'This is a title from an attribute';
+const attrBody = 'This is some body text from an attribute';
+const attrFooter = 'This is some footer text from an attribute';
+const blockTitle = 'This is a title from a block';
+const blockBody = 'This is some body text from a block';
+const blockFooter = 'This is some footer text from a block';
+
+module('Integration | Component | panel', () => {
+    module('invoked using attributes', hooks => {
+        setupRenderingTest(hooks);
+
+        hooks.beforeEach(async function(this: TestContext) {
+            this.setProperties({ attrTitle, attrBody, attrFooter });
+            await render(hbs`
+                <Panel as |panel|>
+                    <panel.heading @title={{this.attrTitle}} />
+                    <panel.body @text={{this.attrBody}} />
+                    <panel.footer @text={{this.attrFooter}} />
+                </Panel>
+            `);
+        });
+
+        test('panel', assert => {
+            assert.dom('[data-test-panel]')
+                .exists('Panel renders');
+        });
+
+        test('heading', assert => {
+            assert.dom('[data-test-panel-heading]')
+                .exists('Panel heading section renders');
+            assert.dom('[data-test-panel-heading] [data-test-panel-title]')
+                .exists('Panel title section renders inside panel heading section');
+            assert.dom('[data-test-panel-title]')
+                .hasText(attrTitle, 'Panel title section contains title text');
+        });
+
+        test('body', assert => {
+            assert.dom('[data-test-panel-body]')
+                .exists('Panel body section renders');
+            assert.dom('[data-test-panel-body]')
+                .hasText(attrBody, 'Panel body section contains body text');
+        });
+
+        test('footer', assert => {
+            assert.dom('[data-test-panel-footer]')
+                .exists('Panel footer section renders');
+            assert.dom('[data-test-panel-footer]')
+                .hasText(attrFooter, 'Panel footer section contains footer text');
+        });
+    });
+
+    module('invoked using blocks', hooks => {
+        setupRenderingTest(hooks);
+
+        hooks.beforeEach(async function(this: TestContext) {
+            this.setProperties({ blockTitle, blockBody, blockFooter });
+            await render(hbs`
+                <Panel as |panel|>
+                    <panel.heading>
+                        {{this.blockTitle}}
+                    </panel.heading>
+                    <panel.body>
+                        {{this.blockBody}}
+                    </panel.body>
+                    <panel.footer>
+                        {{this.blockFooter}}
+                    </panel.footer>
+                </Panel>
+            `);
+        });
+
+        test('panel', assert => {
+            assert.dom('[data-test-panel]').exists('Panel renders');
+        });
+
+        test('heading', assert => {
+            assert.dom('[data-test-panel-heading]')
+                .exists('Panel heading section renders');
+            assert.dom('[data-test-panel-title]')
+                .doesNotExist('Panel title section does not render');
+            assert.dom('[data-test-panel-heading]')
+                .hasText(blockTitle, 'Panel heading section contains title text');
+        });
+
+        test('body', assert => {
+            assert.dom('[data-test-panel-body]')
+                .exists('Panel body section renders');
+            assert.dom('[data-test-panel-body]')
+                .hasText(blockBody, 'Panel body section contains body text');
+        });
+
+        test('footer', assert => {
+            assert.dom('[data-test-panel-footer]')
+                .exists('Panel footer section renders');
+            assert.dom('[data-test-panel-footer]')
+                .hasText(blockFooter, 'Panel footer section contains footer text');
+        });
+    });
+
+    module('invoked using both attributes and blocks', hooks => {
+        setupRenderingTest(hooks);
+
+        hooks.beforeEach(async function(this: TestContext) {
+            this.setProperties({ attrTitle, attrBody, attrFooter, blockTitle, blockBody, blockFooter });
+            await render(hbs`
+                <Panel as |panel|>
+                    <panel.heading @title={{this.attrTitle}}>
+                        {{this.blockTitle}}
+                    </panel.heading>
+                    <panel.body @text={{this.attrBody}}>
+                        {{this.blockBody}}
+                    </panel.body>
+                    <panel.footer @text={{this.attrFooter}}>
+                        {{this.blockFooter}}
+                    </panel.footer>
+                </Panel>
+            `);
+        });
+
+        test('panel', assert => {
+            assert.dom('[data-test-panel]').exists('Panel renders');
+        });
+
+        test('heading', assert => {
+            assert.dom('[data-test-panel-heading]')
+                .exists('Panel heading section renders');
+            assert.dom('[data-test-panel-heading] [data-test-panel-title]')
+                .exists('Panel title section renders inside panel heading section');
+            assert.dom('[data-test-panel-heading]')
+                .hasText(
+                    `${attrTitle} ${blockTitle}`,
+                    'Panel heading section contains title text',
+                );
+        });
+
+        test('body', assert => {
+            assert.dom('[data-test-panel-body]')
+                .exists('Panel body section renders');
+            assert.dom('[data-test-panel-body]')
+                .hasText(
+                    `${attrBody} ${blockBody}`,
+                    'Panel body section contains body text',
+                );
+        });
+
+        test('footer', assert => {
+            assert.dom('[data-test-panel-footer]')
+                .exists('Panel footer section renders');
+            assert.dom('[data-test-panel-footer]')
+                .hasText(
+                    `${attrFooter} ${blockFooter}`,
+                    'Panel footer section contains footer text',
+                );
+        });
+    });
+});


### PR DESCRIPTION
## Purpose

Add a component that is a general-use abstraction of bootstrap panels. This will be used immediately for the account settings page.

## Summary of Changes

### Added
- Components:
    - `panel` - a general-use abstraction of bootstrap panels
- Tests:
    - `panel` component integration test
- Handbook:
    - `panel` component

## Side Effects

None.

## Feature Flags

n/a

## QA Notes

This will be tested as part of the account settings page.

## Ticket

https://openscience.atlassian.net/browse/EMB-369

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
