### PR TITLE
Prod build for handbook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,13 +49,12 @@ jobs:
       env:
         - HANDBOOK_ENABLED=1
         - MIRAGE_ENABLED=1
+        - SHOW_DEV_BANNER=1
         - ROOT_URL=/ember-osf-web/
         - ASSETS_PREFIX=/ember-osf-web/
         - A11Y_AUDIT=0
       script:
-        # TODO: switch back to prod build when ember-cli-mirage is fixed: https://github.com/samselikoff/ember-cli-mirage/pull/1376
-        #- ember build --environment=production && cp dist/index.html dist/404.html
-        - ember build && cp dist/index.html dist/404.html
+        - ember build --environment=production && cp dist/index.html dist/404.html
       deploy:
         provider: pages
         skip-cleanup: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Mirage:
     - Slim down default scenario
     - Allow different set of scenarios to run based on local settings with `MIRAGE_SCENARIOS`
+- Services
+    - `analytics` - allow toast-on-click to be used in production builds (when enabled in dev banner)
 - Components
     - `osf-link` - used to be `link`
         - `@onClick` parameter used to be `@onclick`
+    - `osf-mode-footer` - show dev banner based on `config.showDevBanner`
 - Tests
     - Using new `click` handler everywhere in main app to verify `data-analytics-name` usage
+- Travis
+    - Use a production build for handbook
 
 ### Removed
 - Components:

