### PR TITLE
[EMB-342][EMB-552] developer app fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `settings.account`
 - Styles:
     - All styles from `osf-style`
+- Validators:
+    - `httpUrl` - validates that a string looks like an http url
 
 ### Changed
 - Addons:
@@ -28,6 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `ember-cli-sass@8.0.1`
 - Components:
     - `contributor-list` - takes an optional parameter `truncated`
+- Models:
+    - `developer-app` - use custom `httpUrl` validator for urls
 - Templates:
     - `no-implicit-this` template rule activated
 - Types:

--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -485,6 +485,7 @@ export default {
         phone: '{{description}} must be a valid phone number.',
         url: '{{description}} must be a valid url.',
         // custom
+        https_url: '{{description}} must be a valid https url.',
         email_registered: 'This email address has already been registered.',
         email_invalid: 'Invalid email address. If this should not have occurred, please report this to {{supportEmail}}',
         email_match: 'Email addresses must match.',

--- a/app/models/developer-app.ts
+++ b/app/models/developer-app.ts
@@ -12,7 +12,7 @@ const Validations = buildValidations({
     homeUrl: [
         validator('presence', true),
         validator('length', { min: 1, max: 200 }),
-        validator('format', { type: 'url' }),
+        validator('httpUrl'),
     ],
     description: [
         validator('length', { min: 0, max: 1000 }),
@@ -20,7 +20,7 @@ const Validations = buildValidations({
     callbackUrl: [
         validator('presence', true),
         validator('length', { min: 1, max: 200 }),
-        validator('format', { type: 'url' }),
+        validator('httpUrl', { requireHttps: true }),
     ],
 });
 

--- a/app/settings/developer-apps/template.hbs
+++ b/app/settings/developer-apps/template.hbs
@@ -1,9 +1,7 @@
 {{title (t 'settings.developer-apps.title')}}
-<div class='panel panel-default'>
-    <div class='panel-heading clearfix'>
-        <h3 class='panel-title'>{{t 'settings.developer-apps.title'}}</h3>
-    </div>
-    <div class='panel-body'>
+<Panel as |panel|>
+    <panel.heading @title={{t 'settings.developer-apps.title'}} />
+    <panel.body>
         {{outlet}}
-    </div>
-</div>
+    </panel.body>
+</Panel>

--- a/app/settings/tokens/template.hbs
+++ b/app/settings/tokens/template.hbs
@@ -1,9 +1,7 @@
 {{title (t 'settings.tokens.title')}}
-<div class='panel panel-default'>
-    <div class='panel-heading clearfix'>
-        <h3 class='panel-title'>{{t 'settings.tokens.title'}}</h3>
-    </div>
-    <div class='panel-body'>
+<Panel as |panel|>
+    <panel.heading @title={{t 'settings.tokens.title'}} />
+    <panel.body>
         {{outlet}}
-    </div>
-</div>
+    </panel.body>
+</Panel>

--- a/app/validators/http-url.ts
+++ b/app/validators/http-url.ts
@@ -1,0 +1,31 @@
+import BaseValidator from 'ember-cp-validations/validators/base';
+import { regularExpressions } from 'ember-validators/format';
+
+export interface HttpUrlValidatorOptions {
+    requireHttps: boolean;
+}
+
+const httpRegExes = {
+    // http OR https
+    http: /^https?:\/\/[a-zA-Z0-9]/,
+    // https only
+    https: /^https:\/\/[a-zA-Z0-9]/,
+    // accept either for localhost or 127.0.0.1
+    localhost: /^https?:\/\/(?:localhost|127\.0\.0\.1)(?:[/:?]|$)/,
+};
+
+export default class HttpUrlValidator extends BaseValidator {
+    validate(value: string, options: HttpUrlValidatorOptions = { requireHttps: false }) {
+        const httpRegEx = options.requireHttps ? httpRegExes.https : httpRegExes.http;
+        return (
+            (
+                (httpRegEx.test(value) && regularExpressions.url.test(value))
+                || httpRegExes.localhost.test(value)
+            )
+            || this.createErrorMessage(
+                options.requireHttps ? 'https_url' : 'url',
+                value,
+            )
+        );
+    }
+}

--- a/lib/osf-components/addon/components/panel/component.ts
+++ b/lib/osf-components/addon/components/panel/component.ts
@@ -1,8 +1,10 @@
-import { layout } from '@ember-decorators/component';
 import Component from '@ember/component';
 
+import { layout } from 'ember-osf-web/decorators/component';
+
+import styles from './styles';
 import template from './template';
 
-@layout(template)
+@layout(template, styles)
 export default class Panel extends Component {
 }

--- a/lib/osf-components/addon/components/panel/styles.scss
+++ b/lib/osf-components/addon/components/panel/styles.scss
@@ -1,0 +1,3 @@
+.Panel {
+    overflow-wrap: break-word;
+}

--- a/lib/osf-components/addon/components/panel/template.hbs
+++ b/lib/osf-components/addon/components/panel/template.hbs
@@ -1,4 +1,4 @@
-<div data-test-panel class='panel panel-default'>
+<div data-test-panel class='panel panel-default' local-class='Panel'>
     {{yield (hash heading=(component 'panel/x-heading'))}}
     {{yield (hash body=(component 'panel/x-body'))}}
     {{yield (hash footer=(component 'panel/x-footer'))}}

--- a/mirage/factories/developer-app.ts
+++ b/mirage/factories/developer-app.ts
@@ -12,8 +12,12 @@ export default Factory.extend<DeveloperApp>({
     },
 
     description: faker.lorem.sentence,
+
     homeUrl: faker.internet.url,
-    callbackUrl: faker.internet.url,
+
+    callbackUrl() {
+        return `https://${faker.internet.domainName()}`;
+    },
 
     clientId() {
         return faker.internet.ip();

--- a/tests/acceptance/settings/developer-apps-page-test.ts
+++ b/tests/acceptance/settings/developer-apps-page-test.ts
@@ -53,7 +53,7 @@ module('Acceptance | settings | developer apps', hooks => {
 
         await fillIn('[data-test-developer-app-name] input', appName);
         await fillIn('[data-test-developer-app-homepage] input', 'http://osf.io/');
-        await fillIn('[data-test-developer-app-callback-url] input', 'http://osf.io/');
+        await fillIn('[data-test-developer-app-callback-url] input', 'https://osf.io/');
         await percySnapshot(assert);
         await click('[data-test-create-developer-app-button]');
         await percySnapshot('Acceptance | settings | developer apps | create app | create');

--- a/types/ember-cp-validations/index.d.ts
+++ b/types/ember-cp-validations/index.d.ts
@@ -48,4 +48,4 @@ interface Validations {
 }
 
 export function buildValidations(validations: any, globalOptions?: any): Validations;
-export function validator(attrName: string, message: any): any;
+export function validator(attrName: string, options?: any): any;

--- a/types/ember-validators/format.d.ts
+++ b/types/ember-validators/format.d.ts
@@ -1,0 +1,5 @@
+export const regularExpressions = {
+    email: RegExp(),
+    phone: RegExp(),
+    url: RegExp(),
+};


### PR DESCRIPTION
## Purpose

Fixes for issues identified by QA:
* long developer app names overflow the panel (especially on small screens)
* incorrect validation for urls

This also fixes [EMB-552 - Long token names do not wrap on laptops or smaller screens](https://openscience.atlassian.net/browse/EMB-552).

## Summary of Changes

* prevent text overflow outside panel component
* use panel component for developer apps
* use panel component for personal access tokens
* add custom httpUrl validator
* use httpUrl validator for developer apps
* adjust developer apps test and mirage factory to always use https for callback urls

## Side Effects

Should be none.

## Feature Flags

`ember_user_settings_apps_page`

## QA Notes

This fixes the issues identified in QA testing of [EMB-342](https://openscience.atlassian.net/browse/EMB-342), and also fixes [EMB-552](https://openscience.atlassian.net/browse/EMB-552) at the same time since it uses the same panel component.

The url validation issue actually turned out to be incomplete validation on *both* create and edit. It was not requiring the scheme (`http://` or `https://`). I have fixed this and also restricted the callback URL to `https`, since it should be for security reasons. I *have* included an exception (allow http) for `localhost` and `127.0.0.1` for app development.

## Ticket

https://openscience.atlassian.net/browse/EMB-342
https://openscience.atlassian.net/browse/EMB-552

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
