### PR TITLE
[hotfix] remove guid regex test from resolve-guid route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [19.0.1] - 2019-01-04
+### Fixed
+- Routes:
+    - `resolve-guid` - remove guid regex test because we have old guids that violate it
+
 ## [19.0.0] - 2019-01-03
 ### Added
 - Addons:

--- a/app/resolve-guid/route.ts
+++ b/app/resolve-guid/route.ts
@@ -8,7 +8,6 @@ import DS from 'ember-data';
 import Features from 'ember-feature-flags/services/features';
 import config from 'ember-get-config';
 
-import { GUID_REGEX } from 'ember-osf-web/const/guid-alphabet';
 import param from 'ember-osf-web/utils/param';
 import transitionTargetURL from 'ember-osf-web/utils/transition-target-url';
 
@@ -46,10 +45,6 @@ export default class ResolveGuid extends Route {
         return Boolean(this._router._engineInfoByRoute && route in this._router._engineInfoByRoute);
     }
 
-    looksLikeGUID(guid: string): boolean {
-        return GUID_REGEX.test(guid);
-    }
-
     generateURL(route: string, ...args: any[]): string {
         // NOTE: The router's urlFor is skipped over here as it passes the result of generate into the location
         // implementation, which would rip out the "--PATH" which is used for routing here.
@@ -61,10 +56,6 @@ export default class ResolveGuid extends Route {
             { guid: '', path: '' },
             ...Object.values(transition.params),
         );
-
-        if (!this.isEngineRoute(params.guid) && !this.looksLikeGUID(params.guid)) {
-            throw new Error(`Invalid GUID and no matching engine: ${params.guid}`);
-        }
 
         let expanded: string;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-osf-web",
-  "version": "19.0.0",
+  "version": "19.0.1",
   "description": "Ember front-end for the Open Science Framework",
   "license": "Apache-2.0",
   "author": "Center for Open Science <support@cos.io>",

--- a/tests/acceptance/resolve-guid-test.ts
+++ b/tests/acceptance/resolve-guid-test.ts
@@ -170,30 +170,6 @@ module('Acceptance | resolve-guid', hooks => {
         });
     });
 
-    test('Invalid GUIDs', async assert => {
-        server.create('root', { currentUser: null });
-
-        const testCases = [
-            { url: '/decof', guid: 'decof', test: 'Invalid GUID' },
-            { url: '/dec1f/foo', guid: 'dec1f', test: 'Invalid GUID with sub route' },
-        ];
-
-        for (const testCase of testCases) {
-            try {
-                await visit(testCase.url);
-            } catch (e) {
-                assert.equal(e.message, `Invalid GUID and no matching engine: ${testCase.guid}`);
-            }
-
-            await settled();
-
-            assert.ok(true, testCase.test);
-            assert.equal(currentURL(), testCase.url, 'The URL has not changed');
-            assert.equal(currentLocationURL(), testCase.url, 'The URL has not changed');
-            assert.equal(currentRouteName(), 'not-found', 'The correct route was reached');
-        }
-    });
-
     test('Not found', async assert => {
         server.create('root', { currentUser: null });
 


### PR DESCRIPTION
## Purpose

Remove guid regex test from resolve-guid route because we have old guids that violate it.

## Summary of Changes

### Fixed
- Routes:
    - `resolve-guid` - remove guid regex test because we have old guids that violate it

## Side Effects

`/something_that_doesn't_look_like_a_guid` will round-trip to the API

## Feature Flags

n/a

## QA Notes

Make sure we can still get to all guid routes:
* `/<node-guid>/registrations`
* `/<node-guid>/forks`
* `/<node-guid>/analytics`
* `/<registration-guid>/forks`
* `/<registration-guid>/analytics`
* `/<user-guid>/quickfiles`
* `/<quick-file-guid>`

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
