### PR TITLE
Improve links types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Utils:
+    - `getHref` - get an href from a `Link`
+    - `getRelatedHref` - get an href from a `Relationship`
+### Changed
+- Models:
+    - `osf-model` - use proper types for `links` and `relationshipLinks` attributes
+    - `file` - extend `links` types to include links specific to files
+    - `user` - extend `links` types to include links specific to users
+    - `developer-app` - extend `links` types to include links specific to developer apps
+    - `collection` - improve types for choices fields
+    - `collected-metadatum` - improve types for choice fields
 
 ## [19.1.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Utils:
     - `getHref` - get an href from a `Link`
     - `getRelatedHref` - get an href from a `Relationship`
+    - `tuple` - create a strictly-typed [tuple](https://www.typescriptlang.org/docs/handbook/basic-types.html#tuple)
 ### Changed
 - Models:
     - `osf-model` - use proper types for `links` and `relationshipLinks` attributes

--- a/app/models/collected-metadatum.ts
+++ b/app/models/collected-metadatum.ts
@@ -4,7 +4,7 @@ import { computed as iComputed } from '@ember/object';
 import { alias as iAlias } from '@ember/object/computed';
 import { buildValidations, validator } from 'ember-cp-validations';
 
-import Collection from './collection';
+import Collection, { ChoicesFields } from './collection';
 import Guid from './guid';
 import OsfModel from './osf-model';
 import { SubjectRef } from './taxonomy';
@@ -15,7 +15,14 @@ export interface DisplaySubject {
     path: string;
 }
 
-export const choiceFields: Array<keyof CollectedMetadatumModel> = [
+export type ChoiceFields =
+    'collectedType' |
+    'issue' |
+    'programArea' |
+    'status' |
+    'volume';
+
+export const choiceFields: ChoiceFields[] = [
     'collectedType',
     'issue',
     'programArea',
@@ -88,11 +95,11 @@ export default class CollectedMetadatumModel extends OsfModel.extend(Validations
     }
 
     @computed('collection.displayChoicesFields.[]')
-    get displayChoiceFields(): Array<keyof CollectedMetadatumModel> {
+    get displayChoiceFields() {
         return choiceFields
             .filter(field => this.collection
                 .get('displayChoicesFields')
-                .includes(`${field}Choices` as keyof Collection));
+                .includes(`${field}Choices` as ChoicesFields));
     }
 }
 

--- a/app/models/collected-metadatum.ts
+++ b/app/models/collected-metadatum.ts
@@ -4,6 +4,8 @@ import { computed as iComputed } from '@ember/object';
 import { alias as iAlias } from '@ember/object/computed';
 import { buildValidations, validator } from 'ember-cp-validations';
 
+import tuple from 'ember-osf-web/utils/tuple';
+
 import Collection, { ChoicesFields } from './collection';
 import Guid from './guid';
 import OsfModel from './osf-model';
@@ -15,20 +17,13 @@ export interface DisplaySubject {
     path: string;
 }
 
-export type ChoiceFields =
-    'collectedType' |
-    'issue' |
-    'programArea' |
-    'status' |
-    'volume';
-
-export const choiceFields: ChoiceFields[] = [
+export const choiceFields = tuple(
     'collectedType',
     'issue',
     'programArea',
     'status',
     'volume',
-];
+);
 
 const Validations = buildValidations({
     ...choiceFields.reduce((acc, val) => {

--- a/app/models/collection.ts
+++ b/app/models/collection.ts
@@ -8,7 +8,14 @@ import NodeModel from './node';
 import OsfModel from './osf-model';
 import RegistrationModel from './registration';
 
-export const choicesFields = choiceFields.map(field => `${field}Choices`);
+export type ChoicesFields =
+    'collectedTypeChoices' |
+    'issueChoices' |
+    'programAreaChoices' |
+    'statusChoices' |
+    'volumeChoices';
+
+export const choicesFields = choiceFields.map(field => `${field}Choices`) as ChoicesFields[];
 
 export default class CollectionModel extends OsfModel {
     @attr('fixstring') title!: string;
@@ -33,8 +40,8 @@ export default class CollectionModel extends OsfModel {
     linkedRegistrations!: DS.PromiseManyArray<RegistrationModel>;
 
     @computed(`{${choicesFields.join()}}.length`)
-    get displayChoicesFields(): Array<keyof CollectionModel> {
-        return (choicesFields as Array<keyof CollectionModel>).filter(field => !!this[field].length);
+    get displayChoicesFields() {
+        return choicesFields.filter(field => !!this[field].length);
     }
 }
 

--- a/app/models/developer-app.ts
+++ b/app/models/developer-app.ts
@@ -1,8 +1,12 @@
 import { attr } from '@ember-decorators/data';
 import { buildValidations, validator } from 'ember-cp-validations';
+import { Link } from 'jsonapi-typescript';
 
 import { Document as ApiResponseDocument } from 'osf-api';
-import OsfModel from './osf-model';
+
+import getHref from 'ember-osf-web/utils/get-href';
+
+import OsfModel, { OsfLinks } from './osf-model';
 
 const Validations = buildValidations({
     name: [
@@ -24,7 +28,12 @@ const Validations = buildValidations({
     ],
 });
 
+export interface DeveloperAppLinks extends OsfLinks {
+    reset: Link;
+}
+
 export default class DeveloperAppModel extends OsfModel.extend(Validations) {
+    @attr() links!: DeveloperAppLinks;
     @attr() callbackUrl!: string;
     @attr() clientId!: string;
     @attr() clientSecret!: string;
@@ -37,7 +46,7 @@ export default class DeveloperAppModel extends OsfModel.extend(Validations) {
     // TODO (EMB-407) When the API is updated, remove this method and reset the secret
     // by PATCHing `clientSecret` to `null`
     async resetSecret(): Promise<void> {
-        const resetUrl = this.links.reset;
+        const resetUrl = getHref(this.links.reset);
         const adapter = this.store.adapterFor('developer-app');
         const serializer = this.store.serializerFor('developer-app');
 

--- a/app/models/file.ts
+++ b/app/models/file.ts
@@ -1,13 +1,28 @@
 import { attr, belongsTo, hasMany } from '@ember-decorators/data';
 import DS from 'ember-data';
+import { Link } from 'jsonapi-typescript';
+
+import getHref from 'ember-osf-web/utils/get-href';
 
 import BaseFileItem from './base-file-item';
 import CommentModel from './comment';
 import FileVersionModel from './file-version';
 import NodeModel from './node';
+import { OsfLinks } from './osf-model';
 import UserModel from './user';
 
+export interface FileLinks extends OsfLinks {
+    html: never;
+    info: Link;
+    move: Link;
+    upload: Link;
+    download: Link;
+    delete: Link;
+    new_folder?: Link; // eslint-disable-line camelcase
+}
+
 export default class FileModel extends BaseFileItem {
+    @attr() links!: FileLinks;
     @attr('fixstring') name!: string;
     @attr('fixstring') guid!: string;
     @attr('string') path!: string;
@@ -52,7 +67,7 @@ export default class FileModel extends BaseFileItem {
 
     getContents(): Promise<object> {
         return this.currentUser.authenticatedAJAX({
-            url: this.links.download,
+            url: getHref(this.links.download),
             type: 'GET',
             data: {
                 direct: true,
@@ -63,7 +78,7 @@ export default class FileModel extends BaseFileItem {
 
     async rename(newName: string, conflict = 'replace'): Promise<void> {
         const { data } = await this.currentUser.authenticatedAJAX({
-            url: this.links.upload,
+            url: getHref(this.links.upload),
             type: 'POST',
             xhrFields: {
                 withCredentials: true,
@@ -98,7 +113,7 @@ export default class FileModel extends BaseFileItem {
 
     updateContents(data: string): Promise<null> {
         return this.currentUser.authenticatedAJAX({
-            url: this.links.upload,
+            url: getHref(this.links.upload),
             type: 'PUT',
             xhrFields: { withCredentials: true },
             data,
@@ -107,7 +122,7 @@ export default class FileModel extends BaseFileItem {
 
     move(node: NodeModel): Promise<null> {
         return this.currentUser.authenticatedAJAX({
-            url: this.links.move,
+            url: getHref(this.links.move),
             type: 'POST',
             xhrFields: { withCredentials: true },
             headers: {

--- a/app/models/file.ts
+++ b/app/models/file.ts
@@ -12,12 +12,15 @@ import { OsfLinks } from './osf-model';
 import UserModel from './user';
 
 export interface FileLinks extends OsfLinks {
-    html: never;
     info: Link;
     move: Link;
     upload: Link;
-    download: Link;
     delete: Link;
+
+    // only for files
+    download?: Link;
+
+    // only for folders
     new_folder?: Link; // eslint-disable-line camelcase
 }
 
@@ -66,14 +69,17 @@ export default class FileModel extends BaseFileItem {
     flash: object | null = null;
 
     getContents(): Promise<object> {
-        return this.currentUser.authenticatedAJAX({
-            url: getHref(this.links.download),
-            type: 'GET',
-            data: {
-                direct: true,
-                mode: 'render',
-            },
-        });
+        if (this.isFile) {
+            return this.currentUser.authenticatedAJAX({
+                url: getHref(this.links.download!),
+                type: 'GET',
+                data: {
+                    direct: true,
+                    mode: 'render',
+                },
+            });
+        }
+        return Promise.reject(Error('Can only get the contents of files.'));
     }
 
     async rename(newName: string, conflict = 'replace'): Promise<void> {

--- a/app/models/guid.ts
+++ b/app/models/guid.ts
@@ -10,11 +10,18 @@ export type ReferentModel = ModelRegistry[ReferentModelName];
 export default class GuidModel extends OsfModel {
     @computed('id')
     get referentType() {
-        return singularize(this.links.relationships.referent.data.type) as ReferentModelName;
+        const { relationships } = this.links;
+        if (relationships &&
+            'data' in relationships.referent &&
+            relationships.referent.data &&
+            'type' in relationships.referent.data) {
+            return singularize(relationships.referent.data.type) as ReferentModelName;
+        }
+        return undefined;
     }
 
     resolve() {
-        return this.store.findRecord(this.referentType, this.id);
+        return this.referentType ? this.store.findRecord(this.referentType, this.id) : undefined;
     }
 }
 

--- a/app/models/node.ts
+++ b/app/models/node.ts
@@ -9,6 +9,7 @@ import DS from 'ember-data';
 
 import { Deserialized as NodeLicense } from 'ember-osf-web/transforms/node-license';
 import defaultTo from 'ember-osf-web/utils/default-to';
+import getRelatedHref from 'ember-osf-web/utils/get-related-href';
 
 import BaseFileItem from './base-file-item';
 import CitationModel from './citation';
@@ -221,7 +222,7 @@ export default class NodeModel extends BaseFileItem.extend(Validations, Collecta
     collectable: boolean = defaultTo(this.collectable, false);
 
     makeFork(): Promise<object> {
-        const url = this.links.relationships.forks.links.related.href;
+        const url = getRelatedHref(this.links.relationships!.forks);
         return this.currentUser.authenticatedAJAX({
             url,
             type: 'POST',

--- a/app/models/user.ts
+++ b/app/models/user.ts
@@ -2,12 +2,13 @@ import { attr, belongsTo, hasMany } from '@ember-decorators/data';
 import { alias } from '@ember-decorators/object/computed';
 import { buildValidations, validator } from 'ember-cp-validations';
 import DS from 'ember-data';
+import { Link } from 'jsonapi-typescript';
 
 import ContributorModel from './contributor';
 import FileModel from './file';
 import InstitutionModel from './institution';
 import NodeModel from './node';
-import OsfModel from './osf-model';
+import OsfModel, { OsfLinks } from './osf-model';
 import RegionModel from './region';
 import RegistrationModel from './registration';
 import UserEmailModel from './user-email';
@@ -48,7 +49,12 @@ const Validations = buildValidations({
     ],
 });
 
+export interface UserLinks extends OsfLinks {
+    profile_image: Link; // eslint-disable-line camelcase
+}
+
 export default class UserModel extends OsfModel.extend(Validations) {
+    @attr() links!: UserLinks;
     @attr('fixstring') fullName!: string;
     @attr('fixstring') givenName!: string;
     @attr('fixstring') middleNames!: string;

--- a/app/resolve-guid/route.ts
+++ b/app/resolve-guid/route.ts
@@ -65,7 +65,7 @@ export default class ResolveGuid extends Route {
         } else {
             const guid = await this.store.findRecord('guid', params.guid);
 
-            if (!(guid.referentType in this.routeMap)) {
+            if (!guid.referentType || !(guid.referentType in this.routeMap)) {
                 throw new Error(`Unknown GUID referentType: ${guid.referentType}`);
             }
 

--- a/app/serializers/osf-serializer.ts
+++ b/app/serializers/osf-serializer.ts
@@ -4,15 +4,13 @@ import ModelRegistry from 'ember-data/types/registries/model';
 import { AttributesObject } from 'jsonapi-typescript';
 
 import {
-    NormalLinks,
     PaginatedMeta,
-    Relationships,
     Resource,
     ResourceCollectionDocument,
     SingleResourceDocument,
 } from 'osf-api';
 
-import OsfModel from 'ember-osf-web/models/osf-model';
+import OsfModel, { OsfLinks } from 'ember-osf-web/models/osf-model';
 
 const { JSONAPISerializer } = DS;
 
@@ -106,7 +104,7 @@ export default class OsfSerializer extends JSONAPISerializer {
      * the combination of `resourceHash.links` and `resourceHash.relationships`
      */
     _mergeLinks(resourceHash: Resource): Partial<Resource> {
-        const links: NormalLinks & { relationships?: Relationships } = { ...(resourceHash.links || {}) };
+        const links: OsfLinks = { ...(resourceHash.links || {}) };
         if (resourceHash.relationships) {
             links.relationships = resourceHash.relationships;
         }

--- a/app/utils/get-href.ts
+++ b/app/utils/get-href.ts
@@ -1,0 +1,7 @@
+import { Link } from 'jsonapi-typescript';
+
+import { RelatedLink } from 'osf-api';
+
+export default function getHref(link: Link | RelatedLink) {
+    return typeof link === 'string' ? link : link.href;
+}

--- a/app/utils/get-related-href.ts
+++ b/app/utils/get-related-href.ts
@@ -1,0 +1,10 @@
+import { Relationship } from 'osf-api';
+
+import getHref from './get-href';
+
+export default function getRelatedHref(relationship: Relationship) {
+    if ('links' in relationship) {
+        return getHref(relationship.links.related);
+    }
+    return undefined;
+}

--- a/app/utils/tuple.ts
+++ b/app/utils/tuple.ts
@@ -1,0 +1,2 @@
+type Lit = string | number | boolean | undefined | null | void | {};
+export default <T extends Lit[]>(...args: T) => args;

--- a/app/validators/node-license.ts
+++ b/app/validators/node-license.ts
@@ -9,7 +9,7 @@ import Node from 'ember-osf-web/models/node';
 import { Deserialized } from 'ember-osf-web/transforms/node-license';
 
 interface Options extends EmberObject {
-    on: keyof Node;
+    on: 'license';
 }
 
 export default class NodeLicense extends BaseValidator {

--- a/lib/collections/addon/components/collection-metadata/component.ts
+++ b/lib/collections/addon/components/collection-metadata/component.ts
@@ -3,14 +3,15 @@ import { action, computed } from '@ember-decorators/object';
 import { mapBy } from '@ember-decorators/object/computed';
 import Component from '@ember/component';
 import { underscore } from '@ember/string';
+
 import CollectedMetadatum, { choiceFields } from 'ember-osf-web/models/collected-metadatum';
-import Collection from 'ember-osf-web/models/collection';
+import Collection, { ChoicesFields } from 'ember-osf-web/models/collection';
 import chunkArray from 'ember-osf-web/utils/chunk-array';
 
 interface CollectionMetadataField {
     labelKey: string;
     valuePath: keyof CollectedMetadatum;
-    optionsKey: keyof Collection;
+    optionsKey: ChoicesFields;
 }
 
 @tagName('')

--- a/lib/collections/addon/components/collections-submission/component.ts
+++ b/lib/collections/addon/components/collections-submission/component.ts
@@ -103,7 +103,7 @@ export default class Submit extends Component {
     }).drop();
 
     @computed('collectedMetadatum.displayChoiceFields')
-    get choiceFields(): Array<{ label: string; value: string; }> {
+    get choiceFields(): Array<{ label: string; value?: string; }> {
         return this.collectedMetadatum.displayChoiceFields
             .map(field => ({
                 label: `collections.collection_metadata.${underscore(field)}_label`,

--- a/lib/osf-components/addon/components/file-browser/component.ts
+++ b/lib/osf-components/addon/components/file-browser/component.ts
@@ -19,6 +19,7 @@ import Analytics from 'ember-osf-web/services/analytics';
 import CurrentUser from 'ember-osf-web/services/current-user';
 import Ready from 'ember-osf-web/services/ready';
 import defaultTo from 'ember-osf-web/utils/default-to';
+import getHref from 'ember-osf-web/utils/get-href';
 import pathJoin from 'ember-osf-web/utils/path-join';
 import { ProjectSelectState } from 'osf-components/components/project-selector/component';
 import styles from './styles';
@@ -113,7 +114,7 @@ export default class FileBrowser extends Component {
 
         const selectedItem = this.selectedItems.firstObject;
         const isNewProject = !!this.node && !!this.node.isNew;
-        const isChildNode = !!this.node && !!this.node.links && !!this.node.links.relationships.parent;
+        const isChildNode = !!this.node && !!this.node.links && !!this.node.links.relationships!.parent;
 
         const moveSuccess: boolean = yield this.moveFile(selectedItem as unknown as File, this.node);
 
@@ -345,7 +346,8 @@ export default class FileBrowser extends Component {
 
     @action
     downloadItem() {
-        window.location.href = (this.selectedItems.firstObject as unknown as File).links.download;
+        const file = this.selectedItems.firstObject as unknown as File;
+        window.location.href = getHref(file.links.download);
         if (!this.canEdit) {
             this.analytics.click('button', 'Quick Files - Download');
         }

--- a/lib/osf-components/addon/components/file-browser/component.ts
+++ b/lib/osf-components/addon/components/file-browser/component.ts
@@ -347,7 +347,7 @@ export default class FileBrowser extends Component {
     @action
     downloadItem() {
         const file = this.selectedItems.firstObject as unknown as File;
-        window.location.href = getHref(file.links.download);
+        window.location.href = getHref(file.links.download!);
         if (!this.canEdit) {
             this.analytics.click('button', 'Quick Files - Download');
         }

--- a/lib/osf-components/addon/helpers/get-ancestor-descriptor.ts
+++ b/lib/osf-components/addon/helpers/get-ancestor-descriptor.ts
@@ -24,7 +24,7 @@ function fetchIdFromRelationshipLink(node: Node, relationship: keyof Node) {
     return undefined;
 }
 
-function fetchTitle(node: Node, relationship: keyof Node) {
+function fetchTitle(node: Node, relationship: 'parent' | 'root') {
     // Fetches parent or root title.  If null, marks 'Private'.
     const title = node.get(relationship).get('title');
 

--- a/types/osf-api.d.ts
+++ b/types/osf-api.d.ts
@@ -86,14 +86,7 @@ export interface RelatedLinkMeta {
 }
 
 export interface NormalLinks extends JSONAPI.Links {
-    info?: Link | null;
-    self?: Link | null;
-    move?: Link | null;
-    upload?: Link | null;
-    download?: Link | null;
-    delete?: Link | null;
     self?: Link | null;
     html?: Link | null;
-    profile_image?: Link | null;
 }
 /* eslint-enable no-use-before-define,camelcase */


### PR DESCRIPTION
## Purpose

The `links` attribute and `relationshipLinks` alias on `osf-model` were both typed `any`, which is less than ideal. This PR gives these proper types and deals with the consequences of that. It extends the links types for models (`file`, `user`, `developer-app`) that have extra resource-type-specific links. It also types `apiMeta` while we're there.

## Summary of Changes

### Added
- Utils:
    - `getHref` - get an href from a `Link`
    - `getRelatedHref` - get an href from a `Relationship`
### Changed
- Models:
    - `osf-model` - use proper types for `links` and `relationshipLinks` attributes
    - `file` - extend `links` types to include links specific to files
    - `user` - extend `links` types to include links specific to users
    - `developer-app` - extend `links` types to include links specific to developer apps
    - `collection` - improve types for choices fields
    - `collected-metadatum` - improve types for choice fields

## Side Effects

Should only be type-related (now have to do proper checking for links). Can't just `keyof Model` (but shouldn't be anyways).

## Feature Flags

n/a

## QA Notes

This is mostly be types changes that won't affect running code, but did require some minor code changes. Some light testing of quick files, node registrations tab, and forks (including making a fork) should be sufficient.

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
