### PR TITLE
[EMB-377] fix project links modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         - made tagless
         - use `tags-widget` component instead of `ember-tag-input` directly
         - `encodeURIComponent(tag)` when constructing tags search url
+        - add `readOnly` argument to force-hide the dropdown controls
     - `node-navbar` - use `linkTo` for registrations
     - `paginated-relation` renamed to `paginated-list/has-many`
         - refactored to allow sharing functionality among different types of list
@@ -107,7 +108,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `guid-file` - use `tags-widget` component instead of `ember-tag-input` directly
     - `home` - remove submit task & user-registration model creation (moved to `sign-up-form` component)
 - Engines:
-    - `analytics-page` - use `node-list` component for linked nodes list
+    - `analytics-page` - set `readOnly=true` for node-cards in "links to this project" modal
 - Tests:
     - Removed captcha visibility assertions from logged-out home page test
 - Handbook:

--- a/lib/analytics-page/addon/application/controller.ts
+++ b/lib/analytics-page/addon/application/controller.ts
@@ -55,6 +55,8 @@ export default class ApplicationController extends Controller {
     hideAdblockWarning = Boolean(this.cookies.read(dismissAdblockCookie));
     userIsBot = navigator.userAgent.includes('Prerender');
 
+    linkedByQueryParams = { embed: 'contributors' };
+
     @readOnly('model.taskInstance.value')
     node?: Node;
 

--- a/lib/analytics-page/addon/application/template.hbs
+++ b/lib/analytics-page/addon/application/template.hbs
@@ -35,16 +35,27 @@
                                 closeTitle=(t 'general.close')
                                 onHide=(action 'hideLinksModal')
                             }}
-                                {{#node-list
-                                    modelTaskInstance=this.model.taskInstance
-                                    relationshipName='linkedByNodes'
-                                    analyticsScope='Project Analytics - Links'
-                                    as |nl|
-                                }}
-                                    {{#nl.empty}}
-                                        {{t 'analytics.noLinks'}}
-                                    {{/nl.empty}}
-                                {{/node-list}}
+                                {{#if this.node}}
+                                    <ul class="list-group">
+                                        {{#paginated-list/has-many
+                                            model=this.node
+                                            relationshipName='linkedByNodes'
+                                            query=this.linkedByQueryParams
+                                            analyticsScope='Project Analytics - Links'
+                                            as |list|
+                                        }}
+                                            <list.item as |node|>
+                                                <NodeCard @node={{node}} @readOnly=true @analyticsScope='Project Analytics - Links' />
+                                            </list.item>
+
+                                            <list.empty>
+                                                {{t 'analytics.noLinks'}}
+                                            </list.empty>
+                                        {{/paginated-list/has-many}}
+                                    </ul>
+                                {{else}}
+                                    <LoadingIndicator @dark=true />
+                                {{/if}}
                             {{/bs-modal-simple}}
                         {{/if}}
                     {{/if}}

--- a/lib/osf-components/addon/components/node-card/component.ts
+++ b/lib/osf-components/addon/components/node-card/component.ts
@@ -4,7 +4,7 @@ import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
 import config from 'ember-get-config';
 
-import Node from 'ember-osf-web/models/node';
+import Node, { NodeType } from 'ember-osf-web/models/node';
 import Registration from 'ember-osf-web/models/registration';
 import { Question } from 'ember-osf-web/models/registration-schema';
 import Analytics from 'ember-osf-web/services/analytics';
@@ -28,6 +28,7 @@ export default class NodeCard extends Component {
     delete?: (node: Node) => void;
     showTags: boolean = defaultTo(this.showTags, false);
     analyticsScope?: string;
+    readOnly: boolean = defaultTo(this.readOnly, false);
 
     // Private properties
     searchUrl = pathJoin(baseURL, 'search');
@@ -58,5 +59,10 @@ export default class NodeCard extends Component {
     @computed('analyticsScope')
     get analyticsScopePrefix() {
         return this.analyticsScope ? `${this.analyticsScope} - ` : '';
+    }
+
+    @computed('readOnly', 'node', 'node.nodeType', 'node.currentUserCanEdit')
+    get showDropdown() {
+        return !this.readOnly && this.node && this.node.nodeType === NodeType.Fork && this.node.currentUserCanEdit;
     }
 }

--- a/lib/osf-components/addon/components/node-card/template.hbs
+++ b/lib/osf-components/addon/components/node-card/template.hbs
@@ -36,7 +36,7 @@
             {{/if}}
         </span>
         {{#if @node}}
-            {{#if (and (eq @node.nodeType 'fork') @node.currentUserCanEdit)}}
+            {{#if this.showDropdown}}
                 <div class="pull-right generic-dropdown" local-class="NodeCard__dropdown">
                     {{#bs-dropdown as |dd|}}
                         {{#dd.button local-class='NodeCard__dropdown-button'}}


### PR DESCRIPTION
## Purpose

Fix project links modal issues identified in [EMB-377](https://openscience.atlassian.net/browse/EMB-377) (Problem 6)

## Summary of Changes

* Add readOnly parameter to `node-card` component to force-hide the dropdown controls (currently only shown for forks)
* Use `paginated-list/has-many` directly w/ readOnly=true for links modal

## Side Effects

Should be isolated to "Links to this project" modal since `readOnly` defaults to false.

## Feature Flags

n/a

## QA Notes

Make sure projects listed on "Link to this project" modal display correctly. Forks should not have dropdown controls in this view. Should also spot-check project registrations page and forks page, which both use the `node-card` component and it's logic for displaying the dropdown controls has been slightly refactored.

## Ticket

https://openscience.atlassian.net/browse/EMB-377

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
