### PR TITLE
[EMB-435] Handle embargoed registrations

### DIFF
--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -1107,6 +1107,7 @@ export default {
             form_view: {
                 no_files: 'No files uploaded',
             },
+            embargo_banner: 'This registration is currently embargoed. It will remain private until its embargo end date, {{endDate}}.',
         },
     },
     analytics: {

--- a/app/resolve-guid/guid-route.ts
+++ b/app/resolve-guid/guid-route.ts
@@ -17,10 +17,21 @@ export default abstract class GuidRoute extends Route.extend({
     getModel: task(function *(this: GuidRoute, guid: string) {
         const blocker = this.ready.getBlocker();
 
-        const model = yield this.store.findRecord(this.modelName(), guid, {
-            include: this.include(),
-            adapterOptions: this.adapterOptions(),
-        });
+        let model;
+        try {
+            model = yield this.store.findRecord(this.modelName(), guid, {
+                include: this.include(),
+                adapterOptions: this.adapterOptions(),
+            });
+        } catch (e) {
+            // To do custom error handling, add an error() action to the route that subclasses GuidRoute.
+            if (this.error) {
+                this.send('error');
+            } else {
+                this.send('error');
+                throw e;
+            }
+        }
 
         blocker.done();
 

--- a/lib/registries/addon/overview/route.ts
+++ b/lib/registries/addon/overview/route.ts
@@ -1,5 +1,6 @@
 import { action } from '@ember-decorators/object';
 import { service } from '@ember-decorators/service';
+import RouterService from '@ember/routing/router-service';
 
 import Registration from 'ember-osf-web/models/registration';
 import GuidRoute, { GuidRouteModel } from 'ember-osf-web/resolve-guid/guid-route';
@@ -7,6 +8,7 @@ import Analytics from 'ember-osf-web/services/analytics';
 
 export default class Overview extends GuidRoute {
     @service analytics!: Analytics;
+    @service router!: RouterService;
 
     modelName(): 'registration' {
         return 'registration';
@@ -30,5 +32,10 @@ export default class Overview extends GuidRoute {
         await taskInstance;
         const registration = taskInstance.value;
         this.analytics.trackPage(registration ? registration.public : undefined, 'registrations');
+    }
+
+    @action
+    error () {
+        this.replaceWith('page-not-found', this.router.currentURL.slice(1));
     }
 }

--- a/lib/registries/addon/overview/styles.scss
+++ b/lib/registries/addon/overview/styles.scss
@@ -39,3 +39,9 @@ h1.Title { /* stylelint-disable-line selector-no-qualifying-type*/
     padding: 20px;
     width: 300px;
 }
+
+.EmbargoBanner {
+    :global(.alert) {
+        margin-bottom: 0;
+    }
+}

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -3,9 +3,20 @@
         <LoadingIndicator @dark={{true}} />
     </div>
 {{else}}
+    {{#if this.registration.embargoed}}
+        <div local-class='EmbargoBanner' data-test-embargoed-banner>
+            <BsAlert @type='info' @dismissible={{false}} @type='danger'>
+                <div class='text-center'>
+                    {{t 'registries.overview.embargo_banner'
+                        endDate=(moment-format this.registration.embargoEndDate 'MMMM D, YYYY')
+                    }}
+                </div>
+            </BsAlert>
+        </div>
+    {{/if}}
     <div local-class='TitleBackground'>
         <Container>
-            <h1 local-class='Title'>{{this.registration.title}}</h1>
+            <h1 local-class='Title' data-test-registration-title>{{this.registration.title}}</h1>
         </Container>
     </div>
 

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -6,6 +6,7 @@ import { createDeveloperApp, resetClientSecret } from './views/developer-app';
 import { guidDetail } from './views/guid';
 import { createNode } from './views/node';
 import { osfNestedResource, osfResource } from './views/osf-resource';
+import { registrationDetail } from './views/registration';
 import { rootDetail } from './views/root';
 import { createToken } from './views/token';
 import { userNodeList } from './views/user';
@@ -42,7 +43,8 @@ export default function(this: Server) {
     osfNestedResource(this, 'node', 'registrations', { only: ['index'] });
     osfNestedResource(this, 'node', 'draftRegistrations', { only: ['index'] });
 
-    osfResource(this, 'registration');
+    osfResource(this, 'registration', { except: ['show'] });
+    this.get('/registrations/:id', registrationDetail);
     osfNestedResource(this, 'registration', 'children');
     osfNestedResource(this, 'registration', 'contributors');
     osfNestedResource(this, 'registration', 'linkedNodes', { only: ['index'] });

--- a/mirage/views/registration.ts
+++ b/mirage/views/registration.ts
@@ -1,0 +1,19 @@
+import { HandlerContext, Request, Response, Schema } from 'ember-cli-mirage';
+
+import { process } from './utils';
+
+export function registrationDetail(this: HandlerContext, schema: Schema, request: Request) {
+    const { id } = request.params;
+    const registration = schema.registrations.find(id);
+
+    if (registration.embargoed && (!registration.currentUserPermissions.length)) {
+        return new Response(404, {}, {
+            meta: { version: '2.9' },
+            errors: [{ detail: 'Not found.' }],
+        });
+    }
+
+    const { data } = process(schema, request, this, [this.serialize(registration).data]);
+
+    return { data: data[0] };
+}

--- a/tests/acceptance/resolve-guid-test.ts
+++ b/tests/acceptance/resolve-guid-test.ts
@@ -108,7 +108,7 @@ module('Acceptance | resolve-guid', hooks => {
 
             test('Forks', async assert => {
                 server.create('root', 'oldRegistrationDetail');
-                const reg = server.create('registration');
+                const reg = server.create('registration', { currentUserPermissions: ['admin'] });
 
                 await visit(`/${reg.id}/forks`);
 
@@ -118,7 +118,7 @@ module('Acceptance | resolve-guid', hooks => {
 
             test('Analytics', async assert => {
                 server.create('root', 'oldRegistrationDetail');
-                const reg = server.create('registration');
+                const reg = server.create('registration', { currentUserPermissions: ['admin'] });
 
                 const url = `/${reg.id}/analytics`;
 
@@ -140,7 +140,7 @@ module('Acceptance | resolve-guid', hooks => {
             });
 
             test('Forks', async assert => {
-                const reg = server.create('registration');
+                const reg = server.create('registration', { currentUserPermissions: ['admin'] });
 
                 await visit(`/${reg.id}/forks`);
 
@@ -149,7 +149,7 @@ module('Acceptance | resolve-guid', hooks => {
             });
 
             test('Analytics', async assert => {
-                const reg = server.create('registration');
+                const reg = server.create('registration', { currentUserPermissions: ['admin'] });
 
                 const url = `/${reg.id}/analytics`;
 

--- a/tests/engines/registries/acceptance/overview/index-test.ts
+++ b/tests/engines/registries/acceptance/overview/index-test.ts
@@ -32,6 +32,7 @@ module('Registries | Acceptance | overview.index', hooks => {
         server.loadFixtures('registration-schemas');
         this.set('registration', server.create('registration', {
             registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
+            currentUserPermissions: ['admin'],
         }, 'withContributors'));
     });
 

--- a/tests/engines/registries/acceptance/overview/overview-test.ts
+++ b/tests/engines/registries/acceptance/overview/overview-test.ts
@@ -1,0 +1,76 @@
+import { ModelInstance } from 'ember-cli-mirage';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { TestContext } from 'ember-test-helpers';
+import { module, test } from 'qunit';
+
+import { Permission } from 'ember-osf-web/models/osf-model';
+import Registration from 'ember-osf-web/models/registration';
+
+import { visit } from 'ember-osf-web/tests/helpers';
+import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
+
+interface OverviewTestContext extends TestContext {
+    registration: ModelInstance<Registration>;
+}
+
+module('Registries | Acceptance | overview.overview', hooks => {
+    setupEngineApplicationTest(hooks, 'registries');
+    setupMirage(hooks);
+
+    hooks.beforeEach(function(this: OverviewTestContext) {
+        server.loadFixtures('registration-schemas');
+        const registration = server.create('registration', {
+            registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
+            embargoed: true,
+        });
+
+        this.set('registration', registration);
+    });
+
+    test('admin can view embargoed registration',
+        async function(this: OverviewTestContext, assert: Assert) {
+            this.registration.update({ currentUserPermissions: [Permission.Admin] });
+
+            await visit(`/${this.registration.id}/`);
+
+            assert.dom('[data-test-embargoed-banner]').isVisible();
+            assert.dom('[data-test-registration-title]').isVisible();
+        });
+
+    test('non-admin contrib can view embargoed registration',
+        async function(this: OverviewTestContext, assert: Assert) {
+            this.registration.update({
+                currentUserPermissions: [
+                    Permission.Read,
+                    Permission.Write,
+                ],
+            });
+
+            await visit(`/${this.registration.id}/`);
+
+            assert.dom('[data-test-embargoed-banner]').isVisible();
+            assert.dom('[data-test-registration-title]').isVisible();
+        });
+
+    test('non-contrib user cannot view embargoed registration',
+        async function(this: OverviewTestContext, assert: Assert) {
+            this.registration.update({ currentUserPermissions: [] });
+
+            try {
+                await visit(`/${this.registration.id}/`);
+            } catch (e) {
+                assert.equal(e.errors.length, 1);
+                assert.equal(e.errors[0].detail, 'Not found.');
+            }
+        });
+
+    test('logged out user cannot view embargoed registration',
+        async function(this: OverviewTestContext, assert: Assert) {
+            try {
+                await visit(`/${this.registration.id}/`);
+            } catch (e) {
+                assert.equal(e.errors.length, 1);
+                assert.equal(e.errors[0].detail, 'Not found.');
+            }
+        });
+});


### PR DESCRIPTION
## Purpose

Handle embargoed registrations

## Summary of Changes

- Update overview page to show embargo banner + embargo end date <> Handled by https://github.com/CenterForOpenScience/ember-osf-web/pull/455
- Update guid  routing to make sure only admins, contributors can view the full registration
overview + banner. And 404 for non-contributors.
- Add tests

## Side Effects

## Feature Flags

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
-->

## Ticket

[EMB-435](https://openscience.atlassian.net/browse/EMB-435)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`
