### PR TITLE
[no ticket] Better types for osfResource, osfNestedResource

### DIFF
--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -21,7 +21,7 @@ export default function(this: Server) {
 
     this.get('/', rootDetail);
 
-    osfResource(this, 'developerApps', { path: 'applications', except: ['create'] });
+    osfResource(this, 'developer-app', { path: 'applications', except: ['create'] });
     this.post('/applications', createDeveloperApp);
     this.post('/applications/:id/reset', resetClientSecret);
 
@@ -31,31 +31,30 @@ export default function(this: Server) {
 
     this.get('/institutions');
 
-    osfResource(this, 'nodes', { except: ['create'] });
+    osfResource(this, 'node', { except: ['create'] });
     this.post('/nodes/', createNode);
-    osfNestedResource(this, 'nodes', 'contributors');
-    osfNestedResource(this, 'nodes', 'linkedNodes', { only: ['index'] });
-    osfNestedResource(this, 'nodes', 'registrations', { only: ['index'] });
-    osfNestedResource(this, 'nodes', 'draftRegistrations', { only: ['index'] });
+    osfNestedResource(this, 'node', 'contributors');
+    osfNestedResource(this, 'node', 'linkedNodes', { only: ['index'] });
+    osfNestedResource(this, 'node', 'registrations', { only: ['index'] });
+    osfNestedResource(this, 'node', 'draftRegistrations', { only: ['index'] });
 
-    osfResource(this, 'registrationSchemas', { path: '/schemas/registrations' });
+    osfResource(this, 'registration-schema', { path: '/schemas/registrations' });
 
-    osfResource(this, 'scopes', { only: ['index', 'show'] });
-    osfResource(this, 'regions', { only: ['index', 'show'] });
+    osfResource(this, 'scope', { only: ['index', 'show'] });
+    osfResource(this, 'region', { only: ['index', 'show'] });
 
     this.get('/status', () => {
         return { meta: { version: '2.8' }, maintenance: null };
     });
 
-    osfResource(this, 'tokens', { except: ['create'] });
+    osfResource(this, 'token', { except: ['create'] });
     this.post('/tokens', createToken);
 
-    osfResource(this, 'users', { except: ['create', 'delete'] });
-    osfNestedResource(this, 'users', 'institutions', { only: ['index'] });
-    osfNestedResource(this, 'users', 'emails', { path: '/users/:parentID/settings/emails' });
+    osfResource(this, 'user', { except: ['create', 'delete'] });
+    osfNestedResource(this, 'user', 'institutions', { only: ['index'] });
 
     this.get('/users/:id/nodes', userNodeList);
-    osfNestedResource(this, 'users', 'quickfiles', { only: ['index', 'show'] });
+    osfNestedResource(this, 'user', 'quickfiles', { only: ['index', 'show'] });
 
     // Waterbutler namespace
     this.namespace = '/wb';

--- a/mirage/views/osf-resource.ts
+++ b/mirage/views/osf-resource.ts
@@ -77,7 +77,7 @@ export function osfNestedResource<K extends keyof ModelRegistry>(
 ) {
     const opts: NestedResourceOptions = Object.assign({
         allow: ['list'],
-        path: `/${pluralize(underscore(parentModelName))}/:parentID/${pluralize(underscore(relationshipName))}`,
+        path: `/${pluralize(underscore(parentModelName))}/:parentID/${underscore(relationshipName)}`,
         relatedModelName: relationshipName,
         defaultSortKey: '-id',
     }, options);

--- a/mirage/views/osf-resource.ts
+++ b/mirage/views/osf-resource.ts
@@ -1,5 +1,7 @@
-import { underscore } from '@ember/string';
+import { camelize, underscore } from '@ember/string';
 import { resourceAction, Server } from 'ember-cli-mirage';
+import { ModelRegistry, RelationshipsFor } from 'ember-data';
+import { pluralize } from 'ember-inflector';
 
 import { filter, process } from './utils';
 
@@ -11,7 +13,7 @@ interface ResourceOptions {
 }
 
 interface NestedResourceOptions extends ResourceOptions {
-    relatedModelName: string;
+    relatedModelName: keyof ModelRegistry;
 }
 
 function gatherActions(opts: ResourceOptions) {
@@ -27,11 +29,12 @@ function gatherActions(opts: ResourceOptions) {
 
 export function osfResource(
     server: Server,
-    modelName: string,
+    modelName: keyof ModelRegistry,
     options?: Partial<ResourceOptions>,
 ) {
+    const mirageModelName = pluralize(camelize(modelName));
     const opts: ResourceOptions = Object.assign({
-        path: `/${underscore(modelName)}`,
+        path: `/${pluralize(underscore(modelName))}`,
         defaultSortKey: '-id',
     }, options);
     const detailPath = `${opts.path}/:id`;
@@ -39,7 +42,7 @@ export function osfResource(
 
     if (actions.includes('index')) {
         server.get(opts.path, function(schema, request) {
-            const models = schema[modelName]
+            const models = schema[mirageModelName]
                 .where(m => filter(m, request))
                 .models
                 .map((m: any) => this.serialize(m).data);
@@ -49,41 +52,43 @@ export function osfResource(
     }
 
     if (actions.includes('show')) {
-        server.get(detailPath, modelName);
+        server.get(detailPath, mirageModelName);
     }
 
     if (actions.includes('create')) {
-        server.post(opts.path, modelName);
+        server.post(opts.path, mirageModelName);
     }
 
     if (actions.includes('update')) {
-        server.patch(detailPath, modelName);
-        server.put(detailPath, modelName);
+        server.patch(detailPath, mirageModelName);
+        server.put(detailPath, mirageModelName);
     }
 
     if (actions.includes('delete')) {
-        server.del(detailPath, modelName);
+        server.del(detailPath, mirageModelName);
     }
 }
 
-export function osfNestedResource(
+export function osfNestedResource<K extends keyof ModelRegistry>(
     server: Server,
-    parentModelName: string,
-    relationshipName: string,
+    parentModelName: K,
+    relationshipName: string & RelationshipsFor<ModelRegistry[K]>,
     options?: Partial<NestedResourceOptions>,
 ) {
     const opts: NestedResourceOptions = Object.assign({
         allow: ['list'],
-        path: `/${underscore(parentModelName)}/:parentID/${underscore(relationshipName)}`,
+        path: `/${pluralize(underscore(parentModelName))}/:parentID/${pluralize(underscore(relationshipName))}`,
         relatedModelName: relationshipName,
         defaultSortKey: '-id',
     }, options);
+    const mirageParentModelName = pluralize(camelize(parentModelName));
+    const mirageRelatedModelName = pluralize(camelize(opts.relatedModelName));
     const detailPath = `${opts.path}/:id`;
     const actions = gatherActions(opts);
 
     if (actions.includes('index')) {
         server.get(opts.path, function(schema, request) {
-            const data = schema[parentModelName].find(request.params.parentID)[relationshipName].models.map(
+            const data = schema[mirageParentModelName].find(request.params.parentID)[relationshipName].models.map(
                 (model: any) => this.serialize(model).data,
             );
             return process(schema, request, this, data, { defaultSortKey: opts.defaultSortKey });
@@ -91,19 +96,19 @@ export function osfNestedResource(
     }
 
     if (actions.includes('show')) {
-        server.get(detailPath, opts.relatedModelName);
+        server.get(detailPath, mirageRelatedModelName);
     }
 
     if (actions.includes('create')) {
-        server.post(opts.path, opts.relatedModelName);
+        server.post(opts.path, mirageRelatedModelName);
     }
 
     if (actions.includes('update')) {
-        server.put(opts.path, opts.relatedModelName);
-        server.patch(opts.path, opts.relatedModelName);
+        server.put(opts.path, mirageRelatedModelName);
+        server.patch(opts.path, mirageRelatedModelName);
     }
 
     if (actions.includes('delete')) {
-        server.del(opts.path, opts.relatedModelName);
+        server.del(opts.path, mirageRelatedModelName);
     }
 }


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[EMB-123] some really great stuff`
-->

## Purpose
Make it harder to screw up the mirage config (do I type `developer-app`, `developer-apps`, `developerApps`, or `developerApp`?)
<!-- Describe the purpose of your changes. -->

## Summary of Changes
Add more restrictive types to `osfResource` and `osfNestedResource`, so they now expect a model name from `ModelRegistry`. It will automatically camelize/pluralize the model name to get the collection in mirage.
<!-- Briefly describe or list your changes. -->

## Side Effects
This will mildly mess with anyone with a WIP that adds mirage routes.

Also you might be alerted to a broken thing and have to fix it.
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## Feature Flags
n/a
<!--
  Please list any feature flags that need to be enabled for these changes to go into effect.
  For each flag, what is the expected behavior with the flag enabled vs disabled?
-->

## QA Notes
n/a
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
-->

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
