### PR TITLE
[EMB-347] fix: distinguish between already registered and blacklisted emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Components:
     - `node-navbar` - Choose links to display with the same logic as legacy
+    - `sign-up-form` - Distinguish between alrteady registered and invalid (e.g. blacklisted) emails
 - Models:
     - `node`
         - added `wikiEnabled` boolean attribute
         - added `userHasReadPermission` computed property
         - renamed `currentUserCanEdit` computed property to `userHasWritePermission`
         - renamed `currentUserIsAdmin` computed property to `userHasAdminPermission`
+    - `user-registration` - added invalid email validation and `addInvalidEmail` method
 - Tests:
     - improved integration tests for `node-navbar` component
 - Adapters:

--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -453,6 +453,7 @@ export default {
         url: '{{description}} must be a valid url.',
         // custom
         email_registered: 'This email address has already been registered.',
+        email_invalid: 'Invalid email address. If this should not have occurred, please report this to {{supportEmail}}',
         email_match: 'Email addresses must match.',
         password_email: 'Your password cannot be the same as your email address.',
         password_old: 'Your new password cannot be the same as your old password.',

--- a/app/models/user-registration.ts
+++ b/app/models/user-registration.ts
@@ -2,8 +2,11 @@ import { attr } from '@ember-decorators/data';
 import { computed } from '@ember/object';
 import { buildValidations, validator } from 'ember-cp-validations';
 import DS from 'ember-data';
+import config from 'ember-get-config';
 
 const { Model } = DS;
+
+const { support: { supportEmail } } = config;
 
 const Validations = buildValidations({
     email1: [
@@ -12,7 +15,14 @@ const Validations = buildValidations({
         validator('exclusion', {
             messageKey: 'validationErrors.email_registered',
             in: computed(function(): string[] {
-                return [...this.get('model').get('existingEmails')];
+                return [...this.model.existingEmails];
+            }).volatile(),
+        }),
+        validator('exclusion', {
+            messageKey: 'validationErrors.email_invalid',
+            supportEmail,
+            in: computed(function(): string[] {
+                return [...this.model.invalidEmails];
             }).volatile(),
         }),
         validator('length', {
@@ -71,9 +81,14 @@ export default class UserRegistration extends Model.extend(Validations) {
     @attr('boolean') acceptedTermsOfService!: boolean;
 
     existingEmails: Set<string> = new Set();
+    invalidEmails: Set<string> = new Set();
 
-    addExistingEmail(this: UserRegistration, email?: string) {
-        this.get('existingEmails').add(email || this.get('email1'));
+    addExistingEmail(email?: string) {
+        this.existingEmails.add(email || this.email1);
+    }
+
+    addInvalidEmail(email?: string) {
+        this.invalidEmails.add(email || this.email1);
     }
 }
 

--- a/lib/osf-components/addon/components/sign-up-form/component.ts
+++ b/lib/osf-components/addon/components/sign-up-form/component.ts
@@ -25,9 +25,13 @@ export default class SignUpForm extends Component.extend({
             yield this.userRegistration.save();
         } catch (e) {
             // Handle email already exists error
-            if (+e.errors[0].status === 400) {
+            if (+e.errors[0].status === 409) {
                 this.resetRecaptcha();
                 this.userRegistration.addExistingEmail();
+                yield this.userRegistration.validate();
+            } else if (+e.errors[0].status === 400) {
+                this.resetRecaptcha();
+                this.userRegistration.addInvalidEmail();
                 yield this.userRegistration.validate();
             }
 


### PR DESCRIPTION
## Purpose

Distinguish between already registered and blacklisted emails

## Summary of Changes

### Changed
- Components:
    - `sign-up-form` - Distinguish between already registered and invalid (e.g. blacklisted) emails
- Models:
    - `user-registration` - added invalid email validation and `addInvalidEmail` method

## Side Effects

None.

## Feature Flags

n/a

## QA Notes

Should check that appropriate messages are given for attempting to register a user with an email address that is already in use and an email address that uses a blacklisted domain.

## Ticket

https://openscience.atlassian.net/browse/EMB-347

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