--- a/app/services/analytics.ts
+++ b/app/services/analytics.ts
@@ -26,10 +26,12 @@ export interface TrackedData {
 }
 
 function logEvent(analytics: Analytics, title: string, data: object) {
-    const logMessage = Object.entries(data)
-        .map(([k, v]) => `${k}: ${v}`)
-        .join(', ');
-    debug(`${title}: ${logMessage}`);
+    runInDebug(() => {
+        const logMessage = Object.entries(data)
+            .map(([k, v]) => `${k}: ${v}`)
+            .join(', ');
+        debug(`${title}: ${logMessage}`);
+    });
 
     if (analytics.shouldToastOnEvent) {
         analytics.toast.info(
@@ -157,11 +159,11 @@ export default class Analytics extends Service {
             title: this.router.currentRouteName,
         };
 
-        runInDebug(() => logEvent(this, 'Tracked page', {
+        logEvent(this, 'Tracked page', {
             pagePublic,
             resourceType,
             ...eventParams,
-        }));
+        });
 
         const gaConfig = metricsAdapters.findBy('name', 'GoogleAnalytics');
         if (gaConfig) {
@@ -250,7 +252,7 @@ export default class Analytics extends Service {
     _trackEvent(trackedData: TrackedData) {
         this.metrics.trackEvent(trackedData);
 
-        runInDebug(() => logEvent(this, 'Tracked event', trackedData));
+        logEvent(this, 'Tracked event', trackedData);
     }
 }
 

--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -22,6 +22,7 @@ declare const config: {
     lintOnBuild: boolean;
     testsEnabled: boolean;
     sourcemapsEnabled: boolean;
+    showDevBanner: boolean;
     modulePrefix: string;
     locationType: string;
     rootURL: string;

--- a/config/environment.js
+++ b/config/environment.js
@@ -58,6 +58,7 @@ const {
     SHARE_API_URL: shareApiUrl = 'https://staging-share.osf.io/api/v2',
     SHARE_SEARCH_URL: shareSearchUrl = 'https://staging-share.osf.io/api/v2/search/creativeworks/_search',
     SOURCEMAPS_ENABLED: sourcemapsEnabled = true,
+    SHOW_DEV_BANNER = false,
 } = { ...process.env, ...localConfig };
 
 module.exports = function(environment) {
@@ -69,6 +70,7 @@ module.exports = function(environment) {
         lintOnBuild,
         testsEnabled: false, // Disable tests by default.
         sourcemapsEnabled,
+        showDevBanner: isTruthy(SHOW_DEV_BANNER),
         rootURL,
         assetsPrefix,
         locationType: 'auto',
@@ -305,6 +307,7 @@ module.exports = function(environment) {
             },
             // Conditionally enable tests in development environment.
             testsEnabled: isTruthy(TESTS_ENABLED),
+            showDevBanner: true,
         });
     }
 

--- a/lib/osf-components/addon/components/osf-mode-footer/component.ts
+++ b/lib/osf-components/addon/components/osf-mode-footer/component.ts
@@ -23,6 +23,6 @@ import template from './template';
 export default class OsfModeFooter extends Component {
     @service analytics!: Analytics;
 
-    isDevMode: boolean = config.OSF.devMode;
-    showModal: boolean = false;
+    showDevBanner = config.showDevBanner;
+    showModal = false;
 }

--- a/lib/osf-components/addon/components/osf-mode-footer/template.hbs
+++ b/lib/osf-components/addon/components/osf-mode-footer/template.hbs
@@ -1,4 +1,4 @@
-{{#if this.isDevMode}}
+{{#if this.showDevBanner}}
     <div local-class='DevBanner'>
         <OsfButton
             title={{t 'dev_tools.title'}}

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "ember-cli-inject-live-reload": "^1.8.2",
     "ember-cli-inline-content": "0.4.1",
     "ember-cli-meta-tags": "^5.0.0",
-    "ember-cli-mirage": "^0.4.10",
+    "ember-cli-mirage": "^0.4.14",
     "ember-cli-moment-shim": "^3.5.0",
     "ember-cli-password-strength": "^2.0.0",
     "ember-cli-qunit": "^4.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -608,6 +608,16 @@
   dependencies:
     regenerator-transform "^0.13.3"
 
+"@babel/plugin-transform-runtime@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.2.0.tgz#566bc43f7d0aedc880eaddbd29168d0f248966ea"
+  integrity sha512-jIgkljDdq4RYDnJyQsiWbdvGeei/0MOTtSHKO/rfbd/mXBxNpdlulMx49L0HQ4pug1fXannxoqCI+fYSle9eSw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
 "@babel/plugin-transform-shorthand-properties@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz#6333aee2f8d6ee7e28615457298934a3b46198f0"
@@ -708,6 +718,13 @@
     invariant "^2.2.2"
     js-levenshtein "^1.1.3"
     semver "^5.3.0"
+
+"@babel/runtime@^7.2.0":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.1.tgz#574b03e8e8a9898eaf4a872a92ea20b7846f6f2a"
+  integrity sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==
+  dependencies:
+    regenerator-runtime "^0.12.0"
 
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
@@ -3030,7 +3047,7 @@ broccoli-debug@^0.6.1, broccoli-debug@^0.6.3, broccoli-debug@^0.6.4:
     symlink-or-copy "^1.1.8"
     tree-sync "^1.2.2"
 
-broccoli-debug@^0.6.2:
+broccoli-debug@^0.6.2, broccoli-debug@^0.6.5:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/broccoli-debug/-/broccoli-debug-0.6.5.tgz#164a5cdafd8936e525e702bf8f91f39d758e2e78"
   integrity sha512-RIVjHvNar9EMCLDW/FggxFRXqpjhncM/3qq87bn/y+/zR9tqEkHvTqbyOc4QnB97NO2m6342w4wGkemkaeOuWg==
@@ -3153,7 +3170,7 @@ broccoli-funnel-reducer@^1.0.0:
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
   integrity sha1-ETZbKnha7JsXlyo234fu8kxcwOo=
 
-broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.2, broccoli-funnel@^1.0.8, broccoli-funnel@^1.1.0, broccoli-funnel@^1.2.0:
+broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.8, broccoli-funnel@^1.1.0, broccoli-funnel@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"
   integrity sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=
@@ -3259,6 +3276,14 @@ broccoli-merge-trees@^3.0.0:
     broccoli-plugin "^1.3.0"
     merge-trees "^2.0.0"
 
+broccoli-merge-trees@^3.0.1, broccoli-merge-trees@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz#f33b451994225522b5c9bcf27d59decfd8ba537d"
+  integrity sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==
+  dependencies:
+    broccoli-plugin "^1.3.0"
+    merge-trees "^2.0.0"
+
 broccoli-middleware@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/broccoli-middleware/-/broccoli-middleware-2.0.1.tgz#093314f13e52fad7fa8c4254a4e4a4560c857a65"
@@ -3329,7 +3354,7 @@ broccoli-persistent-filter@^1.4.0:
     symlink-or-copy "^1.0.1"
     walk-sync "^0.3.1"
 
-broccoli-persistent-filter@^2.1.0:
+broccoli-persistent-filter@^2.1.0, broccoli-persistent-filter@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/broccoli-persistent-filter/-/broccoli-persistent-filter-2.1.1.tgz#7bb2b1015baedf5cf58b5b2608495f3d78f81b12"
   integrity sha512-2VCbLJqMg/AWJ6WTmv83X13a6DD3BS7Gngc932jrg1snVqsB8LJDyJh+Hd9v1tQ/vMA+4vbWgwk4tDmI/tAZWg==
@@ -3358,7 +3383,7 @@ broccoli-plugin@1.1.0:
     rimraf "^2.3.4"
     symlink-or-copy "^1.0.1"
 
-broccoli-plugin@^1.0.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0:
+broccoli-plugin@^1.0.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0, broccoli-plugin@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz#a26315732fb99ed2d9fb58f12a1e14e986b4fabd"
   integrity sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==
@@ -3538,6 +3563,26 @@ broccoli-stew@^2.0.0:
     rsvp "^4.8.3"
     symlink-or-copy "^1.2.0"
     walk-sync "^0.3.0"
+
+broccoli-stew@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-2.0.1.tgz#d0a507b79bf5fea9ff84032ae837dc48670ab1dc"
+  integrity sha512-EUzgkbYF4m8YVD2bkEa7OfYJ11V3dQ+yPuxdz/nFh8eMEn6dhOujtuSBnOWsvGDgsS9oqNZgx/MHJxI6Rr3AqQ==
+  dependencies:
+    broccoli-debug "^0.6.5"
+    broccoli-funnel "^2.0.0"
+    broccoli-merge-trees "^3.0.1"
+    broccoli-persistent-filter "^2.1.1"
+    broccoli-plugin "^1.3.1"
+    chalk "^2.4.1"
+    debug "^3.1.0"
+    ensure-posix-path "^1.0.1"
+    fs-extra "^6.0.1"
+    minimatch "^3.0.4"
+    resolve "^1.8.1"
+    rsvp "^4.8.4"
+    symlink-or-copy "^1.2.0"
+    walk-sync "^0.3.3"
 
 broccoli-string-replace@^0.1.1, broccoli-string-replace@^0.1.2:
   version "0.1.2"
@@ -6027,6 +6072,30 @@ ember-cli-babel@^6.6.0, ember-cli-babel@^6.9.2:
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
+ember-cli-babel@^7.0.0:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.4.1.tgz#9892f5883f5a6b1f0f86fb1331fc491338f372ad"
+  integrity sha512-h6qZKHyULm5SYhvjNOeXvLl3kHaBdh37g5QqTTiC/vMiWP/xnyNp2bMoq52qq+SLm/bE8+5UcVTKjrNl0+IqXA==
+  dependencies:
+    "@babel/core" "^7.0.0"
+    "@babel/plugin-transform-modules-amd" "^7.0.0"
+    "@babel/plugin-transform-runtime" "^7.2.0"
+    "@babel/polyfill" "^7.0.0"
+    "@babel/preset-env" "^7.0.0"
+    "@babel/runtime" "^7.2.0"
+    amd-name-resolver "^1.2.1"
+    babel-plugin-debug-macros "^0.2.0-beta.6"
+    babel-plugin-ember-modules-api-polyfill "^2.6.0"
+    babel-plugin-module-resolver "^3.1.1"
+    broccoli-babel-transpiler "^7.1.0"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.1"
+    broccoli-source "^1.1.0"
+    clone "^2.1.2"
+    ember-cli-version-checker "^2.1.2"
+    ensure-posix-path "^1.0.2"
+    semver "^5.5.0"
+
 ember-cli-babel@^7.1.2:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.2.0.tgz#5c5bd877fb73f6fb198c878d3127ba9e18e9b8a0"
@@ -6258,26 +6327,26 @@ ember-cli-meta-tags@^5.0.0:
     ember-cli-head "^0.4.1"
     ember-cli-htmlbars "^2.0.1"
 
-ember-cli-mirage@^0.4.10:
-  version "0.4.10"
-  resolved "https://registry.yarnpkg.com/ember-cli-mirage/-/ember-cli-mirage-0.4.10.tgz#48d71c3941ba038b3d20b24d84f1b8f8237bce9d"
-  integrity sha512-J98oUHIZHU0DGzn1q2ryb08nn6u+/g2n9xOph/v1cNrYkfdjFh1F6yPGZi4Ee4POxJkM++44uG7kO+QkxN6i6A==
+ember-cli-mirage@^0.4.14:
+  version "0.4.14"
+  resolved "https://registry.yarnpkg.com/ember-cli-mirage/-/ember-cli-mirage-0.4.14.tgz#95bf2966c05646be998fb042860a54a0340c7fe1"
+  integrity sha512-1eieAC9hHPT0x3wSsIYenIgyOlCp6uWofhCSDt9xnvwh/xqf/bQB2Cx3f+wbU5TaqLrSio6lYmRqswCZYTLNzw==
   dependencies:
     "@xg-wang/whatwg-fetch" "^3.0.0"
     broccoli-file-creator "^2.1.1"
-    broccoli-funnel "^1.0.2"
-    broccoli-merge-trees "^1.1.0"
-    broccoli-stew "^1.5.0"
+    broccoli-funnel "^2.0.1"
+    broccoli-merge-trees "^3.0.2"
+    broccoli-stew "^2.0.1"
+    broccoli-string-replace "^0.1.2"
     chalk "^1.1.1"
-    ember-cli-babel "^6.8.2"
+    ember-cli-babel "^6.16.0"
     ember-cli-node-assets "^0.2.2"
     ember-get-config "^0.2.2"
     ember-inflector "^2.0.0 || ^3.0.0"
-    ember-lodash "^4.17.3"
+    ember-lodash "^4.19.4"
     fake-xml-http-request "^2.0.0"
     faker "^3.0.0"
-    jsdom "^11.12.0"
-    pretender "2.1.0"
+    pretender "2.1.1"
     route-recognizer "^0.3.4"
 
 ember-cli-moment-shim@^3.5.0:
@@ -7156,16 +7225,16 @@ ember-load-initializers@^1.1.0:
   dependencies:
     ember-cli-babel "^6.6.0"
 
-ember-lodash@^4.17.3:
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/ember-lodash/-/ember-lodash-4.18.0.tgz#45de700d6a4f68f1cd62888d90b50aa6477b9a83"
-  integrity sha1-Rd5wDWpPaPHNYoiNkLUKpkd7moM=
+ember-lodash@^4.19.4:
+  version "4.19.4"
+  resolved "https://registry.yarnpkg.com/ember-lodash/-/ember-lodash-4.19.4.tgz#3e76e6cb04c9312c2158180bf16d7983aae05774"
+  integrity sha512-4O1YjFfFA1EL53XXxyjRwRRl1f1MahxON7dbPhe5Ex3f8lmuvB0fEc1U+kJ1IwefmUqeSyOBsYXG6L9ushOKQQ==
   dependencies:
     broccoli-debug "^0.6.1"
     broccoli-funnel "^2.0.1"
-    broccoli-merge-trees "^2.0.0"
+    broccoli-merge-trees "^3.0.0"
     broccoli-string-replace "^0.1.1"
-    ember-cli-babel "^6.10.0"
+    ember-cli-babel "^7.0.0"
     lodash-es "^4.17.4"
 
 ember-macro-helpers@^0.17.0:
@@ -10646,7 +10715,7 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-jsdom@^11.11.0, jsdom@^11.12.0:
+jsdom@^11.11.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.12.0.tgz#1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8"
   integrity sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==
@@ -13720,10 +13789,10 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-pretender@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/pretender/-/pretender-2.1.0.tgz#cd75bff9624e996bcfadbd7dbd023ca1f4f3033a"
-  integrity sha512-GG1ZtA2yjorrSf9x3DR4Pv5228s/H92itSnIAxRx2wsmz549BsuIuJN+jPJgj0p+tCJBfBlmVgJLFG6t64M+EA==
+pretender@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/pretender/-/pretender-2.1.1.tgz#5085f0a1272c31d5b57c488386f69e6ca207cb35"
+  integrity sha512-IkidsJzaroAanw3I43tKCFm2xCpurkQr9aPXv5/jpN+LfCwDaeI8rngVWtQZTx4qqbhc5zJspnLHJ4N/25KvDQ==
   dependencies:
     "@xg-wang/whatwg-fetch" "^3.0.0"
     fake-xml-http-request "^2.0.0"
@@ -14203,6 +14272,11 @@ regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
+
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+  integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
 
 regenerator-runtime@^0.9.5:
   version "0.9.6"
@@ -14799,7 +14873,7 @@ rsvp@^4.6.1, rsvp@^4.7.0, rsvp@^4.8.1:
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.2.tgz#9d5647108735784eb13418cdddb56f75b919d722"
   integrity sha512-8CU1Wjxvzt6bt8zln+hCjyieneU9s0LRW+lPRsjyVCY8Vm1kTbK7btBIrCGg6yY9U4undLDm/b1hKEEi1tLypg==
 
-rsvp@^4.8.2, rsvp@^4.8.3:
+rsvp@^4.8.2, rsvp@^4.8.3, rsvp@^4.8.4:
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.4.tgz#b50e6b34583f3dd89329a2f23a8a2be072845911"
   integrity sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==
@@ -15023,7 +15097,7 @@ semver@^4.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
   integrity sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=
 
-semver@^5.3.0, semver@^5.4.1:
+semver@^5.3.0, semver@^5.4.1, semver@^5.5.1:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==


### PR DESCRIPTION
## Purpose

Now that https://github.com/samselikoff/ember-cli-mirage/pull/1376 has been merged and released, we can resume using a production build for the handbook deploy on github pages. This PR also makes changes to the dev banner so that it's display is controlled by a config var `showDevBanner` rather than `devMode`. This allows us to turn it on for the handbook production build and it will be off for CI tests and not pollute Percy snapshots. A small change was also made to allow toast-on-click analytics to function in production builds so that, in staging environments, we can turn this on to easily test analytics.

## Summary of Changes

- Services
    - `analytics` - allow toast-on-click to be used in production builds (when enabled in dev banner)
- Components	- Components
    - `osf-mode-footer` - show dev banner based on `config.showDevBanner`
- Travis
    - Use a production build for handbook

## Side Effects

Shouldn't be any.

## Feature Flags

n/a

## QA Notes

This does not require QA, but the dev banner and toast-on-click analytics will be of interest to QA.

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
