### PR TITLE
[EMB-377] Collapse navbar when a link is clicked

### DIFF
--- a/lib/osf-components/addon/components/hyper-link/component.ts
+++ b/lib/osf-components/addon/components/hyper-link/component.ts
@@ -25,6 +25,7 @@ export default class HyperLink extends Component {
     hidden: boolean = defaultTo(this.hidden, false);
     queryParams?: { [k: string]: string };
     params: any[] = defaultTo(this.params, []);
+    onClicked?: () => void;
 
     @computed('route', 'positionalRoute')
     get resolvedRoute(): string {
@@ -56,10 +57,11 @@ export default class HyperLink extends Component {
 
     @action
     onclick(...args: any[]) {
-        if (this.analyticsLabel) {
-            return this.analytics.click('link', this.analyticsLabel, ...args);
+        if (this.onClicked) {
+            this.onClicked();
         }
-
-        return true;
+        if (this.analyticsLabel) {
+            this.analytics.click('link', this.analyticsLabel, ...args);
+        }
     }
 }

--- a/lib/osf-components/addon/components/osf-navbar/auth-dropdown/component.ts
+++ b/lib/osf-components/addon/components/osf-navbar/auth-dropdown/component.ts
@@ -53,6 +53,7 @@ export default class NavbarAuthDropdown extends Component {
     profileURL: string = defaultTo(this.profileURL, pathJoin(baseUrl, 'profile'));
     settingsURL: string = defaultTo(this.settingsURL, pathJoin(baseUrl, 'settings'));
     signUpURL: string = defaultTo(this.signUpURL, pathJoin(baseUrl, 'register'));
+    onLinkClicked?: () => void;
 
     @computed('router.currentURL')
     get signUpNext() {
@@ -90,5 +91,13 @@ export default class NavbarAuthDropdown extends Component {
         // Assuming `redirectUrl` comes back to this app, the session will be invalidated then.
         const query = this.redirectUrl ? `?${param({ next_url: this.redirectUrl })}` : '';
         window.location.href = `${config.OSF.url}logout/${query}`;
+    }
+
+    @action
+    _onLinkClicked(analyticsLabel: string) {
+        this.analytics.click('link', analyticsLabel);
+        if (this.onLinkClicked) {
+            this.onLinkClicked();
+        }
     }
 }

--- a/lib/osf-components/addon/components/osf-navbar/auth-dropdown/styles.scss
+++ b/lib/osf-components/addon/components/osf-navbar/auth-dropdown/styles.scss
@@ -1,3 +1,8 @@
-.headline {
+.Headline {
     margin-left: 10%;
+}
+
+// osf-style interop
+.AuthDropdown {
+    right: 0 !important;
 }

--- a/lib/osf-components/addon/components/osf-navbar/auth-dropdown/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/auth-dropdown/template.hbs
@@ -19,32 +19,32 @@
             <span class="caret"></span>
         {{/dd.toggle}}
 
-        {{#dd.menu classNames='dropdown-menu auth-dropdown' as |ddm|}}
+        {{#dd.menu classNames='auth-dropdown' local-class='AuthDropdown' as |ddm|}}
             {{#if headline}}
-                {{#ddm.item (html-attributes role='none') local-class='headline'}}
+                {{#ddm.item (html-attributes role='none') local-class='Headline'}}
                     {{headline}}
                 {{/ddm.item}}
             {{/if}}
             {{#ddm.item (html-attributes role='menuitem')}}
-                <a href="{{profileURL}}" onclick={{action 'click' 'link' 'Navbar - MyProfile' target=analytics}}>
+                <a href="{{profileURL}}" {{action '_onLinkClicked' 'Navbar - MyProfile'}}>
                     <i class="fa fa-user fa-lg p-r-xs"></i>
                     {{t 'auth_dropdown.my_profile'}}
                 </a>
             {{/ddm.item}}
             {{#ddm.item (html-attributes role='menuitem')}}
-                {{#global-link-to 'support' click=(action 'click' 'link' 'Navbar - Support' target=analytics)}}
+                {{#global-link-to 'support' click=(action '_onLinkClicked' 'Navbar - Support')}}
                     <i class="fa fa-life-ring fa-lg p-r-xs"></i>
                     {{t 'auth_dropdown.osf_support'}}
                 {{/global-link-to}}
             {{/ddm.item}}
             {{#ddm.item (html-attributes role='menuitem')}}
-                <a href="{{settingsURL}}" onclick={{action 'click' 'link' 'Navbar - Settings' target=analytics}}>
+                <a href="{{settingsURL}}" {{action '_onLinkClicked' 'Navbar - Settings'}}>
                     <i class="fa fa-cog fa-lg p-r-xs"></i>
                     {{t 'general.settings'}}
                 </a>
             {{/ddm.item}}
             {{#ddm.item (html-attributes role='menuitem')}}
-                <a class="logoutLink" {{action 'logout'}} onclick={{action 'click' 'button' 'Navbar - Logout' target=analytics}} role="button">
+                <a class="logoutLink" {{action 'logout'}} {{action '_onLinkClicked' 'Navbar - Logout'}} role="button">
                     <i class="fa fa-sign-out fa-lg p-r-xs"></i>
                     {{t 'auth_dropdown.log_out'}}
                 </a>

--- a/lib/osf-components/addon/components/osf-navbar/component.ts
+++ b/lib/osf-components/addon/components/osf-navbar/component.ts
@@ -54,13 +54,18 @@ export default class OsfNavbar extends Component {
     }
 
     @action
+    onClickPrimaryDropdown(this: OsfNavbar) {
+        this.set('showNavLinks', false);
+        this.analytics.click('button', 'Navbar - Dropdown Arrow');
+    }
+
+    @action
     toggleSecondaryNavigation() {
         this.toggleProperty('showNavLinks');
     }
 
     @action
-    onClickPrimaryDropdown(this: OsfNavbar) {
+    onLinkClicked() {
         this.set('showNavLinks', false);
-        this.analytics.click('button', 'Navbar - Dropdown Arrow');
     }
 }

--- a/lib/osf-components/addon/components/osf-navbar/styles.scss
+++ b/lib/osf-components/addon/components/osf-navbar/styles.scss
@@ -6,6 +6,11 @@
     padding: 1px 7px 2px;
 }
 
+// The default 340px isn't quite enough for the auth dropdown
+.secondary-navigation {
+    max-height: 400px !important;
+}
+
 @media (min-width: 992px) {
     .secondary-navigation {
         /* necessary for the parent flexbox container to shrink smaller than the child element's text */

--- a/lib/osf-components/addon/components/osf-navbar/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/template.hbs
@@ -57,7 +57,11 @@
                 collapsed=(not showNavLinks)
             }}
                 <ul class="nav navbar-nav" local-class="links">
-                    {{#let (hash links=(component 'osf-navbar/x-links')) as |ctx|}}
+                    {{#let (hash
+                        links=(component 'osf-navbar/x-links'
+                            onLinkClicked=(action 'onLinkClicked')
+                        )
+                    ) as |ctx|}}
                         {{#if hasBlock}}
                             {{yield ctx}}
                         {{else}}
@@ -65,7 +69,7 @@
                         {{/if}}
                     {{/let}}
 
-                    {{osf-navbar/auth-dropdown campaign=@campaign}}
+                    {{osf-navbar/auth-dropdown onLinkClicked=(action 'onLinkClicked') campaign=@campaign}}
                 </ul>
             {{/bs-collapse}}
         </div>

--- a/lib/osf-components/addon/components/osf-navbar/x-links/component.ts
+++ b/lib/osf-components/addon/components/osf-navbar/x-links/component.ts
@@ -21,6 +21,7 @@ export default class XLinks extends Component {
     searchURL: string = defaultTo(this.searchURL, `${osfURL}search/`);
     myProjectsURL: string = defaultTo(this.myProjectsURL, `${osfURL}myprojects/`);
     myRegistrationsURL: string = defaultTo(this.myRegistrationsURL, `${osfURL}myprojects/#registrations`);
+    onLinkClicked: () => void = defaultTo(this.onLinkClicked, () => null);
 
     @computed('router.currentRouteName')
     get supportURL() {

--- a/lib/osf-components/addon/components/osf-navbar/x-links/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/x-links/template.hbs
@@ -9,6 +9,7 @@
         )
         tagName='li'
         text=(t 'navbar.my_quick_files')
+        onClicked=this.onLinkClicked
     )
     myprojects=(component 'hyper-link'
         this.myProjectsURL
@@ -16,6 +17,7 @@
         hidden=(not this.session.isAuthenticated)
         tagName='li'
         text=(t 'navbar.my_projects')
+        onClicked=this.onLinkClicked
     )
     myregistrations=(component 'hyper-link'
         this.myRegistrationsURL
@@ -23,18 +25,21 @@
         hidden=(not this.session.isAuthenticated)
         tagName='li'
         text=(t 'navbar.my_registrations')
+        onClicked=this.onLinkClicked
     )
     search=(component 'hyper-link'
         this.searchURL
         analyticsLabel='Navbar - navbar.search'
         tagName='li'
         text=(t 'navbar.search')
+        onClicked=this.onLinkClicked
     )
     support=(component 'hyper-link'
         this.supportURL
         analyticsLabel='Navbar - navbar.support'
         tagName='li'
         text=(t 'navbar.support')
+        onClicked=this.onLinkClicked
     )
     donate=(component 'hyper-link'
         'https://cos.io/donate'
@@ -42,6 +47,7 @@
         classNames='navbar-donate-button'
         tagName='li'
         text=(t 'navbar.donate')
+        onClicked=this.onLinkClicked
     )
 ) as |links|}}
     {{#if hasBlock}}

--- a/tests/integration/components/osf-navbar/auth-dropdown/component-test.ts
+++ b/tests/integration/components/osf-navbar/auth-dropdown/component-test.ts
@@ -60,10 +60,8 @@ module('Integration | Component | osf-navbar/auth-dropdown', hooks => {
         this.owner.lookup('service:session').set('isAuthenticated', true);
         this.owner.register('service:analytics', Service.extend({
             clickCalled: false,
-            actions: {
-                click() {
-                    this.set('clickCalled', true);
-                },
+            click() {
+                this.set('clickCalled', true);
             },
         }));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3965,6 +3965,7 @@ commander@^2.12.1, commander@^2.9.0:
 commander@^2.16.0:
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.18.0.tgz#2bf063ddee7c7891176981a2cc798e5754bc6970"
+  integrity sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ==
 
 commander@~2.17.1:
   version "2.17.1"
@@ -10350,6 +10351,7 @@ just-extend@^1.1.27:
 katex@^0.10.0-rc.1:
   version "0.10.0-rc.1"
   resolved "https://registry.yarnpkg.com/katex/-/katex-0.10.0-rc.1.tgz#bd46155281f61c4855a064e2b7a89d137ee04b41"
+  integrity sha512-JmnreLp0lWPA1z1krzO5drN1qBrkhqzMg5qv0l5y+Fr97sqgOuh37k9ky7VD1k/Ec+yvOe2BptiYSR9OoShkFg==
   dependencies:
     commander "^2.16.0"
 


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[EMB-123] some really great stuff`
-->

## Purpose
On small screens, the navbar collapses into a hamburger menu. When the user clicks a link in the expanded menu, the menu should collapse.
<!-- Describe the purpose of your changes. -->

## Summary of Changes
Add actions to various navbar components to notify `osf-navbar` that a link was clicked, so it can appropriately collapse.

There were a couple tiny CSS bugs I couldn't resist fixing while I was digging into the navbar:

On tablet screens, the auth dropdown hangs off the side of the page. No more!
![screen shot 2018-10-18 at 08 44 30](https://user-images.githubusercontent.com/6776190/47158264-46002f00-d2b9-11e8-889d-736f8311888c.png)![screen shot 2018-10-18 at 09 38 01](https://user-images.githubusercontent.com/6776190/47158401-96778c80-d2b9-11e8-8a3d-cb5f1956ecda.png)

On mobile screens, the auth dropdown is cut off and you have to scroll down to log out. Maybe hiding the exit was intentional, but if someone wants out I think it's nicer to let them go.
![screen shot 2018-10-18 at 09 41 31](https://user-images.githubusercontent.com/6776190/47158627-1140a780-d2ba-11e8-8945-70b7361801f8.png)![screen shot 2018-10-18 at 09 39 28](https://user-images.githubusercontent.com/6776190/47158555-ebb39e00-d2b9-11e8-988e-5e015e5d688c.png)

<!-- Briefly describe or list your changes. -->

## Side Effects
n/a
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## Feature Flags
n/a
<!--
  Please list any feature flags that need to be enabled for these changes to go into effect.
  For each flag, what is the expected behavior with the flag enabled vs disabled?
-->

## QA Notes
Mainly needs testing on mobile- and tablet-size screens, but would be good to check desktop as well. I found it easiest to go back and forth between the dashboard, quickfiles, and support pages (both the "support" link and the "osf support" link in the auth dropdown [why do we have both?]), to stay within the ember app.

Whenever you click a link, the navbar should collapse back to a closed hamburger.
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
-->

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
https://openscience.atlassian.net/browse/EMB-377

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
