### PR TITLE
Let mirage create nodes and more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `panel` component integration test
 - Handbook:
     - `panel` component
+- Mirage:
+    - `node` POST view to add currentUser as contributor
+    - `regions` fixtures
+    - `wb` view to move files from user or node to a node
 - Routes:
     - `settings.applications` - list of developer apps
     - `settings.applications.edit`
     - `settings.applications.create`
+
 ### Changed
 - Components:
     - `loading-indicator` - added inline option
@@ -24,6 +29,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `loading-indicator` - added tests for inline
 - Handbook:
     - `loading-indicator` - added examples for inline
+- Mirage:
+    - `root` factory now adds all feature flags, not just route flags
+    - `user` factory has 'withFiles' trait so non-current users can have files easily
+    - `user` serializer has default_region relationship (hardcoded to us)
+
 ### Removed
 - Flags:
     - `ember_project_forks_page` - `guid-node.forks` and `guid-registration.forks` now always on

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -3,10 +3,12 @@ import config from 'ember-get-config';
 
 import { createDeveloperApp, resetClientSecret } from './views/developer-app';
 import { guidDetail } from './views/guid';
+import { createNode } from './views/node';
 import { osfNestedResource, osfResource } from './views/osf-resource';
 import { rootDetail } from './views/root';
 import { createToken } from './views/token';
 import { userNodeList } from './views/user';
+import { moveFile } from './views/wb';
 
 const { OSF: { apiUrl } } = config;
 
