### PR TITLE
Fix links on forks and registrations pages

### DIFF
--- a/app/locations/guid-mixin.ts
+++ b/app/locations/guid-mixin.ts
@@ -1,21 +1,17 @@
 import Mixin from '@ember/object/mixin';
 
+import cleanURL from 'ember-osf-web/utils/clean-url';
+
 export default Mixin.create({
-    pattern: /(?:^|\/)--[^/]+/g,
-
-    cleanURL(url: string) {
-        return url.replace(this.pattern, '');
-    },
-
     setURL(url: string) {
-        return this._super(this.cleanURL(url));
+        return this._super(cleanURL(url));
     },
 
     replaceURL(url: string) {
-        return this._super(this.cleanURL(url));
+        return this._super(cleanURL(url));
     },
 
     formatURL(url: string): string {
-        return this._super(this.cleanURL(url));
+        return this._super(cleanURL(url));
     },
 });

--- a/app/utils/clean-url.ts
+++ b/app/utils/clean-url.ts
@@ -1,0 +1,7 @@
+/**
+ * Remove the --guidtype portions of a URL that are only used for guid routing
+ * and should never appear in a real URL.
+ */
+export default function cleanURL(url: string) {
+    return url.replace(/(?:^|\/)--[^/]+/g, '');
+}

--- a/app/utils/transition-target-url.ts
+++ b/app/utils/transition-target-url.ts
@@ -1,5 +1,7 @@
 import Transition from '@ember/routing/-private/transition';
 
+import cleanURL from 'ember-osf-web/utils/clean-url';
+
 /**
  * Get the URL (path and query string) that the given transition will resolve to,
  * using the given router.
@@ -10,9 +12,11 @@ export default function transitionTargetURL(
     const params = Object.values(transition.params).filter(
         param => Object.values(param).length,
     );
-    return transition.router.generate(
-        transition.targetName,
-        ...params,
-        { queryParams: transition.queryParams },
+    return cleanURL(
+        transition.router.generate(
+            transition.targetName,
+            ...params,
+            { queryParams: transition.queryParams },
+        ),
     );
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -215,6 +215,7 @@ module.exports = function(environment) {
         },
         featureFlagNames: {
             routes: {
+                'guid-node.index': 'ember_project_detail_page',
                 settings: 'ember_user_settings_profile_page',
                 'settings.profile': 'ember_user_settings_profile_page',
                 'settings.profile.education': 'ember_user_settings_profile_page',

--- a/config/environment.js
+++ b/config/environment.js
@@ -216,6 +216,7 @@ module.exports = function(environment) {
         featureFlagNames: {
             routes: {
                 'guid-node.index': 'ember_project_detail_page',
+                'guid-registration.index': 'ember_old_registration_detail_page',
                 settings: 'ember_user_settings_profile_page',
                 'settings.profile': 'ember_user_settings_profile_page',
                 'settings.profile.education': 'ember_user_settings_profile_page',

--- a/tests/unit/locations/auto-guid-test.ts
+++ b/tests/unit/locations/auto-guid-test.ts
@@ -2,47 +2,10 @@ import GuidAutoLocation from 'ember-osf-web/locations/auto';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-const TEST_CASES = [{
-    input: '/--user/abcd/',
-    output: '/abcd/',
-}, {
-    input: '/--user/abcd',
-    output: '/abcd',
-}, {
-    input: '/--user/--nested/abcd/',
-    output: '/abcd/',
-}, {
-    input: '/--registries-engine/overview/',
-    output: '/overview/',
-}, {
-    input: '/collections/--something--else/here/',
-    output: '/collections/here/',
-}, {
-    input: '/--registries/',
-    output: '/',
-}, {
-    input: '/AttheEnd/--registries/',
-    output: '/AttheEnd/',
-}, {
-    input: '/AttheEnd/--registries',
-    output: '/AttheEnd',
-}, {
-    input: '/normal--url/',
-    output: '/normal--url/',
-}];
-
 module('Unit | Location | guid-auto ', hooks => {
     setupTest(hooks);
 
     test('it exists', function(assert) {
         assert.ok(this.owner.lookup('location:auto') instanceof GuidAutoLocation);
-    });
-
-    test('cleanURL', function(assert) {
-        const location = this.owner.lookup('location:auto') as GuidAutoLocation;
-
-        for (const testCase of TEST_CASES) {
-            assert.equal(location.cleanURL(testCase.input), testCase.output);
-        }
     });
 });

--- a/tests/unit/locations/none-guid-test.ts
+++ b/tests/unit/locations/none-guid-test.ts
@@ -35,14 +35,6 @@ module('Unit | Location | none-auto ', hooks => {
         assert.ok(this.owner.lookup('location:none') instanceof GuidNoneLocation);
     });
 
-    test('cleanURL', function(assert) {
-        const location = this.owner.lookup('location:none') as GuidNoneLocation;
-
-        for (const testCase of TEST_CASES) {
-            assert.equal(location.cleanURL(testCase.input), testCase.output);
-        }
-    });
-
     test('setURL does not clean', function(assert) {
         const location = this.owner.lookup('location:none') as GuidNoneLocation;
 

--- a/tests/unit/utils/clean-url-test.ts
+++ b/tests/unit/utils/clean-url-test.ts
@@ -1,0 +1,37 @@
+import { module, test } from 'qunit';
+
+import cleanURL from 'ember-osf-web/utils/clean-url';
+
+const TEST_CASES = [{
+    input: '/--user/abcd',
+    output: '/abcd',
+}, {
+    input: '/--user/--nested/abcd',
+    output: '/abcd',
+}, {
+    input: '/--registries-engine/overview',
+    output: '/overview',
+}, {
+    input: '/collections/--something--else/here',
+    output: '/collections/here',
+}, {
+    input: '/--registries',
+    output: '',
+}, {
+    input: '/AttheEnd/--registries',
+    output: '/AttheEnd',
+}, {
+    input: '/normal--url',
+    output: '/normal--url',
+}];
+
+module('Unit | Utility | cleanURL', () => {
+    test('cleanURL cleans urls', assert => {
+        assert.expect(TEST_CASES.length * 2);
+
+        for (const testCase of TEST_CASES) {
+            assert.equal(cleanURL(testCase.input), testCase.output);
+            assert.equal(cleanURL(`${testCase.input}/`), `${testCase.output}/`);
+        }
+    });
+});


### PR DESCRIPTION
## Purpose

Forks and registrations links are not forcing a reload so ending up on a blank page instead of the appropriate legacy detail page.

## Summary of Changes

- move cleanURL to a utility
- pass transition target URLs through cleanURL
- add route flag for guid-node.index
- add route flag for old registration detail page

## Side Effects

Shouldn't be any

## Feature Flags

Related flags are:
- `ember_project_detail_page`
- `ember_old_registration_detail_page`

but they should both be off or not exist at this point.

## QA Notes

Need to make sure links on project forks and registrations tabs go to detail pages and not blank pages.

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
