### PR TITLE
chore: increase v8 max-old-space-size to 4096 for handbook build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ jobs:
         - ROOT_URL=/ember-osf-web/
         - ASSETS_PREFIX=/ember-osf-web/
         - A11Y_AUDIT=0
+        - NODE_OPTIONS=--max-old-space-size=4096
       script:
         - ember build --environment=production && cp dist/index.html dist/404.html
       deploy:


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[EMB-123] some really great stuff`
-->

## Purpose

Attempt to fix the handbook deploy by increasing the memory limit for v8.

## Summary of Changes

Set `NODE_OPTIONS=--max-old-space-size=4096` for handbook build.

## Side Effects

n/a

## Feature Flags

n/a

## QA Notes

n/a

## Ticket

n/a