### PR TITLE
[hotfix] add missing page tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [19.0.2] - 2019-01-08
+### Changed
+- Routes
+    - `goodbye` - add page tracking
+    - `guid-node.forks` - accurately report resource privacy and type when page tracking
+    - `guid-node.registrations` - accurately report resource privacy and type when page tracking
+    - `guid-registration.forks` - add page tracking
+    - `guid-user.quickfiles` - add resource type to page tracking
+    - `settings.tokens.create` - add page tracking
+    - `settings.tokens.edit` - - add page tracking
+    - `settings.tokens.index` - add page tracking
+- Engines:
+    - `analytics-page` - accurately report resource privacy and type when page tracking
+
 ## [19.0.1] - 2019-01-04
 ### Fixed
 - Routes:

--- a/app/dashboard/route.ts
+++ b/app/dashboard/route.ts
@@ -29,6 +29,6 @@ export default class Dashboard extends Route {
 
     @action
     didTransition(this: Dashboard) {
-        this.get('analytics').trackPage();
+        this.analytics.trackPage();
     }
 }

--- a/app/goodbye/route.ts
+++ b/app/goodbye/route.ts
@@ -1,14 +1,23 @@
+import { action } from '@ember-decorators/object';
 import { service } from '@ember-decorators/service';
 import Route from '@ember/routing/route';
 import Ember from 'ember';
 import Session from 'ember-simple-auth/services/session';
 
+import Analytics from 'ember-osf-web/services/analytics';
+
 export default class Goodbye extends Route {
+    @service analytics!: Analytics;
     @service session!: Session;
 
     async beforeModel(this: Goodbye, transition: Ember.Transition) {
         await super.beforeModel(transition);
         const queryParams = this.session.isAuthenticated ? {} : { goodbye: true };
         this.transitionTo('home', { queryParams });
+    }
+
+    @action
+    didTransition() {
+        this.analytics.trackPage();
     }
 }

--- a/app/guid-node/forks/route.ts
+++ b/app/guid-node/forks/route.ts
@@ -2,6 +2,8 @@ import { action } from '@ember-decorators/object';
 import { service } from '@ember-decorators/service';
 import Route from '@ember/routing/route';
 
+import Node from 'ember-osf-web/models/node';
+import { GuidRouteModel } from 'ember-osf-web/resolve-guid/guid-route';
 import Analytics from 'ember-osf-web/services/analytics';
 import Ready from 'ember-osf-web/services/ready';
 
@@ -14,7 +16,10 @@ export default class GuidNodeForks extends Route {
     }
 
     @action
-    didTransition() {
-        this.analytics.trackPage(true);
+    async didTransition() {
+        const { taskInstance } = this.controller.model as GuidRouteModel<Node>;
+        await taskInstance;
+        const node = taskInstance.value;
+        this.analytics.trackPage(node ? node.public : undefined, 'nodes');
     }
 }

--- a/app/guid-node/registrations/route.ts
+++ b/app/guid-node/registrations/route.ts
@@ -21,7 +21,10 @@ export default class GuidNodeRegistrations extends Route {
     }
 
     @action
-    didTransition() {
-        this.analytics.trackPage(true);
+    async didTransition() {
+        const { taskInstance } = this.controller.model as GuidRouteModel<Node>;
+        await taskInstance;
+        const node = taskInstance.value;
+        this.analytics.trackPage(node ? node.public : undefined, 'nodes');
     }
 }

--- a/app/guid-registration/forks/route.ts
+++ b/app/guid-registration/forks/route.ts
@@ -1,12 +1,25 @@
+import { action } from '@ember-decorators/object';
 import { service } from '@ember-decorators/service';
 import Route from '@ember/routing/route';
 
+import Registration from 'ember-osf-web/models/registration';
+import { GuidRouteModel } from 'ember-osf-web/resolve-guid/guid-route';
+import Analytics from 'ember-osf-web/services/analytics';
 import Ready from 'ember-osf-web/services/ready';
 
 export default class GuidRegistrationForks extends Route {
+    @service analytics!: Analytics;
     @service ready!: Ready;
 
     model(this: GuidRegistrationForks) {
         return this.modelFor('guid-registration');
+    }
+
+    @action
+    async didTransition() {
+        const { taskInstance } = this.controller.model as GuidRouteModel<Registration>;
+        await taskInstance;
+        const registration = taskInstance.value;
+        this.analytics.trackPage(registration ? registration.public : undefined, 'registrations');
     }
 }

--- a/app/guid-user/quickfiles/route.ts
+++ b/app/guid-user/quickfiles/route.ts
@@ -62,6 +62,6 @@ export default class UserQuickfiles extends Route.extend({
         window.addEventListener('dragover', preventDrop);
         window.addEventListener('drop', preventDrop);
 
-        this.analytics.trackPage(true);
+        this.analytics.trackPage(true, 'users');
     }
 }

--- a/app/home/route.ts
+++ b/app/home/route.ts
@@ -20,6 +20,6 @@ export default class Home extends Route {
 
     @action
     didTransition(this: Home) {
-        this.get('analytics').trackPage();
+        this.analytics.trackPage();
     }
 }

