### PR TITLE
[EMB-512][Collections] Allow users to start from wherever they want on edit page

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -26,6 +26,7 @@ const App = Application.extend({
                     'theme',
                     'toast',
                     'router',
+                    'ready',
                 ],
             },
         },

--- a/lib/collections/addon/components/collection-metadata/component.ts
+++ b/lib/collections/addon/components/collection-metadata/component.ts
@@ -19,6 +19,9 @@ export default class CollectionMetadata extends Component {
     collection: Collection = this.collection;
     collectedMetadatum: CollectedMetadatum = this.collectedMetadatum;
     didValidate: boolean = this.didValidate;
+    initialCollectedMetadatumProperties = this.collectedMetadatum.getProperties(
+        'programArea', 'issue', 'status', 'volume', 'collectedType',
+    );
 
     @computed('collection')
     get displayFields(): CollectionMetadataField[] {
@@ -52,8 +55,6 @@ export default class CollectionMetadata extends Component {
 
     @action
     discard() {
-        this.collectedMetadatum.setProperties({
-            ...this.filteredFields.reduce((acc, val) => ({ ...acc, [val]: '' }), {}),
-        });
+        this.collectedMetadatum.setProperties(this.initialCollectedMetadatumProperties);
     }
 }

--- a/lib/collections/addon/components/collections-submission/component.ts
+++ b/lib/collections/addon/components/collections-submission/component.ts
@@ -48,7 +48,14 @@ export default class Submit extends Component {
     isProjectSelectorValid: boolean = false;
     sections = Section;
     activeSection: Section = this.edit ? Section.projectMetadata : Section.project;
-    savedSections: Section[] = this.edit ? [Section.project] : [];
+    savedSections: Section[] = this.edit ? [
+        Section.project,
+        Section.projectMetadata,
+        Section.projectContributors,
+        Section.collectionSubjects,
+        Section.collectionMetadata,
+    ] : [];
+    showCancelDialog: boolean = false;
     i18nKeyPrefix = 'collections.collections_submission.';
     showSubmitModal: boolean = false;
 
@@ -104,8 +111,8 @@ export default class Submit extends Component {
         }
     }).drop();
 
-    @computed('collectedMetadatum.displayChoiceFields')
-    get choiceFields(): Array<{ label: string; value?: string; }> {
+    @computed('collectedMetadatum.{displayChoiceFields,collectedType,issue,volume,programArea,status}')
+    get choiceFields(): Array<{ label: string; value: string | undefined; }> {
         return this.collectedMetadatum.displayChoiceFields
             .map(field => ({
                 label: `collections.collection_metadata.${underscore(field)}_label`,

--- a/lib/collections/addon/components/collections-submission/template.hbs
+++ b/lib/collections/addon/components/collections-submission/template.hbs
@@ -145,9 +145,8 @@
                 <button class='btn btn-default' {{action 'cancel'}}>
                     {{t (concat this.i18nKeyPrefix 'cancel')}}
                 </button>
-
                 {{#if this.edit}}
-                    <button class='btn btn-success' {{action (perform this.save)}} disabled={{not (eq this.activeSection this.sections.submit)}}>
+                    <button class='btn btn-success' {{action (perform this.save)}}>
                         {{t (concat this.i18nKeyPrefix 'update' '_button')}}
                     </button>
                 {{else}}

--- a/lib/collections/addon/engine.js
+++ b/lib/collections/addon/engine.js
@@ -24,6 +24,7 @@ const engine = Engine.extend({
             'theme',
             'toast',
             'router',
+            'ready',
         ],
     },
 });

--- a/lib/collections/addon/guid/edit/controller.ts
+++ b/lib/collections/addon/guid/edit/controller.ts
@@ -1,4 +1,4 @@
-import { action } from '@ember-decorators/object';
+import { action, computed } from '@ember-decorators/object';
 import { alias } from '@ember-decorators/object/computed';
 import Controller from '@ember/controller';
 import config from 'ember-get-config';
@@ -14,6 +14,11 @@ export default class GuidEdit extends Controller {
     @alias('model.taskInstance.value.collectionItem') collectionItem!: Node;
 
     isPageDirty: boolean = false;
+
+    @computed('this.collectedMetadatum.hasDirtyAttributes')
+    get isCollectedMetadatumDirty() {
+        return this.collectedMetadatum.hasDirtyAttributes;
+    }
 
     @action
     returnToProjectOverviewPage() {

--- a/lib/collections/addon/guid/edit/route.ts
+++ b/lib/collections/addon/guid/edit/route.ts
@@ -18,9 +18,9 @@ export default class GuidEdit extends Route.extend(ConfirmationMixin, {}) {
     }
 
     // This tells ember-onbeforeunload's ConfirmationMixin whether or not to stop transitions
-    @computed('controller.isPageDirty')
+    @computed('controller.isPageDirty', 'controller.isCollectedMetadatumDirty')
     get isPageDirty() {
         const controller = this.controller as EditController;
-        return () => controller.isPageDirty;
+        return () => controller.isPageDirty || controller.isCollectedMetadatumDirty;
     }
 }

--- a/lib/collections/addon/guid/edit/template.hbs
+++ b/lib/collections/addon/guid/edit/template.hbs
@@ -1,10 +1,12 @@
-<CollectionsSubmission
-    @edit=true
-    @provider={{this.provider}}
-    @collection={{this.collection}}
-    @collectedMetadatum={{this.collectedMetadatum}}
-    @collectionItem={{this.collectionItem}}
-    @transition={{action this.returnToProjectOverviewPage}}
-    @onNextSection={{action this.setPageDirty}}
-    @resetPageDirty={{action this.resetPageDirty}}
-/>
+{{#if (not this.model.taskInstance.isRunning)}}
+    <CollectionsSubmission
+        @edit=true
+        @provider={{this.provider}}
+        @collection={{this.collection}}
+        @collectedMetadatum={{this.collectedMetadatum}}
+        @collectionItem={{this.collectionItem}}
+        @transition={{action this.returnToProjectOverviewPage}}
+        @onNextSection={{action this.setPageDirty}}
+        @resetPageDirty={{action this.resetPageDirty}}
+    />
+{{/if}}

--- a/lib/collections/addon/submit/template.hbs
+++ b/lib/collections/addon/submit/template.hbs
@@ -1,8 +1,10 @@
-<CollectionsSubmission
-    @provider={{this.provider}}
-    @collection={{this.collection}}
-    @collectedMetadatum={{this.collectedMetadatum}}
-    @transition={{action this.returnToDiscoverPage}}
-    @onNextSection={{action this.setPageDirty}}
-    @resetPageDirty={{action this.resetPageDirty}}
-/>
+{{#if (not this.model.taskInstance.isRunning)}}
+    <CollectionsSubmission
+        @provider={{this.provider}}
+        @collection={{this.collection}}
+        @collectedMetadatum={{this.collectedMetadatum}}
+        @transition={{action this.returnToDiscoverPage}}
+        @onNextSection={{action this.setPageDirty}}
+        @resetPageDirty={{action this.resetPageDirty}}
+    />
+{{/if}}


### PR DESCRIPTION
## Purpose
The main purpose of this PR is to allow users to start from any point on the edit page.
This PR also fixes the problem where `Discard Changes` for `Collection Metadata` section clears all metadata instead of reverting to the saved state.

## Summary of Changes

Respectively,
- `savedSections` in the `collections-submission` component denotes which section of the edit form has been "saved" (meaning the `Continue` or `Save and Continue` button for that section has been clicked). Therefore, for the edit view, we set it all sections, enabling users to be able to click any section to edit.
  - Also change the `isPageDirty` logic to look at `hasDirtyAttributes` of the `collected-metadatum` model.
- Add `initialCollectedMetadatumProperties` to `collection-metadata` component to save initial properties so that we can revert back to the last saved state when clicking "Discard Changes".

## QA Notes

This fixes the problem in [EMB-499](https://openscience.atlassian.net/browse/EMB-499).

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
https://openscience.atlassian.net/browse/EMB-512

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
