### PR TITLE
[EMB-324] Better analytics

### DIFF
--- a/app/instance-initializers/analytics.ts
+++ b/app/instance-initializers/analytics.ts
@@ -1,0 +1,15 @@
+import ApplicationInstance from '@ember/application/instance';
+
+import Analytics from 'ember-osf-web/services/analytics';
+
+export async function initialize(appInstance: ApplicationInstance) {
+    const analytics: Analytics = appInstance.lookup('service:analytics');
+
+    // TODO better ApplicationInstance type
+    const root = document.querySelector((appInstance as any).application.rootElement)!;
+    root.addEventListener('click', analytics.handleClick.bind(analytics, root));
+}
+
+export default {
+    initialize,
+};

--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -347,11 +347,6 @@ export default {
         title: 'API Unavailable',
         body: 'Our API is currently unavailable. Try again in a few minutes. If the issue persists, please report it to <a href="mailto:{{supportEmail}}">{{supportEmail}}</a>.',
     },
-    zoom_to_route: {
-        title: 'Zoom directly to any route',
-        zoom: 'Zoom!',
-        placeholder: 'Choose a route',
-    },
     osf_mode_footer: {
         dev_mode: 'This site is running in development mode.',
     },
@@ -1349,5 +1344,16 @@ export default {
         title: 'tempor nec feugiat nisl pretium',
         sentence: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
         paragraph: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Id velit ut tortor pretium. Nisi porta lorem mollis aliquam ut porttitor leo a. Cras fermentum odio eu feugiat. Eget mi proin sed libero enim. Quam adipiscing vitae proin sagittis. Volutpat consequat mauris nunc congue nisi vitae suscipit tellus. At varius vel pharetra vel turpis nunc eget. Purus ut faucibus pulvinar elementum integer enim neque volutpat. Turpis nunc eget lorem dolor. Mattis pellentesque id nibh tortor id aliquet lectus proin nibh. Arcu felis bibendum ut tristique et egestas quis. Nisl tincidunt eget nullam non nisi est sit amet. Fringilla urna porttitor rhoncus dolor purus non enim.',
+    },
+    dev_tools: {
+        title: 'Dev tools',
+        zoom_to_route: {
+            title: 'Zoom to route',
+            zoom: 'Zoom!',
+            placeholder: 'Choose a route',
+        },
+        options: {
+            toast_events: 'Display toast for tracked events',
+        },
     },
 };

--- a/app/services/analytics.ts
+++ b/app/services/analytics.ts
@@ -18,7 +18,7 @@ const {
     },
 } = config;
 
