### PR TITLE
[hotfix][EMB-466] Don't add ERPC to registries providers

### DIFF
--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -145,6 +145,7 @@ declare const config: {
             institutions: string;
         };
         storageI18n: string;
+        enableInactiveSchemas: string;
     };
     gReCaptcha: {
         siteKey: string;

--- a/config/environment.js
+++ b/config/environment.js
@@ -227,6 +227,7 @@ module.exports = function(environment) {
                 institutions: 'institutions_nav_bar',
             },
             storageI18n: 'storage_i18n',
+            enableInactiveSchemas: 'enable_inactive_schemas',
         },
         gReCaptcha: {
             siteKey: RECAPTCHA_SITE_KEY,

--- a/lib/registries/addon/components/registries-registration-type-facet/component.ts
+++ b/lib/registries/addon/components/registries-registration-type-facet/component.ts
@@ -4,32 +4,49 @@ import EmberArray, { A } from '@ember/array';
 import Component from '@ember/component';
 import { task } from 'ember-concurrency';
 import DS from 'ember-data';
+import Features from 'ember-feature-flags/services/features';
+import appConfig from 'ember-get-config';
 import I18N from 'ember-i18n/services/i18n';
+import Toast from 'ember-toastr/services/toast';
+
 import RegistrationSchema from 'ember-osf-web/adapters/registration-schema';
 import requiredAction from 'ember-osf-web/decorators/required-action';
 import Analytics from 'ember-osf-web/services/analytics';
 import defaultTo from 'ember-osf-web/utils/default-to';
-import Toast from 'ember-toastr/services/toast';
-import config from 'registries/config/environment';
+
+import engineConfig from 'registries/config/environment';
 import { SearchOptions } from 'registries/services/search';
 import { ShareTermsFilter } from 'registries/services/share-search';
 import layout from './template';
+
+const {
+    sourcesWhitelist,
+} = engineConfig;
+
+const {
+    featureFlagNames: {
+        enableInactiveSchemas,
+    },
+} = appConfig;
 
 export default class RegistriesRegistrationTypeFacet extends Component.extend({
     fetchRegistrationTypes: task(function *(this: RegistriesRegistrationTypeFacet): any {
         try {
             const metaschemas: RegistrationSchema[] = yield this.store.findAll('registration-schema');
 
-            this.set('registrationTypes', A(
-                metaschemas.mapBy('name').concat([
+            const metaschemaNames = metaschemas.mapBy('name');
+            if (!this.features.isEnabled(enableInactiveSchemas)) {
+                metaschemaNames.push(
                     // Manually add 'Election Research Preacceptance Competition' to the list of possible
                     // facets. Metaschema was removed from the API as a possible registration type
                     // but should still be searchable
                     'Election Research Preacceptance Competition',
-                ]).sort(),
-            ));
+                );
+            }
+            this.set('registrationTypes', A(metaschemaNames.sort()));
         } catch (e) {
             this.toast.error(this.i18n.t('registries.facets.registration_type.registration_schema_error'));
+            throw e;
         }
     }).on('init'),
 }) {
@@ -39,6 +56,7 @@ export default class RegistriesRegistrationTypeFacet extends Component.extend({
     @service toast!: Toast;
     @service store!: DS.Store;
     @service analytics!: Analytics;
+    @service features!: Features;
 
     searchOptions!: SearchOptions;
     @requiredAction onSearchOptionsUpdated!: (options: SearchOptions) => void;
@@ -53,7 +71,7 @@ export default class RegistriesRegistrationTypeFacet extends Component.extend({
     get onlyOSF() {
         return this.searchOptions.filters.filter(filter => filter.key === 'sources').size === 1
         && this.searchOptions.filters.contains(
-            new ShareTermsFilter('sources', 'OSF', config.sourcesWhitelist.find(x => x.name === 'OSF')!.display!),
+            new ShareTermsFilter('sources', 'OSF', sourcesWhitelist.find(x => x.name === 'OSF')!.display!),
         );
     }
 


### PR DESCRIPTION

<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[EMB-123] some really great stuff`
-->

## Purpose
As part of prereg winddown, inactive registration schemas will be returned by the API by default. This is good, and makes an old hack on the registries discover page unnecessary.
<!-- Describe the purpose of your changes. -->

## Summary of Changes
When the `enable_inactive_schemas` flag is enabled, don't manually append ERPC to the "OSF Registration Type" facet at `/registries/discover`. However, since ERPC should be included in the API response, there's no visible change.
![screen shot 2018-12-18 at 11 56 27](https://user-images.githubusercontent.com/6776190/50169836-66019e00-02bc-11e9-9349-b1cdbd1fa57d.png)

<!-- Briefly describe or list your changes. -->

## Side Effects
n/a
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## Feature Flags
`enable_inactive_schemas`

<!--
  Please list any feature flags that need to be enabled for these changes to go into effect.
  For each flag, what is the expected behavior with the flag enabled vs disabled?
-->

## QA Notes
When the flag is enabled, check ERPC isn't in there twice.
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
-->

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
https://openscience.atlassian.net/browse/EMB-466

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
