### PR TITLE
[EMB-526] Hotfix/filter registration schemas

### DIFF
--- a/app/guid-node/registrations/controller.ts
+++ b/app/guid-node/registrations/controller.ts
@@ -39,7 +39,14 @@ export default class GuidNodeRegistrations extends Controller {
     };
 
     getRegistrationSchemas = task(function *(this: GuidNodeRegistrations) {
-        let schemas = yield this.store.findAll('registration-schema');
+        let schemas = yield this.store.findAll('registration-schema',
+            {
+                adapterOptions: {
+                    query: {
+                        'filter[active]': true,
+                    },
+                },
+            });
         schemas = schemas.toArray();
         schemas.sort((a: RegistrationSchema, b: RegistrationSchema) => {
             return a.name.length - b.name.length;

--- a/mirage/helpers.ts
+++ b/mirage/helpers.ts
@@ -73,3 +73,7 @@ export function draftRegisterNodeMultiple(
     }
     return draftRegistrations;
 }
+
+export function isTruthy(val: any) {
+    return ['true', '1'].includes(val.toString().toLowerCase());
+}

--- a/mirage/views/private/utils.ts
+++ b/mirage/views/private/utils.ts
@@ -2,6 +2,8 @@ import { camelize } from '@ember/string';
 import { HandlerContext, Request, Schema } from 'ember-cli-mirage';
 import { Resource, ResourceCollectionDocument } from 'osf-api';
 
+import { isTruthy } from 'ember-osf-web/mirage/helpers';
+
 export enum ComparisonOperators {
     Eq = 'eq',
     Ne = 'ne',
@@ -227,7 +229,7 @@ export function compare(actualValue: any, comparisonValue: any, operator: Compar
     if (typeof actualValue === 'string') {
         return compareStrings(actualValue, comparisonValue, operator);
     } else if (typeof actualValue === 'boolean') {
-        return compareBooleans(actualValue, comparisonValue, operator);
+        return compareBooleans(actualValue, isTruthy(comparisonValue), operator);
     } else {
         throw new Error(`We haven't implemented comparisons with "${operator}" yet.`);
     }


### PR DESCRIPTION
## Purpose

Filter registration schemas on active=true so that, when Platform adds all of the registration schemas to the default endpoint, we don't get all the schemas.

## Summary of Changes

1. Change the adapter to `filter[active]=true` by default
2. Fix the boolean filtering in mirage
3. Add an `isTruthy` helper to mirage

## QA Notes

This should not change anything on the existing UI because

https://api.osf.io/v2/schemas/registrations/?filter[active]=true

returns the same data as 

https://api.osf.io/v2/schemas/registrations/

But definitely worth checking both when this is merged and after the platform migration is run.

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
https://openscience.atlassian.net/browse/EMB-526

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~ Existing tests covered testable functionality
- [ ] ~~changes described in `CHANGELOG.md`~~ Tiny change

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->