### PR TITLE
[NoTicket] app breaks when styles not specified in collections

### DIFF
--- a/app/models/provider.ts
+++ b/app/models/provider.ts
@@ -33,7 +33,7 @@ export default abstract class ProviderModel extends OsfModel {
     @attr('string') facebookAppId!: string;
     @attr('boolean') allowSubmissions!: boolean;
     @attr('boolean') allowCommenting!: boolean;
-    @attr() assets!: Partial<Assets>; // TODO: camelize in transform
+    @attr() assets?: Partial<Assets>; // TODO: camelize in transform
 
     @hasMany('taxonomy')
     taxonomies!: DS.PromiseManyArray<TaxonomyModel>;

--- a/app/services/theme.ts
+++ b/app/services/theme.ts
@@ -109,8 +109,9 @@ export default class Theme extends Service {
 
     @computed('provider.assets.style', 'assetsDir')
     get stylesheet(): string {
-        return this.provider!.assets.style
-            || `${this.assetsDir}/style.css`;
+        const { assets } = this.provider!;
+
+        return assets && assets.style ? assets.style : `${this.assetsDir}/style.css`;
     }
 
     reset(this: Theme) {


### PR DESCRIPTION
## Purpose

Small bug where missing styles in collections cause the app to fail to render.

## Summary of Changes

Check to see if assets exist, if not return default styles.

## Side Effects

Not that I know of.

## QA Notes

The localhost:5000/collections pages need to be tested (with created collections).

- Need to test if, no styles are provided on new collection, does the page crash.
- If styles are provided, do they render correctly?
- Small risk, worst case is default styles always load (but I doubt this will happen).

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`