-interface TrackedData {
+export interface TrackedData {
     category?: string;
     action?: string;
     extra?: string;

--- a/app/services/analytics.ts
+++ b/app/services/analytics.ts
@@ -108,15 +108,22 @@ class EventInfo {
     _gatherCategory(element: Element) {
         if (element.hasAttribute(analyticsAttrs.category)) {
             this.category = element.getAttribute(analyticsAttrs.category)!;
+        } else if (element.hasAttribute('role')) {
+            this.category = element.getAttribute('role')!;
         } else {
-            const role = (element.getAttribute('role') || '').toLowerCase();
-
-            if (role === 'button' || element.tagName === 'BUTTON') {
+            switch (element.tagName) {
+            case 'BUTTON':
                 this.category = 'button';
-            } else if (role === 'link' || element.tagName === 'A') {
+                break;
+            case 'A':
                 this.category = 'link';
-            } else if (element.tagName === 'INPUT' && element.hasAttribute('type')) {
-                this.category = element.getAttribute('type')!;
+                break;
+            case 'INPUT':
+                if (element.hasAttribute('type')) {
+                    this.category = element.getAttribute('type')!;
+                }
+                break;
+            default:
             }
         }
 

--- a/app/services/analytics.ts
+++ b/app/services/analytics.ts
@@ -34,9 +34,10 @@ function logEvent(analytics: Analytics, title: string, data: any) {
     if (analytics.shouldToastOnEvent) {
         analytics.toast.info(
             Object.entries(data)
-                .map(([k, v]) => `<div>${k}: ${v}</div>`)
+                .map(([k, v]) => `<div>${k}: <strong>${v}</strong></div>`)
                 .join(''),
             title,
+            { preventDuplicates: false },
         );
     }
 }
@@ -44,7 +45,7 @@ function logEvent(analytics: Analytics, title: string, data: any) {
 class EventInfo {
     scopes: string[] = [];
     name?: string;
-    category?: string; // TODO: enum?
+    category?: string;
     action?: string;
     extra?: string;
     ev: Event;

--- a/app/services/analytics.ts
+++ b/app/services/analytics.ts
@@ -1,19 +1,136 @@
 import { action } from '@ember-decorators/object';
 import { service } from '@ember-decorators/service';
-import { debug } from '@ember/debug';
+import { assert, debug, runInDebug } from '@ember/debug';
+import RouterService from '@ember/routing/router-service';
 import Service from '@ember/service';
 import { task, waitForQueue } from 'ember-concurrency';
 import config from 'ember-get-config';
 import Metrics from 'ember-metrics/services/metrics';
 import Session from 'ember-simple-auth/services/session';
+import Toast from 'ember-toastr/services/toast';
 
 import Ready from 'ember-osf-web/services/ready';
+
+const {
+    metricsAdapters,
+    OSF: {
+        analyticsAttrs,
+    },
+} = config;
+
+interface TrackedData {
+    category?: string;
+    action?: string;
+    extra?: string;
+    label: string;
+}
+
+function logEvent(analytics: Analytics, title: string, data: any) {
+    const logMessage = Object.entries(data)
+        .map(([k, v]) => `${k}: ${v}`)
+        .join(', ');
+    debug(`${title}: ${logMessage}`);
+
+    if (analytics.shouldToastOnEvent) {
+        analytics.toast.info(
+            Object.entries(data)
+                .map(([k, v]) => `<div>${k}: ${v}</div>`)
+                .join(''),
+            title,
+        );
+    }
+}
+
+class EventInfo {
+    scopes: string[] = [];
+    name?: string;
+    category?: string; // TODO: enum?
+    action?: string;
+    extra?: string;
+    ev: Event;
+
+    constructor(ev: Event, rootElement: Element) {
+        this.ev = ev;
+        if (ev.target && ev.target instanceof Element) {
+            this.gatherMetadata(ev.target, rootElement);
+        }
+    }
+
+    isValid(): boolean {
+        return Boolean(this.name && this.scopes.length);
+    }
+
+    gatherMetadata(targetElement: Element, rootElement: Element) {
+        let element: Element | null = targetElement;
+        while (element && element !== rootElement) {
+            this._gatherMetadataFromElement(element);
+            element = element.parentElement;
+        }
+    }
+
+    trackedData(): TrackedData {
+        return {
+            category: this.category,
+            action: this.action,
+            label: [...this.scopes.reverse(), this.name].join(' - '),
+            extra: this.extra,
+        };
+    }
+
+    _gatherMetadataFromElement(element: Element) {
+        if (element.hasAttribute(analyticsAttrs.name)) {
+            assert('Multiple names found for an event!', !this.name);
+            this.name = element.getAttribute(analyticsAttrs.name)!;
+
+            this._gatherAction(element);
+            this._gatherExtra(element);
+            this._gatherCategory(element);
+        } else if (element.hasAttribute(analyticsAttrs.scope)) {
+            this.scopes.push(element.getAttribute(analyticsAttrs.scope)!);
+        }
+    }
+
+    _gatherAction(element: Element) {
+        if (element.hasAttribute(analyticsAttrs.action)) {
+            this.action = element.getAttribute(analyticsAttrs.action)!;
+        } else {
+            this.action = this.ev.type;
+        }
+    }
+
+    _gatherExtra(element: Element) {
+        if (element.hasAttribute(analyticsAttrs.extra)) {
+            this.extra = element.getAttribute(analyticsAttrs.extra)!;
+        }
+    }
+
+    _gatherCategory(element: Element) {
+        if (element.hasAttribute(analyticsAttrs.category)) {
+            this.category = element.getAttribute(analyticsAttrs.category)!;
+        } else {
+            const role = (element.getAttribute('role') || '').toLowerCase();
+
+            if (role === 'button' || element.tagName === 'BUTTON') {
+                this.category = 'button';
+            } else if (role === 'link' || element.tagName === 'A') {
+                this.category = 'link';
+            } else if (element.tagName === 'INPUT' && element.hasAttribute('type')) {
+                this.category = element.getAttribute('type')!;
+            }
+        }
+
+        assert('Event category could not be inferred. It must be set explicitly.', Boolean(this.category));
+    }
+}
 
 export default class Analytics extends Service {
     @service metrics!: Metrics;
     @service session!: Session;
     @service ready!: Ready;
-    @service router!: any;
+    @service router!: RouterService;
+    @service toast!: Toast;
+
+    shouldToastOnEvent: boolean = false;
 
     trackPageTask = task(function *(
         this: Analytics,
@@ -23,14 +140,18 @@ export default class Analytics extends Service {
         // Wait until everything has settled
         yield waitForQueue('destroy');
 
-        debug(`Track Page: pagePublic: ${pagePublic}, resourceType: ${resourceType}`);
-
         const eventParams = {
             page: this.router.currentURL,
             title: this.router.currentRouteName,
         };
 
-        const gaConfig = config.metricsAdapters.findBy('name', 'GoogleAnalytics');
+        runInDebug(() => logEvent(this, 'Tracked page', {
+            pagePublic,
+            resourceType,
+            ...eventParams,
+        }));
+
+        const gaConfig = metricsAdapters.findBy('name', 'GoogleAnalytics');
         if (gaConfig) {
             const {
                 authenticated,
@@ -72,29 +193,29 @@ export default class Analytics extends Service {
             // This is to remove the event object when used with onclick
             extra = undefined;
         }
-        this.get('metrics')
-            .trackEvent({
-                category,
-                action: 'click',
-                label,
-                extra,
-            });
+        this._trackEvent({
+            category,
+            action: 'click',
+            label,
+            extra,
+        });
 
         return true;
     }
 
-    track(this: Analytics, category: string, actionName: string, label: string, extraInfo?: string | null) {
+    track(this: Analytics, category: string, actionName: string, label: string, extraInfo?: string) {
         let extra = extraInfo;
         if (extra && typeof extra !== 'string') {
-            extra = null;
+            extra = undefined;
         }
-        this.get('metrics')
-            .trackEvent({
-                category,
-                action: actionName,
-                label,
-                extra,
-            });
+
+        this._trackEvent({
+            category,
+            action: actionName,
+            label,
+            extra,
+        });
+
         return true;
     }
 
@@ -104,6 +225,20 @@ export default class Analytics extends Service {
         resourceType: string = 'n/a',
     ) {
         this.get('trackPageTask').perform(pagePublic, resourceType);
+    }
+
+    handleClick(rootElement: HTMLElement, e: MouseEvent) {
+        const eventInfo = new EventInfo(e, rootElement);
+
+        if (eventInfo.isValid()) {
+            this._trackEvent(eventInfo.trackedData());
+        }
+    }
+
+    _trackEvent(trackedData: TrackedData) {
+        this.metrics.trackEvent(trackedData);
+
+        runInDebug(() => logEvent(this, 'Tracked event', trackedData));
     }
 }
 

--- a/app/services/analytics.ts
+++ b/app/services/analytics.ts
@@ -25,7 +25,7 @@ export interface TrackedData {
     label: string;
 }
 
-function logEvent(analytics: Analytics, title: string, data: any) {
+function logEvent(analytics: Analytics, title: string, data: object) {
     const logMessage = Object.entries(data)
         .map(([k, v]) => `${k}: ${v}`)
         .join(', ');

--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -102,7 +102,6 @@ declare const config: {
         analyticsAttrs: {
             name: string;
             scope: string;
-            page: string;
             category: string;
             extra: string;
             action: string;

--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -99,6 +99,14 @@ declare const config: {
             joinBannerDismissed: string;
         };
         casUrl: string;
+        analyticsAttrs: {
+            name: string;
+            scope: string;
+            page: string;
+            category: string;
+            extra: string;
+            action: string;
+        };
     };
     social: {
         twitter: {

--- a/config/environment.js
+++ b/config/environment.js
@@ -174,6 +174,14 @@ module.exports = function(environment) {
                 joinBannerDismissed: 'slide', // TODO: update legacy UI to use a more unique key
             },
             casUrl,
+            analyticsAttrs: {
+                name: 'data-analytics-name',
+                scope: 'data-analytics-scope',
+                page: 'data-analytics-page',
+                extra: 'data-analytics-extra',
+                category: 'data-analytics-category',
+                action: 'data-analytics-action',
+            },
         },
         social: {
             twitter: {

--- a/config/environment.js
+++ b/config/environment.js
@@ -177,7 +177,6 @@ module.exports = function(environment) {
             analyticsAttrs: {
                 name: 'data-analytics-name',
                 scope: 'data-analytics-scope',
-                page: 'data-analytics-page',
                 extra: 'data-analytics-extra',
                 category: 'data-analytics-category',
                 action: 'data-analytics-action',

--- a/lib/handbook/addon/docs/analytics/template.md
+++ b/lib/handbook/addon/docs/analytics/template.md
@@ -56,6 +56,7 @@ You can optionally fill in the `extra` field on the tracked event by setting `da
     Note: It is currently easy to forget to track non-click events.
     Until we figure out a more automatic approach, try not to forget.
 </aside>
+
 For non-click events, or when the "automatic" approach doesn't fit, call `track()` on the `analytics` service:
 
 ```ts

--- a/lib/handbook/addon/docs/analytics/template.md
+++ b/lib/handbook/addon/docs/analytics/template.md
@@ -1,0 +1,111 @@
+# Analytics
+- Every meaningful user action should be tracked
+- Adding tracking should be easy
+- Forgetting to add tracking should be hard
+
+## Tracking clicks automatically
+Tracking clicks is as easy as adding a few `data-` attributes.
+
+### `data-analytics-name`
+If an element is named with a `data-analytics-name` attribute, click events on that element will be tracked:
+```hbs
+<button
+    data-analytics-name='Create new project'
+    onclick={{action ... }}
+></button>
+```
+
+### `data-analytics-scope`
+Use named scopes to provide more context with the event, like on which page or region of the page the event took place.
+For example, a click on the button below will be tracked with the label "Dashboard - Control bar - Create new project":
+```hbs
+<div data-analytics-scope='Dashboard'>
+    <div data-analytics-scope='Control bar'>
+        <button data-analytics-name='Create new project'></button>
+    </div>
+</div>
+```
+
+### `data-analytics-category`
+The event category generally refers to the type of thing being acted upon. For normal links (`<a>` or `role='link'`)
+and buttons (`<button>` or `role='button'`) the category will be inferred as `link` and `button`, respectively.
+
+If you want to categorize events another way (e.g. `file` for all events that act on file objects), you can add
+`data-analytics-category='mycategory'` to the same element with `data-analytics-name`:
+```hbs
+<button
+    data-analytics-name='Delete file'
+    data-analytics-category='file'
+    onclick={{action this.deleteFile file}}
+>Delete file</button>
+```
+
+### `data-analytics-extra`
+You can optionally fill in the `extra` field on the tracked event by setting `data-analytics-extra='extra data'`:
+```hbs
+<button
+    data-analytics-name='Delete file'
+    data-analytics-category='file'
+    data-analytics-extra={{concat 'File name: ' file.name}}
+    onclick={{action this.deleteFile file}}
+>Delete file</button>
+```
+
+## Tracking events by hand
+<aside>
+    Note: It is currently easy to forget to track non-click events.
+    Until we figure out a more automatic approach, try not to forget.
+</aside>
+For non-click events, or when the "automatic" approach doesn't fit, call `track()` on the `analytics` service:
+
+```ts
+@action
+onKeyUp() {
+    this.analytics.track('search', 'keyUp', 'Search box - Key up');
+    // ...
+}
+```
+
+Params for `track()`:
+- `category`: string
+- `actionName`: string
+- `label`: string
+- `extraInfo` (optional): string
+
+## Tracking page views
+<aside>
+    Note: It is currently easy to forget to add page tracking.
+    Until we figure out a more automatic approach, try not to forget.
+</aside>
+
+Call `trackPage()` on the `analytics` service in the `didTransition` hook for your route or a parent route:
+```ts
+// route.ts
+@action
+didTransition() {
+    this.analytics.trackPage();
+}
+```
+
+If the page is under a GUID route, pass the following two arguments to `trackPage`:
+- `pagePublic`: boolean indicating whether the GUID referent is public or private
+- `resourceType`: string for the API type of the GUID referent (e.g. `nodes`, `registrations`, etc.)
+
+## Testing analytics
+Any action worth testing is worth tracking, and vice versa.
+
+### Custom `click` helper
+The custom `click` helper will error if its target does not have a `data-analytics-name` attribute.
+Use it in all your tests for pages/components that use the "automatic" analytics approach.
+
+```ts
+import { click } from 'ember-osf-web/tests/helpers';
+// ...
+await click('button');
+```
+
+### Manual testing
+In development builds, events that would be tracked are logged to the console.
+
+In addition, you can click on the "development mode" banner in the lower left to open dev options.
+Check "Display toast for tracked events" to display a toast for tracked events.

--- a/lib/handbook/addon/docs/template.hbs
+++ b/lib/handbook/addon/docs/template.hbs
@@ -10,6 +10,7 @@
         <nav.item @label='Troubleshooting' @route='docs.troubleshooting' />
         <nav.item @label='Developer Environment' @route='docs.dev-env' />
         <nav.item @label='Testing' @route='docs.testing' />
+        <nav.item @label='Analytics' @route='docs.analytics' />
         <nav.item @label='Additional resources' @route='docs.resources' />
 
         <nav.section @label='Style guide' />

--- a/lib/handbook/addon/routes.js
+++ b/lib/handbook/addon/routes.js
@@ -13,6 +13,7 @@ export default buildRoutes(function() {
         this.route('dev-env');
         this.route('conventions');
         this.route('testing');
+        this.route('analytics');
         this.route('community');
         this.route('resources');
         this.route('troubleshooting');

--- a/lib/osf-components/addon/components/osf-mode-footer/component.ts
+++ b/lib/osf-components/addon/components/osf-mode-footer/component.ts
@@ -1,7 +1,9 @@
+import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
 import config from 'ember-get-config';
 
 import { layout } from 'ember-osf-web/decorators/component';
+import Analytics from 'ember-osf-web/services/analytics';
 import styles from './styles';
 import template from './template';
 
@@ -12,9 +14,15 @@ import template from './template';
 
 /**
  * If development mode, display a red banner in the footer
+ *
+ * TODO: move to a 'dev-tools' in-repo addon or package, exclude from prod builds
+ *
  * @class osf-mode-footer
  */
 @layout(template, styles)
 export default class OsfModeFooter extends Component {
+    @service analytics!: Analytics;
+
     isDevMode: boolean = config.OSF.devMode;
+    showModal: boolean = false;
 }

--- a/lib/osf-components/addon/components/osf-mode-footer/styles.scss
+++ b/lib/osf-components/addon/components/osf-mode-footer/styles.scss
@@ -5,6 +5,7 @@
     border-top-right-radius: 8px;
     background-color: $color-bg-red;
     padding: 0.5em;
+    z-index: 999;
 
     strong {
         text-transform: uppercase;

--- a/lib/osf-components/addon/components/osf-mode-footer/styles.scss
+++ b/lib/osf-components/addon/components/osf-mode-footer/styles.scss
@@ -4,10 +4,19 @@
     left: 0;
     border-top-right-radius: 8px;
     background-color: $color-bg-red;
-    color: $color-text-white;
     padding: 0.5em;
 
     strong {
         text-transform: uppercase;
+    }
+
+    a {
+        color: $color-text-white;
+    }
+}
+
+.Tabs {
+    :global(.tab-content) {
+        padding: 10px;
     }
 }

--- a/lib/osf-components/addon/components/osf-mode-footer/styles.scss
+++ b/lib/osf-components/addon/components/osf-mode-footer/styles.scss
@@ -10,8 +10,9 @@
         text-transform: uppercase;
     }
 
-    a {
+    button {
         color: $color-text-white;
+        padding: 0;
     }
 }
 

--- a/lib/osf-components/addon/components/osf-mode-footer/template.hbs
+++ b/lib/osf-components/addon/components/osf-mode-footer/template.hbs
@@ -1,13 +1,13 @@
 {{#if this.isDevMode}}
     <div local-class='DevBanner'>
-        <Link
-            role='button'
+        <OsfButton
             title={{t 'dev_tools.title'}}
-            @onclick={{action (mut this.showModal) true}}
+            @type='link'
+            @onClick={{action (mut this.showModal) true}}
         >
             <strong>{{t 'general.warning'}}</strong>: {{t 'osf_mode_footer.dev_mode'}}
             {{fa-icon 'rocket'}}
-        </Link>
+        </OsfButton>
     </div>
     <BsModal
         @open={{this.showModal}}

--- a/lib/osf-components/addon/components/osf-mode-footer/template.hbs
+++ b/lib/osf-components/addon/components/osf-mode-footer/template.hbs
@@ -1,6 +1,32 @@
 {{#if this.isDevMode}}
     <div local-class='DevBanner'>
-        <strong>{{t 'general.warning'}}</strong>: {{t 'osf_mode_footer.dev_mode'}}
-        <ZoomToRoute />
+        <Link
+            role='button'
+            title={{t 'dev_tools.title'}}
+            @onclick={{action (mut this.showModal) true}}
+        >
+            <strong>{{t 'general.warning'}}</strong>: {{t 'osf_mode_footer.dev_mode'}}
+            {{fa-icon 'rocket'}}
+        </Link>
     </div>
+    <BsModal
+        @open={{this.showModal}}
+        @onHide={{action (mut this.showModal) false}}
+        as |modal|
+    >
+        <modal.header @title={{t 'dev_tools.title'}} />
+        <modal.body>
+            <BsTab local-class='Tabs' as |tab|>
+                <tab.pane @title='Options'>
+                    <label>
+                        {{input type='checkbox' checked=this.analytics.shouldToastOnEvent}}
+                        {{t 'dev_tools.options.toast_events'}}
+                    </label>
+                </tab.pane>
+                <tab.pane @title='Zoom to route'>
+                    <ZoomToRoute />
+                </tab.pane>
+            </BsTab>
+        </modal.body>
+    </BsModal>
 {{/if}}

--- a/lib/osf-components/addon/components/osf-navbar/component.ts
+++ b/lib/osf-components/addon/components/osf-navbar/component.ts
@@ -21,11 +21,17 @@ export enum OSFService {
     INSTITUTIONS = 'INSTITUTIONS',
 }
 
-export const OSF_SERVICES = [
+interface ServiceLink {
+    name: string;
+    route?: string;
+    href?: string;
+}
+
+export const OSF_SERVICES: ServiceLink[] = [
     { name: OSFService.HOME, route: 'home' },
-    { name: OSFService.PREPRINTS, route: `${osfURL}preprints/` },
-    { name: OSFService.REGISTRIES, route: config.engines.registries.enabled ? 'registries' : `${osfURL}registries/` },
-    { name: OSFService.MEETINGS, route: `${osfURL}meetings/` },
+    { name: OSFService.PREPRINTS, href: `${osfURL}preprints/` },
+    { name: OSFService.REGISTRIES, route: 'registries' },
+    { name: OSFService.MEETINGS, href: `${osfURL}meetings/` },
     { name: OSFService.INSTITUTIONS, route: 'institutions' },
 ];
 
@@ -39,7 +45,7 @@ export default class OsfNavbar extends Component {
     showNavLinks: boolean = false;
 
     activeService: OSFService = defaultTo(this.activeService, OSFService.HOME);
-    services: Array<{name: OSFService, route: string}> = defaultTo(this.services, OSF_SERVICES);
+    services: ServiceLink[] = defaultTo(this.services, OSF_SERVICES);
 
     @computed('activeService', 'router.currentRouteName')
     get _activeService() {

--- a/lib/osf-components/addon/components/osf-navbar/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/template.hbs
@@ -3,14 +3,14 @@
         <div class='container'>
             <div class='navbar-header'>
                 {{! template-lint-disable no-implicit-this }}
-                {{#global-link-to
-                    'home'
+                <Link
                     data-test-nav-home-link
-                    (html-attributes aria-label=(t 'navbar.go_home'))
+                    aria-label={{t 'navbar.go_home'}}
                     class='navbar-brand'
-                }}
+                    @route='home'
+                >
                     <span class='osf-navbar-logo'></span>
-                {{/global-link-to}}
+                </Link>
                 {{! template-lint-enable no-implicit-this }}
                 {{! Current app }}
                 <div class='service-name'>

--- a/lib/osf-components/addon/components/osf-navbar/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/template.hbs
@@ -3,10 +3,10 @@
         <div class='container'>
             <div class='navbar-header'>
                 {{! template-lint-disable no-implicit-this }}
-                {{#global-link-to 
-                    'home' 
-                    data-test-nav-home-link 
-                    (html-attributes aria-label=(t 'navbar.go_home')) 
+                {{#global-link-to
+                    'home'
+                    data-test-nav-home-link
+                    (html-attributes aria-label=(t 'navbar.go_home'))
                     class='navbar-brand'
                 }}
                     <span class='osf-navbar-logo'></span>
@@ -14,10 +14,13 @@
                 {{! template-lint-enable no-implicit-this }}
                 {{! Current app }}
                 <div class='service-name'>
-                    {{#hyper-link this._activeService.route}}
+                    <Link
+                        @route={{this._activeService.route}}
+                        @href={{this._activeService.href}}
+                    >
                         <span class='hidden-xs'> {{t 'general.OSF'}} </span>
                         <span class='current-service'><strong>{{this._activeService.name}}</strong></span>
-                    {{/hyper-link}}
+                    </Link>
                 </div>
 
                 {{! App list dropdown }}
@@ -35,9 +38,12 @@
                     <dd.menu @classNames='dropdown-menu service-dropdown' as |ddm| >
                         {{#each this.services as |service|}}
                             <ddm.item role='menuitem'>
-                                {{#hyper-link service.route}}
+                                <Link
+                                    @route={{service.route}}
+                                    @href={{service.href}}
+                                >
                                     {{t 'general.OSF'}}<b>{{service.name}}</b>
-                                {{/hyper-link}}
+                                </Link>
                             </ddm.item>
                         {{/each}}
                     </dd.menu>

--- a/lib/osf-components/addon/components/zoom-to-route/component.ts
+++ b/lib/osf-components/addon/components/zoom-to-route/component.ts
@@ -1,9 +1,6 @@
-import { tagName } from '@ember-decorators/component';
 import { action, computed } from '@ember-decorators/object';
 import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
-import { task, waitForQueue } from 'ember-concurrency';
-import $ from 'jquery';
 
 import { layout } from 'ember-osf-web/decorators/component';
 import template from './template';
@@ -17,7 +14,6 @@ import template from './template';
  * @class zoom-to-route
  */
 @layout(template)
-@tagName('span')
 export default class ZoomToRoute extends Component {
     @service router!: any;
 
@@ -25,17 +21,6 @@ export default class ZoomToRoute extends Component {
     targetRoute?: string;
 
     routeArgs: { [k: string]: string } = {};
-
-    setFocus = task(function *(this: ZoomToRoute, selector: string) {
-        yield waitForQueue('afterRender');
-
-        $(`#${this.modalBodyId} ${selector}`).focus();
-    });
-
-    @computed('elementId')
-    get modalBodyId() {
-        return `${this.elementId}-modal-body`;
-    }
 
     @computed()
     get routeNames() {
@@ -51,17 +36,11 @@ export default class ZoomToRoute extends Component {
     }
 
     @action
-    modalShown(this: ZoomToRoute) {
-        this.get('setFocus').perform('div.ember-power-select-trigger');
-    }
-
-    @action
     selectRoute(this: ZoomToRoute, targetRoute: string) {
         this.setProperties({
             targetRoute,
             routeArgs: {},
         });
-        this.get('setFocus').perform('input.form-control');
     }
 
     @action

--- a/lib/osf-components/addon/components/zoom-to-route/template.hbs
+++ b/lib/osf-components/addon/components/zoom-to-route/template.hbs
@@ -1,47 +1,31 @@
-<OsfButton
-    aria-label={{t 'zoom_to_route.title'}}
-    local-class='ZoomRocket'
-    @type='link'
-    @onClick={{action (mut this.showModal) true}}
+<BsForm
+    @model={{this.routeArgs}}
+    @onSubmit={{action 'zoom'}}
+    as |form|
 >
-    {{fa-icon 'rocket'}}
-</OsfButton>
-{{#if this.showModal}}
-    <BsModalSimple
-        @onHide={{action (mut this.showModal) false}}
-        @onShown={{action this.modalShown}}
-        @title={{t 'zoom_to_route.title'}}
-        @closeTitle={{t 'general.cancel'}}
-        @submitTitle={{t 'zoom_to_route.zoom'}}
+    <PowerSelect
+        @options={{this.routeNames}}
+        @selected={{this.targetRoute}}
+        @onchange={{action 'selectRoute'}}
+        @renderInPlace=true
+        @placeholder={{t 'dev_tools.zoom_to_route.placeholder'}}
+        as |name|
     >
-        <div id={{this.modalBodyId}}>
-            <PowerSelect
-                @options={{this.routeNames}}
-                @selected={{this.targetRoute}}
-                @onchange={{action this.selectRoute}}
-                @renderInPlace={{true}}
-                @placeholder={{t 'zoom_to_route.placeholder'}}
-                as |name|
-            >
-                {{name}}
-            </PowerSelect>
-            {{#if this.targetRoute}}
-                <hr>
-                <BsForm
-                    @model={{this.routeArgs}}
-                    @onSubmit={{action this.zoom}}
-                    as |form|
-                >
-                    {{#each this.routeParams as |param|}}
-                        <form.element
-                            @controlType='text'
-                            @label={{param}}
-                            @placeholder={{param}}
-                            @property={{param}}
-                        />
-                    {{/each}}
-                </BsForm>
-            {{/if}}
-        </div>
-    </BsModalSimple>
-{{/if}}
+        {{name}}
+    </PowerSelect>
+    {{#if this.targetRoute}}
+        <hr>
+        {{#each this.routeParams as |param|}}
+            <form.element
+                @controlType='text'
+                @label={{param}}
+                @placeholder={{param}}
+                @property={{param}}
+            />
+        {{/each}}
+        <hr>
+        <OsfButton @buttonType='submit'>
+            {{t 'dev_tools.zoom_to_route.zoom'}}
+        </OsfButton>
+    {{/if}}
+</BsForm>

--- a/lib/registries/addon/application/controller.ts
+++ b/lib/registries/addon/application/controller.ts
@@ -4,16 +4,21 @@ import { service } from '@ember-decorators/service';
 import Controller from '@ember/controller';
 import { camelize } from '@ember/string';
 import Features from 'ember-feature-flags/services/features';
+import config from 'ember-get-config';
+
 import { OSFService } from 'osf-components/components/osf-navbar/component';
-import config from 'registries/config/environment';
 
 const {
-    featureFlagNames: { newStyle },
+    featureFlagNames: {
+        routes: {
+            'registries.overview': newStyleFlag,
+        },
+    },
 } = config;
 
 export default class Application extends Controller {
     @service features!: Features;
-    @alias(`features.${camelize(newStyle)}`) newStyleEnabled!: boolean;
+    @alias(`features.${camelize(newStyleFlag)}`) newStyleEnabled!: boolean;
 
     activeService = OSFService.REGISTRIES;
     searchRoute = 'registries.discover';

--- a/lib/registries/addon/application/styles.scss
+++ b/lib/registries/addon/application/styles.scss
@@ -3,7 +3,7 @@
     flex-direction: column;
 }
 
-:global(.RegistriesStyle) {
+.RegistriesLayout {
     display: flex;
     flex-direction: column;
     flex: 1 0 auto;

--- a/lib/registries/addon/application/template.hbs
+++ b/lib/registries/addon/application/template.hbs
@@ -1,18 +1,20 @@
 {{title (t 'registries.application.page_title') replace=true}}
 
-<div class="{{if this.newStyleEnabled 'RegistriesStyle' 'OldRegistriesStyle'}}">
-
+<div
+    data-analytics-scope='Registries'
+    class="{{if this.newStyleEnabled 'RegistriesStyle' 'OldRegistriesStyle'}}"
+>
     {{#if this.newStyleEnabled}}
         <RegistriesNavbar @campaign='osf-registries' @onSearch={{action 'search'}} />
     {{else}}
         {{#osf-header as |header|}}
-            {{#header.navbar campaign='osf-registries' activeService=activeService as |ctx|}}
+            {{#header.navbar campaign='osf-registries' activeService=this.activeService as |ctx|}}
                 {{#ctx.links as |links|}}
                     {{!-- {{links.quickfiles}} --}}
                     {{!-- {{links.myprojects}} --}}
                     {{links.myregistrations}}
-                    {{links.search route=searchRoute}}
-                    {{links.support route=supportRoute}}
+                    {{links.search route=this.searchRoute}}
+                    {{links.support route=this.supportRoute}}
                     {{links.donate}}
                 {{/ctx.links}}
             {{/header.navbar}}

--- a/lib/registries/addon/application/template.hbs
+++ b/lib/registries/addon/application/template.hbs
@@ -3,18 +3,22 @@
 {{#if this.newStyleEnabled}}
     <RegistriesNavbar class='RegistriesStyle' @campaign='osf-registries' @onSearch={{action 'search'}} />
 {{else}}
-    {{#osf-header as |header|}}
-        {{#header.navbar campaign='osf-registries' activeService=this.activeService as |ctx|}}
-            {{#ctx.links as |links|}}
-                {{!-- {{links.quickfiles}} --}}
-                {{!-- {{links.myprojects}} --}}
-                {{links.myregistrations}}
-                {{links.search route=this.searchRoute}}
-                {{links.support route=this.supportRoute}}
-                {{links.donate}}
-            {{/ctx.links}}
-        {{/header.navbar}}
-    {{/osf-header}}
+    <OsfHeader as |header|>
+        <header.navbar
+            @campaign='osf-registries'
+            @activeService={{this.activeService}}
+            as |ctx|
+        >
+            <ctx.links as |links|>
+                {{! <links.quickfiles /> }}
+                {{! <links.myprojects /> }}
+                <links.myregistrations />
+                <links.search route=this.searchRoute />
+                <links.support route=this.supportRoute />
+                <links.donate />
+            </ctx.links>
+        </header.navbar>
+    </OsfHeader>
 {{/if}}
 
 <div

--- a/lib/registries/addon/application/template.hbs
+++ b/lib/registries/addon/application/template.hbs
@@ -1,25 +1,26 @@
 {{title (t 'registries.application.page_title') replace=true}}
 
+{{#if this.newStyleEnabled}}
+    <RegistriesNavbar class='RegistriesStyle' @campaign='osf-registries' @onSearch={{action 'search'}} />
+{{else}}
+    {{#osf-header as |header|}}
+        {{#header.navbar campaign='osf-registries' activeService=this.activeService as |ctx|}}
+            {{#ctx.links as |links|}}
+                {{!-- {{links.quickfiles}} --}}
+                {{!-- {{links.myprojects}} --}}
+                {{links.myregistrations}}
+                {{links.search route=this.searchRoute}}
+                {{links.support route=this.supportRoute}}
+                {{links.donate}}
+            {{/ctx.links}}
+        {{/header.navbar}}
+    {{/osf-header}}
+{{/if}}
+
 <div
     data-analytics-scope='Registries'
-    class="{{if this.newStyleEnabled 'RegistriesStyle' 'OldRegistriesStyle'}}"
+    local-class='RegistriesLayout'
+    class={{if this.newStyleEnabled 'RegistriesStyle'}}
 >
-    {{#if this.newStyleEnabled}}
-        <RegistriesNavbar @campaign='osf-registries' @onSearch={{action 'search'}} />
-    {{else}}
-        {{#osf-header as |header|}}
-            {{#header.navbar campaign='osf-registries' activeService=this.activeService as |ctx|}}
-                {{#ctx.links as |links|}}
-                    {{!-- {{links.quickfiles}} --}}
-                    {{!-- {{links.myprojects}} --}}
-                    {{links.myregistrations}}
-                    {{links.search route=this.searchRoute}}
-                    {{links.support route=this.supportRoute}}
-                    {{links.donate}}
-                {{/ctx.links}}
-            {{/header.navbar}}
-        {{/osf-header}}
-    {{/if}}
-
     {{outlet}}
 </div>

--- a/lib/registries/addon/components/icon-input/component.ts
+++ b/lib/registries/addon/components/icon-input/component.ts
@@ -7,10 +7,7 @@ import template from './template';
 @tagName('')
 @layout(template)
 export default class Content extends Component {
-    static positionalParams = ['icon'];
-
     icon!: string;
-    class: string = defaultTo(this.class, '');
     dark: boolean = defaultTo(this.dark, false);
 
     value: string = '';

--- a/lib/registries/addon/components/icon-input/template.hbs
+++ b/lib/registries/addon/components/icon-input/template.hbs
@@ -1,15 +1,15 @@
 <span
-    local-class='IconInput {{if this.dark 'Dark'}}'
     data-analytics-category='text'
+    local-class='IconInput {{if this.dark 'Dark'}}'
     ...attributes
 >
     <span>
-        {{fa-icon this.icon fixedWidth=true}}
+        <FaIcon @icon=this.icon @fixedWidth=true />
     </span>
-    {{input
-        type='text'
-        enter=(action '_enter')
-        class=(local-class 'Input')
-        value=(mut this.value)
-    }}
+    <Input
+        @type='text'
+        @enter={{action '_enter'}}
+        @class={{local-class 'Input'}}
+        @value={{mut this.value}}
+    />
 </span>

--- a/lib/registries/addon/components/icon-input/template.hbs
+++ b/lib/registries/addon/components/icon-input/template.hbs
@@ -1,4 +1,8 @@
-<span class="{{this.class}}" local-class="IconInput {{if this.dark 'Dark'}}">
+<span
+    local-class='IconInput {{if this.dark 'Dark'}}'
+    data-analytics-category='text'
+    ...attributes
+>
     <span>
         {{fa-icon this.icon fixedWidth=true}}
     </span>

--- a/lib/registries/addon/components/icon-input/template.hbs
+++ b/lib/registries/addon/components/icon-input/template.hbs
@@ -4,12 +4,12 @@
     ...attributes
 >
     <span>
-        <FaIcon @icon=this.icon @fixedWidth=true />
+        <FaIcon @icon={{this.icon}} @fixedWidth={{true}} />
     </span>
-    <Input
-        @type='text'
-        @enter={{action '_enter'}}
-        @class={{local-class 'Input'}}
-        @value={{mut this.value}}
-    />
+    {{input
+        type='text'
+        enter=(action '_enter')
+        class=(local-class 'Input')
+        value=(mut this.value)
+    }}
 </span>

--- a/lib/registries/addon/components/navbar/template.hbs
+++ b/lib/registries/addon/components/navbar/template.hbs
@@ -1,4 +1,9 @@
-<nav data-test-nav role="navigation" local-class="Nav {{if this.dark 'Dark' 'Light'}} {{if this.mobile 'Mobile'}}">
+<nav
+    data-test-nav
+    role="navigation"
+    local-class="Nav {{if this.dark 'Dark' 'Light'}} {{if this.mobile 'Mobile'}}"
+    ...attributes
+>
     {{yield (hash
         container=(component 'container' class=(local-class 'NavbarContainer'))
         divider=(component 'x-dummy' class=(local-class 'Divider'))

--- a/lib/registries/addon/components/registration-form-view/component.ts
+++ b/lib/registries/addon/components/registration-form-view/component.ts
@@ -114,7 +114,7 @@ export class RegistrationForm {
 /* eslint-enable no-useless-constructor, no-empty-function */
 @tagName('')
 @layout(template)
-export default class RegistrationSchemaView extends Component {
+export default class RegistrationFormView extends Component {
     schema!: Schema;
     answers!: RegistrationMetadata;
 

--- a/lib/registries/addon/components/registration-form-view/template.hbs
+++ b/lib/registries/addon/components/registration-form-view/template.hbs
@@ -1,21 +1,21 @@
 {{#each this.form.sections as |form-section|}}
-    <section local-class="Section {{if (eq form-section this.form.sections.lastObject) 'Last'}}">
-        <a href="#{{slugify form-section.title}}">
-            <h2 id="{{slugify form-section.title}}" local-class="SectionTitle">
+    <section local-class='Section {{if (eq form-section this.form.sections.lastObject) 'Last'}}'>
+        <Link @href='#{{slugify form-section.title}}'>
+            <h2 id='{{slugify form-section.title}}' local-class='SectionTitle'>
                 {{form-section.title}}
             </h2>
-        </a>
+        </Link>
 
         {{#each form-section.questions as |question|}}
-            <a href="#{{slugify form-section.title}}.{{slugify question.title}}">
-                <h3 id="{{slugify form-section.title}}.{{slugify question.title}}" local-class="QuestionTitle">
+            <Link @href='#{{slugify form-section.title}}.{{slugify question.title}}'>
+                <h3 id='{{slugify form-section.title}}.{{slugify question.title}}' local-class='QuestionTitle'>
                     {{question.title}}
                 </h3>
-            </a>
+            </Link>
 
-            <p class="small">{{question.description}}</p>
+            <p class='small'>{{question.description}}</p>
 
-            <div local-class="Answer">
+            <div local-class='Answer'>
                 {{#each question.parts as |part|}}
                     {{component (concat 'registration-form-view/' part.component) part}}
                 {{/each}}

--- a/lib/registries/addon/components/registries-navbar/template.hbs
+++ b/lib/registries/addon/components/registries-navbar/template.hbs
@@ -36,10 +36,15 @@
                     as |ddm|
                 >
                     {{#each this.services as |service|}}
-                        <ddm.item data-analytics-name={{service.name}} role='menuitem'>
-                            {{#hyper-link service.route}}
+                        <ddm.item role='menuitem'>
+                            <Link
+                                data-analytics-name={{service.name}}
+                                {{! each service has one of `route` and `href` }}
+                                @route={{service.route}}
+                                @href={{service.href}}
+                            >
                                 <strong local-class='ServiceDropdownEntry'>{{service.name}}</strong>
-                            {{/hyper-link}}
+                            </Link>
                         </ddm.item>
                     {{/each}}
                 </dd.menu>

--- a/lib/registries/addon/components/registries-navbar/template.hbs
+++ b/lib/registries/addon/components/registries-navbar/template.hbs
@@ -1,105 +1,187 @@
-<Navbar @dark={{true}} as |nav|>
+<Navbar
+    data-analytics-scope='Navbar'
+    @dark={{true}}
+    ...attributes
+    as |nav|
+>
     <nav.container>
-        {{!-- Left Side (Band, Service Dropdown) --}}
+        {{! Left Side (Band, Service Dropdown) }}
         <nav.section data-test-left>
 
-            {{#global-link-to data-test-brand 'home' (html-attributes aria-label=(t 'navbar.go_home'))}}
-                <div local-class="Logo"></div>
-            {{/global-link-to}}
+            <Link
+                data-analytics-name='Brand'
+                data-test-brand
+                @route='home'
+                local-class='Logo'
+                aria-label={{t 'navbar.go_home'}}
+            />
 
-            {{#bs-dropdown as |dd|}}
-                {{#dd.toggle data-test-service classNames=(local-class 'Service Dropdown')}}
-                    <span local-class="HideOnMobile">{{t 'general.OSF'}}</span>
+            <BsDropdown
+                data-analytics-scope='Services dropdown'
+                as |dd|
+            >
+                <dd.toggle
+                    data-analytics-name='Toggle'
+                    data-test-service
+                    @classNames={{local-class 'Service Dropdown'}}
+                >
+                    <span local-class='HideOnMobile'>{{t 'general.OSF'}}</span>
                     <strong>{{t 'general.services.registries'}}</strong>
                     {{nav.icon (if dd.isOpen 'caret-up' 'caret-down')}}
-                {{/dd.toggle}}
+                </dd.toggle>
 
-                {{#dd.menu data-test-service-list classNames=(local-class 'ServiceDropdownMenu DropdownMenu') as |ddm|}}
-                    {{#each services as |service|}}
-                        <ddm.item role="menuitem">
+                <dd.menu
+                    data-test-service-list
+                    @classNames={{local-class 'ServiceDropdownMenu DropdownMenu'}}
+                    as |ddm|
+                >
+                    {{#each this.services as |service|}}
+                        <ddm.item data-analytics-name={{service.name}} role='menuitem'>
                             {{#hyper-link service.route}}
-                                <strong local-class="ServiceDropdownEntry">{{service.name}}</strong>
+                                <strong local-class='ServiceDropdownEntry'>{{service.name}}</strong>
                             {{/hyper-link}}
                         </ddm.item>
                     {{/each}}
-                {{/dd.menu}}
-            {{/bs-dropdown}}
+                </dd.menu>
+            </BsDropdown>
 
         </nav.section>
 
-        {{!-- Right Side (Search, Buttons, Gravatar, Dropdown) --}}
+        {{! Right Side (Search, Buttons, Gravatar, Dropdown) }}
         <nav.section data-test-right>
 
-            <nav.item @classNames={{local-class 'HideOnMobile SearchBar'}} data-test-search-bar="1">
-                {{icon-input 'search' dark=true enter=(action '_onSearch')}}
+            <nav.item @classNames={{local-class 'HideOnMobile SearchBar'}} data-test-search-bar='1'>
+                <IconInput
+                    data-analytics-name='Search box'
+                    @icon='search'
+                    @dark={{true}}
+                    @enter={{action '_onSearch'}}
+                />
             </nav.item>
 
-            <nav.links.secondary @classNames={{local-class 'HideOnMobile'}} href={{this.helpRoute}} data-test-help="1">
+            <nav.links.secondary
+                data-analytics-name='Help'
+                data-test-help='1'
+                @href={{this.helpRoute}}
+                @classNames={{local-class 'HideOnMobile'}}
+            >
                 <h4>{{t 'general.help'}}</h4>
             </nav.links.secondary>
 
-            <nav.links.primary @classNames={{local-class 'HideOnMobile'}} href={{this.donateRoute}} data-test-donate="1">
+            <nav.links.primary
+                data-analytics-name='Donate'
+                data-test-donate='1'
+                @href={{this.donateRoute}}
+                @classNames={{local-class 'HideOnMobile'}}
+            >
                 <h4>{{t 'navbar.donate'}}</h4>
             </nav.links.primary>
 
-            {{#if (not session.isAuthenticated)}}
+            {{#if (not this.session.isAuthenticated)}}
 
                 <nav.divider @classNames={{local-class 'HideOnMobile'}} />
 
-                <nav.links.secondary href={{this.signUpRoute}} data-test-join="1">
+                <nav.links.secondary
+                    data-analytics-name='Sign up'
+                    data-test-join='1'
+                    @href={{this.signUpRoute}}
+                >
                     <h4>{{t 'navbar.join'}}</h4>
                 </nav.links.secondary>
 
-                <nav.buttons.secondary @onclick={{action 'login'}} data-test-login="1">
+                <nav.buttons.secondary
+                    data-analytics-name='Sign in'
+                    data-test-login='1'
+                    @onclick={{action 'login'}}
+                >
                     <h4>{{t 'navbar.login'}}</h4>
                 </nav.buttons.secondary>
 
             {{else}}
 
-                {{#bs-dropdown classNames=(local-class 'AuthDropdown') as |dd|}}
-                    {{#dd.toggle classNames=(local-class 'Dropdown')}}
-                        <img data-test-gravatar alt="{{t 'auth_dropdown.user_gravatar'}}" local-class="Gravatar" src="{{currentUser.user.profileImage}}&s=30">
+                <BsDropdown
+                    data-analytics-scope='User dropdown'
+                    local-class='AuthDropdown'
+                    as |dd|
+                >
+                    <dd.toggle
+                        data-analytics-name='Toggle'
+                        local-class='Dropdown'
+                    >
+                        <img
+                            data-test-gravatar
+                            local-class='Gravatar'
+                            src='{{this.currentUser.user.profileImage}}&s=30'
+                            alt={{t 'auth_dropdown.user_gravatar'}}
+                        >
                         {{nav.icon (if dd.isOpen 'caret-up' 'caret-down')}}
-                    {{/dd.toggle}}
+                    </dd.toggle>
 
-                    {{#dd.menu data-test-auth-dropdown classNames=(concat 'dropdown-menu-right ' (local-class 'AuthDropdownMenu DropdownMenu')) as |ddm|}}
-                        <ddm.item role="menuitem">
-                            <a href="{{profileURL}}" onclick={{action 'click' 'link' 'Navbar - MyProfile' target=analytics}}>
+                    <dd.menu
+                        data-test-auth-dropdown
+                        class='dropdown-menu-right'
+                        local-class='AuthDropdownMenu DropdownMenu'
+                        as |ddm|
+                    >
+                        <ddm.item role='menuitem'>
+                            <Link
+                                data-analytics-name='My Profile'
+                                @href={{this.profileURL}}
+                            >
                                 {{fa-icon 'user' fixedWidth=true}}
                                 {{t 'auth_dropdown.my_profile'}}
-                            </a>
+                            </Link>
                         </ddm.item>
-                        <ddm.item role="menuitem">
-                            {{#global-link-to 'support' click=(action 'click' 'link' 'Navbar - Support' target=analytics)}}
+                        <ddm.item role='menuitem'>
+                            <Link
+                                data-analytics-name='Support'
+                                @route='support'
+                            >
                                 {{fa-icon 'life-ring' fixedWidth=true}}
                                 {{t 'auth_dropdown.osf_support'}}
-                            {{/global-link-to}}
+                            </Link>
                         </ddm.item>
-                        <ddm.item role="menuitem">
-                            <a href="{{settingsURL}}" onclick={{action 'click' 'link' 'Navbar - Settings' target=analytics}}>
+                        <ddm.item role='menuitem'>
+                            <Link
+                                data-analytics-name='Settings'
+                                @href={{this.settingsURL}}
+                            >
                                 {{fa-icon 'cog' fixedWidth=true}}
                                 {{t 'general.settings'}}
-                            </a>
+                            </Link>
                         </ddm.item>
-                        <ddm.item role="menuitem">
-                            <a class="logoutLink" {{action 'logout'}} onclick={{action 'click' 'button' 'Navbar - Logout' target=analytics}} role="button">
+                        <ddm.item role='menuitem'>
+                            <Link
+                                data-analytics-name='Logout'
+                                class='logoutLink'
+                                role='button'
+                                @href='#'
+                                @onclick={{action 'logout'}}
+                            >
                                 {{fa-icon 'sign-out' fixedWidth=true}}
                                 {{t 'auth_dropdown.log_out'}}
-                            </a>
+                            </Link>
                         </ddm.item>
-                    {{/dd.menu}}
-                {{/bs-dropdown}}
-
+                    </dd.menu>
+                </BsDropdown>
             {{/if}}
 
         </nav.section>
     </nav.container>
 </Navbar>
 
-<Container data-test-search-bar-mobile="1" local-class="SearchDropdown {{if (media 'isMobile') '' 'Closed'}}">
-    {{icon-input 'search' dark=true enter=(action '_onSearch')}}
+<Container
+    data-test-search-bar-mobile='1'
+    local-class='SearchDropdown {{if (media 'isMobile') '' 'Closed'}}'
+>
+    <IconInput
+        data-analytics-name='Search box'
+        @icon='search'
+        @dark={{true}}
+        @enter={{action '_onSearch'}}
+    />
 </Container>
 
-{{maintenance-banner}}
-{{status-banner}}
-{{tos-consent-banner}}
+<MaintenanceBanner />
+<StatusBanner />
+<TosConsentBanner />

--- a/lib/registries/addon/components/registries-navbar/template.hbs
+++ b/lib/registries/addon/components/registries-navbar/template.hbs
@@ -9,8 +9,8 @@
         <nav.section data-test-left>
 
             <Link
-                data-analytics-name='Brand'
                 data-test-brand
+                data-analytics-name='Brand'
                 @route='home'
                 local-class='Logo'
                 aria-label={{t 'navbar.go_home'}}
@@ -21,8 +21,8 @@
                 as |dd|
             >
                 <dd.toggle
-                    data-analytics-name='Toggle'
                     data-test-service
+                    data-analytics-name='Toggle'
                     @classNames={{local-class 'Service Dropdown'}}
                 >
                     <span local-class='HideOnMobile'>{{t 'general.OSF'}}</span>
@@ -55,7 +55,10 @@
         {{! Right Side (Search, Buttons, Gravatar, Dropdown) }}
         <nav.section data-test-right>
 
-            <nav.item @classNames={{local-class 'HideOnMobile SearchBar'}} data-test-search-bar='1'>
+            <nav.item
+                data-test-search-bar='1'
+                @classNames={{local-class 'HideOnMobile SearchBar'}}
+            >
                 <IconInput
                     data-analytics-name='Search box'
                     @icon='search'
@@ -65,8 +68,8 @@
             </nav.item>
 
             <nav.links.secondary
-                data-analytics-name='Help'
                 data-test-help='1'
+                data-analytics-name='Help'
                 @href={{this.helpRoute}}
                 @classNames={{local-class 'HideOnMobile'}}
             >
@@ -74,8 +77,8 @@
             </nav.links.secondary>
 
             <nav.links.primary
-                data-analytics-name='Donate'
                 data-test-donate='1'
+                data-analytics-name='Donate'
                 @href={{this.donateRoute}}
                 @classNames={{local-class 'HideOnMobile'}}
             >
@@ -87,16 +90,16 @@
                 <nav.divider @classNames={{local-class 'HideOnMobile'}} />
 
                 <nav.links.secondary
-                    data-analytics-name='Sign up'
                     data-test-join='1'
+                    data-analytics-name='Sign up'
                     @href={{this.signUpRoute}}
                 >
                     <h4>{{t 'navbar.join'}}</h4>
                 </nav.links.secondary>
 
                 <nav.buttons.secondary
-                    data-analytics-name='Sign in'
                     data-test-login='1'
+                    data-analytics-name='Sign in'
                     @onclick={{action 'login'}}
                 >
                     <h4>{{t 'navbar.login'}}</h4>

--- a/lib/registries/addon/components/side-nav/template.hbs
+++ b/lib/registries/addon/components/side-nav/template.hbs
@@ -6,8 +6,8 @@
 >
     <div local-class='Links'>
         {{yield (hash
-            link-to=(component 'side-nav/x-link'
-                onLinkClicked=@onLinkClicked
+            link=(component 'side-nav/x-link'
+                onClick=@onLinkClicked
                 isCollapsed=this.isCollapsed
             )
         )}}
@@ -17,13 +17,11 @@
         {{#let (component 'side-nav/x-link') as |SideNavLink|}}
             <SideNavLink
                 data-analytics-name={{if this.isCollapsed 'Expand' 'Collapse'}}
-                 data-test-toggle='1'
-                 class={{local-class 'Toggle'}}
-                 @href='#'
-                 @onclick={{action this.toggle}}
-                 @isCollapsed={{this.isCollapsed}}
-                 @icon={{if this.isCollapsed 'chevron-right' 'chevron-left'}}
-                 @label={{t (if this.isCollapsed 'registries.overview.expand' 'registries.overview.collapse')}}
+                class={{local-class 'Toggle'}}
+                @onClick={{action this.toggle}}
+                @isCollapsed={{this.isCollapsed}}
+                @icon={{if this.isCollapsed 'chevron-right' 'chevron-left'}}
+                @label={{t (if this.isCollapsed 'registries.overview.expand' 'registries.overview.collapse')}}
             />
         {{/let}}
     {{/if}}

--- a/lib/registries/addon/components/side-nav/template.hbs
+++ b/lib/registries/addon/components/side-nav/template.hbs
@@ -1,10 +1,10 @@
 <nav
-    data-test-side-nav="1"
-    data-test-collapsed="{{this.isCollapsed}}"
-    local-class="SideNav {{if this.isCollapsed 'Collapsed'}}"
+    data-test-side-nav='1'
+    data-test-collapsed='{{this.isCollapsed}}'
+    local-class='SideNav {{if this.isCollapsed 'Collapsed'}}'
     ...attributes
 >
-    <div local-class="Links">
+    <div local-class='Links'>
         {{yield (hash
             link-to=(component 'side-nav/x-link'
                 onLinkClicked=@onLinkClicked
@@ -14,9 +14,10 @@
     </div>
 
     {{#if this.isCollapseAllowed}}
-        {{#let (component 'side-nav/x-link') as |XLink|}}
-            <XLink
-                 data-test-toggle="1"
+        {{#let (component 'side-nav/x-link') as |SideNavLink|}}
+            <SideNavLink
+                data-analytics-name={{if this.isCollapsed 'Expand' 'Collapse'}}
+                 data-test-toggle='1'
                  class={{local-class 'Toggle'}}
                  @href='#'
                  @onclick={{action this.toggle}}

--- a/lib/registries/addon/components/side-nav/x-link/component.ts
+++ b/lib/registries/addon/components/side-nav/x-link/component.ts
@@ -14,15 +14,16 @@ export default class XLink extends Component {
     icon!: string;
     label!: string;
     route?: string;
-    model?: any;
+    href?: string;
+    models?: any[];
     count?: number;
     isCollapsed: boolean = defaultTo(this.isCollapsed, false);
 
-    onclick?: () => void;
+    onClick?: () => void;
 
-    @computed('route')
+    @computed('route', 'href')
     get isButton() {
-        return !this.route;
+        return typeof this.route === 'undefined' && typeof this.href === 'undefined';
     }
 
     @computed('count')

--- a/lib/registries/addon/components/side-nav/x-link/styles.scss
+++ b/lib/registries/addon/components/side-nav/x-link/styles.scss
@@ -8,6 +8,7 @@ $sidenav-link-height: 40px;
     width: 100%;
     padding: 5px 20px;
     color: $primary-blue;
+    outline: 0 !important;
 
     h4 {
         color: inherit;

--- a/lib/registries/addon/components/side-nav/x-link/template.hbs
+++ b/lib/registries/addon/components/side-nav/x-link/template.hbs
@@ -1,7 +1,7 @@
 {{#if this.isButton}}
     <OsfButton
-        class={{local-class this.wrapperClasses}}
         data-test-collapsed='{{this.isCollapsed}}'
+        class={{local-class this.wrapperClasses}}
         @onClick={{@onClick}}
         @type='link'
         ...attributes
@@ -19,12 +19,12 @@
     </OsfButton>
 {{else}}
     <Link
+        data-test-collapsed='{{this.isCollapsed}}'
+        class={{local-class this.wrapperClasses}}
         @models={{@models}}
         @route={{@route}}
         @href={{@href}}
         @onclick={{@onClick}}
-        class={{local-class this.wrapperClasses}}
-        data-test-collapsed='{{this.isCollapsed}}'
         ...attributes
     >
         <span local-class='Label'>

--- a/lib/registries/addon/components/side-nav/x-link/template.hbs
+++ b/lib/registries/addon/components/side-nav/x-link/template.hbs
@@ -1,20 +1,41 @@
-<Link
-    @models={{@models}}
-    @route={{@route}}
-    @href={{@href}}
-    @onclick={{@onLinkClicked}}
-    class={{local-class this.wrapperClasses}}
-    data-test-collapsed="{{this.isCollapsed}}"
-    ...attributes
->
-    <span local-class="Label">
-        {{fa-icon @icon fixedWidth=true class=(local-class 'Icon')}}
-        <h4>{{@label}}</h4>
-    </span>
+{{#if this.isButton}}
+    <OsfButton
+        class={{local-class this.wrapperClasses}}
+        data-test-collapsed='{{this.isCollapsed}}'
+        @onClick={{@onClick}}
+        @type='link'
+        ...attributes
+    >
+        <span local-class='Label'>
+            {{fa-icon @icon fixedWidth=true class=(local-class 'Icon')}}
+            <h4>{{@label}}</h4>
+        </span>
 
-    <span local-class="Count">
-        {{#if this.hasCount}}
-            {{@count}}
-        {{/if}}
-    </span>
-</Link>
+        <span local-class='Count'>
+            {{#if this.hasCount}}
+                {{@count}}
+            {{/if}}
+        </span>
+    </OsfButton>
+{{else}}
+    <Link
+        @models={{@models}}
+        @route={{@route}}
+        @href={{@href}}
+        @onclick={{@onClick}}
+        class={{local-class this.wrapperClasses}}
+        data-test-collapsed='{{this.isCollapsed}}'
+        ...attributes
+    >
+        <span local-class='Label'>
+            {{fa-icon @icon fixedWidth=true class=(local-class 'Icon')}}
+            <h4>{{@label}}</h4>
+        </span>
+
+        <span local-class='Count'>
+            {{#if this.hasCount}}
+                {{@count}}
+            {{/if}}
+        </span>
+    </Link>
+{{/if}}

--- a/lib/registries/addon/components/side-nav/x-link/template.hbs
+++ b/lib/registries/addon/components/side-nav/x-link/template.hbs
@@ -7,7 +7,7 @@
         ...attributes
     >
         <span local-class='Label'>
-            {{fa-icon @icon fixedWidth=true class=(local-class 'Icon')}}
+            <FaIcon @icon={{@icon}} @fixedWidth={{true}} @class={{local-class 'Icon'}} />
             <h4>{{@label}}</h4>
         </span>
 
@@ -28,7 +28,7 @@
         ...attributes
     >
         <span local-class='Label'>
-            {{fa-icon @icon fixedWidth=true class=(local-class 'Icon')}}
+            <FaIcon @icon={{@icon}} @fixedWidth={{true}} @class={{local-class 'Icon'}} />
             <h4>{{@label}}</h4>
         </span>
 

--- a/lib/registries/addon/discover/route.ts
+++ b/lib/registries/addon/discover/route.ts
@@ -1,0 +1,14 @@
+import { action } from '@ember-decorators/object';
+import { service } from '@ember-decorators/service';
+import Route from '@ember/routing/route';
+
+import Analytics from 'ember-osf-web/services/analytics';
+
+export default class RegistriesDiscoverRoute extends Route {
+    @service analytics!: Analytics;
+
+    @action
+    didTransition() {
+        this.analytics.trackPage();
+    }
+}

--- a/lib/registries/addon/index/route.ts
+++ b/lib/registries/addon/index/route.ts
@@ -1,0 +1,14 @@
+import { action } from '@ember-decorators/object';
+import { service } from '@ember-decorators/service';
+import Route from '@ember/routing/route';
+
+import Analytics from 'ember-osf-web/services/analytics';
+
+export default class RegistriesIndexRoute extends Route {
+    @service analytics!: Analytics;
+
+    @action
+    didTransition() {
+        this.analytics.trackPage();
+    }
+}

--- a/lib/registries/addon/overview/route.ts
+++ b/lib/registries/addon/overview/route.ts
@@ -1,6 +1,13 @@
-import GuidRoute from 'ember-osf-web/resolve-guid/guid-route';
+import { action } from '@ember-decorators/object';
+import { service } from '@ember-decorators/service';
+
+import Registration from 'ember-osf-web/models/registration';
+import GuidRoute, { GuidRouteModel } from 'ember-osf-web/resolve-guid/guid-route';
+import Analytics from 'ember-osf-web/services/analytics';
 
 export default class Overview extends GuidRoute {
+    @service analytics!: Analytics;
+
     modelName(): 'registration' {
         return 'registration';
     }
@@ -15,5 +22,13 @@ export default class Overview extends GuidRoute {
                 related_counts: 'forks,linked_nodes,linked_registrations,children',
             },
         };
+    }
+
+    @action
+    async didTransition() {
+        const { taskInstance } = this.controller.model as GuidRouteModel<Registration>;
+        await taskInstance;
+        const registration = taskInstance.value;
+        this.analytics.trackPage(registration ? registration.public : undefined, 'registrations');
     }
 }

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -55,28 +55,28 @@
                     @onLinkClicked={{action (mut this.sidenavGutterClosed) true}}
                     as |nav|
                 >
-                    <nav.link-to
+                    <nav.link
                         data-analytics-name='Overview'
                         @route='registries.overview.index'
                         @models={{array this.registration.id}}
                         @icon='home'
                         @label={{t 'registries.overview.title'}}
                     />
-                    <nav.link-to
+                    <nav.link
                         data-analytics-name='Files'
                         @href='/{{this.registration.id}}/files/'
                         @icon='file-text'
                         @label={{t 'registries.overview.external_links.files'}}
                         @count={{50}}
                     />
-                    <nav.link-to
+                    <nav.link
                         data-analytics-name='Wiki'
                         @href='/{{this.registration.id}}/wiki/'
                         @icon='window-maximize'
                         @label={{t 'registries.overview.external_links.wiki'}}
                         @count={{4}}
                     />
-                    <nav.link-to
+                    <nav.link
                         data-analytics-name='Components'
                         @route='registries.overview.children'
                         @models={{array this.registration.id}}
@@ -84,7 +84,7 @@
                         @label={{t 'registries.overview.components.title'}}
                         @count={{this.registration.relatedCounts.children}}
                     />
-                    <nav.link-to
+                    <nav.link
                         data-analytics-name='Links'
                         @route='registries.overview.links'
                         @models={{array this.registration.id}}
@@ -92,14 +92,14 @@
                         @label={{t 'registries.overview.links.title'}}
                         @count={{this.linksCount}}
                     />
-                    <nav.link-to
+                    <nav.link
                         data-analytics-name='Analytics'
                         @route='registries.overview.analytics'
                         @models={{array this.registration.id}}
                         @icon='bar-chart'
                         @label={{t 'registries.overview.external_links.analytics'}}
                     />
-                    <nav.link-to
+                    <nav.link
                         data-analytics-name='Comments'
                         @route='registries.overview.comments'
                         @models={{array this.registration.id}}

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -1,11 +1,11 @@
-{{#if this.loading }}
-    <div local-class="ContentBackground Loading">
+{{#if this.loading}}
+    <div local-class='ContentBackground Loading'>
         <LoadingIndicator @dark={{true}} />
     </div>
 {{else}}
-    <div local-class="TitleBackground">
+    <div local-class='TitleBackground'>
         <Container>
-            <h1 local-class="Title">{{this.registration.title}}</h1>
+            <h1 local-class='Title'>{{this.registration.title}}</h1>
         </Container>
     </div>
 
@@ -42,69 +42,79 @@
         </Navbar>
     {{/if}}
 
-    <div local-class="ContentBackground">
+    <div local-class='ContentBackground'>
         <Gutters
-             @leftMode={{this.sidenavGutterMode}}
-             @leftClosed={{this.sidenavGutterClosed}}
-             @rightMode={{this.metadataGutterMode}}
-             @rightClosed={{this.metadataGutterClosed}}
-             as |gutters|
-         >
-            <gutters.left-gutter>
-                <SideNav @onLinkClicked={{action (mut this.sidenavGutterClosed) true}} as |nav|>
-                    <nav.link-to data-test-link="overview"
-                        @icon="home"
-                        @label={{t 'registries.overview.title'}}
-                        @route="registries.overview.index"
+            @leftMode={{this.sidenavGutterMode}}
+            @leftClosed={{this.sidenavGutterClosed}}
+            @rightMode={{this.metadataGutterMode}}
+            @rightClosed={{this.metadataGutterClosed}}
+            as |gutters|
+        >
+            <gutters.left-gutter data-analytics-scope='Left sidenav'>
+                <SideNav
+                    @onLinkClicked={{action (mut this.sidenavGutterClosed) true}}
+                    as |nav|
+                >
+                    <nav.link-to
+                        data-analytics-name='Overview'
+                        @route='registries.overview.index'
                         @models={{array this.registration.id}}
+                        @icon='home'
+                        @label={{t 'registries.overview.title'}}
                     />
-                    <nav.link-to data-test-link="files"
-                        @icon="file-text"
+                    <nav.link-to
+                        data-analytics-name='Files'
+                        @href='/{{this.registration.id}}/files/'
+                        @icon='file-text'
                         @label={{t 'registries.overview.external_links.files'}}
-                        @href="/{{this.registration.id}}/files/"
                         @count={{50}}
                     />
-                    <nav.link-to data-test-link="wiki"
-                        @icon="window-maximize"
+                    <nav.link-to
+                        data-analytics-name='Wiki'
+                        @href='/{{this.registration.id}}/wiki/'
+                        @icon='window-maximize'
                         @label={{t 'registries.overview.external_links.wiki'}}
-                        @href="/{{this.registration.id}}/wiki/"
                         @count={{4}}
                     />
-                    <nav.link-to data-test-link="components"
-                        @icon="puzzle-piece"
+                    <nav.link-to
+                        data-analytics-name='Components'
+                        @route='registries.overview.children'
+                        @models={{array this.registration.id}}
+                        @icon='puzzle-piece'
                         @label={{t 'registries.overview.components.title'}}
                         @count={{this.registration.relatedCounts.children}}
-                        @route="registries.overview.children"
-                        @models={{array this.registration.id}}
                     />
-                    <nav.link-to data-test-link="links"
-                        @icon="link"
+                    <nav.link-to
+                        data-analytics-name='Links'
+                        @route='registries.overview.links'
+                        @models={{array this.registration.id}}
+                        @icon='link'
                         @label={{t 'registries.overview.links.title'}}
                         @count={{this.linksCount}}
-                        @route="registries.overview.links"
-                        @models={{array this.registration.id}}
                     />
-                    <nav.link-to data-test-link="analytics"
-                        @icon="bar-chart"
+                    <nav.link-to
+                        data-analytics-name='Analytics'
+                        @route='registries.overview.analytics'
+                        @models={{array this.registration.id}}
+                        @icon='bar-chart'
                         @label={{t 'registries.overview.external_links.analytics'}}
-                        @route="registries.overview.analytics"
-                        @models={{array this.registration.id}}
                     />
-                    <nav.link-to data-test-link="comments"
-                        @icon="comments"
-                        @label={{t 'registries.overview.comments.title'}}
-                        @route="registries.overview.comments"
+                    <nav.link-to
+                        data-analytics-name='Comments'
+                        @route='registries.overview.comments'
                         @models={{array this.registration.id}}
+                        @icon='comments'
+                        @label={{t 'registries.overview.comments.title'}}
                         @count={{28}}
                     />
                 </SideNav>
             </gutters.left-gutter>
 
-            <gutters.body local-class="OverviewBody">
+            <gutters.body local-class='OverviewBody'>
                 {{outlet}}
             </gutters.body>
 
-            <gutters.right-gutter>
+            <gutters.right-gutter data-analytics-scope='Right panel'>
                 <RegistriesMetadata
                     @onLinkClicked={{action (mut this.metadataGutterClosed) true}}
                     @registration={{this.registration}}

--- a/lib/registries/config/environment.d.ts
+++ b/lib/registries/config/environment.d.ts
@@ -11,9 +11,6 @@ declare const config: {
         urlRegex: string;
         display?: string;
     }>;
-    featureFlagNames: {
-        newStyle: string;
-    };
     externalLinks: {
         help: string;
         donate: string;

--- a/lib/registries/config/environment.js
+++ b/lib/registries/config/environment.js
@@ -49,9 +49,6 @@ module.exports = function(environment) {
             name: 'Research Registry',
             urlRegex: '^https?://.*researchregistry\\.com.*$',
         }],
-        featureFlagNames: {
-            newStyle: 'ember_registries_new_style',
-        },
         externalLinks: {
             help: 'http://help.osf.io/m/registrations/',
             donate: 'https://cos.io/donate',

--- a/mirage/factories/root.ts
+++ b/mirage/factories/root.ts
@@ -1,4 +1,4 @@
-import { association, Factory, ModelInstance, trait, Trait } from 'ember-cli-mirage';
+import { association, Factory } from 'ember-cli-mirage';
 import config from 'ember-get-config';
 import { Links } from 'jsonapi-typescript';
 
@@ -21,11 +21,7 @@ export interface Root {
     currentUser?: User;
 }
 
-interface RootTraits {
-    withNewRegistriesStyle: Trait;
-}
-
-export default Factory.extend<Root & RootTraits>({
+export default Factory.extend<Root>({
     activeFlags: [
         ...Object.values(routes),
         ...Object.values(navigation),
@@ -36,10 +32,4 @@ export default Factory.extend<Root & RootTraits>({
     version: '2.8',
     links: {},
     currentUser: association() as User,
-
-    withNewRegistriesStyle: trait({
-        afterCreate(root: ModelInstance<Root>) {
-            root.activeFlags.push('ember_registries_new_style');
-        },
-    }),
 });

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -17,7 +17,6 @@ const {
 } = config;
 
 export default function(server: Server) {
-    server.create('root', 'withNewRegistriesStyle');
     const currentUser = defaultLoggedOut ? server.create('user') : server.create('user', 'loggedIn');
 
     server.create('user-setting', { user: currentUser });

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -17,14 +17,8 @@ const {
 } = config;
 
 export default function(server: Server) {
-    let currentUser = null;
-
-    if (defaultLoggedOut) {
-        currentUser = server.create('user');
-        server.create('root', { currentUser: null });
-    } else {
-        currentUser = server.create('user', 'loggedIn');
-    }
+    server.create('root', 'withNewRegistriesStyle');
+    const currentUser = defaultLoggedOut ? server.create('user') : server.create('user', 'loggedIn');
 
     server.create('user-setting', { user: currentUser });
     const registrationNode = server.create('node', { id: 'regis', currentUserPermissions: Object.values(Permission) });

--- a/tests/engines/registries/acceptance/overview/comments-test.ts
+++ b/tests/engines/registries/acceptance/overview/comments-test.ts
@@ -10,7 +10,7 @@ module('Registries | Acceptance | overview.comments', hooks => {
     setupMirage(hooks);
 
     hooks.beforeEach(function(this: TestContext) {
-        server.create('root', { currentUser: null }, 'withNewRegistriesStyle');
+        server.create('root', { currentUser: null });
     });
 
     test('it renders', async function(this: TestContext, assert: Assert) {

--- a/tests/engines/registries/acceptance/overview/index-test.ts
+++ b/tests/engines/registries/acceptance/overview/index-test.ts
@@ -1,5 +1,5 @@
 import Service from '@ember/service';
-import { click, currentRouteName } from '@ember/test-helpers';
+import { currentRouteName } from '@ember/test-helpers';
 import { ModelInstance } from 'ember-cli-mirage';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { percySnapshot } from 'ember-percy';
@@ -7,7 +7,7 @@ import { TestContext } from 'ember-test-helpers';
 import { module, test } from 'qunit';
 
 import Registration from 'ember-osf-web/models/registration';
-import { currentURL, visit } from 'ember-osf-web/tests/helpers';
+import { click, currentURL, visit } from 'ember-osf-web/tests/helpers';
 import { loadEngine, setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
 
 interface OverviewTestContext extends TestContext {
@@ -50,19 +50,19 @@ module('Registries | Acceptance | overview.index', hooks => {
         analyticsEngine.register('service:keen', KeenStub);
 
         const testCases = [{
-            name: 'comments',
+            name: 'Comments',
             route: 'registries.overview.comments',
             url: `/--registries/${this.registration.id}/comments`,
         }, {
-            name: 'analytics',
+            name: 'Analytics',
             route: 'guid-registration.analytics.index',
             url: `/--registration/${this.registration.id}/analytics`,
         }, {
-            name: 'components',
+            name: 'Components',
             route: 'registries.overview.children',
             url: `/--registries/${this.registration.id}/components`,
         }, {
-            name: 'links',
+            name: 'Links',
             route: 'registries.overview.links',
             url: `/--registries/${this.registration.id}/links`,
         }];
@@ -70,7 +70,7 @@ module('Registries | Acceptance | overview.index', hooks => {
         for (const testCase of testCases) {
             await visit(`/${this.registration.id}/`);
 
-            await click(`[data-test-link="${testCase.name}"]`);
+            await click(`[data-analytics-name="${testCase.name}"]`);
             await percySnapshot(`Registries sidenav - ${testCase.name}`);
 
             assert.equal(currentURL(), testCase.url, 'At the correct URL');
@@ -80,10 +80,10 @@ module('Registries | Acceptance | overview.index', hooks => {
 
     test('sidenav hrefs', async function(this: OverviewTestContext, assert: Assert) {
         const testCases = [{
-            selector: '[data-test-link="files"]',
+            selector: '[data-analytics-name="Files"]',
             href: `/${this.registration.id}/files/`,
         }, {
-            selector: '[data-test-link="wiki"]',
+            selector: '[data-analytics-name="Wiki"]',
             href: `/${this.registration.id}/wiki/`,
         }];
 

--- a/tests/engines/registries/acceptance/overview/index-test.ts
+++ b/tests/engines/registries/acceptance/overview/index-test.ts
@@ -29,7 +29,7 @@ module('Registries | Acceptance | overview.index', hooks => {
     setupMirage(hooks);
 
     hooks.beforeEach(function(this: OverviewTestContext) {
-        server.create('root', { currentUser: null }, 'withNewRegistriesStyle');
+        server.create('root', { currentUser: null });
         server.loadFixtures('registration-schemas');
         this.set('registration', server.create('registration', {
             registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),

--- a/tests/engines/registries/integration/components/registries-navbar/component-test.ts
+++ b/tests/engines/registries/integration/components/registries-navbar/component-test.ts
@@ -51,7 +51,9 @@ module('Registries | Integration | Component | registries-navbar', hooks => {
     setupEngineRenderingTest(hooks, 'registries');
 
     hooks.beforeEach(function(this: TestContext) {
-        this.owner.lookup('service:router').set('_router.currentURL', 'FakeURL');
+        sinon.stub(this.owner.lookup('service:router'), 'urlFor').returns('FakeURL');
+        sinon.stub(this.owner.lookup('service:router'), 'isActive').returns(false);
+        sinon.stub(this.owner.lookup('service:router'), 'currentURL').get(() => 'FakeURL');
 
         this.owner.register('service:session', sessionStub);
         this.owner.register('service:features', featuresStub);

--- a/tests/engines/registries/integration/components/side-nav/component-test.ts
+++ b/tests/engines/registries/integration/components/side-nav/component-test.ts
@@ -43,7 +43,7 @@ module('Registries | Integration | Component | side-nav', hooks => {
     test('it yielded component render splattributes', async function(assert) {
         await render(hbs`
             <SideNav as |nav|>
-                <nav.link-to data-for-a-test="bar" @route="home" @icon="home" @label="test" />
+                <nav.link data-for-a-test="bar" @route="home" @icon="home" @label="test" />
             </SideNav>
         `);
 

--- a/tests/helpers/index.ts
+++ b/tests/helpers/index.ts
@@ -1,8 +1,15 @@
-import { settled, visit as _visit } from '@ember/test-helpers';
+import { click as _click, settled, Target, visit as _visit } from '@ember/test-helpers';
 import { getContext } from '@ember/test-helpers/setup-context';
 import { faker } from 'ember-cli-mirage';
+import config from 'ember-get-config';
 import { setupApplicationTest } from 'ember-qunit';
 import { TestContext } from 'ember-test-helpers';
+
+const {
+    OSF: {
+        analyticsAttrs,
+    },
+} = config;
 
 // With the current implementation of visit, if the transition is
 // aborted for any reason (e.g. Redirects via guid routing) an
@@ -23,6 +30,21 @@ export async function visit(url: string) {
     }
 
     await settled();
+}
+
+/*
+ * Custom click helper! In addition to calling the normal click helper from
+ * @ember/test-helpers, will error the click target is not correctly
+ * ornamented with a "data-analytics-name" attribute. If a click is important
+ * enough to be in a test, it's important enough to warrant analytics.
+ */
+export async function click(target: Target) {
+    const element: Element = (target instanceof Element) ? target : document.querySelector(target)!;
+    if (!element.hasAttribute(analyticsAttrs.name)) {
+        throw Error(`Untracked click! Add a "${analyticsAttrs.name}" attribute to ${target}`);
+    }
+
+    await _click(target);
 }
 
 // The current implementation of currentURL pulls

--- a/tests/integration/analytics-test.ts
+++ b/tests/integration/analytics-test.ts
@@ -1,0 +1,228 @@
+import { click, render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+import sinon, { SinonStub } from 'sinon';
+
+// import { initialize } from 'ember-osf-web/instance-initializers/analytics';
+
+interface AnalyticsTestContext extends TestContext {
+    trackEventStub: SinonStub;
+}
+
+module('Integration | Analytics handling', hooks => {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function(this: AnalyticsTestContext) {
+        const analytics = this.owner.lookup('service:analytics');
+        this.trackEventStub = sinon.stub(analytics.metrics, 'trackEvent');
+    });
+
+    test('handle click', async function(this: AnalyticsTestContext, assert) {
+        await render(hbs`
+            <div data-analytics-scope='Scope!'>
+                <button data-analytics-name='Button!'></button>
+            </div>
+        `);
+
+        await click('button');
+
+        assert.deepEqual(this.trackEventStub.args, [
+            [{
+                category: 'button',
+                action: 'click',
+                label: 'Scope! - Button!',
+                extra: undefined,
+            }],
+        ], 'One click event');
+    });
+
+    test('extra', async function(this: AnalyticsTestContext, assert) {
+        await render(hbs`
+            <div data-analytics-scope='Scope!'>
+                <button
+                    data-analytics-name='Button!'
+                    data-analytics-extra='Foo'
+                ></button>
+            </div>
+        `);
+
+        await click('button');
+
+        assert.deepEqual(this.trackEventStub.args, [
+            [{
+                category: 'button',
+                action: 'click',
+                label: 'Scope! - Button!',
+                extra: 'Foo',
+            }],
+        ], 'One click event');
+    });
+
+    test('duplicate events', async function(this: AnalyticsTestContext, assert) {
+        await render(hbs`
+            <div data-analytics-scope='Scope!'>
+                <button data-analytics-name='Button!'></button>
+            </div>
+        `);
+
+        await click('button');
+        await click('button');
+
+        assert.deepEqual(this.trackEventStub.args, [
+            [{
+                category: 'button',
+                action: 'click',
+                label: 'Scope! - Button!',
+                extra: undefined,
+            }], [{
+                category: 'button',
+                action: 'click',
+                label: 'Scope! - Button!',
+                extra: undefined,
+            }],
+        ], 'Two click events');
+    });
+
+    test('nested scope', async function(this: AnalyticsTestContext, assert) {
+        await render(hbs`
+            <div data-analytics-scope='Scope 1'>
+            <div>
+            <div data-analytics-scope='Scope 2'>
+            <div>
+            <div>
+            <div>
+            <div data-analytics-scope='Scope 3'>
+                <button data-analytics-name='Button!'></button>
+            </div>
+            </div>
+            </div>
+            </div>
+            </div>
+            </div>
+            </div>
+        `);
+
+        await click('button');
+
+        assert.deepEqual(this.trackEventStub.args, [
+            [{
+                category: 'button',
+                action: 'click',
+                label: 'Scope 1 - Scope 2 - Scope 3 - Button!',
+                extra: undefined,
+            }],
+        ], 'One click event with nested scopes');
+    });
+
+    test('multiple targets', async function(this: AnalyticsTestContext, assert) {
+        await render(hbs`
+            <div data-analytics-scope='Scope 1'>
+                <div data-analytics-scope='Scope 2'>
+                    <button data-analytics-name='Button!'></button>
+                </div>
+                <div data-analytics-scope='Scope 3'>
+                    <a data-analytics-name='Link!'></a>
+                </div>
+            </div>
+        `);
+
+        await click('a');
+        await click('button');
+
+        assert.deepEqual(this.trackEventStub.args, [
+            [{
+                category: 'link',
+                action: 'click',
+                label: 'Scope 1 - Scope 3 - Link!',
+                extra: undefined,
+            }], [{
+                category: 'button',
+                action: 'click',
+                label: 'Scope 1 - Scope 2 - Button!',
+                extra: undefined,
+            }],
+        ], 'One button, one link');
+    });
+
+    test('category inference', async function(this: AnalyticsTestContext, assert) {
+        await render(hbs`
+            <div data-analytics-scope='Scope!'>
+                <button data-analytics-name='Button!'></button>
+                <a data-analytics-name='Link!'></a>
+                <a role='button' data-analytics-name='Button link!'></a>
+                <input type='checkbox' data-analytics-name='Checkbox!' />
+                <input type='radio' data-analytics-name='Radio' />
+                <button
+                    id='explicit-category'
+                    data-analytics-name='Other button!'
+                    data-analytics-category='other'
+                ></button>
+            </div>
+        `);
+
+        await click('button');
+        await click('a');
+        await click('a[role="button"]');
+        await click('input[type="checkbox"]');
+        await click('#explicit-category');
+
+        assert.deepEqual(this.trackEventStub.args, [
+            [{
+                category: 'button',
+                action: 'click',
+                label: 'Scope! - Button!',
+                extra: undefined,
+            }],
+            [{
+                category: 'link',
+                action: 'click',
+                label: 'Scope! - Link!',
+                extra: undefined,
+            }],
+            [{
+                category: 'button',
+                action: 'click',
+                label: 'Scope! - Button link!',
+                extra: undefined,
+            }],
+            [{
+                category: 'checkbox',
+                action: 'click',
+                label: 'Scope! - Checkbox!',
+                extra: undefined,
+            }],
+            [{
+                category: 'other',
+                action: 'click',
+                label: 'Scope! - Other button!',
+                extra: undefined,
+            }],
+        ], 'Correct categories');
+    });
+
+    test('ignore click with no name', async function(this: AnalyticsTestContext, assert) {
+        await render(hbs`
+            <div data-analytics-scope='Scope!'>
+                <button></button>
+            </div>
+        `);
+
+        await click('button');
+
+        assert.ok(this.trackEventStub.notCalled, 'click ignored');
+    });
+
+    test('ignore click with no scope', async function(this: AnalyticsTestContext, assert) {
+        await render(hbs`
+            <div>
+                <button data-analytics-name='Button!'></button>
+            </div>
+        `);
+
+        await click('button');
+
+        assert.ok(this.trackEventStub.notCalled, 'click ignored');
+    });
+});

--- a/tests/integration/analytics-test.ts
+++ b/tests/integration/analytics-test.ts
@@ -5,8 +5,6 @@ import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
 import sinon, { SinonStub } from 'sinon';
 
-// import { initialize } from 'ember-osf-web/instance-initializers/analytics';
-
 interface AnalyticsTestContext extends TestContext {
     trackEventStub: SinonStub;
 }

--- a/tests/integration/components/hyper-link/component-test.ts
+++ b/tests/integration/components/hyper-link/component-test.ts
@@ -1,5 +1,4 @@
 import { click, render } from '@ember/test-helpers';
-import Analytics from 'ember-osf-web/services/analytics';
 import { setupRenderingTest } from 'ember-qunit';
 import sinonTest from 'ember-sinon-qunit/test-support/test';
 import { TestContext } from 'ember-test-helpers';
@@ -74,8 +73,7 @@ module('Integration | Component | hyper-link', hooks => {
     });
 
     test('it calls analytics on non-ember routes', async function(this: TestContext) {
-        const analytics = sinon.createStubInstance(Analytics);
-        this.owner.register('service:analytics', analytics, { instantiate: false });
+        const analytics = sinon.stub(this.owner.lookup('service:analytics'));
 
         // Prevent Redirects
         analytics.click.callsFake((...args: any[]) => {
@@ -98,13 +96,12 @@ module('Integration | Component | hyper-link', hooks => {
 
     sinonTest('it calls analytics on ember routes', async function() {
         const routing = this.owner.lookup('service:-routing');
-        const analytics = this.sandbox.createStubInstance(Analytics);
+        const analyticsClick = this.stub(this.owner.lookup('service:analytics'), 'click');
 
         this.stub(routing, 'transitionTo');
-        this.owner.register('service:analytics', analytics, { instantiate: false });
 
         // Prevent Redirects
-        analytics.click.callsFake((...args: any[]) => {
+        analyticsClick.callsFake((...args: any[]) => {
             for (const arg of args) {
                 if (arg.preventDefault) {
                     arg.preventDefault();
@@ -118,8 +115,8 @@ module('Integration | Component | hyper-link', hooks => {
 
         await click('a');
 
-        this.sandbox.assert.calledOnce(analytics.click);
+        this.sandbox.assert.calledOnce(analyticsClick);
         this.sandbox.assert.calledOnce(routing.transitionTo);
-        this.sandbox.assert.calledWith(analytics.click, 'link', 'This is a second test');
+        this.sandbox.assert.calledWith(analyticsClick, 'link', 'This is a second test');
     });
 });

--- a/tests/integration/components/osf-navbar/auth-dropdown/component-test.ts
+++ b/tests/integration/components/osf-navbar/auth-dropdown/component-test.ts
@@ -4,6 +4,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { TestContext } from 'ember-test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 const sessionStub = Service.extend({
     isAuthenticated: false,
@@ -58,17 +59,16 @@ module('Integration | Component | osf-navbar/auth-dropdown', hooks => {
 
     test('onLinkClicked called', async function(assert) {
         this.owner.lookup('service:session').set('isAuthenticated', true);
-        this.owner.register('service:analytics', Service.extend({
-            clickCalled: false,
-            click() {
-                this.set('clickCalled', true);
-            },
-        }));
+
+        let clickCalled = false;
+        sinon.stub(this.owner.lookup('service:analytics'), 'click').callsFake(() => {
+            clickCalled = true;
+        });
 
         await render(hbs`{{osf-navbar/auth-dropdown}}`);
 
-        assert.ok(!this.owner.lookup('service:analytics').clickCalled);
+        assert.ok(!clickCalled);
         await click('.fa-life-ring');
-        assert.ok(this.owner.lookup('service:analytics').clickCalled);
+        assert.ok(clickCalled);
     });
 });

--- a/tests/integration/components/osf-navbar/component-test.ts
+++ b/tests/integration/components/osf-navbar/component-test.ts
@@ -7,6 +7,12 @@ import { module, test } from 'qunit';
 
 const routerStub = Service.extend({
     currentURL: '',
+    urlFor() {
+        return 'FakeURL';
+    },
+    isActive() {
+        return false;
+    },
 });
 
 module('Integration | Component | osf-navbar', hooks => {

--- a/types/@glimmer/env.d.ts
+++ b/types/@glimmer/env.d.ts
@@ -1,0 +1,2 @@
+export const DEBUG: boolean;
+export const CI: boolean;

--- a/types/ember-toastr/index.d.ts
+++ b/types/ember-toastr/index.d.ts
@@ -1,10 +1,28 @@
 declare module 'ember-toastr/services/toast' {
     import Service from '@ember/service';
 
+    interface ToastOptions {
+        closeButton: boolean;
+        debug: boolean;
+        newestOnTop: boolean;
+        progressBar: boolean;
+        positionClass: string;
+        preventDuplicates: boolean;
+        showDuration: number;
+        hideDuration: number;
+        timeOut: number;
+        extendedTimeOut: number;
+        showEasing: string;
+        hideEasing: string;
+        showMethod: string;
+        hideMethod: string;
+        tapToDismiss: boolean;
+    }
+
     export default class Toast extends Service {
-        error(message: string, title?: string, options?: any): void;
-        info(message: string, title?: string, options?: any): void;
-        success(message: string, title?: string, options?: any): void;
-        warning(message: string, title?: string, options?: any): void;
+        error(message: string, title?: string, options?: Partial<ToastOptions>): void;
+        info(message: string, title?: string, options?: Partial<ToastOptions>): void;
+        success(message: string, title?: string, options?: Partial<ToastOptions>): void;
+        warning(message: string, title?: string, options?: Partial<ToastOptions>): void;
     }
 }


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[EMB-123] some really great stuff`
-->

## Purpose
Implement an easier way to track user actions, using `data-` attributes
<!-- Describe the purpose of your changes. -->

## Summary of Changes
- Support tracking click events by adding `data-` attrs (documented in the handbook and below)
- Add click tracking to registries pages
- Add page tracking to registries pages
- Add "dev options" menu, accessible by clicking on the red dev-mode banner in the lower left
  - "Display toast on tracked events" will display a toast on tracked events, for convenient manual testing of analytics
- Add custom `click` helper in `ember-osf-web/tests/helpers` that will error if the click target doesn't have a `data-analytics-name` attr
- Remove the `ember_registries_new_style` flag -- instead base new styles on the overview page's waffle flag. The `new_style` flag has never been used.
<!-- Briefly describe or list your changes. -->

## Side Effects
- Adding `data-analytics-name` to reusable components may result in duplicate events if they're also tracked the "old" way.
- Because the analytics service is now used in an instance initializer, the singleton is instantiated before tests begin to run. Therefore, trying to stub it with `this.owner.register('service:analytics', MyStub)` has no effect. Instead, consider using [sinon](https://sinonjs.org/releases/v7.2.2/stubs/) to stub methods in place:
  ```ts
  import sinon from 'sinon';
  // ...
  const analytics = this.owner.lookup('service:analytics');
  const clickStub = sinon.stub(analytics, 'click');
  ```
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## Feature Flags

<!--
  Please list any feature flags that need to be enabled for these changes to go into effect.
  For each flag, what is the expected behavior with the flag enabled vs disabled?
-->

## QA Notes
Should be no visible changes, except to the dev-mode banner.
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
-->

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
https://openscience.atlassian.net/browse/EMB-324

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->

-----
# Analytics docs (copied from handbook)
- Every meaningful user action should be tracked
- Adding tracking should be easy
- Forgetting to add tracking should be hard

## Tracking clicks automatically
Tracking clicks is as easy as adding a few `data-` attributes.

### `data-analytics-name`
If an element is named with a `data-analytics-name` attribute, click events on that element will be tracked:
```hbs
<button
    data-analytics-name='Create new project'
    onclick={{action ... }}
></button>
```

### `data-analytics-scope`
Use named scopes to provide more context with the event, like on which page or region of the page the event took place.
For example, a click on the button below will be tracked with the label "Dashboard - Control bar - Create new project":
```hbs
<div data-analytics-scope='Dashboard'>
    <div data-analytics-scope='Control bar'>
        <button data-analytics-name='Create new project'></button>
    </div>
</div>
```

### `data-analytics-category`
The event category generally refers to the type of thing being acted upon. For normal links (`<a>` or `role='link'`)
and buttons (`<button>` or `role='button'`) the category will be inferred as `link` and `button`, respectively.

If you want to categorize events another way (e.g. `file` for all events that act on file objects), you can add
`data-analytics-category='mycategory'` to the same element with `data-analytics-name`:
```hbs
<button
    data-analytics-name='Delete file'
    data-analytics-category='file'
    onclick={{action this.deleteFile file}}
>Delete file</button>
```

### `data-analytics-extra`
You can optionally fill in the `extra` field on the tracked event by setting `data-analytics-extra='extra data'`:
```hbs
<button
    data-analytics-name='Delete file'
    data-analytics-category='file'
    data-analytics-extra={{concat 'File name: ' file.name}}
    onclick={{action this.deleteFile file}}
>Delete file</button>
```

## Tracking events by hand
<aside>
    Note: It is currently easy to forget to track non-click events.
    Until we figure out a more automatic approach, try not to forget.
</aside>

For non-click events, or when the "automatic" approach doesn't fit, call `track()` on the `analytics` service:

```ts
@action
onKeyUp() {
    this.analytics.track('search', 'keyUp', 'Search box - Key up');
    // ...
}
```

Params for `track()`:
- `category`: string
- `actionName`: string
- `label`: string
- `extraInfo` (optional): string

## Tracking page views
<aside>
    Note: It is currently easy to forget to add page tracking.
    Until we figure out a more automatic approach, try not to forget.
</aside>

Call `trackPage()` on the `analytics` service in the `didTransition` hook for your route or a parent route:
```ts
// route.ts
@action
didTransition() {
    this.analytics.trackPage();
}
```

If the page is under a GUID route, pass the following two arguments to `trackPage`:
- `pagePublic`: boolean indicating whether the GUID referent is public or private
- `resourceType`: string for the API type of the GUID referent (e.g. `nodes`, `registrations`, etc.)

## Testing analytics
Any action worth testing is worth tracking, and vice versa.

### Custom `click` helper
The custom `click` helper will error if its target does not have a `data-analytics-name` attribute.
Use it in all your tests for pages/components that use the "automatic" analytics approach.

```ts
import { click } from 'ember-osf-web/tests/helpers';
// ...
await click('button');
```

### Manual testing
In development builds, events that would be tracked are logged to the console.

In addition, you can click on the "development mode" banner in the lower left to open dev options.
Check "Display toast for tracked events" to display a toast for tracked events.
