### PR TITLE
[EMB-377] Fix draft registrations reloading after delete

### DIFF
--- a/app/guid-node/registrations/template.hbs
+++ b/app/guid-node/registrations/template.hbs
@@ -41,7 +41,7 @@
                                     as |list|
                                 }}
                                     {{#list.item as |draftRegistration|}}
-                                        {{draft-registration-card draftRegistration=draftRegistration onDelete=list.doReload}}
+                                        <DraftRegistrationCard @draftRegistration={{draftRegistration}} @onDelete={{action list.doReload 1}} />
                                     {{/list.item}}
 
                                     {{#list.empty}}


### PR DESCRIPTION
## Purpose

Fix error with draft registrations reloading after delete

## Summary of Changes

* Make sure first argument to doReload is 1 (page number)
* Use angle bracket invocation for draft registration card

## Side Effects

n/a

## Feature Flags

n/a

## QA Notes

Make sure draft registrations list reloads properly after deleting one.

## Ticket

https://openscience.atlassian.net/browse/EMB-377

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
