### PR TITLE
Improve mirage server.create() types

### DIFF
--- a/mirage/helpers.ts
+++ b/mirage/helpers.ts
@@ -1,34 +1,32 @@
-import { faker, ModelInstance, Server } from 'ember-cli-mirage';
-import { AttributesFor, RelationshipsFor } from 'ember-data';
+import { faker, ModelAttrs, ModelInstance, Server } from 'ember-cli-mirage';
 
+import Contributor from 'ember-osf-web/models/contributor';
 import DraftRegistration from 'ember-osf-web/models/draft-registration';
 import Node from 'ember-osf-web/models/node';
 import Registration from 'ember-osf-web/models/registration';
+import RegistrationSchema from 'ember-osf-web/models/registration-schema';
 
 import { DraftRegistrationTraits } from './factories/draft-registration';
 import { NodeTraits } from './factories/node';
 
-// eslint-disable-next-line space-infix-ops
-type Props<T> = {
-    [P in AttributesFor<T> | RelationshipsFor<T>]?: T[P];
-};
-
 export function registerNode(
     server: Server,
     node: ModelInstance<Node>,
-    props: Props<Registration> = {},
+    props: Partial<ModelAttrs<Registration>> = {},
     ...traits: string[] // tslint:disable-line trailing-comma
 ) {
-    const registration = server.create('registration', {
+    const registration = server.create<Registration>('registration', {
         registeredFrom: node,
         category: node.category,
         title: node.title,
         description: node.description,
-        registrationSchema: faker.random.arrayElement(server.schema.registrationSchemas.all().models),
+        registrationSchema: faker.random.arrayElement(
+            server.schema.registrationSchemas.all().models as Array<ModelInstance<RegistrationSchema>>,
+        ),
         ...props,
     }, ...traits);
     node.contributors.models.forEach((contributor: any) =>
-        server.create('contributor', { node: registration, users: contributor.users }));
+        server.create<Contributor>('contributor', { node: registration, users: contributor.users }));
     return registration;
 }
 
@@ -36,7 +34,7 @@ export function registerNodeMultiple(
     server: Server,
     node: ModelInstance<Node>,
     count: number,
-    props: Props<Registration> = {},
+    props: Partial<ModelAttrs<Registration>> = {},
     ...traits: string[] // tslint:disable-line trailing-comma
 ) {
     const registrations = [];
@@ -49,13 +47,15 @@ export function registerNodeMultiple(
 export function draftRegisterNode(
     server: Server,
     node: ModelInstance<Node>,
-    props: Props<DraftRegistration> = {},
+    props: Partial<ModelAttrs<DraftRegistration>> = {},
     ...traits: Array<keyof DraftRegistrationTraits> // tslint:disable-line trailing-comma
 ) {
-    return server.create('draft-registration', {
+    return server.create<DraftRegistration>('draft-registration', {
         branchedFrom: node,
         initiator: node.contributors.models.length ? node.contributors.models[0].users : null,
-        registrationSchema: faker.random.arrayElement(server.schema.registrationSchemas.all().models),
+        registrationSchema: faker.random.arrayElement(
+            server.schema.registrationSchemas.all().models as Array<ModelInstance<RegistrationSchema>>,
+        ),
         ...props,
     }, ...traits);
 }
@@ -64,7 +64,7 @@ export function draftRegisterNodeMultiple(
     server: Server,
     node: ModelInstance<Node>,
     count: number,
-    props: Props<DraftRegistration> = {},
+    props: Partial<ModelAttrs<DraftRegistration>> = {},
     ...traits: Array<keyof DraftRegistrationTraits> // tslint:disable-line trailing-comma
 ) {
     const draftRegistrations = [];
@@ -77,10 +77,10 @@ export function draftRegisterNodeMultiple(
 export function forkNode(
     server: Server,
     node: ModelInstance<Node>,
-    props: Props<Node> = {},
+    props: Partial<ModelAttrs<Node>> = {},
     ...traits: Array<keyof NodeTraits> // tslint:disable-line trailing-comma
 ) {
-    const nodeFork = server.create('node', {
+    const nodeFork = server.create<Node>('node', {
         forkedFrom: node,
         category: node.category,
         fork: true,
@@ -89,6 +89,6 @@ export function forkNode(
         ...props,
     }, ...traits);
     node.contributors.models.forEach((contributor: any) =>
-        server.create('contributor', { node: nodeFork, users: contributor.users }));
+        server.create<Contributor>('contributor', { node: nodeFork, users: contributor.users }));
     return nodeFork;
 }

--- a/types/ember-cli-mirage/index.d.ts
+++ b/types/ember-cli-mirage/index.d.ts
@@ -1,3 +1,4 @@
+import DS from 'ember-data';
 import { Document } from 'osf-api';
 
 export { default as faker } from 'faker';
@@ -140,6 +141,11 @@ function handlerDefinition(
 
 export type resourceAction = 'index' | 'show' | 'create' | 'update' | 'delete';
 
+export type ModelAttrs<T> = {
+    [P in keyof T]: T[P] extends DS.Model & DS.PromiseObject<infer M> ? ModelInstance<M> :
+        T[P] extends DS.Model ? ModelInstance<T[P]> : T[P];
+};
+
 export interface Server {
     schema: Schema;
     db: Database;
@@ -173,7 +179,7 @@ export interface Server {
     ): ModelInstance<T>;
     create<T extends AnyAttrs = AnyAttrs>(
         modelName: string,
-        attrs?: Partial<T>,
+        attrs?: Partial<ModelAttrs<T>>,
         ...traits: string[]
     ): ModelInstance<T>;
 
@@ -185,7 +191,7 @@ export interface Server {
     createList<T extends AnyAttrs = AnyAttrs>(
         modelName: string,
         amount: number,
-        attrs?: Partial<T>,
+        attrs?: Partial<ModelAttrs<T>>,
         ...traits: string[]
     ): Array<ModelInstance<T>>;
 


### PR DESCRIPTION
## Purpose

Map relationship types to `ModelInstance` so that we can get type checking on `server.create()`.

## Summary of Changes

- map relationship types to `ModelInstance`
- use stronger types in mirage helpers

## Side Effects

n/a

## Feature Flags

n/a

## QA Notes

n/a

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(types only)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
