### PR TITLE
[EMB-478] send campaign with user registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         - added validations for name fields
     - `provider` - made partial assets acceptable
     - `preprint-provider` - added `documentType` computed property for preprint word lookup
+    - `user-registration` - added `campaign` property
 - Routes:
     - `settings` - redirects to `settings.profile.name`
     - `register` - add branding for registries and preprint providers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Components:
     - `node-navbar` - Choose links to display with the same logic as legacy
     - `validated-model-form` - Add an optional hook for onWillDestroy
+    - `sign-up-form` - accept `campaign` as an optional argument and set on user-registration model
 - Handbook:
     - `validated-model-form` - Show how onWillDestroy works and use ember-onbeforeunload
 - Models:

--- a/app/models/user-registration.ts
+++ b/app/models/user-registration.ts
@@ -79,6 +79,7 @@ export default class UserRegistration extends Model.extend(Validations) {
     @attr('string') recaptchaResponse!: string;
     @attr('string') password!: string;
     @attr('boolean') acceptedTermsOfService!: boolean;
+    @attr('string') campaign!: string;
 
     existingEmails: Set<string> = new Set();
     invalidEmails: Set<string> = new Set();

--- a/app/register/controller.ts
+++ b/app/register/controller.ts
@@ -35,6 +35,8 @@ export default class Register extends Controller.extend(registerQueryParams.Mixi
 }) {
     @service analytics!: Analytics;
 
+    signUpCampaign?: string;
+
     hasProvider: boolean = false;
     provider?: PreprintProvider;
 
@@ -73,6 +75,7 @@ export default class Register extends Controller.extend(registerQueryParams.Mixi
         if (queryParams.campaign) {
             const matches = queryParams.campaign.match(/^(.*)-(.*)$/);
             if (matches && matches.length > 2) {
+                this.set('signUpCampaign', queryParams.campaign);
                 const [, provider, type] = matches;
                 if (provider === 'osf') {
                     switch (type) {

--- a/app/register/template.hbs
+++ b/app/register/template.hbs
@@ -68,7 +68,7 @@
             <hr local-class="hr-text" data-content="OR">
 
             <div local-class="sign-up-form" class="m-sm">
-                <SignUpForm />
+                <SignUpForm @campaign={{this.signUpCampaign}} />
             </div>
         </div>
     </div>

--- a/lib/osf-components/addon/components/sign-up-form/component.ts
+++ b/lib/osf-components/addon/components/sign-up-form/component.ts
@@ -43,6 +43,10 @@ export default class SignUpForm extends Component.extend({
         this.set('hasSubmitted', true);
     }).drop(),
 }) {
+    // Optional parameters
+    campaign?: string;
+
+    // Private properties
     userRegistration!: UserRegistration;
 
     hasSubmitted: boolean = false;
@@ -97,6 +101,9 @@ export default class SignUpForm extends Component.extend({
 
     init() {
         this.set('userRegistration', this.store.createRecord('user-registration'));
+        if (this.campaign) {
+            this.userRegistration.set('campaign', this.campaign);
+        }
         return super.init();
     }
 


### PR DESCRIPTION
## Purpose

Branded sign ups should send branded emails.

## Summary of Changes

 ### Changed
- Components:
    - `sign-up-form` - accept `campaign` as an optional argument and set on `user-registration` model
- Models:
    - `user-registration` - added `campaign` property

## Side Effects

None expected.

## Feature Flags

`ember_auth_register`

## QA Notes

Should test that registering a user from a branded sign up page sends a branded verification email.

## Ticket

https://openscience.atlassian.net/browse/EMB-478

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