--- a/app/register/route.ts
+++ b/app/register/route.ts
@@ -24,6 +24,6 @@ export default class Register extends Route {
 
     @action
     didTransition(this: Register) {
-        this.get('analytics').trackPage();
+        this.analytics.trackPage();
     }
 }

--- a/app/services/analytics.ts
+++ b/app/services/analytics.ts
@@ -1,5 +1,6 @@
 import { action } from '@ember-decorators/object';
 import { service } from '@ember-decorators/service';
+import { debug } from '@ember/debug';
 import Service from '@ember/service';
 import { task, waitForQueue } from 'ember-concurrency';
 import config from 'ember-get-config';
@@ -21,6 +22,8 @@ export default class Analytics extends Service {
     ) {
         // Wait until everything has settled
         yield waitForQueue('destroy');
+
+        debug(`Track Page: pagePublic: ${pagePublic}, resourceType: ${resourceType}`);
 
         const eventParams = {
             page: this.router.currentURL,

--- a/app/settings/tokens/edit/route.ts
+++ b/app/settings/tokens/edit/route.ts
@@ -4,6 +4,8 @@ import Route from '@ember/routing/route';
 import RouterService from '@ember/routing/router-service';
 import { task } from 'ember-concurrency';
 
+import Analytics from 'ember-osf-web/services/analytics';
+
 import SettingsTokensEditController from './controller';
 
 export default class SettingsTokensEditRoute extends Route.extend({
@@ -16,6 +18,7 @@ export default class SettingsTokensEditRoute extends Route.extend({
         }
     }),
 }) {
+    @service analytics!: Analytics;
     @service router!: RouterService;
 
     model(this: SettingsTokensEditRoute, params: { token_id: string }) {
@@ -34,5 +37,10 @@ export default class SettingsTokensEditRoute extends Route.extend({
     @action
     refreshRoute() {
         this.refresh();
+    }
+
+    @action
+    didTransition() {
+        this.analytics.trackPage();
     }
 }

--- a/app/settings/tokens/index/route.ts
+++ b/app/settings/tokens/index/route.ts
@@ -4,7 +4,7 @@ import Route from '@ember/routing/route';
 
 import Analytics from 'ember-osf-web/services/analytics';
 
-export default class SettingsTokensCreateRoute extends Route {
+export default class SettingsTokensRoute extends Route {
     @service analytics!: Analytics;
 
     @action

--- a/app/support/route.ts
+++ b/app/support/route.ts
@@ -9,6 +9,6 @@ export default class Support extends Route {
 
     @action
     didTransition(this: Support) {
-        this.get('analytics').trackPage();
+        this.analytics.trackPage();
     }
 }

--- a/lib/analytics-page/addon/application/route.ts
+++ b/lib/analytics-page/addon/application/route.ts
@@ -5,8 +5,10 @@ import Route from '@ember/routing/route';
 import Transition from '@ember/routing/transition';
 import { task, TaskInstance } from 'ember-concurrency';
 import DS from 'ember-data';
+import { pluralize } from 'ember-inflector';
 
 import Node from 'ember-osf-web/models/node';
+import { GuidRouteModel } from 'ember-osf-web/resolve-guid/guid-route';
 import AnalyticsService from 'ember-osf-web/services/analytics';
 import Ready, { Blocker } from 'ember-osf-web/services/ready';
 
@@ -62,7 +64,13 @@ export default class AnalyticsPageRoute extends Route {
     }
 
     @action
-    didTransition() {
-        this.analytics.trackPage(true, (this as any).currentModel.modelName);
+    async didTransition() {
+        const { taskInstance } = this.controller.model as GuidRouteModel<Node>;
+        await taskInstance;
+        const model = taskInstance.value;
+        this.analytics.trackPage(
+            model ? model.public : undefined,
+            model ? pluralize(model.modelName) : undefined,
+        );
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-osf-web",
-  "version": "19.0.1",
+  "version": "19.0.2",
   "description": "Ember front-end for the Open Science Framework",
   "license": "Apache-2.0",
   "author": "Center for Open Science <support@cos.io>",


### PR DESCRIPTION
## Purpose

Add missing page tracking to active routes.

## Summary of Changes

### Changed
- Routes
    - `goodbye` - add page tracking
    - `guid-node.forks` - accurately report resource privacy and type when page tracking
    - `guid-node.registrations` - accurately report resource privacy and type when page tracking
    - `guid-registration.forks` - add page tracking
    - `guid-user.quickfiles` - add resource type to page tracking
    - `settings.tokens.create` - add page tracking
    - `settings.tokens.edit` - - add page tracking
    - `settings.tokens.index` - add page tracking
- Engines:
    - `analytics-page` - accurately report resource privacy and type when page tracking

## Side Effects

Analytics page resource types are now pluralized, which is inconsistent with how they were being reported (but consistent with API resource types).

## Feature Flags

n/a

## QA Notes

Need to make sure all routes have page tracking.

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
