### PR TITLE
Dev build optimizations

### DIFF
--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -20,6 +20,7 @@ export interface KeenConfig {
 declare const config: {
     environment: any;
     lintOnBuild: boolean;
+    testsEnabled: boolean;
     sourcemapsEnabled: boolean;
     modulePrefix: string;
     locationType: string;

--- a/config/environment.js
+++ b/config/environment.js
@@ -23,6 +23,7 @@ const {
     REGISTRIES_ENABLED = false,
     HANDBOOK_ENABLED = false,
     HANDBOOK_DOC_GENERATION_ENABLED = false,
+    TESTS_ENABLED = false,
     FB_APP_ID,
     GIT_COMMIT: release,
     GOOGLE_ANALYTICS_ID,
@@ -62,6 +63,7 @@ module.exports = function(environment) {
         modulePrefix: 'ember-osf-web',
         environment,
         lintOnBuild,
+        testsEnabled: false, // Disable tests by default.
         sourcemapsEnabled,
         rootURL,
         assetsPrefix,
@@ -291,6 +293,8 @@ module.exports = function(environment) {
                     turnAuditOff: !isTruthy(A11Y_AUDIT),
                 },
             },
+            // Conditionally enable tests in development environment.
+            testsEnabled: isTruthy(TESTS_ENABLED),
         });
     }
 
@@ -300,6 +304,8 @@ module.exports = function(environment) {
             locationType: 'none',
             // Test environment needs to find assets in the "regular" location.
             assetsPrefix: '/',
+            // Always enable tests in test environment.
+            testsEnabled: true,
             // Always enable mirage for tests.
             'ember-cli-mirage': {
                 enabled: true,

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,7 +3,7 @@
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 const { EMBER_ENV } = process.env;
-const useCdn = EMBER_ENV === 'production';
+const IS_PROD = EMBER_ENV === 'production';
 
 function postProcess(content) {
     return content.trim().replace(/^\s{20}/mg, '');
@@ -56,7 +56,7 @@ module.exports = function(defaults) {
             importBootstrapCSS: false,
         },
         'ember-cli-password-strength': {
-            bundleZxcvbn: !useCdn,
+            bundleZxcvbn: !IS_PROD,
         },
         fingerprint: {
             enabled: true,
@@ -92,7 +92,7 @@ module.exports = function(defaults) {
                 content: config.assetsPrefix,
             },
             raven: {
-                enabled: useCdn,
+                enabled: IS_PROD,
                 content: `
                     <script src="https://cdn.ravenjs.com/3.22.1/ember/raven.min.js"></script>
                     <script>
@@ -106,7 +106,7 @@ module.exports = function(defaults) {
                 postProcess,
             },
             zxcvbn: {
-                enabled: useCdn,
+                enabled: IS_PROD,
                 /* eslint-disable max-len */
                 content: `
                     <script src="https://cdnjs.cloudflare.com/ajax/libs/zxcvbn/4.4.2/zxcvbn.js"
@@ -121,7 +121,7 @@ module.exports = function(defaults) {
             },
         },
         'ember-cli-babel': {
-            includePolyfill: true,
+            includePolyfill: IS_PROD,
         },
         assetLoader: {
             generateURI(filePath) {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -38,6 +38,7 @@ module.exports = function(defaults) {
     const app = new EmberApp(defaults, {
         ...handbookOptions,
         hinting: config.lintOnBuild,
+        tests: config.testsEnabled,
         ace: {
             modes: ['handlebars'],
         },

--- a/lib/handbook/addon/docs/dev-env/template.md
+++ b/lib/handbook/addon/docs/dev-env/template.md
@@ -26,6 +26,12 @@ This thing you're reading right now? It's the handbook. If you'd like to be able
 
 [Mirage](http://www.ember-cli-mirage.com) is a client-side API server that we use to mock the OSF API during automated testing. It can also be used for local development. Setting this to true will allow you to run the OSF front-end without having to run the OSF API back-end.
 
+#### TESTS_ENABLED
+* **Type**: _boolean_
+* **Default**: false
+
+This controls whether tests are included in `development` builds. Set this to `true` if you wish to run tests by accessing `/tests` when you `ember serve`.
+
 #### A11Y_AUDIT
 * **Type**: _boolean_
 * **Default**: true (well, in develop mode)
@@ -36,4 +42,4 @@ This thing you're reading right now? It's the handbook. If you'd like to be able
 #### NEW_AND_NOTEWORTHY_LINKS_NODE
 * **Type**: _string_
 
-If you're doing local development with the OSF API running and want to see the New and Noteworthy and Popular sections of the Dashboard page filled out, then set each of these to the guid of a node in your local database that has links to other nodes. If you are not using a local OSF instance but are instead using Mirage, then you don't have to override these at all. 
+If you're doing local development with the OSF API running and want to see the New and Noteworthy and Popular sections of the Dashboard page filled out, then set each of these to the guid of a node in your local database that has links to other nodes. If you are not using a local OSF instance but are instead using Mirage, then you don't have to override these at all.


### PR DESCRIPTION
## Purpose

A couple of build optimizations. These shave about 10s off the initial build time.

## Summary of Changes

* made building of tests in `development` environment conditional (and disabled by default)
* only include babel polyfill in production builds

## Side Effects

* by default, `/tests` won't work for `ember serve` (can re-enable by setting `TESTS_ENABLED: true` in `config/local.js`)
* can't develop on IE 11 (but why would you?)

## Feature Flags

n/a

## QA Notes

n/a

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~
- [ ] ~~changes described in `CHANGELOG.md`~~

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
