### PR TITLE
[EMB-528] Eliminate implicit this in templates 1/?

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -8,7 +8,8 @@ module.exports = {
     rules: {
         'block-indentation': 4,
         'no-bare-strings': true,
-        'no-nested-interactive': false,
+        'no-implicit-this': { allow: ['data-test-'] },
+        'no-nested-interactive': true,
     },
 
     ignore: [

--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -8,8 +8,8 @@ module.exports = {
     rules: {
         'block-indentation': 4,
         'no-bare-strings': true,
-        'no-implicit-this': { allow: ['data-test-'] },
-        'no-nested-interactive': true,
+        'no-implicit-this': true,
+        'no-nested-interactive': false,
     },
 
     ignore: [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         - added validations for name fields
 - Routes:
     - `settings` - redirects to `settings.profile.name`
+- Templates:
+    - `no-implicit-this` template rule activated
 - Tests:
     - improved integration tests for `node-navbar` component
 - Adapters:

--- a/lib/osf-components/addon/components/bs-alert/template.hbs
+++ b/lib/osf-components/addon/components/bs-alert/template.hbs
@@ -1,5 +1,5 @@
-{{#unless hidden}}
-    {{#if dismissible}}
+{{#unless this.hidden}}
+    {{#if this.dismissible}}
         <button class="close" aria-label={{t 'general.close'}} {{action "dismiss"}}>
             <span aria-hidden="true">{{fa-icon 'times'}}</span>
         </button>

--- a/lib/osf-components/addon/components/contributor-list/contributor/template.hbs
+++ b/lib/osf-components/addon/components/contributor-list/contributor/template.hbs
@@ -1,5 +1,5 @@
-{{#if (and useLink contributor.id)~}}
-    <a href='/{{contributor.id}}'>{{~contributor.title~}}</a>
+{{#if (and this.useLink this.contributor.id)~}}
+    <a href='/{{this.contributor.id}}'>{{~this.contributor.title~}}</a>
 {{~else~}}
-    {{~contributor.title~}}
+    {{~this.contributor.title~}}
 {{/if}}

--- a/lib/osf-components/addon/components/contributor-list/template.hbs
+++ b/lib/osf-components/addon/components/contributor-list/template.hbs
@@ -1,11 +1,11 @@
-{{#inline-list items=contributorList truncate=3 as |l|}}
+{{#inline-list items=this.contributorList truncate=3 as |l|}}
     {{#if l.item}}
-        {{~contributor-list/contributor useLink=useLink contributor=l.item~}}
+        {{~contributor-list/contributor useLink=this.useLink contributor=l.item~}}
     {{else if l.truncate}}
-        {{#if useLink}}
-            <a href='/{{nodeId}}'>{{t 'contributor_list.and_x_more' x=rest}}</a>
+        {{#if this.useLink}}
+            <a href='/{{this.nodeId}}'>{{t 'contributor_list.and_x_more' x=this.rest}}</a>
         {{else}}
-            {{~t 'contributor_list.and_x_more' x=rest}}
+            {{~t 'contributor_list.and_x_more' x=this.rest}}
         {{/if}}
     {{/if}}
 {{/inline-list}}

--- a/lib/osf-components/addon/components/cookie-banner/template.hbs
+++ b/lib/osf-components/addon/components/cookie-banner/template.hbs
@@ -1,4 +1,4 @@
-{{#if showBanner}}
+{{#if this.showBanner}}
     <div local-class="CookieBanner">
         <div local-class="Warning">
             {{t 'cookieBanner.cookieWarning'}}

--- a/lib/osf-components/addon/components/dashboard-item/template.hbs
+++ b/lib/osf-components/addon/components/dashboard-item/template.hbs
@@ -1,22 +1,22 @@
-<a href="{{node.links.html}}"
-   onclick={{action 'click' 'link' 'Dashboard - visit_node' target=analytics}}
+<a href="{{@node.links.html}}"
+   onclick={{action 'click' 'link' 'Dashboard - visit_node' target=this.analytics}}
 >
     <div class="m-v-sm" local-class="DashboardItem">
         <div class="row">
             <div>
                 <div class="col-sm-3 col-md-6 p-v-xs">
                     <div local-class="DashboardItem__col" class="di-title">
-                        {{#each ancestry as |ancestorTitle|}}
+                        {{#each this.ancestry as |ancestorTitle|}}
                             {{ancestorTitle}} /
                         {{/each}}
-                        <strong data-test-dashboard-item-title>{{node.title}}</strong>
+                        <strong data-test-dashboard-item-title>{{@node.title}}</strong>
                     </div>
                 </div>
                 <div class="col-sm-3 col-md-3 p-v-xs">
-                    <div local-class="DashboardItem__col" class="di-contributors">{{contributor-list contributors=contributors}}</div>
+                    <div local-class="DashboardItem__col" class="di-contributors">{{contributor-list contributors=this.contributors}}</div>
                 </div>
                 <div class="col-sm-3 col-md-3 p-v-xs">
-                    <div local-class="DashboardItem__col" class="di-date">{{date}}</div>
+                    <div local-class="DashboardItem__col" class="di-date">{{this.date}}</div>
                 </div>
             </div>
         </div>

--- a/lib/osf-components/addon/components/delete-button/template.hbs
+++ b/lib/osf-components/addon/components/delete-button/template.hbs
@@ -4,7 +4,7 @@
         aria-label={{this.buttonLabel}}
         @type='link'
         @size='sm'
-        @local-class='SmallDelete'
+        local-class='SmallDelete'
         @onClick={{action this._show}}
         @disabled={{this.disabled}}
     >

--- a/lib/osf-components/addon/components/delete-button/template.hbs
+++ b/lib/osf-components/addon/components/delete-button/template.hbs
@@ -2,9 +2,9 @@
     <BsButton 
         data-test-delete-button
         aria-label={{this.buttonLabel}}
-        @type='link'
-        @size='sm'
-        local-class='SmallDelete'
+        @type="link"
+        @size="sm"
+        local-class="SmallDelete"
         @onClick={{action this._show}}
         @disabled={{this.disabled}}
     >
@@ -13,7 +13,7 @@
 {{else}}
     <BsButton 
         data-test-delete-button
-        @type='default'
+        @type="default"
         @onClick={{action this._show}}
         @disabled={{this.disabled}}
     >
@@ -23,24 +23,24 @@
 
 {{#if this.modalShown}}
     <BsModal
-        @tagName='span'
+        @tagName="span"
         @onHide={{action this._cancel}}
         as |modal|
     >
         <modal.header>
-            <h3 class='modal-title'>{{this.modalTitle}}</h3>
+            <h3 class="modal-title">{{this.modalTitle}}</h3>
         </modal.header>
 
         <modal.body>
-            {{#if @hasBlock}}
+            {{#if (has-block)}}
                 {{yield}}
             {{else}}
                 <p>{{this.modalBody}}</p>
             {{/if}}
 
             {{#if this.hardConfirm}}
-                <label local-class='Modal__confirmBlock' data-test-confirm-scientist-name>
-                    <p local-class='Modal__confirmPrompt'>
+                <label local-class="Modal__confirmBlock" data-test-confirm-scientist-name>
+                    <p local-class="Modal__confirmPrompt">
                         {{t 'osf-components.delete-button.hardConfirm' text=this.scientistName}}
                     </p>
                     {{input
@@ -61,7 +61,7 @@
             />
             <BsButton 
                 data-test-confirm-delete
-                @type='danger'
+                @type="danger"
                 @disabled={{this.confirmDisabled}}
                 @onClick={{perform this._deleteTask}}
                 @defaultText={{this.confirmButtonText}}

--- a/lib/osf-components/addon/components/delete-button/template.hbs
+++ b/lib/osf-components/addon/components/delete-button/template.hbs
@@ -1,36 +1,38 @@
-{{#if small}}
-    {{#bs-button data-test-delete-button
-        (html-attributes aria-label=this.buttonLabel)
-        type='link'
-        size='sm'
-        local-class='SmallDelete'
-        onClick=(action this._show)
-        disabled=this.disabled
-    }}
+{{#if this.small}}
+    <BsButton 
+        data-test-delete-button
+        aria-label={{this.buttonLabel}}
+        @type='link'
+        @size='sm'
+        @local-class='SmallDelete'
+        @onClick={{action this._show}}
+        @disabled={{this.disabled}}
+    >
         {{fa-icon 'times' size='lg'}}
-    {{/bs-button}}
+    </BsButton>
 {{else}}
-    {{#bs-button data-test-delete-button
-        type='default'
-        onClick=(action this._show)
-        disabled=this.disabled
-    }}
+    <BsButton 
+        data-test-delete-button
+        @type='default'
+        @onClick={{action this._show}}
+        @disabled={{this.disabled}}
+    >
         {{this.buttonLabel}}
-    {{/bs-button}}
+    </BsButton>
 {{/if}}
 
 {{#if this.modalShown}}
-    {{#bs-modal
-        tagName='span'
-        onHide=(action this._cancel)
+    <BsModal
+        @tagName='span'
+        @onHide={{action this._cancel}}
         as |modal|
-    }}
-        {{#modal.header}}
+    >
+        <modal.header>
             <h3 class='modal-title'>{{this.modalTitle}}</h3>
-        {{/modal.header}}
+        </modal.header>
 
-        {{#modal.body}}
-            {{#if hasBlock}}
+        <modal.body>
+            {{#if @hasBlock}}
                 {{yield}}
             {{else}}
                 <p>{{this.modalBody}}</p>
@@ -48,20 +50,22 @@
                     }}
                 </label>
             {{/if}}
-        {{/modal.body}}
+        </modal.body>
 
-        {{#modal.footer}}
-            {{bs-button data-test-cancel-delete
-                disabled=this._deleteTask.isRunning
-                onClick=modal.close
-                defaultText=this.cancelButtonText
-            }}
-            {{bs-button data-test-confirm-delete
-                type='danger'
-                disabled=this.confirmDisabled
-                onClick=(perform this._deleteTask)
-                defaultText=this.confirmButtonText
-            }}
-        {{/modal.footer}}
-    {{/bs-modal}}
+        <modal.footer>
+            <BsButton
+                data-test-cancel-delete
+                @disabled={{this._deleteTask.isRunning}}
+                @onClick={{modal.close}}
+                @defaultText={{this.cancelButtonText}}
+            />
+            <BsButton 
+                data-test-confirm-delete
+                @type='danger'
+                @disabled={{this.confirmDisabled}}
+                @onClick={{perform this._deleteTask}}
+                @defaultText={{this.confirmButtonText}}
+            />
+        </modal.footer>
+    </BsModal>
 {{/if}}

--- a/lib/osf-components/addon/components/delete-node-modal/template.hbs
+++ b/lib/osf-components/addon/components/delete-node-modal/template.hbs
@@ -2,28 +2,28 @@
     @open={{@openModal}}
     @onSubmit={{action @delete}}
     @onHidden={{action @closeModal}}
-    as |m|
+    as |modal|
 >
-    <m.header>
+    <modal.header>
         <h3>{{t 'delete_modal.title' nodeType=(t this.nodeTypeKey)}}</h3>
-    </m.header>
-    <m.body class=componentCssClassName>
+    </modal.header>
+    <modal.body class=componentCssClassName>
         <p>{{t 'delete_modal.body' nodeType=(t this.nodeTypeKey)}}</p>
-        <label local-class='DeleteModal__label-wrap'>
-            <p local-class='DeleteModal__input-label'>{{t 'delete_modal.type_this'}} <strong>{{this.scientistName}}</strong></p>
+        <label local-class="DeleteModal__label-wrap">
+            <p local-class="DeleteModal__input-label">{{t 'delete_modal.type_this'}} <strong>{{this.scientistName}}</strong></p>
             {{input class="form-control" local-class="DeleteModal__input" value=this.scientistInput}}
         </label>
-    </m.body>
-    <m.footer>
-        <BsButton @onClick={{action m.close}}>
+    </modal.body>
+    <modal.footer>
+        <BsButton @onClick={{action modal.close}}>
             {{t 'general.cancel'}}
         </BsButton>
         <BsButton 
             @disabled={{not (eq this.scientistInput this.scientistName)}} 
-            @onClick={{action m.submit}} 
-            @type='danger'
+            @onClick={{action modal.submit}} 
+            @type="danger"
         >
             {{t 'general.delete'}}
         </BsButton>
-    </m.footer>
+    </modal.footer>
 </BsModal>

--- a/lib/osf-components/addon/components/delete-node-modal/template.hbs
+++ b/lib/osf-components/addon/components/delete-node-modal/template.hbs
@@ -1,16 +1,29 @@
-{{#bs-modal open=openModal onSubmit=(action delete) onHidden=(action closeModal) as |m|}}
-    {{#m.header}}
-        <h3>{{t 'delete_modal.title' nodeType=(t nodeTypeKey)}}</h3>
-    {{/m.header}}
-    {{#m.body class=componentCssClassName}}
-        <p>{{t 'delete_modal.body' nodeType=(t nodeTypeKey)}}</p>
+<BsModal 
+    @open={{@openModal}}
+    @onSubmit={{action @delete}}
+    @onHidden={{action @closeModal}}
+    as |m|
+>
+    <m.header>
+        <h3>{{t 'delete_modal.title' nodeType=(t this.nodeTypeKey)}}</h3>
+    </m.header>
+    <m.body class=componentCssClassName>
+        <p>{{t 'delete_modal.body' nodeType=(t this.nodeTypeKey)}}</p>
         <label local-class='DeleteModal__label-wrap'>
-            <p local-class='DeleteModal__input-label'>{{t 'delete_modal.type_this'}} <strong>{{scientistName}}</strong></p>
-            {{input class="form-control" local-class="DeleteModal__input" value=scientistInput}}
+            <p local-class='DeleteModal__input-label'>{{t 'delete_modal.type_this'}} <strong>{{this.scientistName}}</strong></p>
+            {{input class="form-control" local-class="DeleteModal__input" value=this.scientistInput}}
         </label>
-    {{/m.body}}
-    {{#m.footer}}
-        {{#bs-button onClick=(action m.close)}}{{t 'general.cancel'}}{{/bs-button}}
-        {{#bs-button disabled=(not (eq scientistInput scientistName)) onClick=(action m.submit) type='danger'}}{{t 'general.delete'}}{{/bs-button}}
-    {{/m.footer}}
-{{/bs-modal}}
+    </m.body>
+    <m.footer>
+        <BsButton @onClick={{action m.close}}>
+            {{t 'general.cancel'}}
+        </BsButton>
+        <BsButton 
+            @disabled={{not (eq this.scientistInput this.scientistName)}} 
+            @onClick={{action m.submit}} 
+            @type='danger'
+        >
+            {{t 'general.delete'}}
+        </BsButton>
+    </m.footer>
+</BsModal>

--- a/lib/osf-components/addon/components/draft-registration-card/template.hbs
+++ b/lib/osf-components/addon/components/draft-registration-card/template.hbs
@@ -42,8 +42,7 @@
                     @disabled={{not this.draftRegistration}}
                 >
                     {{fa-icon 'pencil'}} {{t 'general.edit'}}
-                </BsButton>
-                <BsButton 
+                </BsButton><BsButton {{! template-lint-disable }}
                     @type='default' 
                     @onClick={{action this.delete}}
                     disabled={{not this.draftRegistration}}

--- a/lib/osf-components/addon/components/draft-registration-card/template.hbs
+++ b/lib/osf-components/addon/components/draft-registration-card/template.hbs
@@ -1,59 +1,91 @@
 <div local-class="DraftRegistrationCard" data-test-draft-registration-card>
     <h4 local-class="DraftRegistratrionCard__title" data-test-draft-registration-card-title>
-        {{#if draftRegistration}}
-            {{draftRegistration.registrationSchema.name}}
+        {{#if this.draftRegistration}}
+            {{this.draftRegistration.registrationSchema.name}}
         {{else}}
-            {{#content-placeholders as |placeholder|}}
-                {{placeholder.text lines=1}}
-            {{/content-placeholders}}
+            <ContentPlaceholders as |placeholder|>
+                <placeholder.text @lines={{1}} />
+            </ContentPlaceholders>
         {{/if}}
     </h4>
     <h4 local-class="DraftRegistratrionCard__body" data-test-draft-registration-card-body>
         <small>
-            {{#if draftRegistration}}
-                {{#if showProgress}}
+            {{#if this.draftRegistration}}
+                {{#if this.showProgress}}
                     <div class="progress progress-bar-md" data-test-draft-registration-card-progress-bar>
-                        <div class="progress-bar" style={{progressStyle}}></div>
+                        <div class="progress-bar" style={{this.progressStyle}}></div>
                     </div>
                 {{/if}}
-                <p>{{t 'osf-components.draft-registration-card.initiated_by'}} {{draftRegistration.initiator.fullName}}</p>
-                <p>{{t 'osf-components.draft-registration-card.started'}} {{moment draftRegistration.datetimeInitiated}}</p>
-                <p>{{t 'osf-components.draft-registration-card.last_updated'}} {{moment draftRegistration.datetimeUpdated}}</p>
+                <p>
+                    {{t 'osf-components.draft-registration-card.initiated_by'}} 
+                    {{this.draftRegistration.initiator.fullName}}
+                </p>
+                <p>
+                    {{t 'osf-components.draft-registration-card.started'}} 
+                    {{moment this.draftRegistration.datetimeInitiated}}
+                </p>
+                <p>
+                    {{t 'osf-components.draft-registration-card.last_updated'}} 
+                    {{moment this.draftRegistration.datetimeUpdated}}
+                </p>
             {{else}}
-                {{#content-placeholders as |placeholder|}}
-                    {{placeholder.text lines=3}}
-                {{/content-placeholders}}
+                <ContentPlaceholders as |placeholder|>
+                    <placeholder.text @lines={{3}} />
+                </ContentPlaceholders>
             {{/if}}
         </small>
         <div class="row">
             <div class="col-md-10">
-                {{#bs-button type='default' onClick=(action edit) disabled=(not draftRegistration)}}
+                <BsButton 
+                    @type='default' 
+                    @onClick={{action this.edit}}
+                    @disabled={{not this.draftRegistration}}
+                >
                     {{fa-icon 'pencil'}} {{t 'general.edit'}}
-                {{/bs-button}}
-                {{#bs-button type='default' onClick=(action delete) disabled=(not draftRegistration)}}
+                </BsButton>
+                <BsButton 
+                    @type='default' 
+                    @onClick={{action this.delete}}
+                    disabled={{not this.draftRegistration}}
+                >
                     {{fa-icon 'times'}} {{t 'general.delete'}}
-                {{/bs-button}}
-                {{#bs-modal open=deleteModalOpen onHidden=(action cancelDelete) class='delete_draft_registration' as |modal|}}
-                    {{#modal.header}}
+                </BsButton>
+                <BsModal
+                    @open={{this.deleteModalOpen}}
+                    @onHidden={{action this.cancelDelete}}
+                    class='delete_draft_registration' 
+                    as |modal|
+                >
+                    <modal.header>
                         <h4>{{t 'general.please_confirm'}}</h4>
-                    {{/modal.header}}
-                    {{#modal.body}}
+                    </modal.header>
+                    <modal.body>
                         {{t 'osf-components.draft-registration-card.delete_draft_confirm'}}
-                    {{/modal.body}}
-                    {{#modal.footer}}
-                        {{#bs-button onClick=(action modal.close) type='default'}}
+                    </modal.body>
+                    <modal.footer>
+                        <BsButton
+                            @onClick={{action modal.close}}
+                            @type='default'
+                        >
                             {{t 'general.cancel'}}
-                        {{/bs-button}}
-                        {{#bs-button onClick=(action 'confirmDelete') type='danger'}}
+                        </BsButton>
+                        <BsButton
+                            @onClick={{action 'confirmDelete'}}
+                            @type='danger'
+                        >
                             {{t 'general.delete'}}
-                        {{/bs-button}}
-                    {{/modal.footer}}
-                {{/bs-modal}}
+                        </BsButton>
+                    </modal.footer>
+                </BsModal>
             </div>
             <div class="col-md-1">
-                {{#bs-button type='default' onClick=(action register) disabled=(not enableRegister)}}
+                <BsButton
+                    @type='default'
+                    @onClick={{action this.register}}
+                    @disabled={{not this.enableRegister}}
+                >
                     {{t 'osf-components.draft-registration-card.register'}}
-                {{/bs-button}}
+                </BsButton>
             </div>
         </div>
     </h4>

--- a/lib/osf-components/addon/components/draft-registration-card/template.hbs
+++ b/lib/osf-components/addon/components/draft-registration-card/template.hbs
@@ -17,15 +17,15 @@
                     </div>
                 {{/if}}
                 <p>
-                    {{t 'osf-components.draft-registration-card.initiated_by'}} 
+                    {{t 'osf-components.draft-registration-card.initiated_by'}}
                     {{this.draftRegistration.initiator.fullName}}
                 </p>
                 <p>
-                    {{t 'osf-components.draft-registration-card.started'}} 
+                    {{t 'osf-components.draft-registration-card.started'}}
                     {{moment this.draftRegistration.datetimeInitiated}}
                 </p>
                 <p>
-                    {{t 'osf-components.draft-registration-card.last_updated'}} 
+                    {{t 'osf-components.draft-registration-card.last_updated'}}
                     {{moment this.draftRegistration.datetimeUpdated}}
                 </p>
             {{else}}


### PR DESCRIPTION
## Purpose

Eliminate implicit this in templates. This may take several PRs to try to minimize potential merge conflicts.

## Summary of Changes

For the files changed:
1. Use `this.` or `@` for parameter usage so we know where the data is coming from
2. Update to angle-bracket invocation (might not be comprehensive for this pass, but later files are converted) because `data-test` selectors don't lint with curly-brace invocation 

## QA Notes

I don't think we're percying placeholders, so a quick scan a node registrations page (draft registrations tab) that has draft registrations to make sure placeholders still work wouldn't be a bad idea.

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
https://openscience.atlassian.net/browse/EMB-528

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~ Only existing tests
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
