### PR TITLE
[No ticket] Make seedrandom available to all

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -13,6 +13,7 @@ function postProcess(content) {
 module.exports = function(defaults) {
     const config = defaults.project.config(EMBER_ENV);
     const handbookEnabled = config.engines.handbook.enabled;
+    const mirageEnabled = config['ember-cli-mirage'].enabled;
 
     /*
      * Options just used by child addons of the handbook engine. Some addons
@@ -136,11 +137,11 @@ module.exports = function(defaults) {
         test: 'vendor/ember/ember-template-compiler.js',
     });
 
-    app.import({
-        test: 'node_modules/seedrandom/seedrandom.min.js',
-    }, {
-        using: [{ transformation: 'amd', as: 'seedrandom' }],
-    });
+    if (mirageEnabled) {
+        app.import('node_modules/seedrandom/seedrandom.min.js', {
+            using: [{ transformation: 'amd', as: 'seedrandom' }],
+        });
+    }
 
     app.import('node_modules/keen-tracking/dist/keen-tracking.min.js', {
         using: [{ transformation: 'amd', as: 'keen-tracking' }],


### PR DESCRIPTION
## Purpose

Let you use Mirage in local development, not just in tests.

## Summary of Changes

Modify the ember-cli-build file to add seedrandom everywhere if mirage is enabled

## QA Notes

No QA

## Ticket

No ticket

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~
- [ ] ~~changes described in `CHANGELOG.md`~~

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
