### PR TITLE
Reduce load time in local/handbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         - added helper methods for creating and deleting M2M relationships:
             - `createM2MRelationship`
             - `deleteM2MRelationship`
+- Mirage:
+    - Slim down default scenario
+    - Allow different set of scenarios to run based on local settings with `MIRAGE_SCENARIOS`
 - Components
     - `osf-link` - used to be `link`
         - `@onClick` parameter used to be `@onclick`
@@ -37,6 +40,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         - `node` (required)
         - `shouldTruncate` (default true)
         - `shouldLinkUsers` (default false)
+- Mirage:
+    - `DEFAULT_LOGGED_OUT` setting is now redundant
 
 ## [19.1.0] - 2019-01-23
 ### Added

--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -170,8 +170,10 @@ declare const config: {
     };
     'ember-cli-mirage': {
         enabled: boolean;
-        defaultLoggedOut: boolean;
     };
+
+    mirageScenarios: string[];
+
     engines: {
         collections: {
             enabled: boolean;

--- a/config/environment.js
+++ b/config/environment.js
@@ -30,7 +30,12 @@ const {
     KEEN_CONFIG: keenConfig,
     LINT_ON_BUILD: lintOnBuild = false,
     MIRAGE_ENABLED = false,
-    MIRAGE_DEFAULT_LOGGED_OUT = false,
+    MIRAGE_SCENARIOS = [
+        'loggedIn',
+        'dashboard',
+        'settings',
+        'handbook',
+    ],
     OAUTH_SCOPES: scope,
     OSF_STATUS_COOKIE: statusCookie = 'osf_status',
     OSF_COOKIE_DOMAIN: cookieDomain = 'localhost',
@@ -278,8 +283,8 @@ module.exports = function(environment) {
         },
         'ember-cli-mirage': {
             enabled: Boolean(MIRAGE_ENABLED),
-            defaultLoggedOut: Boolean(MIRAGE_DEFAULT_LOGGED_OUT),
         },
+        mirageScenarios: MIRAGE_SCENARIOS,
 
         defaultProvider: 'osf',
     };
@@ -315,7 +320,6 @@ module.exports = function(environment) {
             // Always enable mirage for tests.
             'ember-cli-mirage': {
                 enabled: true,
-                defaultLoggedOut: false,
             },
             APP: {
                 ...ENV.APP,

--- a/config/environment.js
+++ b/config/environment.js
@@ -34,7 +34,6 @@ const {
         'loggedIn',
         'dashboard',
         'settings',
-        'handbook',
     ],
     OAUTH_SCOPES: scope,
     OSF_STATUS_COOKIE: statusCookie = 'osf_status',

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -12,9 +12,12 @@ const {
         popularNode,
     },
     mirageScenarios,
+    engines: {
+        handbook: {
+            enabled: handbookEnabled,
+        },
+    },
 } = config;
-
-const handbookEnabled = config.engines.handbook.enabled;
 
 function registrationScenario(server: Server, currentUser: ModelInstance) {
     const registrationNode = server.create(

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -14,6 +14,8 @@ const {
     mirageScenarios,
 } = config;
 
+const handbookEnabled = config.engines.handbook.enabled;
+
 function registrationScenario(server: Server, currentUser: ModelInstance) {
     const registrationNode = server.create(
         'node',
@@ -142,7 +144,7 @@ export default function(server: Server) {
     if (mirageScenarios.includes('settings')) {
         settingsScenario(server, currentUser);
     }
-    if (mirageScenarios.includes('handbook')) {
+    if (handbookEnabled) {
         handbookScenario(server);
     }
 }

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -11,23 +11,10 @@ const {
         noteworthyNode,
         popularNode,
     },
-    'ember-cli-mirage': {
-        defaultLoggedOut,
-    },
+    mirageScenarios,
 } = config;
 
-export default function(server: Server) {
-    const userTraits = defaultLoggedOut ? [] :
-        [
-            'loggedIn',
-            'withInstitutions',
-            'withSettings',
-            'withAlternateEmail',
-            'withUnconfirmedEmail',
-        ];
-    const currentUser = server.create('user', ...userTraits);
-
-    server.create('user-setting', { user: currentUser });
+function registrationScenario(server: Server, currentUser: ModelInstance) {
     const registrationNode = server.create(
         'node',
         {
@@ -41,14 +28,28 @@ export default function(server: Server) {
         permission: 'admin',
         index: 0,
     });
-    const forksNode = server.create('node', { id: 'fork5', currentUserPermissions: Object.values(Permission) });
-    server.create('contributor', {
-        node: forksNode,
-        users: currentUser,
-        permission: 'admin',
-        index: 0,
-    });
 
+    registerNodeMultiple(
+        server,
+        registrationNode as ModelInstance<Node>,
+        12,
+        { currentUserPermissions: Object.values(Permission) },
+        'withArbitraryState',
+    );
+    draftRegisterNodeMultiple(server, registrationNode as ModelInstance<Node>, 12, {}, 'withRegistrationMetadata');
+
+    server.create('registration', { id: 'beefs' });
+
+    const reg = server.create('registration', {
+        id: 'decaf',
+        registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
+        linkedNodes: server.createList('node', 21),
+        linkedRegistrations: server.createList('registration', 19),
+    }, 'withContributors', 'withComments');
+    server.createList('registration', 15, { parent: reg });
+}
+
+function dashboardScenario(server: Server, currentUser: ModelInstance) {
     const firstNode = server.create('node', {});
     server.create('contributor', { node: firstNode, users: currentUser, index: 0 });
     const nodes = server.createList<Node>('node', 10, {
@@ -79,36 +80,20 @@ export default function(server: Server) {
         server.create('contributor', { node, users: currentUser, index: 11 });
     }
     server.createList('institution', 20);
-    server.createList('token', 23);
-    server.createList('scope', 5);
-    server.createList('developer-app', 12);
-    server.loadFixtures('registration-schemas');
-    server.loadFixtures('regions');
+}
 
+function forksScenario(server: Server, currentUser: ModelInstance) {
+    const forksNode = server.create('node', { id: 'fork5', currentUserPermissions: Object.values(Permission) });
+    server.create('contributor', {
+        node: forksNode,
+        users: currentUser,
+        permission: 'admin',
+        index: 0,
+    });
     forkNode(server, forksNode as ModelInstance<Node>, { currentUserPermissions: Object.values(Permission) });
-    registerNodeMultiple(
-        server,
-        registrationNode as ModelInstance<Node>,
-        12,
-        { currentUserPermissions: Object.values(Permission) },
-        'withArbitraryState',
-    );
-    draftRegisterNodeMultiple(server, registrationNode as ModelInstance<Node>, 12, {}, 'withRegistrationMetadata');
+}
 
-    server.create('registration', { id: 'beefs' });
-
-    const reg = server.create('registration', {
-        id: 'decaf',
-        registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
-        linkedNodes: server.createList('node', 21),
-        linkedRegistrations: server.createList('registration', 19),
-    }, 'withContributors', 'withComments');
-    server.createList('registration', 15, { parent: reg });
-
-    server.loadFixtures('preprint-providers');
-
-    // For the handbook
-
+function handbookScenario(server: Server) {
     // ValidatedModelForm
     server.create('node', {
         id: 'extng',
@@ -120,5 +105,44 @@ export default function(server: Server) {
     for (const contributorCount of [1, 2, 3, 23]) {
         const node = server.create('node', { id: `clst${contributorCount}` });
         server.createList('contributor', contributorCount, { node });
+    }
+}
+
+function settingsScenario(server: Server, currentUser: ModelInstance) {
+    server.create('user-setting', { user: currentUser });
+    server.createList('token', 23);
+    server.createList('scope', 5);
+    server.createList('developer-app', 12);
+}
+
+export default function(server: Server) {
+    server.loadFixtures('registration-schemas');
+    server.loadFixtures('regions');
+    server.loadFixtures('preprint-providers');
+    const userTraits = !mirageScenarios.includes('loggedIn') ? [] :
+        [
+            'loggedIn',
+            'withInstitutions',
+            'withSettings',
+            'withAlternateEmail',
+            'withUnconfirmedEmail',
+        ];
+    const currentUser = server.create('user', ...userTraits);
+
+    // Optional Scenarios
+    if (mirageScenarios.includes('dashboard')) {
+        dashboardScenario(server, currentUser);
+    }
+    if (mirageScenarios.includes('registration')) {
+        registrationScenario(server, currentUser);
+    }
+    if (mirageScenarios.includes('forks')) {
+        forksScenario(server, currentUser);
+    }
+    if (mirageScenarios.includes('settings')) {
+        settingsScenario(server, currentUser);
+    }
+    if (mirageScenarios.includes('handbook')) {
+        handbookScenario(server);
     }
 }


### PR DESCRIPTION
## Purpose

Make local development faster for most cases (and no slower for the rest) by allowing the mirage default scenario to be more easily configurable. Cuts the load time in half using default settings.

## Summary of Changes

1. Split up mirage scenarios into functions
2. Add an environment variable to define which scenarios to load (with a good default)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
