### PR TITLE
[EMB-576] improve mirage types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Mirage:
     - Slim down default scenario
     - Allow different set of scenarios to run based on local settings with `MIRAGE_SCENARIOS`
+    - types:
+        - `server.create(modelName, ...)` now looks up the `modelName` in the `ModelRegistry` and properly types the
+          return values as `ModelInstance<ModelFromTheRegistry>` and type checks any model properties passed in.
+        - same as above, but for `server.createList`
+        - traits now take a type argument (the model they are a trait for) which results in proper typing for
+          `afterCreate(model, server)` without requiring manual typing of its args.
+        - the `afterCreate` method of mirage factories is typed similarly to trait's `afterCreate`
+        - mirage model class methods now take a type argument and their return value will be properly typed.
+          (e.g `server.schema.users.find<User>()` will return `ModelInstance<User>`)
 - Services
     - `analytics` - allow toast-on-click to be used in production builds (when enabled in dev banner)
 - Components

--- a/app/models/registration-schema.ts
+++ b/app/models/registration-schema.ts
@@ -51,19 +51,12 @@ export interface RegistrationMetadata {
     [qid: string]: Answer<string | string[] | boolean | RegistrationMetadata>;
 }
 
-class RegistrationSchemaModel extends OsfModel {
+export default class RegistrationSchemaModel extends OsfModel {
     @attr('boolean') active!: boolean;
     @attr('fixstring') name!: string;
     @attr('number') schemaVersion!: number;
     @attr('object') schema!: Schema;
 }
-
-interface RegistrationSchemaModel {
-    // this is for mirage types
-    schemaNoConflict: Schema;
-}
-
-export default RegistrationSchemaModel;
 
 declare module 'ember-data/types/registries/model' {
     export default interface ModelRegistry {

--- a/app/models/registration-schema.ts
+++ b/app/models/registration-schema.ts
@@ -51,12 +51,19 @@ export interface RegistrationMetadata {
     [qid: string]: Answer<string | string[] | boolean | RegistrationMetadata>;
 }
 
-export default class RegistrationSchemaModel extends OsfModel {
+class RegistrationSchemaModel extends OsfModel {
     @attr('boolean') active!: boolean;
     @attr('fixstring') name!: string;
     @attr('number') schemaVersion!: number;
     @attr('object') schema!: Schema;
 }
+
+interface RegistrationSchemaModel {
+    // this is for mirage types
+    schemaNoConflict: Schema;
+}
+
+export default RegistrationSchemaModel;
 
 declare module 'ember-data/types/registries/model' {
     export default interface ModelRegistry {

--- a/mirage/factories/comment-report.ts
+++ b/mirage/factories/comment-report.ts
@@ -1,22 +1,25 @@
-import { association, Factory, faker, ModelInstance } from 'ember-cli-mirage';
+import { association, Factory, faker } from 'ember-cli-mirage';
 
+import Comment from 'ember-osf-web/models/comment';
 import CommentReport from 'ember-osf-web/models/comment-report';
+
+import { Root } from './root';
 import { guid } from './utils';
 
 export default Factory.extend<CommentReport>({
     id: guid('comment-report'),
-    afterCreate(commentReport: ModelInstance<CommentReport>, server: any) {
-        const root = server.schema.roots.first();
-        const reporter = (!root || faker.random.boolean()) ? server.create('user').id : root.currentUser.id;
+    afterCreate(commentReport, server) {
+        const root = server.schema.roots.first<Root>();
+        const reporter = (!root || faker.random.boolean()) ? server.create('user').id : root.currentUser!.id;
         commentReport.update({
             reporter,
         });
 
-        const comment = server.schema.comments.find(commentReport.comment.id);
+        const comment = server.schema.comments.find<Comment>(commentReport.comment.id);
         if (comment) {
             comment.update({
                 isAbuse: true,
-                hasReport: !root || root.currentUser.id === reporter,
+                hasReport: !root || root.currentUser!.id === reporter,
             });
         }
     },

--- a/mirage/factories/comment.ts
+++ b/mirage/factories/comment.ts
@@ -1,4 +1,4 @@
-import { association, Factory, faker, ModelInstance, trait, Trait } from 'ember-cli-mirage';
+import { association, Factory, faker, trait, Trait } from 'ember-cli-mirage';
 
 import Comment from 'ember-osf-web/models/comment';
 import { guid } from './utils';
@@ -13,7 +13,7 @@ export default Factory.extend<Comment & CommentTraits>({
     node: association() as Comment['node'],
     user: association() as Comment['user'],
 
-    afterCreate(comment: ModelInstance<Comment>) {
+    afterCreate(comment) {
         if (!comment.targetID && !comment.targetType) {
             comment.update({
                 targetID: comment.node.id,

--- a/mirage/factories/comment.ts
+++ b/mirage/factories/comment.ts
@@ -41,8 +41,8 @@ export default Factory.extend<Comment & CommentTraits>({
     targetType: '',
     hasChildren: false,
 
-    withReplies: trait({
-        afterCreate(comment: any, server: any) {
+    withReplies: trait<Comment>({
+        afterCreate(comment, server) {
             const siblings = server.schema.comments.where({ targetID: comment.targetID });
             const count = faker.random.number({ min: 0, max: siblings.length - 1 });
 
@@ -61,8 +61,8 @@ export default Factory.extend<Comment & CommentTraits>({
         },
     }),
 
-    asAbuse: trait({
-        afterCreate(comment: any, server: any) {
+    asAbuse: trait<Comment>({
+        afterCreate(comment, server) {
             server.create('comment-report', { comment });
         },
     }),

--- a/mirage/factories/draft-registration.ts
+++ b/mirage/factories/draft-registration.ts
@@ -30,7 +30,7 @@ export default Factory.extend<DraftRegistration & DraftRegistrationTraits>({
     withRegistrationMetadata: trait<DraftRegistration>({
         afterCreate(draftRegistration) {
             draftRegistration.update({
-                registrationMetadata: createRegistrationMetadata(draftRegistration.registrationSchema.schemaNoConflict),
+                registrationMetadata: createRegistrationMetadata(draftRegistration.registrationSchema),
             });
         },
     }),

--- a/mirage/factories/draft-registration.ts
+++ b/mirage/factories/draft-registration.ts
@@ -27,8 +27,8 @@ export default Factory.extend<DraftRegistration & DraftRegistrationTraits>({
 
     registrationMetadata: {},
 
-    withRegistrationMetadata: trait({
-        afterCreate(draftRegistration: any) {
+    withRegistrationMetadata: trait<DraftRegistration>({
+        afterCreate(draftRegistration) {
             draftRegistration.update({
                 registrationMetadata: createRegistrationMetadata(draftRegistration.registrationSchema.schemaNoConflict),
             });

--- a/mirage/factories/node.ts
+++ b/mirage/factories/node.ts
@@ -7,6 +7,10 @@ import RegistrationSchema from 'ember-osf-web/models/registration-schema';
 
 import { guid, guidAfterCreate } from './utils';
 
+export interface MirageNode extends Node {
+    regionId: string | number;
+}
+
 export interface NodeTraits {
     withContributors: Trait;
     withRegistrations: Trait;

--- a/mirage/factories/registration-schema.ts
+++ b/mirage/factories/registration-schema.ts
@@ -2,12 +2,12 @@ import { Factory, faker } from 'ember-cli-mirage';
 
 import RegistrationSchema from 'ember-osf-web/models/registration-schema';
 
-export interface RegistrationSchemaFactory extends
+export interface MirageRegistrationSchema extends
     Pick<RegistrationSchema, Exclude<keyof RegistrationSchema, 'schema'>> {
-    schemaNoConflict: RegistrationSchema['schema'];
+    schemaNoConflict?: RegistrationSchema['schema'];
 }
 
-export default Factory.extend<RegistrationSchemaFactory>({
+export default Factory.extend<MirageRegistrationSchema>({
     active: true,
     name() {
         return faker.lorem.sentence().replace('.', '');
@@ -28,3 +28,9 @@ export default Factory.extend<RegistrationSchemaFactory>({
         };
     },
 });
+
+declare module 'ember-cli-mirage/types/registries/model' {
+    export default interface MirageModelRegistry {
+        'registration-schema': MirageRegistrationSchema;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/registration.ts
+++ b/mirage/factories/registration.ts
@@ -1,4 +1,4 @@
-import { association, faker, ModelInstance, trait, Trait } from 'ember-cli-mirage';
+import { association, faker, trait, Trait } from 'ember-cli-mirage';
 
 import Registration from 'ember-osf-web/models/registration';
 
@@ -78,7 +78,7 @@ export default NodeFactory.extend<Registration & RegistrationExtra>({
         } else if (!newReg.registeredMeta) {
             const registrationSchema = newReg.registrationSchema ||
                 faker.random.arrayElement(server.schema.registrationSchemas.all().models) ||
-                server.create('registrationSchema');
+                server.create('registration-schema');
             newReg.update({
                 registrationSchema,
                 registeredMeta: createRegistrationMetadata(registrationSchema.schemaNoConflict, true),
@@ -104,41 +104,41 @@ export default NodeFactory.extend<Registration & RegistrationExtra>({
     index(i) {
         return i;
     },
-    withComments: trait({
-        afterCreate(registration: any, server: any) {
+    withComments: trait<Registration>({
+        afterCreate(registration, server) {
             server.createList(
                 'comment', 6,
+                { node: registration, targetID: registration.id, targetType: 'registrations' },
                 'withReplies',
                 'asAbuse',
-                { node: registration, targetID: registration.id, targetType: 'registrations' },
             );
             server.createList(
                 'comment', 3,
-                'withReplies',
                 { node: registration, targetID: registration.id, targetType: 'registrations' },
+                'withReplies',
             );
         },
     }),
-    isPendingApproval: trait({
+    isPendingApproval: trait<Registration>({
         ...stateAttrs.pendingApproval,
     }),
-    isArchiving: trait({
+    isArchiving: trait<Registration>({
         ...stateAttrs.archiving,
     }),
-    isEmbargoed: trait({
+    isEmbargoed: trait<Registration>({
         ...stateAttrs.embargoed,
     }),
-    isPendingEmbargoApproval: trait({
+    isPendingEmbargoApproval: trait<Registration>({
         ...stateAttrs.pendingEmbargoApproval,
     }),
-    isPendingWithdrawal: trait({
+    isPendingWithdrawal: trait<Registration>({
         ...stateAttrs.pendingWithdrawal,
     }),
-    isWithdrawn: trait({
+    isWithdrawn: trait<Registration>({
         ...stateAttrs.withdrawn,
     }),
-    withArbitraryState: trait({
-        afterCreate(registration: ModelInstance<Registration> & RegistrationExtra) {
+    withArbitraryState: trait<Registration & RegistrationExtra>({
+        afterCreate(registration) {
             const arbitraryState =
                 faker.list.cycle(...Object.keys(stateAttrs))(registration.index);
             const attrsToUse = stateAttrs[arbitraryState as keyof typeof stateAttrs];

--- a/mirage/factories/root.ts
+++ b/mirage/factories/root.ts
@@ -19,6 +19,7 @@ export interface Root {
     version: string;
     links: Links;
     currentUser?: ModelInstance<User>;
+    currentUserId?: string;
 }
 
 interface RootTraits {

--- a/mirage/factories/root.ts
+++ b/mirage/factories/root.ts
@@ -18,7 +18,7 @@ export interface Root {
     message: string;
     version: string;
     links: Links;
-    currentUser?: User;
+    currentUser?: ModelInstance<User>;
 }
 
 interface RootTraits {
@@ -39,11 +39,17 @@ export const defaultRootAttrs = {
 
 export default Factory.extend<Root & RootTraits>({
     ...defaultRootAttrs,
-    currentUser: association() as User,
+    currentUser: association() as ModelInstance<User>,
 
-    oldRegistrationDetail: trait({
-        afterCreate(root: ModelInstance<Root>) {
+    oldRegistrationDetail: trait<Root>({
+        afterCreate(root) {
             root.update('activeFlags', root.activeFlags.filter(f => f !== routes['registries.overview']));
         },
     }),
 });
+
+declare module 'ember-cli-mirage/types/registries/model' {
+    export default interface MirageModelRegistry {
+        root: Root;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/token.ts
+++ b/mirage/factories/token.ts
@@ -1,12 +1,13 @@
 import { Factory, faker } from 'ember-cli-mirage';
 
+import Scope from 'ember-osf-web/models/scope';
 import Token from 'ember-osf-web/models/token';
 
-interface TokenAttrs extends Token {
+export interface MirageToken extends Token {
     scopeIds: string[];
 }
 
-export default Factory.extend<TokenAttrs>({
+export default Factory.extend<MirageToken>({
     id(i: number) {
         return i.toString().padStart(5, '0');
     },
@@ -16,7 +17,13 @@ export default Factory.extend<TokenAttrs>({
     },
 
     afterCreate(token, server) {
-        const scope = server.schema.scopes.first() || server.create('scope');
+        const scope = server.schema.scopes.first<Scope>() || server.create('scope');
         token.update('scopeIds', [scope.id]);
     },
 });
+
+declare module 'ember-cli-mirage/types/registries/model' {
+    export default interface MirageModelRegistry {
+        token: MirageToken;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/user-setting.ts
+++ b/mirage/factories/user-setting.ts
@@ -25,3 +25,9 @@ export default Factory.extend<MirageUserSetting>({
 
     user: association(),
 });
+
+declare module 'ember-cli-mirage/types/registries/model' {
+    export default interface MirageModelRegistry {
+        'user-setting': MirageUserSetting;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/user-setting.ts
+++ b/mirage/factories/user-setting.ts
@@ -2,8 +2,8 @@ import { association, Factory } from 'ember-cli-mirage';
 
 import UserSetting from 'ember-osf-web/models/user-setting';
 
-interface MirageUserSetting extends UserSetting {
-    userId: string;
+export interface MirageUserSetting extends UserSetting {
+    userId: string | number;
 }
 
 export default Factory.extend<MirageUserSetting>({

--- a/mirage/factories/user.ts
+++ b/mirage/factories/user.ts
@@ -1,16 +1,14 @@
-import {
-    association,
-    Factory,
-    faker,
-    ModelInstance,
-    Server,
-    trait,
-    Trait,
-} from 'ember-cli-mirage';
+import { association, Factory, faker, trait, Trait } from 'ember-cli-mirage';
 
+import Region from 'ember-osf-web/models/region';
 import User from 'ember-osf-web/models/user';
 
+import { Root } from './root';
 import { guid, guidAfterCreate } from './utils';
+
+export interface MirageUser extends User {
+    contributorIds: string[];
+}
 
 export interface UserTraits {
     withFiles: Trait;
@@ -24,9 +22,9 @@ export interface UserTraits {
     withUsRegion: Trait;
 }
 
-export default Factory.extend<User & UserTraits>({
+export default Factory.extend<MirageUser & UserTraits>({
     id: guid('user'),
-    afterCreate(user: ModelInstance<User>, server: Server) {
+    afterCreate(user, server) {
         guidAfterCreate(user, server);
         server.create('user-email', { user, primary: true });
         if (!user.fullName && (user.givenName || user.familyName)) {
@@ -61,21 +59,21 @@ export default Factory.extend<User & UserTraits>({
         return faker.date.past(2, new Date(2018, 0, 0));
     },
 
-    withFiles: trait<User>({
+    withFiles: trait<MirageUser>({
         afterCreate(user, server) {
             server.createList('file', 5, { user });
         },
     }),
 
-    withInstitutions: trait<User>({
+    withInstitutions: trait<MirageUser>({
         afterCreate(user, server) {
             server.createList('institution', 5, { users: [user] });
         },
     }),
 
-    loggedIn: trait<User>({
+    loggedIn: trait<MirageUser>({
         afterCreate(currentUser, server) {
-            const root = server.schema.roots.first();
+            const root = server.schema.roots.first<Root>();
             if (root) {
                 root.update({ currentUser });
             } else {
@@ -84,40 +82,46 @@ export default Factory.extend<User & UserTraits>({
         },
     }),
 
-    withSettings: trait<User>({
+    withSettings: trait<MirageUser>({
         afterCreate(user, server) {
             server.create('user-setting', { user });
         },
     }),
 
-    withAlternateEmail: trait<User>({
+    withAlternateEmail: trait<MirageUser>({
         afterCreate(user, server) {
             server.create('user-email', { user });
         },
     }),
 
-    withUnconfirmedEmail: trait<User>({
+    withUnconfirmedEmail: trait<MirageUser>({
         afterCreate(user, server) {
             server.create('user-email', { user, confirmed: false });
         },
     }),
 
-    withUnverifiedEmail: trait<User>({
+    withUnverifiedEmail: trait<MirageUser>({
         afterCreate(user, server) {
             server.create('user-email', { user, verified: false });
         },
     }),
 
-    withUnverifiedEmails: trait<User>({
+    withUnverifiedEmails: trait<MirageUser>({
         afterCreate(user, server) {
             server.create('user-email', { user, verified: false, isMerge: true });
             server.create('user-email', { user, verified: false, isMerge: false });
         },
     }),
-    withUsRegion: trait<User>({
+    withUsRegion: trait<MirageUser>({
         afterCreate(user, server) {
-            const defaultRegion = server.schema.regions.find('us');
+            const defaultRegion = server.schema.regions.find<Region>('us');
             user.update({ defaultRegion });
         },
     }),
 });
+
+declare module 'ember-cli-mirage/types/registries/model' {
+    export default interface MirageModelRegistry {
+        user: MirageUser;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/user.ts
+++ b/mirage/factories/user.ts
@@ -13,7 +13,6 @@ import User from 'ember-osf-web/models/user';
 import { guid, guidAfterCreate } from './utils';
 
 export interface UserTraits {
-    withNodes: Trait;
     withFiles: Trait;
     loggedIn: Trait;
     withInstitutions: Trait;
@@ -62,25 +61,19 @@ export default Factory.extend<User & UserTraits>({
         return faker.date.past(2, new Date(2018, 0, 0));
     },
 
-    withNodes: trait({
-        afterCreate(user, server) {
-            server.createList('node', 5, { user }, 'withContributors');
-        },
-    }),
-
-    withFiles: trait({
+    withFiles: trait<User>({
         afterCreate(user, server) {
             server.createList('file', 5, { user });
         },
     }),
 
-    withInstitutions: trait({
+    withInstitutions: trait<User>({
         afterCreate(user, server) {
             server.createList('institution', 5, { users: [user] });
         },
     }),
 
-    loggedIn: trait({
+    loggedIn: trait<User>({
         afterCreate(currentUser, server) {
             const root = server.schema.roots.first();
             if (root) {
@@ -91,37 +84,37 @@ export default Factory.extend<User & UserTraits>({
         },
     }),
 
-    withSettings: trait({
+    withSettings: trait<User>({
         afterCreate(user, server) {
             server.create('user-setting', { user });
         },
     }),
 
-    withAlternateEmail: trait({
+    withAlternateEmail: trait<User>({
         afterCreate(user, server) {
             server.create('user-email', { user });
         },
     }),
 
-    withUnconfirmedEmail: trait({
+    withUnconfirmedEmail: trait<User>({
         afterCreate(user, server) {
             server.create('user-email', { user, confirmed: false });
         },
     }),
 
-    withUnverifiedEmail: trait({
+    withUnverifiedEmail: trait<User>({
         afterCreate(user, server) {
             server.create('user-email', { user, verified: false });
         },
     }),
 
-    withUnverifiedEmails: trait({
+    withUnverifiedEmails: trait<User>({
         afterCreate(user, server) {
             server.create('user-email', { user, verified: false, isMerge: true });
             server.create('user-email', { user, verified: false, isMerge: false });
         },
     }),
-    withUsRegion: trait({
+    withUsRegion: trait<User>({
         afterCreate(user, server) {
             const defaultRegion = server.schema.regions.find('us');
             user.update({ defaultRegion });

--- a/mirage/factories/utils.ts
+++ b/mirage/factories/utils.ts
@@ -2,7 +2,9 @@ import { faker, ModelInstance, Server } from 'ember-cli-mirage';
 import SeedRandom from 'seedrandom';
 
 import { GUID_ALPHABET } from 'ember-osf-web/const/guid-alphabet';
-import { AbstractQuestion, Answer, RegistrationMetadata, Schema } from 'ember-osf-web/models/registration-schema';
+import { AbstractQuestion, Answer, RegistrationMetadata } from 'ember-osf-web/models/registration-schema';
+
+import { MirageRegistrationSchema } from './registration-schema';
 
 export function guid(referentType: string) {
     return (id: number) => {
@@ -52,27 +54,32 @@ function fakeAnswer(question: AbstractQuestion, answerIfRequired: boolean): Answ
 /**
  * Create registration metadata with a random number of questions answered.
  *
- * @param {Schema} schema - The schema to generate metadata for.
+ * @param {MirageRegistrationSchema} registrationsSchema - The registration schema to generate metadata for.
  * @param {boolean} answerAllRequired - Whether to ensure all required questions are answered.
  * @return {RegistrationMetadata}
  */
-export function createRegistrationMetadata(schema: Schema, answerAllRequired = false) {
+export function createRegistrationMetadata(
+    registrationSchema: ModelInstance<MirageRegistrationSchema>,
+    answerAllRequired = false,
+) {
     const registrationMetadata: RegistrationMetadata = {};
-    schema.pages.forEach(page =>
-        page.questions.forEach(question => {
-            if (question.type === 'object' && question.properties) {
-                const value: RegistrationMetadata = { };
-                question.properties.forEach(property => {
-                    value[property.id] = fakeAnswer(property, answerAllRequired);
-                });
-                registrationMetadata[question.qid] = {
-                    comments: [],
-                    extra: [],
-                    value,
-                };
-            } else {
-                registrationMetadata[question.qid] = fakeAnswer(question, answerAllRequired);
-            }
-        }));
+    if (registrationSchema.schemaNoConflict) {
+        registrationSchema.schemaNoConflict.pages.forEach(page =>
+            page.questions.forEach(question => {
+                if (question.type === 'object' && question.properties) {
+                    const value: RegistrationMetadata = { };
+                    question.properties.forEach(property => {
+                        value[property.id] = fakeAnswer(property, answerAllRequired);
+                    });
+                    registrationMetadata[question.qid] = {
+                        comments: [],
+                        extra: [],
+                        value,
+                    };
+                } else {
+                    registrationMetadata[question.qid] = fakeAnswer(question, answerAllRequired);
+                }
+            }));
+    }
     return registrationMetadata;
 }

--- a/mirage/helpers.ts
+++ b/mirage/helpers.ts
@@ -51,7 +51,7 @@ export function draftRegisterNode(
 ) {
     return server.create('draft-registration', {
         branchedFrom: node,
-        initiator: node.contributors.models.length ? node.contributors.models[0].users : null,
+        initiator: node.contributors.models.length ? node.contributors.models[0].users : undefined,
         registrationSchema: faker.random.arrayElement(
             server.schema.registrationSchemas.all<RegistrationSchema>().models,
         ),

--- a/mirage/helpers.ts
+++ b/mirage/helpers.ts
@@ -1,17 +1,16 @@
-import { faker, ModelAttrs, ModelInstance, ModelRegistry, Server } from 'ember-cli-mirage';
+import { faker, ModelAttrs, ModelInstance, Server } from 'ember-cli-mirage';
 
 import DraftRegistration from 'ember-osf-web/models/draft-registration';
-import Node from 'ember-osf-web/models/node';
-import Registration from 'ember-osf-web/models/registration';
 import RegistrationSchema from 'ember-osf-web/models/registration-schema';
 
 import { DraftRegistrationTraits } from './factories/draft-registration';
-import { NodeTraits } from './factories/node';
+import { MirageNode, NodeTraits } from './factories/node';
+import { MirageRegistration } from './factories/registration';
 
 export function registerNode(
     server: Server,
-    node: ModelInstance<Node>,
-    props: Partial<ModelAttrs<Registration>> = {},
+    node: ModelInstance<MirageNode>,
+    props: Partial<ModelAttrs<MirageRegistration>> = {},
     ...traits: string[] // tslint:disable-line trailing-comma
 ) {
     const registration = server.create('registration', {
@@ -24,16 +23,16 @@ export function registerNode(
         ),
         ...props,
     }, ...traits);
-    node.contributors.models.forEach((contributor: any) =>
+    node.contributors.models.forEach(contributor =>
         server.create('contributor', { node: registration, users: contributor.users }));
     return registration;
 }
 
 export function registerNodeMultiple(
     server: Server,
-    node: ModelInstance<Node>,
+    node: ModelInstance<MirageNode>,
     count: number,
-    props: Partial<ModelAttrs<Registration>> = {},
+    props: Partial<ModelAttrs<MirageRegistration>> = {},
     ...traits: string[] // tslint:disable-line trailing-comma
 ) {
     const registrations = [];
@@ -45,7 +44,7 @@ export function registerNodeMultiple(
 
 export function draftRegisterNode(
     server: Server,
-    node: ModelInstance<Node>,
+    node: ModelInstance<MirageNode>,
     props: Partial<ModelAttrs<DraftRegistration>> = {},
     ...traits: Array<keyof DraftRegistrationTraits> // tslint:disable-line trailing-comma
 ) {
@@ -61,7 +60,7 @@ export function draftRegisterNode(
 
 export function draftRegisterNodeMultiple(
     server: Server,
-    node: ModelInstance<Node>,
+    node: ModelInstance<MirageNode>,
     count: number,
     props: Partial<ModelAttrs<DraftRegistration>> = {},
     ...traits: Array<keyof DraftRegistrationTraits> // tslint:disable-line trailing-comma
@@ -75,8 +74,8 @@ export function draftRegisterNodeMultiple(
 
 export function forkNode(
     server: Server,
-    node: ModelInstance<Node>,
-    props: Partial<ModelAttrs<ModelRegistry['node']>> = {},
+    node: ModelInstance<MirageNode>,
+    props: Partial<ModelAttrs<MirageNode>> = {},
     ...traits: Array<keyof NodeTraits> // tslint:disable-line trailing-comma
 ) {
     const nodeFork = server.create('node', {
@@ -87,7 +86,7 @@ export function forkNode(
         description: node.description,
         ...props,
     }, ...traits);
-    node.contributors.models.forEach((contributor: any) =>
+    node.contributors.models.forEach(contributor =>
         server.create('contributor', { node: nodeFork, users: contributor.users }));
     return nodeFork;
 }

--- a/mirage/helpers.ts
+++ b/mirage/helpers.ts
@@ -1,6 +1,5 @@
-import { faker, ModelAttrs, ModelInstance, Server } from 'ember-cli-mirage';
+import { faker, ModelAttrs, ModelInstance, ModelRegistry, Server } from 'ember-cli-mirage';
 
-import Contributor from 'ember-osf-web/models/contributor';
 import DraftRegistration from 'ember-osf-web/models/draft-registration';
 import Node from 'ember-osf-web/models/node';
 import Registration from 'ember-osf-web/models/registration';
@@ -15,18 +14,18 @@ export function registerNode(
     props: Partial<ModelAttrs<Registration>> = {},
     ...traits: string[] // tslint:disable-line trailing-comma
 ) {
-    const registration = server.create<Registration>('registration', {
+    const registration = server.create('registration', {
         registeredFrom: node,
         category: node.category,
         title: node.title,
         description: node.description,
         registrationSchema: faker.random.arrayElement(
-            server.schema.registrationSchemas.all().models as Array<ModelInstance<RegistrationSchema>>,
+            server.schema.registrationSchemas.all<RegistrationSchema>().models,
         ),
         ...props,
     }, ...traits);
     node.contributors.models.forEach((contributor: any) =>
-        server.create<Contributor>('contributor', { node: registration, users: contributor.users }));
+        server.create('contributor', { node: registration, users: contributor.users }));
     return registration;
 }
 
@@ -50,11 +49,11 @@ export function draftRegisterNode(
     props: Partial<ModelAttrs<DraftRegistration>> = {},
     ...traits: Array<keyof DraftRegistrationTraits> // tslint:disable-line trailing-comma
 ) {
-    return server.create<DraftRegistration>('draft-registration', {
+    return server.create('draft-registration', {
         branchedFrom: node,
         initiator: node.contributors.models.length ? node.contributors.models[0].users : null,
         registrationSchema: faker.random.arrayElement(
-            server.schema.registrationSchemas.all().models as Array<ModelInstance<RegistrationSchema>>,
+            server.schema.registrationSchemas.all<RegistrationSchema>().models,
         ),
         ...props,
     }, ...traits);
@@ -77,10 +76,10 @@ export function draftRegisterNodeMultiple(
 export function forkNode(
     server: Server,
     node: ModelInstance<Node>,
-    props: Partial<ModelAttrs<Node>> = {},
+    props: Partial<ModelAttrs<ModelRegistry['node']>> = {},
     ...traits: Array<keyof NodeTraits> // tslint:disable-line trailing-comma
 ) {
-    const nodeFork = server.create<Node>('node', {
+    const nodeFork = server.create('node', {
         forkedFrom: node,
         category: node.category,
         fork: true,
@@ -89,6 +88,6 @@ export function forkNode(
         ...props,
     }, ...traits);
     node.contributors.models.forEach((contributor: any) =>
-        server.create<Contributor>('contributor', { node: nodeFork, users: contributor.users }));
+        server.create('contributor', { node: nodeFork, users: contributor.users }));
     return nodeFork;
 }

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -1,7 +1,6 @@
 import { ModelInstance, Server } from 'ember-cli-mirage';
 import config from 'ember-get-config';
 
-import Node from 'ember-osf-web/models/node';
 import { Permission } from 'ember-osf-web/models/osf-model';
 import RegistrationSchema from 'ember-osf-web/models/registration-schema';
 import User from 'ember-osf-web/models/user';
@@ -49,9 +48,7 @@ function registrationScenario(server: Server, currentUser: ModelInstance<User>) 
 
     server.create('registration', {
         id: 'decaf',
-        registrationSchema: server.schema.registrationSchemas.find(
-            'prereg_challenge',
-        ) as ModelInstance<RegistrationSchema>,
+        registrationSchema: server.schema.registrationSchemas.find<RegistrationSchema>('prereg_challenge'),
         linkedNodes: server.createList('node', 2),
         linkedRegistrations: server.createList('registration', 2),
         root: null,
@@ -102,7 +99,7 @@ function forksScenario(server: Server, currentUser: ModelInstance<User>) {
         permission: Permission.Admin,
         index: 0,
     });
-    forkNode(server, forksNode as ModelInstance<Node>, { currentUserPermissions: Object.values(Permission) });
+    forkNode(server, forksNode, { currentUserPermissions: Object.values(Permission) });
 }
 
 function handbookScenario(server: Server) {

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -51,7 +51,7 @@ function registrationScenario(server: Server, currentUser: ModelInstance<User>) 
         registrationSchema: server.schema.registrationSchemas.find<RegistrationSchema>('prereg_challenge'),
         linkedNodes: server.createList('node', 2),
         linkedRegistrations: server.createList('registration', 2),
-        root: null,
+        root: undefined,
         currentUserPermissions: Object.values(Permission),
     }, 'withContributors', 'withComments', 'withDoi', 'withLicense');
     // Current user Bookmarks collection

--- a/mirage/serializers/application.ts
+++ b/mirage/serializers/application.ts
@@ -1,5 +1,5 @@
 import { underscore } from '@ember/string';
-import { JSONAPISerializer, Model, ModelInstance, Request } from 'ember-cli-mirage';
+import { Collection, JSONAPISerializer, ModelInstance, Request } from 'ember-cli-mirage';
 import { RelationshipsFor } from 'ember-data';
 import config from 'ember-get-config';
 import { RelatedLinkMeta, Relationship } from 'osf-api';
@@ -28,8 +28,8 @@ export default class ApplicationSerializer<T> extends JSONAPISerializer {
         if (this.request.queryParams.related_counts) {
             relatedCounts = this.request.queryParams.related_counts.split(',');
         }
-        // We have to narrow model here because keys in ModelInstanceShared don't have .models
-        const related = (model as Model<T>)[relationship];
+        // We have to cast the relationship to a Collection here because only hasManys will have .models
+        const related = model[relationship] as unknown as Collection<T>;
         const count = Array.isArray(related.models) ? related.models.length : 0;
         return relatedCounts.includes(this.keyForRelationship(relationship)) ? { count } : {};
     }

--- a/mirage/serializers/draft-registration.ts
+++ b/mirage/serializers/draft-registration.ts
@@ -1,3 +1,4 @@
+import { ModelInstance } from 'ember-cli-mirage';
 import config from 'ember-get-config';
 import DraftRegistration from 'ember-osf-web/models/draft-registration';
 import ApplicationSerializer from './application';
@@ -5,7 +6,7 @@ import ApplicationSerializer from './application';
 const { OSF: { apiUrl } } = config;
 
 export default class DraftRegistrationSerializer extends ApplicationSerializer<DraftRegistration> {
-    buildRelationships(model: DraftRegistration) {
+    buildRelationships(model: ModelInstance<DraftRegistration>) {
         return {
             branchedFrom: {
                 links: {

--- a/mirage/serializers/guid.ts
+++ b/mirage/serializers/guid.ts
@@ -13,7 +13,7 @@ export default class GuidSerializer extends ApplicationSerializer<SerializedGuid
     attrs = [];
 
     buildRelationships(guid: ModelInstance<SerializedGuid>) {
-        const pluralizedType = pluralize(guid.referentType);
+        const pluralizedType = pluralize(guid.referentType!);
         const referent = guid._schema[pluralizedType].find(guid.id);
         const typeKey = this.typeKeyForModel(referent);
         return {

--- a/mirage/serializers/token.ts
+++ b/mirage/serializers/token.ts
@@ -1,9 +1,10 @@
+import { ModelInstance, Request } from 'ember-cli-mirage';
 import { SingleResourceDocument } from 'osf-api';
 
-import Token from 'ember-osf-web/models/token';
+import { MirageToken } from '../factories/token';
 import ApplicationSerializer from './application';
 
-export default class TokenSerializer extends ApplicationSerializer<Token> {
+export default class TokenSerializer extends ApplicationSerializer<MirageToken> {
     normalize(json: SingleResourceDocument) {
         if (json.data.attributes && json.data.attributes.scopes) {
             const { scopes } = json.data.attributes;
@@ -25,7 +26,7 @@ export default class TokenSerializer extends ApplicationSerializer<Token> {
         return super.normalize(json);
     }
 
-    serialize(token: any, request: any) {
+    serialize(token: ModelInstance<MirageToken>, request: Request) {
         const scopeIds = token.attrs.scopeIds || [];
 
         delete token.attrs.scopeIds; // eslint-disable-line no-param-reassign

--- a/mirage/views/comment.ts
+++ b/mirage/views/comment.ts
@@ -1,9 +1,11 @@
 import { HandlerContext, ModelInstance, Request, Schema } from 'ember-cli-mirage';
 
+import Comment from 'ember-osf-web/models/comment';
+
 export function reportDelete(this: HandlerContext, schema: Schema, request: Request) {
     const { id, reporter_id: reporterId } = request.params;
-    const comment = schema.comments.find(id);
-    const report: ModelInstance = comment.reports.filter((r: ModelInstance) => r.reporter === reporterId).firstObject;
+    const comment = schema.comments.find<Comment>(id);
+    const report = comment.reports.filter((r: ModelInstance) => r.reporter === reporterId).firstObject;
 
     comment.update({
         isAbuse: false,

--- a/mirage/views/developer-app.ts
+++ b/mirage/views/developer-app.ts
@@ -1,16 +1,18 @@
 import { faker, HandlerContext, Request, Schema } from 'ember-cli-mirage';
 
+import DeveloperApp from 'ember-osf-web/models/developer-app';
+
 export function createDeveloperApp(this: HandlerContext, schema: Schema) {
     const attrs = {
         ...this.normalizedRequestAttrs('developerApp'),
         clientId: faker.internet.ip(),
         clientSecret: faker.random.uuid(),
     };
-    return schema.developerApps.create(attrs);
+    return schema.developerApps.create<DeveloperApp>(attrs);
 }
 
 export function resetClientSecret(this: HandlerContext, schema: Schema, request: Request) {
-    const developerApp = schema.developerApps.find(request.params.id);
+    const developerApp = schema.developerApps.find<DeveloperApp>(request.params.id);
     developerApp.update('clientSecret', faker.random.uuid());
     return this.serialize(developerApp);
 }

--- a/mirage/views/guid.ts
+++ b/mirage/views/guid.ts
@@ -1,11 +1,13 @@
 import { HandlerContext, Request, Response, Schema } from 'ember-cli-mirage';
 
+import Guid from 'ember-osf-web/models/guid';
+
 import { queryParamIsTruthy } from './utils';
 
 export function guidDetail(this: HandlerContext, schema: Schema, request: Request) {
     const { id } = request.params;
     const { resolve } = request.queryParams;
-    const guid = schema.guids.find(id);
+    const guid = schema.guids.find<Guid>(id);
 
     if (!guid) {
         return new Response(404, {}, {
@@ -15,7 +17,7 @@ export function guidDetail(this: HandlerContext, schema: Schema, request: Reques
     }
 
     if (queryParamIsTruthy(resolve)) {
-        return schema[guid.referentType].find(id);
+        return schema[guid.referentType!].find(id);
     }
 
     return guid;

--- a/mirage/views/node.ts
+++ b/mirage/views/node.ts
@@ -1,16 +1,26 @@
 import { HandlerContext, Schema } from 'ember-cli-mirage';
 
+import Contributor from 'ember-osf-web/models/contributor';
+import Node from 'ember-osf-web/models/node';
+import User from 'ember-osf-web/models/user';
+
+import { Root } from '../factories/root';
+
 export function createNode(this: HandlerContext, schema: Schema) {
     const attrs = this.normalizedRequestAttrs();
     const now = (new Date()).toISOString();
-    const node = schema.nodes.create({
+    const node = schema.nodes.create<Node>({
         ...attrs,
         dateModified: now,
         dateCreated: now,
     });
-    const userId = schema.roots.first().currentUserId;
-    const currentUser = schema.users.find(userId);
-    schema.contributors.create({ node, users: currentUser, index: 0 });
+
+    const userId = schema.roots.first<Root>().currentUserId;
+
+    if (userId) {
+        const currentUser = schema.users.find<User>(userId);
+        schema.contributors.create<Contributor>({ node, users: currentUser, index: 0 });
+    }
 
     return node;
 }

--- a/mirage/views/osf-resource.ts
+++ b/mirage/views/osf-resource.ts
@@ -47,7 +47,7 @@ export function osfResource(
             const models = schema[mirageModelName]
                 .where(m => filter(m, request))
                 .models
-                .map((m: any) => this.serialize(m).data);
+                .map(m => this.serialize(m).data);
 
             return process(schema, request, this, models, options);
         });
@@ -98,7 +98,7 @@ export function osfNestedResource<K extends keyof ModelRegistry>(
                 .find(request.params.parentID)[relationshipName]
                 .models
                 .filter((m: ModelInstance) => filter(m, request))
-                .map((model: any) => this.serialize(model).data);
+                .map((model: ModelInstance) => this.serialize(model).data);
             return process(schema, request, this, data, { defaultSortKey: opts.defaultSortKey });
         });
     }

--- a/mirage/views/registration.ts
+++ b/mirage/views/registration.ts
@@ -1,13 +1,15 @@
-import { HandlerContext, ModelInstance, Request, Response, Schema } from 'ember-cli-mirage';
+import { HandlerContext, Request, Response, Schema } from 'ember-cli-mirage';
+
 import Registration from 'ember-osf-web/models/registration';
+import RegistrationSchema from 'ember-osf-web/models/registration-schema';
 
 import { process } from './utils';
 
 export function forkRegistration(this: HandlerContext, schema: Schema) {
     const attrs = this.normalizedRequestAttrs();
-    const forkedFrom = schema.registrations.find(attrs.id) as ModelInstance<Registration>;
-    const registrationSchema = schema.registrationSchemas.find('prereg_challenge');
-    const newFork = schema.registrations.create({
+    const forkedFrom = schema.registrations.find<Registration>(attrs.id);
+    const registrationSchema = schema.registrationSchemas.find<RegistrationSchema>('prereg_challenge');
+    const newFork = schema.registrations.create<Registration>({
         forkedDate: new Date(),
         fork: true,
         forkedFrom,
@@ -19,7 +21,7 @@ export function forkRegistration(this: HandlerContext, schema: Schema) {
 
 export function registrationDetail(this: HandlerContext, schema: Schema, request: Request) {
     const { id } = request.params;
-    const registration = schema.registrations.find(id);
+    const registration = schema.registrations.find<Registration>(id);
 
     if (registration.embargoed && !registration.currentUserPermissions.length) {
         return new Response(404, {}, {

--- a/mirage/views/update-email.ts
+++ b/mirage/views/update-email.ts
@@ -1,19 +1,21 @@
 import { HandlerContext, Request, Schema } from 'ember-cli-mirage';
+
+import User from 'ember-osf-web/models/user';
 import UserEmail from 'ember-osf-web/models/user-email';
 
 export function updateEmails(this: HandlerContext, schema: Schema, request: Request) {
     const { parentID } = request.params;
     const { emailID } = request.params;
-    const emailList = schema.users.find(parentID).emails;
+    const emailList = schema.users.find<User>(parentID).emails;
     const attrs = this.normalizedRequestAttrs('userEmail');
-    const updatedInfo = schema.userEmails.find(emailID).update(attrs);
+    const updatedInfo = schema.userEmails.find<UserEmail>(emailID).update(attrs);
 
     /*
     // If the user is updating an email to be primary,
     // manually make all other emails primary = false
     */
     if (attrs.primary) {
-        emailList.models.forEach((email: UserEmail) => {
+        emailList.models.forEach(email => {
             if (email.id !== emailID) {
                 const updatedEmail = email;
                 updatedEmail.primary = false;
@@ -28,7 +30,7 @@ export function updateEmails(this: HandlerContext, schema: Schema, request: Requ
 export function createEmails(this: HandlerContext, schema: Schema, request: Request) {
     const { parentID } = request.params;
     const attrs = this.normalizedRequestAttrs('userEmail');
-    const user = schema.users.find(parentID);
+    const user = schema.users.find<User>(parentID);
     /*
     // If the user is adding an email, check if primary.
     // If has primary value use that. Otherwise it's false.

--- a/mirage/views/user-setting.ts
+++ b/mirage/views/user-setting.ts
@@ -1,9 +1,11 @@
 import { HandlerContext, Request, Response, Schema } from 'ember-cli-mirage';
 
+import { MirageUserSetting } from '../factories/user-setting';
+
 export function updateUserSetting(this: HandlerContext, schema: Schema, request: Request) {
     const attrs = this.normalizedRequestAttrs('userSetting');
     const userId = request.params.parentID;
-    const userSettings = schema.userSettings.findBy({ userId });
+    const userSettings = schema.userSettings.findBy<MirageUserSetting>({ userId });
     const { twoFactorEnabled, twoFactorConfirmed } = userSettings;
     let { secret } = userSettings;
 
@@ -40,7 +42,7 @@ export function updateUserSetting(this: HandlerContext, schema: Schema, request:
 }
 
 export function getUserSetting(this: HandlerContext, schema: Schema, request: Request) {
-    const userSetting = schema.userSettings.findBy({ userId: request.params.id });
+    const userSetting = schema.userSettings.findBy<MirageUserSetting>({ userId: request.params.id });
     const { twoFactorEnabled, twoFactorConfirmed } = userSetting;
     if (twoFactorEnabled && !twoFactorConfirmed) {
         userSetting.secret = 'S3CR3TSHH';

--- a/mirage/views/user.ts
+++ b/mirage/views/user.ts
@@ -1,5 +1,7 @@
 import { HandlerContext, Request, Schema } from 'ember-cli-mirage';
 
+import Contributor from 'ember-osf-web/models/contributor';
+
 import { filter, process } from './utils';
 
 export function userNodeList(this: HandlerContext, schema: Schema, request: Request) {
@@ -7,7 +9,7 @@ export function userNodeList(this: HandlerContext, schema: Schema, request: Requ
     const nodes = [];
     const { contributorIds } = user;
     for (const contributorId of contributorIds as string[]) {
-        const { node } = schema.contributors.find(contributorId);
+        const { node } = schema.contributors.find<Contributor>(contributorId);
         if (filter(node, request) && node.modelName === 'node') {
             nodes.push(this.serialize(node).data);
         }

--- a/mirage/views/user.ts
+++ b/mirage/views/user.ts
@@ -2,10 +2,11 @@ import { HandlerContext, Request, Schema } from 'ember-cli-mirage';
 
 import Contributor from 'ember-osf-web/models/contributor';
 
+import { MirageUser } from '../factories/user';
 import { filter, process } from './utils';
 
 export function userNodeList(this: HandlerContext, schema: Schema, request: Request) {
-    const user = schema.users.find(request.params.id);
+    const user = schema.users.find<MirageUser>(request.params.id);
     const nodes = [];
     const { contributorIds } = user;
     for (const contributorId of contributorIds as string[]) {

--- a/mirage/views/utils/-private.ts
+++ b/mirage/views/utils/-private.ts
@@ -28,6 +28,10 @@ const alwaysEmbed: { [key: string]: string[] } = {
     contributors: ['users'],
 };
 
+interface WithAttributes {
+    attributes: { [index: string]: any };
+}
+
 // https://stackoverflow.com/a/4760279
 export function dynamicSort(property: string) {
     let sortOrder = 1;
@@ -36,7 +40,7 @@ export function dynamicSort(property: string) {
         sortOrder = -1;
         newProp = newProp.substr(1);
     }
-    return (a: any, b: any) => {
+    return (a: WithAttributes, b: WithAttributes) => {
         let aAt = a.attributes;
         let bAt = b.attributes;
         if (newProp === 'id') {

--- a/mirage/views/wb.ts
+++ b/mirage/views/wb.ts
@@ -1,9 +1,11 @@
 import { HandlerContext, Schema } from 'ember-cli-mirage';
 
+import File from 'ember-osf-web/models/file';
+
 export function moveFile(this: HandlerContext, schema: Schema) {
     const fileId = this.request.params.id;
     const nodeId = JSON.parse(this.request.requestBody).resource;
-    const file = schema.files.find(fileId);
+    const file = schema.files.find<File>(fileId);
     file.update({
         userId: null,
         nodeId,
@@ -14,7 +16,7 @@ export function moveFile(this: HandlerContext, schema: Schema) {
 export function renameFile(this: HandlerContext, schema: Schema) {
     const fileId = this.request.params.id;
     const name = JSON.parse(this.request.requestBody).rename;
-    const file = schema.files.find(fileId);
+    const file = schema.files.find<File>(fileId);
     file.update({
         name,
     });
@@ -23,7 +25,7 @@ export function renameFile(this: HandlerContext, schema: Schema) {
 
 export function deleteFile(this: HandlerContext, schema: Schema) {
     const fileId = this.request.params.id;
-    const file = schema.files.find(fileId);
+    const file = schema.files.find<File>(fileId);
     file.destroy();
     return null;
 }

--- a/tests/acceptance/dashboard-test.ts
+++ b/tests/acceptance/dashboard-test.ts
@@ -5,6 +5,7 @@ import { percySnapshot } from 'ember-percy';
 import { selectChoose, selectSearch } from 'ember-power-select/test-support';
 import { module, test } from 'qunit';
 
+import { MirageNode } from 'ember-osf-web/mirage/factories/node';
 import { Permission } from 'ember-osf-web/models/osf-model';
 import { click, setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
 
@@ -287,7 +288,7 @@ module('Acceptance | dashboard', hooks => {
         assert.dom('div[class*="quick-project"]')
             .doesNotIncludeText('You have no projects yet. Create a project with the button on the top right.');
         assert.dom('div[class*="quick-project"]').includesText(title);
-        const newNode = server.schema.nodes.findBy({ title });
+        const newNode = server.schema.nodes.findBy<MirageNode>({ title });
         assert.equal(newNode.attrs.regionId, 'us');
     });
 
@@ -418,7 +419,7 @@ module('Acceptance | dashboard', hooks => {
         await click('[data-test-create-project-submit]');
         await click('[data-test-stay-here]');
 
-        const newNode = server.schema.nodes.findBy({ title });
+        const newNode = server.schema.nodes.findBy<MirageNode>({ title });
         assert.equal(newNode.attrs.description, description);
         assert.equal(newNode.attrs.regionId, 'de-1');
         assert.equal(newNode.attrs.templateFrom, nodeTwo.id);

--- a/tests/acceptance/dashboard-test.ts
+++ b/tests/acceptance/dashboard-test.ts
@@ -5,6 +5,7 @@ import { percySnapshot } from 'ember-percy';
 import { selectChoose, selectSearch } from 'ember-power-select/test-support';
 import { module, test } from 'qunit';
 
+import { Permission } from 'ember-osf-web/models/osf-model';
 import { click, setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
 
 const {
@@ -167,15 +168,15 @@ module('Acceptance | dashboard', hooks => {
         );
         server.create(
             'contributor',
-            { node: nodeOne, users: currentUser, index: 0, permission: 'admin', bibliographic: true },
+            { node: nodeOne, users: currentUser, index: 0, permission: Permission.Admin, bibliographic: true },
         );
         server.create(
             'contributor',
-            { node: nodeTwo, users: currentUser, index: 0, permission: 'admin', bibliographic: true },
+            { node: nodeTwo, users: currentUser, index: 0, permission: Permission.Admin, bibliographic: true },
         );
         server.create(
             'contributor',
-            { node: nodeThree, users: currentUser, index: 0, permission: 'admin', bibliographic: true },
+            { node: nodeThree, users: currentUser, index: 0, permission: Permission.Admin, bibliographic: true },
         );
         await visit('/dashboard');
 
@@ -235,15 +236,15 @@ module('Acceptance | dashboard', hooks => {
         );
         server.create(
             'contributor',
-            { node: nodeOne, users: currentUser, index: 0, permission: 'admin', bibliographic: true },
+            { node: nodeOne, users: currentUser, index: 0, permission: Permission.Admin, bibliographic: true },
         );
         server.create(
             'contributor',
-            { node: nodeTwo, users: currentUser, index: 0, permission: 'admin', bibliographic: true },
+            { node: nodeTwo, users: currentUser, index: 0, permission: Permission.Admin, bibliographic: true },
         );
         server.create(
             'contributor',
-            { node: nodeThree, users: currentUser, index: 0, permission: 'admin', bibliographic: true },
+            { node: nodeThree, users: currentUser, index: 0, permission: Permission.Admin, bibliographic: true },
         );
         await visit('/dashboard');
 
@@ -374,15 +375,15 @@ module('Acceptance | dashboard', hooks => {
         );
         server.create(
             'contributor',
-            { node: nodeOne, users: currentUser, index: 0, permission: 'admin', bibliographic: true },
+            { node: nodeOne, users: currentUser, index: 0, permission: Permission.Admin, bibliographic: true },
         );
         server.create(
             'contributor',
-            { node: nodeTwo, users: currentUser, index: 0, permission: 'admin', bibliographic: true },
+            { node: nodeTwo, users: currentUser, index: 0, permission: Permission.Admin, bibliographic: true },
         );
         server.create(
             'contributor',
-            { node: nodeThree, users: currentUser, index: 0, permission: 'admin', bibliographic: true },
+            { node: nodeThree, users: currentUser, index: 0, permission: Permission.Admin, bibliographic: true },
         );
         await visit('/dashboard');
         assert.dom('div[class*="quick-project"]').doesNotIncludeText(title);

--- a/tests/acceptance/guid-node/registrations-test.ts
+++ b/tests/acceptance/guid-node/registrations-test.ts
@@ -11,16 +11,14 @@ import {
 } from 'ember-osf-web/mirage/helpers';
 import { click, currentURL, setupOSFApplicationTest, visit } from 'ember-osf-web/tests/helpers';
 
-import Node from 'ember-osf-web/models/node';
 import { Permission } from 'ember-osf-web/models/osf-model';
-import User from 'ember-osf-web/models/user';
 
 module('Acceptance | guid-node/registrations', hooks => {
     setupOSFApplicationTest(hooks);
     setupMirage(hooks);
 
     test('logged out, no registrations', async assert => {
-        const node = server.create<Node>('node', { id: 'decaf', currentUserPermissions: [] });
+        const node = server.create('node', { id: 'decaf', currentUserPermissions: [] });
 
         const url = `/${node.id}/registrations`;
 
@@ -62,7 +60,7 @@ module('Acceptance | guid-node/registrations', hooks => {
     test('logged in admin, no registrations', async assert => {
         server.create('user', 'loggedIn');
 
-        const node = server.create<Node>('node', { id: 'decaf', currentUserPermissions: [Permission.Admin] });
+        const node = server.create('node', { id: 'decaf', currentUserPermissions: [Permission.Admin] });
 
         const url = `/${node.id}/registrations`;
 
@@ -91,7 +89,7 @@ module('Acceptance | guid-node/registrations', hooks => {
     test('logged in admin, 1 registration', async assert => {
         const contributorUser = server.create('user', 'loggedIn');
 
-        const node = server.create<Node>('node', {
+        const node = server.create('node', {
             id: 'decaf',
             title: 'Test Title',
             currentUserPermissions: [Permission.Admin],
@@ -139,7 +137,7 @@ module('Acceptance | guid-node/registrations', hooks => {
     test('logged in admin, 12 registrations', async assert => {
         const contributorUser = server.create('user', 'loggedIn');
 
-        const node = server.create<Node>('node', {
+        const node = server.create('node', {
             id: 'decaf',
             title: 'Test Title',
             currentUserPermissions: [Permission.Admin],
@@ -182,9 +180,9 @@ module('Acceptance | guid-node/registrations', hooks => {
     });
 
     test('logged in admin, 1 draft registration', async assert => {
-        const initiator = server.create<User>('user', 'loggedIn');
+        const initiator = server.create('user', 'loggedIn');
 
-        const node = server.create<Node>('node', {
+        const node = server.create('node', {
             id: 'decaf',
             currentUserPermissions: [Permission.Admin],
         });
@@ -235,9 +233,9 @@ module('Acceptance | guid-node/registrations', hooks => {
     });
 
     test('logged in admin, 12 draft registrations', async assert => {
-        const initiator = server.create<User>('user', 'loggedIn');
+        const initiator = server.create('user', 'loggedIn');
 
-        const node = server.create<Node>('node', {
+        const node = server.create('node', {
             id: 'decaf',
             currentUserPermissions: [Permission.Admin],
         });
@@ -274,7 +272,7 @@ module('Acceptance | guid-node/registrations', hooks => {
     test('logged in admin, new registration', async assert => {
         server.create('user', 'loggedIn');
 
-        const node = server.create<Node>('node', { id: 'decaf', currentUserPermissions: [Permission.Admin] });
+        const node = server.create('node', { id: 'decaf', currentUserPermissions: [Permission.Admin] });
 
         server.loadFixtures('registration-schemas');
 
@@ -306,7 +304,7 @@ module('Acceptance | guid-node/registrations', hooks => {
     test('logged in admin, prereg challenge modal', async assert => {
         server.create('user', 'loggedIn');
 
-        const node = server.create<Node>('node', { id: 'decaf', currentUserPermissions: [Permission.Admin] });
+        const node = server.create('node', { id: 'decaf', currentUserPermissions: [Permission.Admin] });
 
         server.loadFixtures('registration-schemas');
 

--- a/tests/acceptance/guid-node/registrations-test.ts
+++ b/tests/acceptance/guid-node/registrations-test.ts
@@ -12,6 +12,7 @@ import {
 import { click, currentURL, setupOSFApplicationTest, visit } from 'ember-osf-web/tests/helpers';
 
 import { Permission } from 'ember-osf-web/models/osf-model';
+import RegistrationSchema from 'ember-osf-web/models/registration-schema';
 
 module('Acceptance | guid-node/registrations', hooks => {
     setupOSFApplicationTest(hooks);
@@ -99,13 +100,12 @@ module('Acceptance | guid-node/registrations', hooks => {
 
         server.loadFixtures('registration-schemas');
         const registrationSchemaName = 'Prereg Challenge';
-        const registrationSchema = server.schema.registrationSchemas.all().models.filter(schema =>
+        const registrationSchema = server.schema.registrationSchemas.all<RegistrationSchema>().models.filter(schema =>
             schema.name === registrationSchemaName)[0];
         const registrationTitle = 'Registration Title';
         const registeredMeta = {
             q1: { comments: [], value: registrationTitle, extra: [] },
         };
-        // @ts-ignore until we kill async relationships
         registerNode(server, node, { registrationSchema, registeredMeta });
 
         const url = `/${node.id}/registrations`;
@@ -146,8 +146,8 @@ module('Acceptance | guid-node/registrations', hooks => {
         server.create('contributor', { node, users: contributorUser });
 
         server.loadFixtures('registration-schemas');
-        const registrationSchema = server.schema.registrationSchemas.all().models[0];
-        // @ts-ignore until we kill async relationships
+        const registrationSchema = server.schema.registrationSchemas.all<RegistrationSchema>().models[0];
+
         registerNodeMultiple(server, node, 12, { registrationSchema }, 'withArbitraryState');
 
         const url = `/${node.id}/registrations`;
@@ -189,14 +189,13 @@ module('Acceptance | guid-node/registrations', hooks => {
 
         server.loadFixtures('registration-schemas');
 
-        const registrationSchema = server.schema.registrationSchemas.all().models.filter(schema =>
+        const registrationSchema = server.schema.registrationSchemas.all<RegistrationSchema>().models.filter(schema =>
             schema.name === 'Prereg Challenge')[0];
 
         const registrationMetadata = {
             q1: { comments: [], value: 'Registration Title', extra: [] },
         };
 
-        // @ts-ignore until we kill async relationships
         draftRegisterNode(server, node, { initiator, registrationSchema, registrationMetadata });
 
         const url = `/${node.id}/registrations`;
@@ -242,7 +241,6 @@ module('Acceptance | guid-node/registrations', hooks => {
 
         server.loadFixtures('registration-schemas');
 
-        // @ts-ignore until we kill async relationships
         draftRegisterNodeMultiple(server, node, 12, { initiator });
 
         const url = `/${node.id}/registrations`;

--- a/tests/acceptance/guid-user/quickfiles-test.ts
+++ b/tests/acceptance/guid-user/quickfiles-test.ts
@@ -12,6 +12,7 @@ import { selectChoose } from 'ember-power-select/test-support';
 import moment from 'moment';
 import { module, test } from 'qunit';
 
+import Node from 'ember-osf-web/models/node';
 import { Permission } from 'ember-osf-web/models/osf-model';
 import { click, setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
 import pathJoin from 'ember-osf-web/utils/path-join';
@@ -80,7 +81,7 @@ module('Acceptance | Guid User Quickfiles', hooks => {
             await click('[data-test-stay-here]');
             const newFiles = this.element.querySelectorAll('div[class*="file-browser-item"]');
             assert.equal(newFiles.length, files.length - 1);
-            const newNode = server.schema.nodes.findBy({ title });
+            const newNode = server.schema.nodes.findBy<Node>({ title });
             assert.equal(newNode.attrs.public, true, 'Projects created from quickfiles should be public.');
         });
 

--- a/tests/acceptance/guid-user/quickfiles-test.ts
+++ b/tests/acceptance/guid-user/quickfiles-test.ts
@@ -12,6 +12,7 @@ import { selectChoose } from 'ember-power-select/test-support';
 import moment from 'moment';
 import { module, test } from 'qunit';
 
+import { Permission } from 'ember-osf-web/models/osf-model';
 import { click, setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
 import pathJoin from 'ember-osf-web/utils/path-join';
 
@@ -146,7 +147,7 @@ module('Acceptance | Guid User Quickfiles', hooks => {
             );
             server.create(
                 'contributor',
-                { node, users: currentUser, index: 0, permission: 'admin', bibliographic: true },
+                { node, users: currentUser, index: 0, permission: Permission.Admin, bibliographic: true },
             );
 
             await visit(`--user/${currentUser.id}/quickfiles`);
@@ -189,7 +190,7 @@ module('Acceptance | Guid User Quickfiles', hooks => {
                     node,
                     users: currentUser,
                     index: 0,
-                    permission: 'admin',
+                    permission: Permission.Admin,
                     bibliographic: true,
                 },
             );
@@ -226,7 +227,7 @@ module('Acceptance | Guid User Quickfiles', hooks => {
             );
             server.create(
                 'contributor',
-                { node, users: currentUser, index: 0, permission: 'admin', bibliographic: true },
+                { node, users: currentUser, index: 0, permission: Permission.Admin, bibliographic: true },
             );
             server.loadFixtures('regions');
 
@@ -261,7 +262,7 @@ module('Acceptance | Guid User Quickfiles', hooks => {
             );
             server.create(
                 'contributor',
-                { node, users: currentUser, index: 0, permission: 'admin', bibliographic: true },
+                { node, users: currentUser, index: 0, permission: Permission.Admin, bibliographic: true },
             );
             server.loadFixtures('regions');
 

--- a/tests/acceptance/resolve-guid-test.ts
+++ b/tests/acceptance/resolve-guid-test.ts
@@ -5,6 +5,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { TestContext } from 'ember-test-helpers';
 import { module, test } from 'qunit';
 
+import { Permission } from 'ember-osf-web/models/osf-model';
 import { currentURL as currentLocationURL, visit } from 'ember-osf-web/tests/helpers';
 import { loadEngine } from 'ember-osf-web/tests/helpers/engines';
 
@@ -108,7 +109,7 @@ module('Acceptance | resolve-guid', hooks => {
 
             test('Forks', async assert => {
                 server.create('root', 'oldRegistrationDetail');
-                const reg = server.create('registration', { currentUserPermissions: ['admin'] });
+                const reg = server.create('registration', { currentUserPermissions: [Permission.Admin] });
 
                 await visit(`/${reg.id}/forks`);
 
@@ -118,7 +119,7 @@ module('Acceptance | resolve-guid', hooks => {
 
             test('Analytics', async assert => {
                 server.create('root', 'oldRegistrationDetail');
-                const reg = server.create('registration', { currentUserPermissions: ['admin'] });
+                const reg = server.create('registration', { currentUserPermissions: [Permission.Admin] });
 
                 const url = `/${reg.id}/analytics`;
 
@@ -140,7 +141,7 @@ module('Acceptance | resolve-guid', hooks => {
             });
 
             test('Forks', async assert => {
-                const reg = server.create('registration', { currentUserPermissions: ['admin'] });
+                const reg = server.create('registration', { currentUserPermissions: [Permission.Admin] });
 
                 await visit(`/${reg.id}/forks`);
 
@@ -149,7 +150,7 @@ module('Acceptance | resolve-guid', hooks => {
             });
 
             test('Analytics', async assert => {
-                const reg = server.create('registration', { currentUserPermissions: ['admin'] });
+                const reg = server.create('registration', { currentUserPermissions: [Permission.Admin] });
 
                 const url = `/${reg.id}/analytics`;
 

--- a/tests/acceptance/verify-email-test.ts
+++ b/tests/acceptance/verify-email-test.ts
@@ -6,11 +6,10 @@ import { percySnapshot } from 'ember-percy';
 import { module, test } from 'qunit';
 
 import User from 'ember-osf-web/models/user';
-import UserEmail from 'ember-osf-web/models/user-email';
 import { click, setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
 
 function unverifiedEmails(user: ModelInstance<User>) {
-    return (user.emails.models as Array<ModelInstance<UserEmail>>)
+    return user.emails.models
         .filter(email => !email.verified)
         .sort((a, b) => parseInt(b.id, 10) - parseInt(a.id, 10));
 }
@@ -41,9 +40,7 @@ module('Acceptance | verify email', hooks => {
         user.reload();
         assert.dom('[data-test-verify-email-prompt').doesNotExist();
         assert.equal(user.emails.length, beforeCount, 'Correct number of user emails');
-        assert.ok(user.emails.models.every(
-            (email: ModelInstance<UserEmail>) => email.verified,
-        ), 'All user emails verified');
+        assert.ok(user.emails.models.every(email => email.verified), 'All user emails verified');
     });
 
     test('verify emails', async assert => {
@@ -65,15 +62,12 @@ module('Acceptance | verify email', hooks => {
         user.reload();
         assert.dom('[data-test-verify-email-prompt').doesNotExist();
         assert.equal(user.emails.length, beforeCount, 'Correct number of user emails');
-        assert.ok(user.emails.models.every(
-            (email: ModelInstance<UserEmail>) => email.verified,
-        ), 'All user emails verified');
+        assert.ok(user.emails.models.every(email => email.verified), 'All user emails verified');
     });
 
     test('deny email', async assert => {
         const user = server.create('user', 'loggedIn', 'withUnverifiedEmail');
-        // @ts-ignore TODO: upgrade ember types
-        const beforeCount: number = user.emails.length;
+        const beforeCount = user.emails.length;
 
         await visit('/dashboard');
 
@@ -84,15 +78,12 @@ module('Acceptance | verify email', hooks => {
         user.reload();
         assert.dom('[data-test-verify-email-prompt').doesNotExist();
         assert.equal(user.emails.length, beforeCount - 1, 'Correct number of user emails');
-        assert.ok(user.emails.models.every(
-            (email: ModelInstance<UserEmail>) => email.verified,
-        ), 'All user emails verified');
+        assert.ok(user.emails.models.every(email => email.verified), 'All user emails verified');
     });
 
     test('deny emails', async assert => {
         const user = server.create('user', 'loggedIn', 'withUnverifiedEmails');
-        // @ts-ignore TODO: upgrade ember types
-        const beforeCount: number = user.emails.length;
+        const beforeCount = user.emails.length;
 
         await visit('/dashboard');
 
@@ -110,8 +101,6 @@ module('Acceptance | verify email', hooks => {
         user.reload();
         assert.dom('[data-test-verify-email-prompt').doesNotExist();
         assert.equal(user.emails.length, beforeCount - 2, 'Correct number of user emails');
-        assert.ok(user.emails.models.every(
-            (email: ModelInstance<UserEmail>) => email.verified,
-        ), 'All user emails verified');
+        assert.ok(user.emails.models.every(email => email.verified), 'All user emails verified');
     });
 });

--- a/tests/acceptance/verify-email-test.ts
+++ b/tests/acceptance/verify-email-test.ts
@@ -47,7 +47,7 @@ module('Acceptance | verify email', hooks => {
     });
 
     test('verify emails', async assert => {
-        const user = server.create<User>('user', 'loggedIn', 'withUnverifiedEmail');
+        const user = server.create('user', 'loggedIn', 'withUnverifiedEmail');
         const beforeCount = user.emails.length;
         await visit('/dashboard');
 
@@ -71,7 +71,7 @@ module('Acceptance | verify email', hooks => {
     });
 
     test('deny email', async assert => {
-        const user = server.create<User>('user', 'loggedIn', 'withUnverifiedEmail');
+        const user = server.create('user', 'loggedIn', 'withUnverifiedEmail');
         // @ts-ignore TODO: upgrade ember types
         const beforeCount: number = user.emails.length;
 
@@ -90,7 +90,7 @@ module('Acceptance | verify email', hooks => {
     });
 
     test('deny emails', async assert => {
-        const user = server.create<User>('user', 'loggedIn', 'withUnverifiedEmails');
+        const user = server.create('user', 'loggedIn', 'withUnverifiedEmails');
         // @ts-ignore TODO: upgrade ember types
         const beforeCount: number = user.emails.length;
 

--- a/tests/engines/registries/acceptance/overview/comments-test.ts
+++ b/tests/engines/registries/acceptance/overview/comments-test.ts
@@ -4,6 +4,7 @@ import { percySnapshot } from 'ember-percy';
 import { TestContext } from 'ember-test-helpers';
 import { module, test } from 'qunit';
 
+import { Permission } from 'ember-osf-web/models/osf-model';
 import { currentURL, visit } from 'ember-osf-web/tests/helpers';
 import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
 
@@ -14,7 +15,7 @@ module('Registries | Acceptance | overview.comments', hooks => {
     test('it renders', async function(this: TestContext, assert: Assert) {
         const registration = server.create(
             'registration',
-            { currentUserPermissions: ['admin'] },
+            { currentUserPermissions: [Permission.Admin] },
             'withComments',
         );
 

--- a/tests/engines/registries/acceptance/overview/index-test.ts
+++ b/tests/engines/registries/acceptance/overview/index-test.ts
@@ -35,9 +35,7 @@ module('Registries | Acceptance | overview.index', hooks => {
         this.set('registration', server.create('registration', {
             archiving: false,
             withdrawn: false,
-            registrationSchema: server.schema.registrationSchemas.find(
-                'prereg_challenge',
-            ) as ModelInstance<RegistrationSchema>,
+            registrationSchema: server.schema.registrationSchemas.find<RegistrationSchema>('prereg_challenge'),
             currentUserPermissions: [Permission.Admin],
         }, 'withContributors'));
     });

--- a/tests/engines/registries/acceptance/overview/index-test.ts
+++ b/tests/engines/registries/acceptance/overview/index-test.ts
@@ -6,7 +6,9 @@ import { percySnapshot } from 'ember-percy';
 import { TestContext } from 'ember-test-helpers';
 import { module, test } from 'qunit';
 
+import { Permission } from 'ember-osf-web/models/osf-model';
 import Registration from 'ember-osf-web/models/registration';
+import RegistrationSchema from 'ember-osf-web/models/registration-schema';
 import { click, currentURL, visit } from 'ember-osf-web/tests/helpers';
 import { loadEngine, setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
 
@@ -33,8 +35,10 @@ module('Registries | Acceptance | overview.index', hooks => {
         this.set('registration', server.create('registration', {
             archiving: false,
             withdrawn: false,
-            registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
-            currentUserPermissions: ['admin'],
+            registrationSchema: server.schema.registrationSchemas.find(
+                'prereg_challenge',
+            ) as ModelInstance<RegistrationSchema>,
+            currentUserPermissions: [Permission.Admin],
         }, 'withContributors'));
     });
 

--- a/tests/engines/registries/acceptance/overview/overview-test.ts
+++ b/tests/engines/registries/acceptance/overview/overview-test.ts
@@ -4,6 +4,7 @@ import { TestContext } from 'ember-test-helpers';
 import { module, test } from 'qunit';
 
 import Registration from 'ember-osf-web/models/registration';
+import RegistrationSchema from 'ember-osf-web/models/registration-schema';
 
 import { visit } from 'ember-osf-web/tests/helpers';
 import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
@@ -19,7 +20,7 @@ module('Registries | Acceptance | overview.overview', hooks => {
     hooks.beforeEach(function(this: OverviewTestContext) {
         server.loadFixtures('registration-schemas');
         const registration = server.create('registration', {
-            registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
+            registrationSchema: server.schema.registrationSchemas.find<RegistrationSchema>('prereg_challenge'),
             embargoed: true,
         });
 

--- a/tests/integration/components/contributor-list/component-test.ts
+++ b/tests/integration/components/contributor-list/component-test.ts
@@ -50,7 +50,7 @@ module('Integration | Component | contributor-list', hooks => {
         const node = server.create('node');
         const users = server.createList('user', 4);
         for (const user of users) {
-            server.create('contributor', { node, users: user, unregisteredContributor: null });
+            server.create('contributor', { node, users: user, unregisteredContributor: undefined });
         }
         const nodeWithContribs = await this.store.findRecord('node', node.id, { include: 'contributors' });
         this.set('node', nodeWithContribs);

--- a/types/ember-cli-mirage/index.d.ts
+++ b/types/ember-cli-mirage/index.d.ts
@@ -65,6 +65,7 @@ export interface Collection<T> {
     models: Array<ModelInstance<T>>;
     length: number;
     modelName: string;
+    firstObject: ModelInstance<T>;
     update<K extends keyof T>(key: K, val: T[K]): void;
     save(): void;
     reload(): void;
@@ -237,7 +238,7 @@ export function association(...args: any[]): any;
 export type FactoryAttrs<T> = {
     [P in keyof T]?: T[P] | ((index: number) => T[P]);
 } & {
-    afterCreate?(newObj: any, server: Server): void;
+    afterCreate?(newObj: ModelInstance<T>, server: Server): void;
 };
 
 export class FactoryClass {

--- a/types/ember-cli-mirage/index.d.ts
+++ b/types/ember-cli-mirage/index.d.ts
@@ -61,7 +61,7 @@ interface ModelInstanceShared<T> {
 
 export type ModelInstance<T = AnyAttrs> = ModelInstanceShared<T> & Model<T>;
 
-interface Collection<T> {
+export interface Collection<T> {
     models: Array<ModelInstance<T>>;
     length: number;
     modelName: string;
@@ -74,14 +74,14 @@ interface Collection<T> {
 }
 
 interface ModelClass<T = AnyAttrs> {
-    new(attrs: T): ModelInstance<T>;
-    create(attrs: T): ModelInstance<T>;
-    update(attrs: T): ModelInstance<T>;
+    new<M = T>(attrs: Partial<ModelAttrs<M>>): ModelInstance<M>;
+    create<M = T>(attrs: Partial<ModelAttrs<M>>): ModelInstance<M>;
+    update<M = T>(attrs: Partial<ModelAttrs<M>>): ModelInstance<M>;
     all<M = T>(): Collection<M>;
-    find<S extends ID | ID[]>(ids: S): S extends ID ? ModelInstance<T> : Collection<T>;
-    findBy(query: T): ModelInstance<T>;
-    first(): ModelInstance<T>;
-    where(query: T | ((r: ModelInstance<T>) => boolean)): Collection<T>;
+    find<M = T, S extends ID | ID[] = ID>(ids: S): S extends ID ? ModelInstance<M> : Collection<M>;
+    findBy<M = T>(query: Partial<ModelAttrs<M>>): ModelInstance<M>;
+    first<M = T>(): ModelInstance<M>;
+    where<M = T>(query: Partial<ModelAttrs<M>> | ((r: ModelInstance<M>) => boolean)): Collection<M>;
 }
 
 export interface Schema {

--- a/types/ember-cli-mirage/types/registries/model.d.ts
+++ b/types/ember-cli-mirage/types/registries/model.d.ts
@@ -1,0 +1,3 @@
+interface MirageModelRegistry {} // tslint:disable-line:no-empty-interface
+
+export default MirageModelRegistry;


### PR DESCRIPTION
## Purpose

A number of improvements to ember-cli-mirage types for better type checking and ergonomics.

## Summary of Changes

- `server.create(modelName, ...)` now looks up the `modelName` in the `ModelRegistry` and properly types the
   return values as `ModelInstance<ModelFromTheRegistry>` and type checks any model properties passed in. This makes use of a `MirageModelRegistry` so that mirage-specific properties can be added and merged with the ember-data model.
- same as above, but for `server.createList`
- traits now take a type argument (the model they are a trait for) which results in proper typing for `afterCreate(model, server)` without requiring manual typing of its args.
- the `afterCreate` method of mirage factories is typed similarly to trait's `afterCreate`
- mirage model class methods now take a type argument and their return value will be properly typed. (e.g `server.schema.users.find<User>()` will return `ModelInstance<User>`)
- lots of cleanup as a result of and to make use of the above

## Side Effects

n/a

## Feature Flags

n/a

## QA Notes

n/a

## Ticket

https://openscience.atlassian.net/browse/EMB-576

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [x] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
