### PR TITLE
Filter only for nodes where the current user is admin for the collect…

### DIFF
--- a/lib/collections/addon/components/collection-item-picker/component.ts
+++ b/lib/collections/addon/components/collection-item-picker/component.ts
@@ -8,7 +8,7 @@ import I18N from 'ember-i18n/services/i18n';
 import requiredAction from 'ember-osf-web/decorators/required-action';
 import Collection from 'ember-osf-web/models/collection';
 import Node from 'ember-osf-web/models/node';
-import { QueryHasManyResult } from 'ember-osf-web/models/osf-model';
+import { Permission, QueryHasManyResult } from 'ember-osf-web/models/osf-model';
 import CurrentUser from 'ember-osf-web/services/current-user';
 import defaultTo from 'ember-osf-web/utils/default-to';
 import { stripDiacritics } from 'ember-power-select/utils/group-utils';
@@ -63,7 +63,10 @@ export default class CollectionItemPicker extends Component.extend({
         }
 
         const nodes: QueryHasManyResult<Node> = yield user.queryHasMany('nodes', {
-            filter: this.filter ? { title: this.filter } : undefined,
+            filter: {
+                current_user_permission: Permission.Admin,
+                title: this.filter ? this.filter : undefined,
+            },
             page: this.page,
         });
 


### PR DESCRIPTION
…ion-item-picker

‼ Needs CenterForOpenScience/osf.io#8754

## Purpose

Only allow user's nodes where they have admin to be options in the collection-item-picker component (used on the Collections submit page)

## Summary of Changes

Adds filter query param for admin permissions

## Side Effects

N/A

## Feature Flags

None

## QA Notes

Only affects the collections submission page

## Ticket

N/A

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->