### PR TITLE
Start 19.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [19.1.0]
 ### Added
 - Addons:
     - `loaders-css` - For animated loading indicators

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-osf-web",
-  "version": "19.0.1",
+  "version": "19.1.0",
   "description": "Ember front-end for the Open Science Framework",
   "license": "Apache-2.0",
   "author": "Center for Open Science <support@cos.io>",


### PR DESCRIPTION
Updating changelog and bumping version now so we continue merging to `develop` without conflicts.