### PR TITLE
Enable registries by default

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -20,7 +20,7 @@ const {
     CLIENT_ID: clientId,
     ENABLED_LOCALES = 'en, en-US',
     COLLECTIONS_ENABLED = false,
-    REGISTRIES_ENABLED = false,
+    REGISTRIES_ENABLED = true,
     HANDBOOK_ENABLED = false,
     HANDBOOK_DOC_GENERATION_ENABLED = false,
     TESTS_ENABLED = false,


### PR DESCRIPTION
## Purpose

Enable registries by default in dev environment since mirage turns on the waffle flag and we link to it in the nav bar (it errors if disabled).

## Summary of Changes

set `REGISTRIES_ENABLED = true,` in `config/environment.js`

## Side Effects

The registries engine will always be enabled.

## Feature Flags

n/a

## QA Notes

n/a

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(small dev change)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