@@ -29,7 +31,8 @@ export default function(this: Server) {
 
     this.get('/institutions');
 
-    osfResource(this, 'nodes');
+    osfResource(this, 'nodes', { except: ['create'] });
+    this.post('/nodes/', createNode);
     osfNestedResource(this, 'nodes', 'contributors');
     osfNestedResource(this, 'nodes', 'linkedNodes', { only: ['index'] });
     osfNestedResource(this, 'nodes', 'registrations', { only: ['index'] });
@@ -38,6 +41,7 @@ export default function(this: Server) {
     osfResource(this, 'registrationSchemas', { path: '/schemas/registrations' });
 
     osfResource(this, 'scopes', { only: ['index', 'show'] });
+    osfResource(this, 'regions', { only: ['index', 'show'] });
 
     this.get('/status', () => {
         return { meta: { version: '2.8' }, maintenance: null };
@@ -52,6 +56,10 @@ export default function(this: Server) {
 
     this.get('/users/:id/nodes', userNodeList);
     osfNestedResource(this, 'users', 'quickfiles', { only: ['index', 'show'] });
+
+    // Waterbutler namespace
+    this.namespace = '/wb';
+    this.post('/files/:id/move', moveFile);
 
     // Private namespace
     this.namespace = '/_';

--- a/mirage/factories/root.ts
+++ b/mirage/factories/root.ts
@@ -7,6 +7,8 @@ import User from 'ember-osf-web/models/user';
 const {
     featureFlagNames: {
         routes,
+        navigation,
+        storageI18n,
     },
 } = config;
 
@@ -15,11 +17,15 @@ export interface Root {
     message: string;
     version: string;
     links: Links;
-    currentUser: User;
+    currentUser?: User;
 }
 
 export default Factory.extend<Root>({
-    activeFlags: Object.values(routes), // Pretend all routes are flagged on
+    activeFlags: [
+        ...Object.values(routes),
+        ...Object.values(navigation),
+        storageI18n,
+    ],
     message: 'Welcome to the OSF API.',
     version: '2.8',
     links: {},

--- a/mirage/factories/user.ts
+++ b/mirage/factories/user.ts
@@ -6,6 +6,7 @@ import { guid, guidAfterCreate } from './utils';
 
 export interface UserTraits {
     withNodes: Trait;
+    withFiles: Trait;
     loggedIn: Trait;
 }
 
@@ -44,6 +45,11 @@ export default Factory.extend<User & UserTraits>({
     withNodes: trait({
         afterCreate(user, server) {
             server.createList('node', 5, { user }, 'withContributors');
+        },
+    }),
+    withFiles: trait({
+        afterCreate(user, server) {
+            server.createList('file', 5, { user });
         },
     }),
     loggedIn: trait({

--- a/mirage/fixtures/regions.ts
+++ b/mirage/fixtures/regions.ts
@@ -1,0 +1,18 @@
+export default [
+    {
+        id: 'us',
+        name: 'United States',
+    },
+    {
+        id: 'de-1',
+        name: 'Germany - Frankfurt',
+    },
+    {
+        id: 'ca-1',
+        name: 'Canada - Montréal',
+    },
+    {
+        id: 'au-1',
+        name: 'Australia - Sydney',
+    },
+];

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -40,6 +40,8 @@ export default function(server: Server) {
     server.createList('scope', 5);
     server.createList('developer-app', 12);
     server.loadFixtures('registration-schemas');
+    server.loadFixtures('regions');
+
     registerNodeMultiple(server, nodes[0], 12, {
         currentUserPermissions: Object.values(Permission),
     }, 'withRegisteredMeta');

--- a/mirage/serializers/file.ts
+++ b/mirage/serializers/file.ts
@@ -2,14 +2,24 @@ import { ModelInstance } from 'ember-cli-mirage';
 import config from 'ember-get-config';
 import File from 'ember-osf-web/models/file';
 
-import ApplicationSerializer from './application';
+import ApplicationSerializer, { SerializedRelationships } from './application';
 
 const { OSF: { apiUrl } } = config;
 
 export default class FileSerializer extends ApplicationSerializer<File> {
     buildRelationships(model: ModelInstance<File>) {
-        return {
-            user: {
+        const returnValue: SerializedRelationships<File> = {
+            versions: {
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/files/${model.id}/versions/`,
+                        meta: this.buildRelatedLinkMeta(model, 'versions'),
+                    },
+                },
+            },
+        };
+        if (model.user !== null) {
+            returnValue.user = {
                 data: {
                     type: 'users',
                     id: model.user.id,
@@ -20,16 +30,23 @@ export default class FileSerializer extends ApplicationSerializer<File> {
                         meta: this.buildRelatedLinkMeta(model, 'user'),
                     },
                 },
-            },
-            versions: {
+            };
+        }
+        if (model.node !== null) {
+            returnValue.node = {
+                data: {
+                    type: 'nodes',
+                    id: model.node.id,
+                },
                 links: {
                     related: {
-                        href: `${apiUrl}/v2/files/${model.id}/versions/`,
-                        meta: this.buildRelatedLinkMeta(model, 'versions'),
+                        href: `${apiUrl}/v2/${model.node.id}/`,
+                        meta: this.buildRelatedLinkMeta(model, 'node'),
                     },
                 },
-            },
-        };
+            };
+        }
+        return returnValue;
     }
 
     buildNormalLinks(model: ModelInstance<File>) {

--- a/mirage/serializers/file.ts
+++ b/mirage/serializers/file.ts
@@ -40,7 +40,7 @@ export default class FileSerializer extends ApplicationSerializer<File> {
                 },
                 links: {
                     related: {
-                        href: `${apiUrl}/v2/${model.node.id}/`,
+                        href: `${apiUrl}/v2/nodes/${model.node.id}/`,
                         meta: this.buildRelatedLinkMeta(model, 'node'),
                     },
                 },

--- a/mirage/serializers/root.ts
+++ b/mirage/serializers/root.ts
@@ -11,7 +11,7 @@ interface RootObject {
     message: string;
     version: string;
     links: Links;
-    currentUser: ModelInstance<User>;
+    currentUser?: ModelInstance<User>;
 }
 
 export default class RootSerializer extends ApplicationSerializer<RootObject> {

--- a/mirage/serializers/user.ts
+++ b/mirage/serializers/user.ts
@@ -32,12 +32,24 @@ export default class UserSerializer extends ApplicationSerializer<User> {
                     },
                 },
             },
+            default_region: {
+                data: {
+                    type: 'regions',
+                    id: 'us',
+                },
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/regions/us/`,
+                        meta: {},
+                    },
+                },
+            },
         };
     }
 
     buildNormalLinks(model: ModelInstance<User>) {
         return {
-            ...super.buildNormalLinks(model),
+            self: `${apiUrl}/v2/users/${model.id}/`,
             profile_image: `https://www.gravatar.com/avatar/${faker.random.uuid().replace(/-/g, '')}?d=identicon`,
         };
     }

--- a/mirage/serializers/user.ts
+++ b/mirage/serializers/user.ts
@@ -49,7 +49,7 @@ export default class UserSerializer extends ApplicationSerializer<User> {
 
     buildNormalLinks(model: ModelInstance<User>) {
         return {
-            self: `${apiUrl}/v2/users/${model.id}/`,
+            ...super.buildNormalLinks(model),
             profile_image: `https://www.gravatar.com/avatar/${faker.random.uuid().replace(/-/g, '')}?d=identicon`,
         };
     }

--- a/mirage/views/node.ts
+++ b/mirage/views/node.ts
@@ -1,0 +1,14 @@
+import { HandlerContext, Schema } from 'ember-cli-mirage';
+
+export function createNode(this: HandlerContext, schema: Schema) {
+    const attrs = this.normalizedRequestAttrs();
+    const node = schema.nodes.create(attrs);
+    const now = (new Date()).toISOString();
+    node.attrs.dateModified = now;
+    node.attrs.dateCreated = now;
+    const userId = schema.roots.first().attrs.currentUserId;
+    const currentUser = schema.users.find(userId);
+    schema.contributors.create({ node, users: currentUser, index: 0 });
+
+    return node;
+}

--- a/mirage/views/node.ts
+++ b/mirage/views/node.ts
@@ -2,11 +2,13 @@ import { HandlerContext, Schema } from 'ember-cli-mirage';
 
 export function createNode(this: HandlerContext, schema: Schema) {
     const attrs = this.normalizedRequestAttrs();
-    const node = schema.nodes.create(attrs);
     const now = (new Date()).toISOString();
-    node.attrs.dateModified = now;
-    node.attrs.dateCreated = now;
-    const userId = schema.roots.first().attrs.currentUserId;
+    const node = schema.nodes.create({
+        ...attrs,
+        dateModified: now,
+        dateCreated: now,
+    });
+    const userId = schema.roots.first().currentUserId;
     const currentUser = schema.users.find(userId);
     schema.contributors.create({ node, users: currentUser, index: 0 });
 

--- a/mirage/views/wb.ts
+++ b/mirage/views/wb.ts
@@ -2,8 +2,11 @@ import { HandlerContext, Schema } from 'ember-cli-mirage';
 
 export function moveFile(this: HandlerContext, schema: Schema) {
     const fileId = this.request.params.id;
-    const nodeId = this.request.requestBody.resource;
+    const nodeId = JSON.parse(this.request.requestBody).resource;
     const file = schema.files.find(fileId);
-    file.attrs.userId = null;
-    file.attrs.nodeId = nodeId;
+    file.update({
+        userId: null,
+        nodeId,
+    });
+    return file;
 }

--- a/mirage/views/wb.ts
+++ b/mirage/views/wb.ts
@@ -1,0 +1,9 @@
+import { HandlerContext, Schema } from 'ember-cli-mirage';
+
+export function moveFile(this: HandlerContext, schema: Schema) {
+    const fileId = this.request.params.id;
+    const nodeId = this.request.requestBody.resource;
+    const file = schema.files.find(fileId);
+    file.attrs.userId = null;
+    file.attrs.nodeId = nodeId;
+}

--- a/types/ember-cli-mirage/index.d.ts
+++ b/types/ember-cli-mirage/index.d.ts
@@ -89,6 +89,7 @@ export interface Request {
 }
 
 export interface HandlerContext {
+    request: Request;
     serialize(modelOrCollection: ModelInstance | ModelInstance[] | ModelClass, serializerName?: string): any;
     normalizedRequestAttrs(): any;
 }


### PR DESCRIPTION
## Purpose

Pull mirage-only things from the Create Project refactor into its own PR

## Summary of Changes

1. Give mirage regions
2. Teach mirage to move files
3. Make it possible to create Mirage users with files without them being logged in
4. All the feature flags are enabled, not just route feature flags
5. When creating nodes, add the current user as a contributor to the node

## QA Notes

This is dev-only; no user facing changes, so no QA

## Ticket

Ultimately this is for https://openscience.atlassian.net/browse/EMB-359

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~ Tests come with the big PR for EMB-359
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
