### PR TITLE
[EMB-491][Collections] Remove truncating of contributor list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Components:
     - `node-navbar` - Choose links to display with the same logic as legacy
     - `validated-model-form` - Add an optional hook for onWillDestroy
+    - `contributor-list` - takes an optional parameter `truncated`
 - Handbook:
     - `validated-model-form` - Show how onWillDestroy works and use ember-onbeforeunload
 - Models:

--- a/lib/collections/addon/components/collections-submission/template.hbs
+++ b/lib/collections/addon/components/collections-submission/template.hbs
@@ -112,7 +112,7 @@
                 }}
             {{/section.active}}
             {{#section.complete}}
-                <p>{{contributor-list contributors=this.collectionItem.contributors}}</p>
+                <p>{{contributor-list contributors=this.collectionItem.contributors truncated=false}}</p>
             {{/section.complete}}
         {{/sections.section}}
 

--- a/lib/osf-components/addon/components/contributor-list/component.ts
+++ b/lib/osf-components/addon/components/contributor-list/component.ts
@@ -55,7 +55,7 @@ export default class ContributorList extends Component {
     }
 
     @computed('truncated')
-    get truncate(this: ContributorList) {
+    get truncate() {
         return this.truncated ? 3 : undefined;
     }
 }

--- a/lib/osf-components/addon/components/contributor-list/component.ts
+++ b/lib/osf-components/addon/components/contributor-list/component.ts
@@ -8,7 +8,8 @@ import I18N from 'ember-i18n/services/i18n';
 
 import { layout } from 'ember-osf-web/decorators/component';
 import Contributor from 'ember-osf-web/models/contributor';
-import template from './template';
+import defaultTo from 'ember-osf-web/utils/default-to';
+import layout from './template';
 
 export interface Contrib {
     title: string;
@@ -20,7 +21,7 @@ export interface Contrib {
 export default class ContributorList extends Component {
     @service i18n!: I18N;
     max = 3;
-    truncated = true;
+    truncated: boolean = defaultTo(this.truncated, true);
     nodeId?: string;
     useLink?: boolean;
     contributors!: DS.PromiseManyArray<Contributor> & { meta: { total: number } };

--- a/lib/osf-components/addon/components/contributor-list/component.ts
+++ b/lib/osf-components/addon/components/contributor-list/component.ts
@@ -20,6 +20,7 @@ export interface Contrib {
 export default class ContributorList extends Component {
     @service i18n!: I18N;
     max = 3;
+    truncated = true;
     nodeId?: string;
     useLink?: boolean;
     contributors!: DS.PromiseManyArray<Contributor> & { meta: { total: number } };

--- a/lib/osf-components/addon/components/contributor-list/component.ts
+++ b/lib/osf-components/addon/components/contributor-list/component.ts
@@ -55,7 +55,7 @@ export default class ContributorList extends Component {
     }
 
     @computed('truncated')
-    get truncate(this: ContributorList): number | undefined {
+    get truncate(this: ContributorList) {
         return this.truncated ? 3 : undefined;
     }
 }

--- a/lib/osf-components/addon/components/contributor-list/component.ts
+++ b/lib/osf-components/addon/components/contributor-list/component.ts
@@ -9,7 +9,7 @@ import I18N from 'ember-i18n/services/i18n';
 import { layout } from 'ember-osf-web/decorators/component';
 import Contributor from 'ember-osf-web/models/contributor';
 import defaultTo from 'ember-osf-web/utils/default-to';
-import layout from './template';
+import template from './template';
 
 export interface Contrib {
     title: string;

--- a/lib/osf-components/addon/components/contributor-list/component.ts
+++ b/lib/osf-components/addon/components/contributor-list/component.ts
@@ -53,4 +53,9 @@ export default class ContributorList extends Component {
     get rest(this: ContributorList): number {
         return this.contributors.meta.total - this.max;
     }
+
+    @computed('truncated')
+    get truncate(this: ContributorList): number | undefined {
+        return this.truncated ? 3 : undefined;
+    }
 }

--- a/lib/osf-components/addon/components/contributor-list/template.hbs
+++ b/lib/osf-components/addon/components/contributor-list/template.hbs
@@ -1,19 +1,11 @@
-{{#if truncated}}
-    {{#inline-list items=contributorList truncate=3 as |l|}}
-        {{#if l.item}}
-            {{~contributor-list/contributor useLink=useLink contributor=l.item~}}
-        {{else if l.truncate}}
-            {{#if useLink}}
-                <a href='/{{nodeId}}'>{{t 'contributor_list.and_x_more' x=rest}}</a>
-            {{else}}
-                {{~t 'contributor_list.and_x_more' x=rest}}
-            {{/if}}
+{{#inline-list items=contributorList truncate=this.truncate as |l|}}
+    {{#if l.item}}
+        {{~contributor-list/contributor useLink=useLink contributor=l.item~}}
+    {{else if l.truncate}}
+        {{#if useLink}}
+            <a href='/{{nodeId}}'>{{t 'contributor_list.and_x_more' x=rest}}</a>
+        {{else}}
+            {{~t 'contributor_list.and_x_more' x=rest}}
         {{/if}}
-    {{/inline-list}}
-{{else}}
-    {{#inline-list items=contributorList as |l|}}
-        {{#if l.item}}
-            {{~contributor-list/contributor useLink=useLink contributor=l.item~}}
-        {{/if}}
-    {{/inline-list}}
-{{/if}}
+    {{/if}}
+{{/inline-list}}

--- a/lib/osf-components/addon/components/contributor-list/template.hbs
+++ b/lib/osf-components/addon/components/contributor-list/template.hbs
@@ -1,11 +1,19 @@
-{{#inline-list items=this.contributorList truncate=3 as |l|}}
-    {{#if l.item}}
-        {{~contributor-list/contributor useLink=this.useLink contributor=l.item~}}
-    {{else if l.truncate}}
-        {{#if this.useLink}}
-            <a href='/{{this.nodeId}}'>{{t 'contributor_list.and_x_more' x=this.rest}}</a>
-        {{else}}
-            {{~t 'contributor_list.and_x_more' x=this.rest}}
+{{#if truncated}}
+    {{#inline-list items=contributorList truncate=3 as |l|}}
+        {{#if l.item}}
+            {{~contributor-list/contributor useLink=useLink contributor=l.item~}}
+        {{else if l.truncate}}
+            {{#if useLink}}
+                <a href='/{{nodeId}}'>{{t 'contributor_list.and_x_more' x=rest}}</a>
+            {{else}}
+                {{~t 'contributor_list.and_x_more' x=rest}}
+            {{/if}}
         {{/if}}
-    {{/if}}
-{{/inline-list}}
+    {{/inline-list}}
+{{else}}
+    {{#inline-list items=contributorList as |l|}}
+        {{#if l.item}}
+            {{~contributor-list/contributor useLink=useLink contributor=l.item~}}
+        {{/if}}
+    {{/inline-list}}
+{{/if}}

--- a/lib/osf-components/addon/components/inline-list/component.ts
+++ b/lib/osf-components/addon/components/inline-list/component.ts
@@ -23,4 +23,9 @@ export default class InlineList extends Component {
         }
         return this.items.slice(1, -1);
     }
+
+    @computed('items', 'truncate')
+    get shouldTruncate() {
+        return (this.truncate && (this.items.length > this.truncate));
+    }
 }

--- a/lib/osf-components/addon/components/inline-list/component.ts
+++ b/lib/osf-components/addon/components/inline-list/component.ts
@@ -24,7 +24,7 @@ export default class InlineList extends Component {
         return this.items.slice(1, -1);
     }
 
-    @computed('items', 'truncate')
+    @computed('items.[]', 'truncate')
     get shouldTruncate() {
         return (this.truncate && (this.items.length > this.truncate));
     }

--- a/lib/osf-components/addon/components/inline-list/template.hbs
+++ b/lib/osf-components/addon/components/inline-list/template.hbs
@@ -1,4 +1,4 @@
-{{#if (gt items.length truncate)}}
+{{#if shouldTruncate}}
     {{yield (hash item=first)~}}
     {{~t 'list.many_item.first_delimiter'~}}
     {{#each rest as | i index |}}


### PR DESCRIPTION
## Purpose

Modify the `contributor-list` component so that it takes an optional `truncated` boolean param which defaults to `true`. If `truncated` is set to `false`, then we show the complete list.

## Summary of Changes

In `contributor-list/template.hbs`, conditionals are added.

## QA Notes

Make sure all of the contributors' last names appear on the list.
Also checks and see if other places using the `contributor-list` component (e.g. the dashboard page) shows the truncated form.

## Ticket

https://openscience.atlassian.net/browse/EMB-491

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
