### PR TITLE
[EMB-511][EMB-505][Collections] Change logic of displaySubjects; new collection-subjects-list component

### DIFF
--- a/app/models/collected-metadatum.ts
+++ b/app/models/collected-metadatum.ts
@@ -69,14 +69,21 @@ export default class CollectedMetadatum extends OsfModel.extend(Validations) {
 
     @computed('subjects')
     get displaySubjects(): DisplaySubject[] {
-        return this.subjects.map(subject => {
-            const names = subject.mapBy('text');
-
-            return {
-                text: names.get('lastObject'),
-                path: ['', ...names].join('|'),
-            };
+        // returns a list of unique subjects and its path for display and filtering
+        const displaySubjects: DisplaySubject[] = [];
+        this.subjects.forEach(subjectPathArray => {
+            let index = 0;
+            const includedTester = (element: DisplaySubject) => element.text === subjectPathArray[index].text;
+            for (index = 0; index < subjectPathArray.length; index++) {
+                // Only append the subjects if they are not already included in the list
+                if (!displaySubjects.some(includedTester)) {
+                    const { text } = subjectPathArray[index];
+                    const path = ['', ...subjectPathArray.slice(0, index + 1).map(item => item.text)].join('|');
+                    displaySubjects.push({ text, path });
+                }
+            }
         });
+        return displaySubjects;
     }
 
     @computed('collection.displayChoicesFields.[]')

--- a/lib/collections/addon/components/collection-search-result/component.ts
+++ b/lib/collections/addon/components/collection-search-result/component.ts
@@ -57,7 +57,12 @@ export default class CollectionSearchResult extends Component {
     }
 
     @action
-    addFilter(facet: string, item: string): void {
+    addTaxonomyFilter(subject: DisplaySubject) {
+        this.facetContexts.findBy('component', 'taxonomy')!.updateFilters(subject.path);
+    }
+
+    @action
+    addChoiceFilter(facet: string, item: string) {
         this.facetContexts.findBy('component', facet)!.updateFilters(item);
     }
 

--- a/lib/collections/addon/components/collection-search-result/node/component.ts
+++ b/lib/collections/addon/components/collection-search-result/node/component.ts
@@ -12,10 +12,9 @@ import { SubjectRef } from 'ember-osf-web/models/taxonomy';
 import Analytics from 'ember-osf-web/services/analytics';
 import Theme from 'ember-osf-web/services/theme';
 import defaultTo from 'ember-osf-web/utils/default-to';
-import styles from './styles';
 import template from './template';
 
-@layout(template, styles)
+@layout(template)
 @classNames('row')
 export default class SearchResultNode extends Component.extend({
     didRender(...args: any[]) {

--- a/lib/collections/addon/components/collection-search-result/node/template.hbs
+++ b/lib/collections/addon/components/collection-search-result/node/template.hbs
@@ -1,7 +1,7 @@
 <div class="col-xs-12">
     {{!Title}}
     <h4>
-        <a href="{{item.links.html}}">{{item.title}}</a>
+        <a href="{{this.item.links.html}}">{{this.item.title}}</a>
     </h4>
 </div>
 
@@ -14,34 +14,24 @@
 </div> --}}
 
 <div class="col-xs-12">
-    {{contributor-list contributors=item.contributors}}
+    {{contributor-list contributors=this.item.contributors}}
 
-    {{#if subjects}}
-        <div class="m-t-sm">
-            {{#each subjects as |subject|}}
-                <span
-                    role="button"
-                    local-class="pointer subject-preview"
-                    onclick={{action addFilter 'taxonomy' subject.path}}
-                >
-                    {{subject.text}}
-                </span>
-            {{/each}}
-        </div>
+    {{#if this.subjects}}
+        {{collection-subjects-list subjects=this.subjects onClickSubject=(action @addTaxonomyFilter)}}
     {{/if}}
-    {{#if extraSubjects}}
-        <span class="text-muted">+{{extraSubjects.length}}</span>
+    {{#if @extraSubjects}}
+        <span class="text-muted">+{{@extraSubjects.length}}</span>
     {{/if}}
 
     {{!Description}}
     <p>
         <div class="text-muted m-t-sm">
-            {{#if showBody}}
-                {{unescape-xml-entities item.description}}
+            {{#if this.showBody}}
+                {{unescape-xml-entities this.item.description}}
             {{else}}
-                {{#if abbreviation}}
-                    {{abbreviation}}
-                    {{#if abbreviated}}
+                {{#if this.abbreviation}}
+                    {{this.abbreviation}}
+                    {{#if this.abbreviated}}
                         <span class="text-muted">{{t 'general.ellipsis'}}</span>
                     {{/if}}
                 {{/if}}
@@ -50,12 +40,12 @@
     </p>
 
     {{!Last edited on on}}
-    {{#if item.dateModified}}
+    {{#if this.item.dateModified}}
         <div class="m-t-sm">
             <em>
                 {{t
                     'discover.search_results.lastEdited'
-                    date=(moment-format item.dateModified 'YYYY-MM-DD')
+                    date=(moment-format this.item.dateModified 'YYYY-MM-DD')
                 }}
             </em>
         </div>

--- a/lib/collections/addon/components/collection-search-result/template.hbs
+++ b/lib/collections/addon/components/collection-search-result/template.hbs
@@ -1,16 +1,16 @@
 {{#component
-    (concat 'collection-search-result/' type)
-    item=item
-    collectedType=result.collectedType
-    status=result.status
-    subjects=subjects
-    addFilter=(action 'addFilter')
+    (concat 'collection-search-result/' this.type)
+    item=this.item
+    collectedType=this.result.collectedType
+    status=this.result.status
+    subjects=this.subjects
+    addTaxonomyFilter=(action 'addTaxonomyFilter')
 }}
     {{#each this.choiceFilters as |choiceFilter|}}
         <span
             role="button"
             local-class="choiceFilter"
-            onclick={{action 'addFilter' choiceFilter.facet choiceFilter.value}}
+            onclick={{action 'addChoiceFilter' choiceFilter.facet choiceFilter.value}}
         >
             <b>
                 {{t choiceFilter.label}}
@@ -20,15 +20,15 @@
     {{/each}}
 {{/component}}
 
-{{#if expandable}}
+{{#if @expandable}}
     <div class="text-center">
         <button
             class='btn btn-link'
             local-class="toggleShowBody"
-            aria-label={{t (concat 'collections.collection_search_result.' (if showBody 'collapse' 'expand'))}}
+            aria-label={{t (concat 'collections.collection_search_result.' (if this.showBody 'collapse' 'expand'))}}
             {{action 'toggleShowBody'}}
         >
-            {{fa-icon (concat 'caret-' (if showBody 'up' 'down'))}}
+            {{fa-icon (concat 'caret-' (if this.showBody 'up' 'down'))}}
         </button>
     </div>
 {{/if}}

--- a/lib/collections/addon/components/collection-subjects-list/component.ts
+++ b/lib/collections/addon/components/collection-subjects-list/component.ts
@@ -1,0 +1,13 @@
+import Component from '@ember/component';
+import { layout, requiredAction } from 'ember-osf-web/decorators/component';
+import { DisplaySubject } from 'ember-osf-web/models/collected-metadatum';
+import defaultTo from 'ember-osf-web/utils/default-to';
+import styles from './styles';
+import template from './template';
+
+@layout(template, styles)
+export default class CollectionMetadata extends Component {
+    subjects: DisplaySubject[] = defaultTo(this.subjects, []);
+    @requiredAction
+    onClickSubject!: () => void;
+}

--- a/lib/collections/addon/components/collection-subjects-list/styles.scss
+++ b/lib/collections/addon/components/collection-subjects-list/styles.scss
@@ -6,6 +6,3 @@
     padding: 1px 7px;
     margin-bottom: 4px;
 }
-
-
-

--- a/lib/collections/addon/components/collection-subjects-list/template.hbs
+++ b/lib/collections/addon/components/collection-subjects-list/template.hbs
@@ -1,0 +1,11 @@
+<div class="m-t-sm">
+    {{#each this.subjects as |subject|}}
+        <span
+            role="button"
+            local-class="pointer subject-preview"
+            onclick={{action this.onClickSubject subject}}
+        >
+            {{subject.text}}
+        </span>
+    {{/each}}
+</div>

--- a/lib/collections/addon/components/collections-submission/template.hbs
+++ b/lib/collections/addon/components/collections-submission/template.hbs
@@ -49,7 +49,7 @@
             {{#section.complete}}
                 <p>
                     <em>{{t (concat this.i18nKeyPrefix 'project_select_project_label')}}</em>
-                    <span>{{collectionItem.title}}</span>
+                    <span>{{this.collectionItem.title}}</span>
                 </p>
             {{/section.complete}}
         {{/sections.section}}
@@ -134,15 +134,7 @@
                 }}
             {{/section.active}}
             {{#section.complete}}
-                <div>
-                    {{#each this.collectedMetadatum.subjects as |subject|}}
-                        <div local-class="subject">
-                            {{#each subject as |segment|}}
-                                <span>{{segment.text}}</span>
-                            {{/each}}
-                        </div>
-                    {{/each}}
-                </div>
+                {{collection-subjects-list subjects=this.collectedMetadatum.displaySubjects onClickSubject=(action this.noop)}}
             {{/section.complete}}
         {{/sections.section}}
 


### PR DESCRIPTION
## Purpose

Currently on discover page, the list of subjects for a collected item does not show the top-level/secondary-level subjects if a secondary-level/tertiary level subject exists. This PR fixes the problem by changing the logic of a computed property on `collected-metadatum` model, then refactor the template into using a newly created `collection-subjects-list` component.

## Summary of Changes

1. On `collected-metadatum` model, the `displaySubjects` computed property is modified to return unique subjects.
2. A new `collection-subjects-list` component is created.
3. Making use of the newly created component, we also fix the same problem on the submission/edit page. (EMB-505)

## QA Notes

Subject list on discover and submission/edit page should not behave just like the preprints app.

## Ticket

https://openscience.atlassian.net/browse/EMB-511
https://openscience.atlassian.net/browse/EMB-505

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
