### PR TITLE
[no ticket] chore: upgrade to osf-style 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - Added `parentRelationship` property to `osf-adapter`. Allows creating records at nested endpoints.
 - Routes:
     - Add email verification modal to application template
+- Misc:
+    - Upgraded to `osf-style` 1.8.0
 
 ## [18.1.2] - 2018-11-05
 - Engines:

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@centerforopenscience/eslint-config": "^2.0.0",
-    "@centerforopenscience/osf-style": "https://github.com/CenterForOpenScience/osf-style#e15bf09f4d4e3c6f3f89fcfdaf6d72e91faf8a7d",
+    "@centerforopenscience/osf-style": "1.8.0",
     "@ember/jquery": "^0.5.2",
     "@ember/optional-features": "^0.6.3",
     "@ember/test-helpers": "^0.7.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -311,9 +311,10 @@
     eslint-plugin-eslint-comments "^1.0.0"
     eslint-plugin-import "^2.7.0"
 
-"@centerforopenscience/osf-style@https://github.com/CenterForOpenScience/osf-style#e15bf09f4d4e3c6f3f89fcfdaf6d72e91faf8a7d":
-  version "1.7.0"
-  resolved "https://github.com/CenterForOpenScience/osf-style#e15bf09f4d4e3c6f3f89fcfdaf6d72e91faf8a7d"
+"@centerforopenscience/osf-style@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@centerforopenscience/osf-style/-/osf-style-1.8.0.tgz#adde9771ec09d930b408a39a121ff10b925f2fd5"
+  integrity sha512-s6rwcQN44CVUuRpRihZHEMaDiQ7SBj6rXxisKORCGCq8BEd0GlogGYGHnTIUnNF/aJxufaVwjmLXRcI63FavJA==
 
 "@ember-decorators/argument@^0.8.13":
   version "0.8.13"


### PR DESCRIPTION
## Purpose

Upgrade to `osf-style` 1.8.0. `osf.io` and `ember-osf-preprints` are already using this (via a pinned commit) in production and reviews has just been updated as well. `ember-of-web` is currently on a pinned commit that does not include https://github.com/CenterForOpenScience/osf-style/commit/5720e5cacce23deed8d8180f08f0a98da036ff37, but we [currently override](https://github.com/CenterForOpenScience/ember-osf-web/blob/develop/app/styles/_accessibility.scss) the colors for button styles we use.

## Summary of Changes

`yarn upgrade @centerforopenscience/osf-style@1.8.0`

## Side Effects

Should be none as we override all button and brand colors:

https://github.com/CenterForOpenScience/ember-osf-web/blob/bed6a01ad4ec6ec6248050c15fb811ef32bb5a68/app/styles/_variables.scss#L57-L59

## Feature Flags

n/a

## QA Notes

n/a

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
