### PR TITLE
chore(tests): remove Percy snapshot for prereg challenge modal

### DIFF
--- a/tests/acceptance/guid-node/registrations-test.ts
+++ b/tests/acceptance/guid-node/registrations-test.ts
@@ -339,7 +339,6 @@ module('Acceptance | guid-node/registrations', hooks => {
             await click('[data-test-new-registration-modal-create-draft-button]');
             assert.dom('[data-test-prereg-challenge-modal-body]').isVisible();
             assert.dom('[data-test-prereg-challenge-modal-continue-button]').isDisabled();
-            await percySnapshot(`Acceptance | guid-node/registrations | logged in admin, prereg challenge modal ${i}`);
             await click('[data-test-prereg-challenge-modal-consent-checkbox]');
             assert.dom('[data-test-prereg-challenge-modal-continue-button]').isNotDisabled();
             await click('[data-test-prereg-challenge-modal-cancel-button]');


### PR DESCRIPTION
## Purpose

These snapshots are probabilistically diffing and we won't care about them soon anyways.

## Summary of Changes

Remove the snapshot from

## Side Effects

n/a

## Feature Flags

n/a

## QA Notes

There will be no Percy snapshots for the Prereg Challenge modal.

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
