### PR TITLE
Replace guid-based `link-to`s with `Link`s

### DIFF
--- a/app/guid-node/registrations/template.hbs
+++ b/app/guid-node/registrations/template.hbs
@@ -203,9 +203,12 @@
     {{#if this.isComponentRootAdmin}}
         <div class='row'>
             {{t 'node.registrations.register_entire_project' rootNodeTitle=this.node.root.title}}
-            {{#global-link-to 'guid-node.registrations' this.node.root.id}}
+            <Link
+                @route='guid-node.registrations'
+                @models={{array this.node.root.id}}
+            >
                 {{t 'node.registrations.here'~}}
-            {{/global-link-to}}
+            </Link>
             {{~t 'general.period'}}
         </div>
     {{/if}}

--- a/app/guid-node/registrations/template.hbs
+++ b/app/guid-node/registrations/template.hbs
@@ -203,9 +203,9 @@
     {{#if this.isComponentRootAdmin}}
         <div class='row'>
             {{t 'node.registrations.register_entire_project' rootNodeTitle=this.node.root.title}}
-            {{#link-to 'guid-node.registrations' this.node.root.id}}
+            {{#global-link-to 'guid-node.registrations' this.node.root.id}}
                 {{t 'node.registrations.here'~}}
-            {{/link-to}}
+            {{/global-link-to}}
             {{~t 'general.period'}}
         </div>
     {{/if}}

--- a/lib/osf-components/addon/components/node-navbar/link/template.hbs
+++ b/lib/osf-components/addon/components/node-navbar/link/template.hbs
@@ -1,26 +1,26 @@
 {{#if this.useLinkTo}}
-    {{#global-link-to
-        this.routeName
-        @node.id
-        data-test-node-navbar-link=(or @destination @node.id)
-        class=this.extraClasses
-    }}
-        {{#if (has-block)}}
-            {{yield}}
-        {{else}}
-            {{t this.translatingKey}}
-        {{/if}}
-    {{/global-link-to}}
-{{else}}
-    <a
+    <Link
         data-test-node-navbar-link={{or @destination @node.id}}
-        href='/{{@node.id}}/{{@destination}}'
         class={{this.extraClasses}}
+        @route={{this.routeName}}
+        @models={{array @node.id}}
     >
         {{#if (has-block)}}
             {{yield}}
         {{else}}
             {{t this.translatingKey}}
         {{/if}}
-    </a>
+    </Link>
+{{else}}
+    <Link
+        data-test-node-navbar-link={{or @destination @node.id}}
+        class={{this.extraClasses}}
+        @href='/{{@node.id}}/{{@destination}}'
+    >
+        {{#if (has-block)}}
+            {{yield}}
+        {{else}}
+            {{t this.translatingKey}}
+        {{/if}}
+    </Link>
 {{/if}}

--- a/lib/osf-components/addon/components/node-navbar/link/template.hbs
+++ b/lib/osf-components/addon/components/node-navbar/link/template.hbs
@@ -1,5 +1,5 @@
 {{#if this.useLinkTo}}
-    {{#link-to
+    {{#global-link-to
         this.routeName
         @node.id
         data-test-node-navbar-link=(or @destination @node.id)
@@ -10,7 +10,7 @@
         {{else}}
             {{t this.translatingKey}}
         {{/if}}
-    {{/link-to}}
+    {{/global-link-to}}
 {{else}}
     <a
         data-test-node-navbar-link={{or @destination @node.id}}

--- a/lib/osf-components/addon/components/quickfile-nav/template.hbs
+++ b/lib/osf-components/addon/components/quickfile-nav/template.hbs
@@ -1,9 +1,9 @@
 <div class='container'>
     {{#if @user}}
         <h3>
-            {{#link-to 'guid-user.quickfiles' @user.id}}
+            {{#global-link-to 'guid-user.quickfiles' @user.id}}
                 {{t 'quickfiles.title' user-name=@user.fullName}}
-            {{/link-to}}
+            {{/global-link-to}}
         </h3>
     {{/if}}
 </div>

--- a/lib/osf-components/addon/components/quickfile-nav/template.hbs
+++ b/lib/osf-components/addon/components/quickfile-nav/template.hbs
@@ -1,9 +1,12 @@
 <div class='container'>
     {{#if @user}}
         <h3>
-            {{#global-link-to 'guid-user.quickfiles' @user.id}}
+            <Link
+                @route='guid-user.quickfiles'
+                @models={{array @user.id}}
+            >
                 {{t 'quickfiles.title' user-name=@user.fullName}}
-            {{/global-link-to}}
+            </Link>
         </h3>
     {{/if}}
 </div>

--- a/tests/integration/components/node-navbar/component-test.ts
+++ b/tests/integration/components/node-navbar/component-test.ts
@@ -1,9 +1,10 @@
-import Service from '@ember/service';
 import { render } from '@ember/test-helpers';
 import { setupRenderingTest } from 'ember-qunit';
 import faker from 'faker';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
+
+import { OsfLinkRouterStub } from '../../helpers/osf-link-router-stub';
 
 enum NavCondition {
     HasParent,
@@ -42,6 +43,9 @@ export class FakeNode {
     userHasWritePermission: boolean = false;
     userHasReadPermission: boolean = false;
     parentId: string | null = null;
+    links = {
+        html: 'http://localhost:4200/fak3d',
+    };
 
     constructor(conditions: NavCondition[] = []) {
         for (const condition of conditions) {
@@ -63,10 +67,7 @@ module('Integration | Component | node-navbar', () => {
         setupRenderingTest(hooks);
 
         test('it renders', async function(assert) {
-            const routerStub = Service.extend({
-                isActive: () => false,
-            });
-            this.owner.register('service:router', routerStub);
+            this.owner.register('service:router', OsfLinkRouterStub);
 
             this.set('node', new FakeNode());
             await render(hbs`{{node-navbar node=this.node renderInPlace=true}}`);
@@ -75,7 +76,7 @@ module('Integration | Component | node-navbar', () => {
         });
 
         test('it renders active tab when in proper route', async function(assert) {
-            const routerStub = Service.extend({
+            const routerStub = OsfLinkRouterStub.extend({
                 isActive(routeName: string) {
                     return routeName.includes('guid-node.wiki');
                 },
@@ -92,7 +93,7 @@ module('Integration | Component | node-navbar', () => {
         });
 
         test('it renders no active tabs', async function(assert) {
-            const routerStub = Service.extend({
+            const routerStub = OsfLinkRouterStub.extend({
                 isActive(routeName: string) {
                     return routeName.includes('guid-node.forks');
                 },
@@ -272,11 +273,7 @@ module('Integration | Component | node-navbar', () => {
 
         testCases.forEach((testCase, i) => {
             test(`it renders the correct links (${i})`, async function(assert) {
-                const routerStub = Service.extend({
-                    isActive: () => false,
-                });
-
-                this.owner.register('service:router', routerStub);
+                this.owner.register('service:router', OsfLinkRouterStub);
 
                 const node = new FakeNode(testCase.conditions);
                 this.set('node', node);

--- a/tests/integration/components/node-navbar/link/component-test.ts
+++ b/tests/integration/components/node-navbar/link/component-test.ts
@@ -1,32 +1,27 @@
-import Service from '@ember/service';
 import { render } from '@ember/test-helpers';
 import { setupRenderingTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 import { module, test } from 'qunit';
 
 import hbs from 'htmlbars-inline-precompile';
 
+import { OsfLinkRouterStub } from '../../../helpers/osf-link-router-stub';
 import { FakeNode } from '../component-test';
 
 module('Integration | Component | node-navbar/link', hooks => {
     setupRenderingTest(hooks);
 
-    test('destination', async function(assert) {
-        const routerStub = Service.extend({
-            isActive: () => false,
-        });
-        this.owner.register('service:router', routerStub);
+    hooks.beforeEach(function(this: TestContext) {
+        this.owner.register('service:router', OsfLinkRouterStub);
+    });
 
+    test('destination', async function(assert) {
         this.set('node', new FakeNode());
         await render(hbs`{{node-navbar/link node=this.node destination='registrations'}}`);
         assert.dom(this.element).hasText('Registrations');
     });
 
     test('block', async function(assert) {
-        const routerStub = Service.extend({
-            isActive: () => false,
-        });
-        this.owner.register('service:router', routerStub);
-
         this.set('node', new FakeNode());
         await render(hbs`
             {{#node-navbar/link node=this.node}}

--- a/tests/integration/components/quickfile-nav/component-test.ts
+++ b/tests/integration/components/quickfile-nav/component-test.ts
@@ -1,15 +1,22 @@
 import { render } from '@ember/test-helpers';
-import { make, setupFactoryGuy } from 'ember-data-factory-guy';
 import { setupRenderingTest } from 'ember-qunit';
+import faker from 'faker';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
 
+import { OsfLinkRouterStub } from '../../helpers/osf-link-router-stub';
+
+class FakeUser {
+    id: string = faker.random.uuid();
+    fullName: string = `${faker.name.firstName()} ${faker.name.lastName()}`;
+}
+
 module('Integration | Component | quickfile-nav', hooks => {
     setupRenderingTest(hooks);
-    setupFactoryGuy(hooks);
 
     test('it renders', async function(assert) {
-        this.set('user', make('user'));
+        this.set('user', new FakeUser());
+        this.owner.register('service:router', OsfLinkRouterStub);
 
         await render(hbs`{{quickfile-nav user=user}}`);
 

--- a/tests/integration/helpers/osf-link-router-stub.ts
+++ b/tests/integration/helpers/osf-link-router-stub.ts
@@ -1,0 +1,21 @@
+import Service from '@ember/service';
+import defaultTo from 'ember-osf-web/utils/default-to';
+
+export class OsfLinkRouterStub extends Service {
+    urlForResponse: string = defaultTo(this.urlForResponse, 'https://localhost:4200/route');
+    transitionToResponse: string = defaultTo(this.transitionToResponse, '');
+    isActiveResponse: boolean = defaultTo(this.isActiveResponse, false);
+    currentURL: string = defaultTo(this.currentURL, 'https://localhost:4200/current');
+
+    urlFor() {
+        return this.urlForResponse;
+    }
+
+    transitionTo() {
+        return this.transitionToResponse;
+    }
+
+    isActive() {
+        return this.isActiveResponse;
+    }
+}


### PR DESCRIPTION
## Purpose

Try to make node-navbar links to registrations tab work. Should totally work.

## Summary of Changes

Replaced some `#link-to`s with `Link`s.

## Ticket

N/A

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~
- [ ] ~~changes described in `CHANGELOG.md`~~

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
