### PR TITLE
[EMB-347] fix(register): don't encode #show_login in orcid url

### DIFF
--- a/app/register/controller.ts
+++ b/app/register/controller.ts
@@ -18,7 +18,7 @@ export default class Register extends Controller {
         client_id: orcidClientId || '',
         scope: '/authenticate',
         response_type: 'code',
-        redirect_uri: `${casUrl}/login?client_name=OrcidClient#show_login`,
+        redirect_uri: `${casUrl}/login?client_name=OrcidClient`,
     })}`;
 
     @computed('next')

--- a/app/register/template.hbs
+++ b/app/register/template.hbs
@@ -7,7 +7,7 @@
             <div local-class="sign-up-buttons" class="m-md">
                 <a
                     data-test-orcid-button
-                    href={{orcidUrl}}
+                    href="{{orcidUrl}}#show_login"
                     local-class="sign-up-button"
                     onclick={{action "click" "button" "Sign up - ORCID" target=analytics}}
                 >


### PR DESCRIPTION
## Purpose

The #show_login at the end of the orcid url needs to be unencoded.

## Summary of Changes

Move the #show_login to the template.

## Side Effects

None.

## Feature Flags

`ember_auth_register`

## QA Notes

Orcid login from the sign up page should work now.

## Ticket

https://openscience.atlassian.net/browse/EMB-347

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
