### PR TITLE
[EMB-359] AD from QA for Move to Project

### DIFF
--- a/lib/osf-components/addon/components/new-project-modal/styles.scss
+++ b/lib/osf-components/addon/components/new-project-modal/styles.scss
@@ -20,3 +20,7 @@
 .NewProject__placeholder {
     color: $color-text-gray-dark;
 }
+
+.NewProject__modal {
+    overflow-y: auto !important;
+}

--- a/lib/osf-components/addon/components/new-project-modal/template.hbs
+++ b/lib/osf-components/addon/components/new-project-modal/template.hbs
@@ -1,4 +1,4 @@
-{{#bs-modal onHidden=closeModal as |modal|}}
+{{#bs-modal local-class="NewProject__modal" onHidden=closeModal as |modal|}}
     {{#modal.header}}
         <h3 data-test-create-project-header class="modal-title">{{t 'new_project.header'}}</h3>
     {{/modal.header}}

--- a/lib/osf-components/addon/components/new-project-navigation-modal/template.hbs
+++ b/lib/osf-components/addon/components/new-project-navigation-modal/template.hbs
@@ -27,7 +27,7 @@
             class="btn btn-success"
             onclick={{action 'click' 'link' (concat page ' - New Project - go_to_new_project') target=analytics}}
         >
-            {{t 'new_project.go_to_new'}}
+            {{t 'move_to_project.go_to_project'}}
         </a>
     {{/modal.footer}}
 {{/bs-modal}}

--- a/tests/integration/components/new-project-navigation-modal/component-test.ts
+++ b/tests/integration/components/new-project-navigation-modal/component-test.ts
@@ -27,7 +27,7 @@ module('Integration | Component | new-project-navigation-modal', hooks => {
         />`);
 
         assert.dom(this.element)
-            .hasText('New project created successfully! Keep working here Go to new project', 'Contents were correct');
+            .hasText('New project created successfully! Keep working here Go to project', 'Contents were correct');
         assert.dom('[data-test-go-to-new][href="/linkValue/"]').exists('Navigation link was correct');
         await click('[data-test-stay-here]');
     });


### PR DESCRIPTION
## Purpose

1. Make it possible to scroll the Create a Project dialog on the quickfiles page (and everywhere it's used in the future)
2. In the "Go to project" dialog, always say, "Go to project," rather than, "Go to new project" because that's more correct

## Summary of Changes

1. Add a local class to the Create a project dialog that gives it `overflow-y: auto !important;`
2. Change the translation key for the button

## QA Notes

The original request was to have it decide whether it was a new project or not and say something different each time, but after a brief chat with Sara, that was deemed Not Worth the Effort.

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
https://openscience.atlassian.net/browse/EMB-359

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~
- [ ] ~~changes described in `CHANGELOG.md`~~

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
