### PR TITLE
[EMB-533] Bubble events from bootstrap buttons

### DIFF
--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -7,6 +7,7 @@
                 {{this.model.file.name}}
                 <OsfButton
                     local-class='TitleBar__version-link'
+                    @bubble={{true}}
                     @type='link'
                     @onClick={{action 'changeView' 'revision'}}
                 >
@@ -15,12 +16,13 @@
             </h2>
         </div>
         <div local-class='TitleBar__buttons'>
-            <div id='toggleBar' class='pull-right'>
+            <div class='pull-right'>
                 <div class='btn-toolbar m-t-md'>
                     {{#if this.canDelete}}
                         <div class='btn-group m-l-xs m-t-xs'>
                             <OsfButton 
                                 data-test-delete-button
+                                @bubble={{true}}
                                 @type='default'
                                 @size='sm'
                                 @onClick={{action this.openDeleteModal}}
@@ -32,6 +34,7 @@
                     <div class='btn-group m-l-xs m-t-xs'>
                         <OsfButton 
                             data-test-download-button
+                            @bubble={{true}}
                             @type='primary'
                             @size='sm'
                             @onClick={{action this.download this.model.file.currentVersion}}
@@ -47,17 +50,20 @@
                             {{#if this.canEdit}}
                                 <OsfButton
                                     local-class='TitleBar__button-label'
+                                    @bubble={{true}}
                                     @disabled={{true}}
                                 >
                                     {{t 'file_detail.toggle'}}
                                 </OsfButton>
                                 <OsfButton
+                                    @bubble={{true}}
                                     @type='{{if (or (eq this.show 'view') (eq this.show 'view_edit')) 'primary' 'default'}}'
                                     @onClick={{action this.changeView 'view'}}
                                 >
                                     {{t 'general.view'}}
                                 </OsfButton>
                                 <OsfButton
+                                    @bubble={{true}}
                                     @type='{{if (or (eq this.show 'edit') (eq this.show 'view_edit')) 'primary' 'default'}}'
                                     @onClick={{action this.changeView 'edit'}}
                                 >
@@ -65,6 +71,7 @@
                                 </OsfButton>
                             {{else}}
                                 <OsfButton
+                                    @bubble={{true}}
                                     @type='{{if (or (eq this.show 'view') (eq this.show 'view_edit')) 'primary' 'default'}}'
                                     @onClick={{action this.changeView 'view'}}
                                 >
@@ -75,6 +82,7 @@
                     {{else}}
                         <div class='btn-group m-l-xs m-t-xs'>
                             <OsfButton
+                                @bubble={{true}}
                                 @type='{{if (or (eq this.show 'view') (eq this.show 'view_edit')) 'primary' 'default'}}'
                                 @size='sm'
                                 @onClick={{action this.changeView 'view'}}
@@ -86,6 +94,7 @@
                     <div class='btn-group m-l-xs m-t-xs'>
                         <OsfButton
                             data-test-revisions-tab
+                            @bubble={{true}}
                             @type='{{if (eq this.show 'revision') 'primary' 'default'}}'
                             @size='sm'
                             @onClick={{action this.changeView 'revision'}}
@@ -191,7 +200,7 @@
                 </div>
             {{/if}}
             {{#if (eq this.show 'revision')}}
-                <div id='revisionsPanel' class='panel panel-default' local-class='RevisionsPanel'>
+                <div class='panel panel-default' local-class='RevisionsPanel'>
                     <div class='clearfix' local-class='TagsPanel__heading'>
                         <h3 class='panel-title'>
                             {{t 'general.revisions'}}

--- a/lib/osf-components/addon/components/file-browser/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/template.hbs
@@ -53,6 +53,7 @@
             {{#if this.canEdit}}
                 <OsfButton
                     local-class='action-button'
+                    @bubble={{true}}
                     @class='dz-upload-button'
                     @disabled={{this.isUploading}}
                 >
@@ -90,6 +91,7 @@
                     <OsfButton 
                         data-test-download-button
                         local-class='action-button'
+                        @bubble={{true}}
                         @onClick={{action this.downloadItem}}
                     >
                         {{fa-icon 'download'}}
@@ -98,6 +100,7 @@
                     <OsfButton
                         data-test-view-button
                         local-class='action-button'
+                        @bubble={{true}}
                         @onClick={{action this.viewItem}}
                     >
                         {{fa-icon 'file-o'}}
@@ -107,6 +110,7 @@
                         <OsfButton
                             data-test-move-button
                             local-class='action-button'
+                            @bubble={{true}}
                             @onClick={{action (mut this.currentModal) 'move'}}
                         >
                             {{fa-icon 'level-up'}}
@@ -115,6 +119,7 @@
                         <OsfButton
                             data-test-delete-button 
                             local-class='action-button'
+                            @bubble={{true}}
                             @onClick={{action (mut this.currentModal) 'delete'}}
                         >
                             {{fa-icon 'trash'}}
@@ -123,6 +128,7 @@
                         <OsfButton
                             data-test-rename-button
                             local-class='action-button'
+                            @bubble={{true}}
                             @onClick={{action (mut this.showRename) true}}
                         >
                             {{fa-icon 'pencil'}}
@@ -134,6 +140,7 @@
                         <OsfButton
                             data-test-delete-multiple-button
                             local-class='action-button'
+                            @bubble={{true}}
                             @onClick={{action (mut this.currentModal) 'deleteMultiple'}}
                         >
                             {{fa-icon 'trash'}}
@@ -144,7 +151,8 @@
             {{else if this.hasItems}}
                 <OsfButton 
                     data-test-download-zip-button
-                    local-class='action-button' 
+                    local-class='action-button'
+                    @bubble={{true}}
                     @onClick={{action this.downloadZip}}
                 >
                     {{fa-icon 'download'}} {{t 'file_browser.download_zip'}}
@@ -154,6 +162,7 @@
                 <OsfButton
                     data-test-filter-button
                     local-class='action-button'
+                    @bubble={{true}}
                     @onClick={{action (mut this.showFilterClicked) true}}
                 >
                     {{fa-icon 'search'}}
@@ -163,6 +172,7 @@
             <OsfButton
                 data-test-info-button
                 local-class='action-button'
+                @bubble={{true}}
                 @onClick={{action (mut this.currentModal) 'info'}}
             >
                 {{fa-icon 'info'}}


### PR DESCRIPTION
## Purpose

Clicking anywhere except on a bootstrap button caused the share panel to go away. Clicking on a bootstrap button (and thus, and OsfButton) did not. This ensures that the share popover goes away.

## Summary of Changes

1. Add `@bubble=true` to relevant `OsfButton`s
2. Remove unused `id`s from html elements.

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
https://openscience.atlassian.net/browse/EMB-533

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable ~~and includes test(s)~~ Too much to put tests in quickfiles, but soooon.
- [ ] ~~changes described in `CHANGELOG.md`~~

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
