### PR TITLE
don't run a Travis build for tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
   include:
     - stage: "test"
       if: |
-        branch ~= /^develop$|^master$|^\d+\.\d+\.\d+$|^release\/.+$/ OR \
+        branch ~= /^develop$|^master$|^release\/.+$/ OR \
         type = pull_request OR \
         env(RESTRICT_PUSH_BUILDS) != true
       addons:


### PR DESCRIPTION
## Purpose

Exclude release tags from Travis builds because they are always == `master` and these builds waste Travis and Percy resources.

## Summary of Changes

Remove release tag pattern from Travis test stage condition.

## Side Effects

n/a

## Feature Flags

n/a

## QA Notes

n/a

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~ *(we don't want to include tests ;)*
- [ ] ~~changes described in `CHANGELOG.md`~~ *(small, non-code change)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
