### PR TITLE
[no ticket] chore(mergify): prevent merge if PR title contains WIP

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,6 +8,7 @@ pull_request_rules:
       - "#approved-reviews-by>0"                            # at least one approval from someone with write permission
       - "#changes-requested-reviews-by=0"                   # no changes requested
       - label!=no merge                                     # use this label to prevent automatic merge
+      - -title~=\b[Ww][Ii][Pp]\b
     actions:
       merge:
         method: merge                                       # merge with a merge commit


### PR DESCRIPTION
## Purpose

Prevent automatic merge of PRs with `WIP` in the title. Mergify is implemented in python and [uses its standard `re` library to match](https://github.com/Mergifyio/mergify-engine/blob/30489adbd7724d631b66158c49d710e4efb6eff3/mergify_engine/rules/filter.py#L82). This RegEx will match the string `WIP` case insensitively` (using python's `re.IGNORECASE` does not appear to be possible) with word boundaries on either side.

All of these will prevent merge:
* `WIP really great stuff`
* `this is WIP and is really great`
* `[WIP] really great stuff`
* `really great stuff [WIP]`
* `really great stuff (WIP)`
* `wip really great stuff`
* `WiP really great stuff`

These will not:
* `this will wipe your HD`
* `swipe right to indicate superficial approval of the project`

## Summary of Changes

Added Mergify *negated* condition to match titles containing `WIP`.

## Side Effects

n/a

## Feature Flags

n/a

## QA Notes

n/a

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] ~~easy to understand~~ *(no code changes)*
- [ ] ~~DRY~~ *(no code changes)*
- [ ] ~~testable and includes test(s)~~ *(no code changes)*
- [ ] ~~changes described in `CHANGELOG.md`~~ *(no code changes)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
