### PR TITLE
Configure mergify properly for team and travis

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,12 +3,12 @@
 pull_request_rules:
   - name: automatic strict merge on CI success and review
     conditions:
-      - base~=^develop$|^release/                       # only for PRs targeting develop or release branches
-      - status-success=continuous-integration/travis-ci # must pass travis
-      - approved-reviews-by=front-end                   # at least one approval from the front-end team
-      - "#changes-requested-reviews-by=0"               # no changes requested
-      - label!=no merge                                 # use this label to prevent automatic merge
+      - base~=^develop$|^release/                           # only for PRs targeting develop or release branches
+      - status-success=continuous-integration/travis-ci/pr  # must pass travis
+      - approved-reviews-by=@front-end                      # at least one approval from the front-end team
+      - "#changes-requested-reviews-by=0"                   # no changes requested
+      - label!=no merge                                     # use this label to prevent automatic merge
     actions:
       merge:
-        method: merge                                   # merge with a merge commit
-        strict: smart                                   # make sure PR is up-to-date before merging (but queue updates)
+        method: merge                                       # merge with a merge commit
+        strict: smart                                       # make sure PR is up-to-date before merging (but queue updates)


### PR DESCRIPTION
## Purpose

Mergify's docs are less than stellar.

From Mergify support:

> We can see that "status-success" and "approved-reviews-by" conditions do 
not match.
>
> For "status-success", I'm guessing the CI is 
> "continuous-integration/travis-ci/pr"
> instead of "continuous-integration/travis-ci"
> 
> For "approved-reviews-by", only user "jamescdavis" have review the PR, 
> not "front-end".
> But maybe "front-end" is a team ? if yes, you should prefix it with "@" 
> (approved-reviews-by=@front-end).

## Summary of Changes

* prefix team name with `@`
* append `/pr` to `status-success`

## Side Effects

Can haz merge now?

## Feature Flags

n/a

## QA Notes

n/a

## Ticket

n/a