### PR TITLE
[EMB-347] fix(register): let CAS redirect to ORCID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `sign-up-form` - Distinguish between alrteady registered and invalid (e.g. blacklisted) emails
 - Models:
     - `user-registration` - added invalid email validation and `addInvalidEmail` method
+- Routes:
+    - `register` - let CAS redirect to ORCID
 
 ## [18.1.2] - 2018-11-05
 - Engines:

--- a/app/register/controller.ts
+++ b/app/register/controller.ts
@@ -6,7 +6,7 @@ import config from 'ember-get-config';
 import Analytics from 'ember-osf-web/services/analytics';
 import param from 'ember-osf-web/utils/param';
 
-const { OSF: { casUrl, orcidClientId, url: baseUrl } } = config;
+const { OSF: { casUrl, url: baseUrl } } = config;
 
 export default class Register extends Controller {
     queryParams = ['next'];
@@ -14,12 +14,13 @@ export default class Register extends Controller {
 
     @service analytics!: Analytics;
 
-    orcidUrl = `https://www.orcid.org/oauth/authorize?${param({
-        client_id: orcidClientId || '',
-        scope: '/authenticate',
-        response_type: 'code',
-        redirect_uri: `${casUrl}/login?client_name=OrcidClient`,
-    })}`;
+    @computed('next')
+    get orcidUrl() {
+        return `${casUrl}/login?${param({
+            redirectOrcid: 'true',
+            service: `${baseUrl}/login/?next=${encodeURIComponent(this.next || baseUrl)}`,
+        })}`;
+    }
 
     @computed('next')
     get institutionUrl() {

--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -97,7 +97,6 @@ declare const config: {
             authSession: string;
             joinBannerDismissed: string;
         };
-        orcidClientId?: string;
         casUrl: string;
     };
     social: {

--- a/config/environment.js
+++ b/config/environment.js
@@ -30,7 +30,6 @@ const {
     LINT_ON_BUILD: lintOnBuild = false,
     MIRAGE_ENABLED = false,
     OAUTH_SCOPES: scope,
-    ORCID_CLIENT_ID: orcidClientId,
     OSF_STATUS_COOKIE: statusCookie = 'osf_status',
     OSF_COOKIE_DOMAIN: cookieDomain = 'localhost',
     OSF_URL: url = 'http://localhost:5000/',
@@ -171,7 +170,6 @@ module.exports = function(environment) {
                 authSession: 'embosf-auth-session',
                 joinBannerDismissed: 'slide', // TODO: update legacy UI to use a more unique key
             },
-            orcidClientId,
             casUrl,
         },
         social: {


### PR DESCRIPTION
## Purpose

We need to bounce off CAS first before we go to ORCID.

## Summary of Changes

Go to CAS with redirectOrcid=true instead of ORCID directly.

## Side Effects

none

## Feature Flags

`ember_auth_register`

## QA Notes

ORCID sign up should full work now.

## Ticket

https://openscience.atlassian.net/browse/EMB-347

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
