### PR TITLE
[EMB-391] Ensure that logout banner won't reappear on home page

### DIFF
--- a/app/home/route.ts
+++ b/app/home/route.ts
@@ -6,6 +6,8 @@ import Session from 'ember-simple-auth/services/session';
 
 import Analytics from 'ember-osf-web/services/analytics';
 
+import Controller from './controller';
+
 export default class Home extends Route {
     @service analytics!: Analytics;
     @service session!: Session;
@@ -21,5 +23,11 @@ export default class Home extends Route {
     @action
     didTransition(this: Home) {
         this.get('analytics').trackPage();
+    }
+
+    resetController(controller: Controller, isExiting: boolean, _: Ember.Transition) {
+        if (isExiting) {
+            controller.set('goodbye', null);
+        }
     }
 }

--- a/app/home/template.hbs
+++ b/app/home/template.hbs
@@ -1,6 +1,7 @@
 {{title (t 'home.title')}}
 {{#if goodbye}}
     {{#bs-alert
+        data-test-goodbye-banner
         type='success'
         classNames='text-center'
         local-class='goodbye'

--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -159,8 +159,9 @@ declare const config: {
             turnAuditOff: boolean,
         },
     };
-    'ember-cli-mirage'?: {
+    'ember-cli-mirage': {
         enabled: boolean;
+        defaultLoggedOut: boolean;
     };
     engines: {
         collections: {

--- a/config/environment.js
+++ b/config/environment.js
@@ -29,6 +29,7 @@ const {
     KEEN_CONFIG: keenConfig,
     LINT_ON_BUILD: lintOnBuild = false,
     MIRAGE_ENABLED = false,
+    MIRAGE_DEFAULT_LOGGED_OUT = false,
     OAUTH_SCOPES: scope,
     OSF_STATUS_COOKIE: statusCookie = 'osf_status',
     OSF_COOKIE_DOMAIN: cookieDomain = 'localhost',
@@ -263,6 +264,7 @@ module.exports = function(environment) {
         },
         'ember-cli-mirage': {
             enabled: Boolean(MIRAGE_ENABLED),
+            defaultLoggedOut: Boolean(MIRAGE_DEFAULT_LOGGED_OUT),
         },
 
         defaultProvider: 'osf',
@@ -295,6 +297,7 @@ module.exports = function(environment) {
             // Always enable mirage for tests.
             'ember-cli-mirage': {
                 enabled: true,
+                defaultLoggedOut: false,
             },
             APP: {
                 ...ENV.APP,

--- a/lib/osf-components/addon/components/osf-navbar/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/template.hbs
@@ -2,7 +2,12 @@
     <nav class="navbar navbar-inverse navbar-fixed-top" id="navbarScope" role="navigation">
         <div class="container">
             <div class="navbar-header">
-                {{#global-link-to 'home' (html-attributes aria-label=(t 'navbar.go_home')) class='navbar-brand'}}
+                {{#global-link-to 
+                    'home' 
+                    data-test-nav-home-link 
+                    (html-attributes aria-label=(t 'navbar.go_home')) 
+                    class='navbar-brand'
+                }}
                     <span class="osf-navbar-logo"></span>
                 {{/global-link-to}}
 

--- a/lib/osf-components/addon/components/osf-navbar/x-links/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/x-links/template.hbs
@@ -53,10 +53,10 @@
     {{#if hasBlock}}
         {{yield links}}
     {{else}}
-        {{links.quickfiles}}
-        {{links.myprojects}}
-        {{links.search}}
-        {{links.support}}
-        {{links.donate}}
+        {{links.quickfiles data-test-nav-quickfiles-link}}
+        {{links.myprojects data-test-nav-my-projects-link}}
+        {{links.search data-test-nav-search-link}}
+        {{links.support data-test-nav-support-link}}
+        {{links.donate data-test-nav-donate-link}}
     {{/if}}
 {{/let}}

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -14,7 +14,13 @@ const {
 } = config;
 
 export default function(server: Server) {
-    const currentUser = server.create('user', 'loggedIn');
+    // const currentUser = server.create('user', 'loggedIn');
+
+    // Use the following instead of the above to run the app logged out
+
+    const currentUser = server.create('user');
+    server.create('root', { currentUser: null });
+
     const firstNode = server.create('node', {});
     server.create('contributor', { node: firstNode, users: currentUser, index: 0 });
     const nodes = server.createList<Node>('node', 10, {

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -11,15 +11,20 @@ const {
         noteworthyNode,
         popularNode,
     },
+    'ember-cli-mirage': {
+        defaultLoggedOut,
+    },
 } = config;
 
 export default function(server: Server) {
-    // const currentUser = server.create('user', 'loggedIn');
+    let currentUser = null;
 
-    // Use the following instead of the above to run the app logged out
-
-    const currentUser = server.create('user');
-    server.create('root', { currentUser: null });
+    if (defaultLoggedOut) {
+        currentUser = server.create('user');
+        server.create('root', { currentUser: null });
+    } else {
+        currentUser = server.create('user', 'loggedIn');
+    }
 
     const firstNode = server.create('node', {});
     server.create('contributor', { node: firstNode, users: currentUser, index: 0 });

--- a/tests/acceptance/logged-out-home-page-test.ts
+++ b/tests/acceptance/logged-out-home-page-test.ts
@@ -38,4 +38,19 @@ module('Acceptance | logged-out home page', hooks => {
         // Alt text for integration logos
         assert.dom('[class*="_integrations"] img[alt*="Dropbox logo"]').exists();
     });
+
+    test('visiting /?goodbye=true', async assert => {
+        server.create('root', { currentUser: null });
+
+        await visit('/?goodbye=true');
+        assert.equal(currentURL(), '/?goodbye=true', "Still at '/?goodbye=true'.");
+
+        assert.dom('[data-test-goodbye-banner').exists();
+        await percySnapshot(assert);
+        await click('a[href="/support"]');
+        assert.equal(currentURL(), '/support', "Made it to '/support'.");
+        await click('a[href="/"]');
+        assert.equal(currentURL(), '/', 'No more query parameter');
+        assert.dom('[data-test-goodbye-banner').doesNotExist('No goodbye banner when returning to the page');
+    });
 });


### PR DESCRIPTION
## Purpose

Keep the logout banner/query parameter from showing up on visits to the landing page within the embosf app.

## Summary of Changes

1. Clear the goodbye query parameter in the home page route's `resetController` hook (per https://guides.emberjs.com/v1.10.0/routing/query-params/ )
2. Test (with Percy snapshot so we can see if the goodbye banner changes)
3. Add a local override to easily change the default scenario to be logged out.
4. Add some test selectors, because test selectors are nice

## QA Notes

The acceptance test I wrote covers the steps from the ticket:

1. Log into the OSF
2. Log out of the OSF (See that you wind up on the logged out landing page)
3. Click "support" in the navbar to navigate to the support page
4. Click "OSFHome" to navigate back home

## Ticket

https://openscience.atlassian.net/browse/EMB-391

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ Tiny change

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->