### PR TITLE
Remove unnecessary and irksome flag

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -215,7 +215,6 @@ module.exports = function(environment) {
         },
         featureFlagNames: {
             routes: {
-                'guid-node.registrations': 'ember_project_registrations_page',
                 settings: 'ember_user_settings_profile_page',
                 'settings.profile': 'ember_user_settings_profile_page',
                 'settings.profile.education': 'ember_user_settings_profile_page',


### PR DESCRIPTION
## Purpose

Make node-registration pages accessible from within the ember app on environments without the waffle flag set.

## Summary of Changes

Remove the feature flag.

## Feature Flags

`ember-project-registrations-page` will no longer be necessary.

## QA Notes

On staging, go to a node's analytics page, then click on the registrations tab. If it works, this worked.

## Ticket

N/A

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~
- [ ] ~~changes described in `CHANGELOG.md`~~

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
