### PR TITLE
Configure mergify.io

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,15 @@
+# see: https://doc.mergify.io/configuration.html
+
+pull_request_rules:
+  - name: automatic strict merge on CI success and review
+    conditions:
+      - base~=develop|^release/                         # only for PRs targeting develop or release branches
+      - status-success=continuous-integration/travis-ci # must pass travis
+      - approved-reviews-by=front-end                   # only accept approvals from the front-end team
+      - "#approved-reviews-by>=1"                       # at least one approval
+      - "#changes-requested-reviews-by=0"               # no changes requested
+      - label!=no merge                                 # use this label to prevent automatic merge
+    actions:
+      merge:
+        method: merge                                   # merge with a merge commit
+        strict: smart                                   # make sure PR is up-to-date before merging (but queue updates)

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,10 +3,9 @@
 pull_request_rules:
   - name: automatic strict merge on CI success and review
     conditions:
-      - base~=develop|^release/                         # only for PRs targeting develop or release branches
+      - base~=^develop$|^release/                       # only for PRs targeting develop or release branches
       - status-success=continuous-integration/travis-ci # must pass travis
-      - approved-reviews-by=front-end                   # only accept approvals from the front-end team
-      - "#approved-reviews-by>=1"                       # at least one approval
+      - approved-reviews-by=front-end                   # at least one approval from the front-end team
       - "#changes-requested-reviews-by=0"               # no changes requested
       - label!=no merge                                 # use this label to prevent automatic merge
     actions:


### PR DESCRIPTION
## Purpose

Let's try this.

## Summary of Changes

Configure [mergify](https://mergify.io) for this repo to auto-merge PRs that:
* target the `develop` branch or `release/*` branches
* pass Travis CI
* have at least one approval
* have no changes requested
* do not have the [`no merge`](https://github.com/CenterForOpenScience/ember-osf-web/labels/no%20merge) label

## Side Effects

All ur PRs are belong to `develop`.

## Feature Flags

n/a

## QA Notes

n/a

## Ticket

n/a