### PR TITLE
Change double-string quotes to single, remove trailing commas

### DIFF
--- a/lib/app-components/addon/components/license-picker/template.hbs
+++ b/lib/app-components/addon/components/license-picker/template.hbs
@@ -14,8 +14,8 @@
 {{/validated-input/power-select}}
 <small>
     <a
-        target="_blank"
-        rel="noopener"
+        target='_blank'
+        rel='noopener'
         href={{this.helpLink}}
     >
         {{t 'app_components.license_picker.faq'}}
@@ -31,7 +31,7 @@
     }}
         {{#each this.requiredFields as |key|}}
             <br>
-            <label for="nodeLicense-{{key}}">{{t (concat 'app_components.license_picker.fields.' key)}}</label>
+            <label for='nodeLicense-{{key}}'>{{t (concat 'app_components.license_picker.fields.' key)}}</label>
             <br>
             {{input
                 class='form-control'
@@ -41,7 +41,7 @@
             }}
         {{/each}}
     {{/validated-input/custom}}
-    <a role="button" onclick={{action (mut this.showText) (not this.showText)}}>
+    <a role='button' onclick={{action (mut this.showText) (not this.showText)}}>
         {{t (concat 'app_components.license_picker.' (if this.showText 'hide' 'show'))}}
     </a>
     {{#if this.showText}}

--- a/lib/app-components/addon/components/project-contributors/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/template.hbs
@@ -1,11 +1,11 @@
-<div class="col-xs-12 col-md-5" local-class="col-division-right">
+<div class='col-xs-12 col-md-5' local-class='col-division-right'>
     {{project-contributors/search
         node=this.node
         contributors=this.contributors
     }}
 </div>
-<div class="col-xs-12 col-md-7">
-    <h2 local-class="inline">{{t 'app_components.project_contributors.title'}}</h2>
+<div class='col-xs-12 col-md-7'>
+    <h2 local-class='inline'>{{t 'app_components.project_contributors.title'}}</h2>
     {{#fa-icon 'question-circle'}}
         {{#bs-popover
             placement='bottom'

--- a/lib/app-components/addon/components/project-metadata/template.hbs
+++ b/lib/app-components/addon/components/project-metadata/template.hbs
@@ -1,4 +1,4 @@
-<div class="col-md-6">
+<div class='col-md-6'>
     <label>
         {{t 'app_components.project_metadata.field_title_label'}}
     </label>
@@ -18,7 +18,7 @@
         shouldShowMessages=@didValidate
     }}
 </div>
-<div class="col-md-6">
+<div class='col-md-6'>
     {{#license-picker node=this.node}}
         {{t 'app_components.project_metadata.field_license_label'}}
     {{/license-picker}}

--- a/lib/app-components/addon/components/subject-picker/template.hbs
+++ b/lib/app-components/addon/components/subject-picker/template.hbs
@@ -1,25 +1,25 @@
-<div local-class="current-subjects">
+<div local-class='current-subjects'>
     {{#each this.currentSubjects as |subject index|}}
-        <span local-class="subject">
+        <span local-class='subject'>
             {{#each subject as |segment|}}
-                <div local-class="subject-container">
-                    <span local-class="subject-container-text">
+                <div local-class='subject-container'>
+                    <span local-class='subject-container-text'>
                         {{segment.text}}
                         <button
-                            class="fa fa-close"
-                            local-class="remove-subject"
-                            aria-label="{{t 'submit.body.remove_subject_aria'}}"
-                            title="{{t 'app_components.subject_picker.remove'}}"
+                            class='fa fa-close'
+                            local-class='remove-subject'
+                            aria-label={{t 'submit.body.remove_subject_aria'}}
+                            title={{t 'app_components.subject_picker.remove'}}
                             {{action 'deselect' index}}
                         ></button>
                     </span>
                 </div>
-                <span local-class="right-arrow"></span>
+                <span local-class='right-arrow'></span>
             {{/each}}
         </span>
     {{/each}}
 </div>
-<div local-class="columns">
+<div local-class='columns'>
     {{#each this.columns as |column tier|}}
         {{subject-picker/column
             selection=column.selection

--- a/lib/app-components/addon/components/submit-section-buttons/template.hbs
+++ b/lib/app-components/addon/components/submit-section-buttons/template.hbs
@@ -1,5 +1,5 @@
 {{#if this.showDiscard}}
-    <button class="btn btn-default" {{action this.discard}}>
+    <button class='btn btn-default' {{action this.discard}}>
         {{#if @discardButtonLabel}}
             {{@discardButtonLabel}}
         {{else}}
@@ -7,7 +7,7 @@
         {{/if}}
     </button>
 {{/if}}
-<button class="btn btn-primary" {{action this.continue}} disabled={{this.continueDisabled}}>
+<button class='btn btn-primary' {{action this.continue}} disabled={{this.continueDisabled}}>
     {{#if @continueButtonLabel}}
         {{@continueButtonLabel}}
     {{else}}

--- a/lib/app-components/addon/components/submit-section/active/template.hbs
+++ b/lib/app-components/addon/components/submit-section/active/template.hbs
@@ -1,4 +1,4 @@
-<header local-class="{{if (not this.panel.open) 'closed'}}">
+<header local-class={{if (not this.panel.open) 'closed'}}>
     {{this.title}}
 </header>
 {{#this.panel.body}}

--- a/lib/collections/addon/components/collection-metadata/template.hbs
+++ b/lib/collections/addon/components/collection-metadata/template.hbs
@@ -1,7 +1,7 @@
 {{#each this.chunkedDisplayFields as |fields|}}
-    <div class="row">
+    <div class='row'>
         {{#each fields as |field|}}
-            <div class="col-md-6">
+            <div class='col-md-6'>
                 <label>
                     {{t (concat 'collections.collection_metadata.' field.labelKey)}}
                 </label>

--- a/lib/collections/addon/components/collection-search-result/node/template.hbs
+++ b/lib/collections/addon/components/collection-search-result/node/template.hbs
@@ -1,7 +1,7 @@
-<div class="col-xs-12">
+<div class='col-xs-12'>
     {{!Title}}
     <h4>
-        <a href="{{this.item.links.html}}">{{this.item.title}}</a>
+        <a href='{{this.item.links.html}}'>{{this.item.title}}</a>
     </h4>
 </div>
 
@@ -13,26 +13,26 @@
     </span>
 </div> --}}
 
-<div class="col-xs-12">
+<div class='col-xs-12'>
     {{contributor-list contributors=this.item.contributors}}
 
     {{#if this.subjects}}
         {{collection-subjects-list subjects=this.subjects onClickSubject=(action @addTaxonomyFilter)}}
     {{/if}}
     {{#if @extraSubjects}}
-        <span class="text-muted">+{{@extraSubjects.length}}</span>
+        <span class='text-muted'>+{{@extraSubjects.length}}</span>
     {{/if}}
 
     {{!Description}}
     <p>
-        <div class="text-muted m-t-sm">
+        <div class='text-muted m-t-sm'>
             {{#if this.showBody}}
                 {{unescape-xml-entities this.item.description}}
             {{else}}
                 {{#if this.abbreviation}}
                     {{this.abbreviation}}
                     {{#if this.abbreviated}}
-                        <span class="text-muted">{{t 'general.ellipsis'}}</span>
+                        <span class='text-muted'>{{t 'general.ellipsis'}}</span>
                     {{/if}}
                 {{/if}}
             {{/if}}
@@ -41,7 +41,7 @@
 
     {{!Last edited on on}}
     {{#if this.item.dateModified}}
-        <div class="m-t-sm">
+        <div class='m-t-sm'>
             <em>
                 {{t
                     'discover.search_results.lastEdited'
@@ -51,7 +51,7 @@
         </div>
     {{/if}}
 
-    <div class="m-t-sm">
+    <div class='m-t-sm'>
         {{yield}}
     </div>
 </div>

--- a/lib/collections/addon/components/collection-search-result/template.hbs
+++ b/lib/collections/addon/components/collection-search-result/template.hbs
@@ -8,8 +8,8 @@
 }}
     {{#each this.choiceFilters as |choiceFilter|}}
         <span
-            role="button"
-            local-class="choiceFilter"
+            role='button'
+            local-class='choiceFilter'
             onclick={{action 'addChoiceFilter' choiceFilter.facet choiceFilter.value}}
         >
             <b>
@@ -21,10 +21,10 @@
 {{/component}}
 
 {{#if @expandable}}
-    <div class="text-center">
+    <div class='text-center'>
         <button
             class='btn btn-link'
-            local-class="toggleShowBody"
+            local-class='toggleShowBody'
             aria-label={{t (concat 'collections.collection_search_result.' (if this.showBody 'collapse' 'expand'))}}
             {{action 'toggleShowBody'}}
         >

--- a/lib/collections/addon/components/collection-subjects-list/template.hbs
+++ b/lib/collections/addon/components/collection-subjects-list/template.hbs
@@ -1,8 +1,8 @@
-<div class="m-t-sm">
+<div class='m-t-sm'>
     {{#each this.subjects as |subject|}}
         <span
-            role="button"
-            local-class="pointer subject-preview"
+            role='button'
+            local-class='pointer subject-preview'
             onclick={{action this.onClickSubject subject}}
         >
             {{subject.text}}

--- a/types/ember-cli-mirage/index.d.ts
+++ b/types/ember-cli-mirage/index.d.ts
@@ -169,24 +169,24 @@ export interface Server {
 
     create<T extends AnyAttrs = AnyAttrs>(
         modelName: string,
-        ...traits: string[],
+        ...traits: string[]
     ): ModelInstance<T>;
     create<T extends AnyAttrs = AnyAttrs>(
         modelName: string,
         attrs?: Partial<T>,
-        ...traits: string[],
+        ...traits: string[]
     ): ModelInstance<T>;
 
     createList<T extends AnyAttrs = AnyAttrs>(
         modelName: string,
         amount: number,
-        ...traits: string[],
+        ...traits: string[]
     ): Array<ModelInstance<T>>;
     createList<T extends AnyAttrs = AnyAttrs>(
         modelName: string,
         amount: number,
         attrs?: Partial<T>,
-        ...traits: string[],
+        ...traits: string[]
     ): Array<ModelInstance<T>>;
 
     shutdown(): void;


### PR DESCRIPTION
## Purpose

Update noted template files to use single quotations instead of double and remove trailing commas in mirage types file.

## Summary of Changes

- Change double quotes to single
- Remove trailing commas in `ember-cli-mirage` types file

## Side Effects

N/A

## Feature Flags

N/A

## QA Notes

N/A

## Ticket

N/A

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~ *(only syntax changes)*
- [ ] ~~changes described in `CHANGELOG.md`~~ *(minimal changes)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
