### PR TITLE
[EMB-581] fix navigating with URL fragment

### DIFF
--- a/app/locations/history.ts
+++ b/app/locations/history.ts
@@ -1,74 +1,58 @@
 import { service } from '@ember-decorators/service';
 import { getOwner } from '@ember/application';
 import HistoryLocation from '@ember/routing/history-location';
-import { scheduleOnce } from '@ember/runloop';
+import { task, waitForQueue } from 'ember-concurrency';
+
 import GuidLocationMixin from 'ember-osf-web/locations/guid-mixin';
 import Ready from 'ember-osf-web/services/ready';
 import scrollTo from 'ember-osf-web/utils/scroll-to';
 
-// Only history has the ability to support fragments in the URL
-// Other implementations may use fragments for URL tracking. (Not that we use them).
-export default class FragmentHistoryLocation extends HistoryLocation.extend(GuidLocationMixin) {
+function splitFragment(url: string): [string, string?] {
+    const [pathAndQuery, fragment] = url.split(/#(.+)?/, 2);
+
+    // Strip any trailing slashes off the path, to match ember's treatment
+    return [pathAndQuery.replace(/\/+(?=($|\?))/, ''), fragment];
+}
+
+// Add support for scrolling to elements according to the URL's #fragment.
+export default class FragmentHistoryLocation extends HistoryLocation.extend(GuidLocationMixin, {
+    scrollToFragment: task(function *(this: FragmentHistoryLocation, fragment: string) {
+        yield this.ready.ready();
+
+        yield waitForQueue('afterRender');
+
+        // Not using `#id` as fragment could contain a `.`
+        const element = document.querySelector(`[id="${fragment}"]`) as HTMLElement;
+        if (element) {
+            scrollTo(getOwner(this), element);
+        }
+    }).restartable(),
+}) {
     @service ready!: Ready;
 
-    replaceURL(url: string) {
+    replaceURL(newURL: string) {
+        // As part of the initial transition, ember will try to strip away any URL fragment.
+        // Instead, preserve the fragment and scroll to the element it identifies.
         const currentURL = this.getURL();
-        const [fragmentLess, fragment] = this.splitFragment(currentURL);
+        const [currentPathAndQuery, fragment] = splitFragment(currentURL);
 
-        // if there's not fragment or a real URL change/replace don't do anything
-        if (!fragment || fragmentLess !== url) {
-            return super.replaceURL(url);
+        if (fragment && newURL === currentPathAndQuery) {
+            this.scrollToFragment.perform(fragment);
+            return super.replaceURL(`${newURL}#${fragment}`);
+        } else {
+            return super.replaceURL(newURL);
         }
-
-        // Wait for the page to be completely loaded
-        this.ready.ready().then(
-            // Schedule the scrollTo afterRender to maximize
-            // the chance that the target element is rendered
-            () => scheduleOnce('afterRender', this, () => {
-                // Not using #id as fragment could contain a `.`
-                const element = document.querySelector(`[id="${fragment}"]`) as HTMLElement;
-
-                // No harm no foul
-                if (!element) {
-                    return;
-                }
-
-                scrollTo(getOwner(this), element);
-            }),
-        );
-
-        return super.replaceURL(currentURL);
     }
 
-    onUpdateURL(callback: (url: string) => void) {
-        this._removeEventListener();
-
-        this._popstateHandler = () => {
-            const url = this.getURL();
-            const fragmentLess = this.stripFragment(url);
-
-            // If only the fragment has changed, eat the event.
-            // The browser will scroll to the first element with id=fragment
-            // Ember shouldn't do anything
-            if (this._previousURL && fragmentLess === this.stripFragment(this._previousURL)) {
-                return;
+    onUpdateURL(callback: (newURL: string) => void) {
+        // When the user clicks a link with `href="#fragment"`, don't call ember's `popstate` callback.
+        // Instead, let the browser scroll to the fragment-identified element as normal.
+        const maybeCallback = (newURL: string) => {
+            const pathOrQueryChanged = splitFragment(this._previousURL)[0] !== splitFragment(newURL)[0];
+            if (pathOrQueryChanged) {
+                callback(newURL);
             }
-
-            // callback here is a method on the router that strips out
-            // URL fragments anyways. So it doesn't matter if the passed URL
-            // contains one.
-            callback(url);
         };
-
-        window.addEventListener('popstate', this._popstateHandler);
-    }
-
-    private splitFragment(url: string): [string, string?] {
-        const [fragmentLess, fragment] = url.split(/#(.+)?/);
-        return [fragmentLess, fragment];
-    }
-
-    private stripFragment(url: string): string {
-        return url.split(/#(.+)?/)[0];
+        return super.onUpdateURL(maybeCallback);
     }
 }

--- a/tests/unit/locations/history-fragment-test.ts
+++ b/tests/unit/locations/history-fragment-test.ts
@@ -1,0 +1,142 @@
+import HistoryLocation from 'ember-osf-web/locations/history';
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+interface HistoryState {
+    path: string;
+    uuid: string;
+}
+
+class FakeHistory {
+    state: HistoryState | null = null;
+    private states: HistoryState[] = [];
+
+    replaceState(state: HistoryState) {
+        this.state = state;
+        this.states[0] = state;
+    }
+
+    pushState(state: HistoryState) {
+        this.state = state;
+        this.states.unshift(state);
+    }
+}
+
+function mockBrowserLocation(path: string): typeof window.location {
+    // This is a neat trick to auto-magically extract the hostname from any
+    // url by letting the browser do the work ;)
+    const tmp = document.createElement('a');
+    tmp.href = path;
+
+    const protocol = !tmp.protocol || tmp.protocol === ':' ? 'http' : tmp.protocol;
+    const pathname = tmp.pathname.match(/^\//) ? tmp.pathname : `/${tmp.pathname}`;
+
+    return {
+        hash: tmp.hash,
+        host: tmp.host || 'localhost',
+        hostname: tmp.hostname || 'localhost',
+        href: tmp.href,
+        pathname,
+        port: tmp.port || '',
+        protocol,
+        search: tmp.search,
+    } as typeof window.location;
+}
+
+module('Unit | Location | history with fragments', hooks => {
+    setupTest(hooks);
+
+    test('replaceURL preserves URL fragment', assert => {
+        const testCases = [
+            { start: '/', replaceWith: '/boron', expect: '/boron' },
+            { start: '/boron', replaceWith: '/boron#summary', expect: '/boron#summary' },
+            { start: '/boron#summary', replaceWith: '/boron', expect: '/boron#summary' },
+            { start: '/boron/#summary', replaceWith: '/boron', expect: '/boron#summary' },
+            { start: '/boron#summary', replaceWith: '/borox', expect: '/borox' },
+            { start: '/boron?foo#summary', replaceWith: '/boron', expect: '/boron' },
+            { start: '/boron?foo#summary', replaceWith: '/boron?foo', expect: '/boron?foo#summary' },
+            { start: '/boron/?foo#summary', replaceWith: '/boron?foo', expect: '/boron?foo#summary' },
+        ];
+        for (const testCase of testCases) {
+            const historyLocation = HistoryLocation.create({
+                history: new FakeHistory(),
+                location: mockBrowserLocation(testCase.start),
+                scrollToFragment: { perform: () => null },
+            });
+
+            historyLocation.replaceURL(testCase.replaceWith);
+
+            assert.equal(
+                historyLocation.history.state.path,
+                testCase.expect,
+                `Correctly handled fragment replacing '${testCase.start}' with '${testCase.replaceWith}'`,
+            );
+        }
+    });
+
+    test('onUpdateURL callback called only when path/query update', assert => {
+        const testCases = [
+            // yes callback
+            { previousURL: '/', newURL: '/foo', expectCall: true },
+            { previousURL: '/foo', newURL: '/', expectCall: true },
+            { previousURL: '/boron', newURL: '/boron?foo', expectCall: true },
+            { previousURL: '/boron/#summary', newURL: '/boron/foo#summary', expectCall: true },
+            { previousURL: '/boron/#summary', newURL: '/boron/foo#foo', expectCall: true },
+
+            // no callback
+            { previousURL: '/', newURL: '/#foo', expectCall: false },
+            { previousURL: '/boron', newURL: '/boron#summary', expectCall: false },
+            { previousURL: '/boron#summary', newURL: '/boron#foo', expectCall: false },
+            { previousURL: '/boron#summary', newURL: '/boron/#foo', expectCall: false },
+            { previousURL: '/boron#summary', newURL: '/boron/#summary', expectCall: false },
+            { previousURL: '/boron/#summary', newURL: '/boron/#foo', expectCall: false },
+            { previousURL: '/boron/#summary', newURL: '/boron#foo', expectCall: false },
+            { previousURL: '/boron/#summary', newURL: '/boron#summary', expectCall: false },
+            { previousURL: '/boron?foo', newURL: '/boron?foo', expectCall: false },
+            { previousURL: '/boron?foo', newURL: '/boron?foo#hash', expectCall: false },
+            { previousURL: '/boron?foo', newURL: '/boron/?foo', expectCall: false },
+            { previousURL: '/boron?foo', newURL: '/boron/?foo#hash', expectCall: false },
+            { previousURL: '/boron/?foo', newURL: '/boron/?foo', expectCall: false },
+            { previousURL: '/boron/?foo', newURL: '/boron/?foo#hash', expectCall: false },
+            { previousURL: '/boron/?foo', newURL: '/boron?foo', expectCall: false },
+            { previousURL: '/boron/?foo', newURL: '/boron?foo#hash', expectCall: false },
+            { previousURL: '/boron?foo#summary', newURL: '/boron?foo', expectCall: false },
+            { previousURL: '/boron?foo#summary', newURL: '/boron?foo#hash', expectCall: false },
+            { previousURL: '/boron?foo#summary', newURL: '/boron/?foo#summary', expectCall: false },
+            { previousURL: '/boron?foo#summary', newURL: '/boron?foo#hash', expectCall: false },
+            { previousURL: '/boron/?foo#summary', newURL: '/boron?foo', expectCall: false },
+            { previousURL: '/boron/?foo#summary', newURL: '/boron?foo#hash', expectCall: false },
+            { previousURL: '/boron/?foo#summary', newURL: '/boron/?foo#summary', expectCall: false },
+            { previousURL: '/boron/?foo#summary', newURL: '/boron?foo#hash', expectCall: false },
+        ];
+
+        assert.expect(testCases.length);
+
+        for (const testCase of testCases) {
+            const historyLocation = HistoryLocation.create({
+                history: new FakeHistory(),
+                _previousURL: testCase.previousURL,
+                location: mockBrowserLocation(testCase.newURL),
+            });
+
+            const callback = sinon.stub();
+
+            historyLocation.onUpdateURL(callback);
+            window.dispatchEvent(new Event('popstate'));
+            historyLocation.destroy();
+
+            if (testCase.expectCall) {
+                assert.ok(
+                    callback.calledOnceWithExactly(testCase.newURL),
+                    `onUpdateURL callback called on transiton from ${testCase.previousURL} to ${testCase.newURL}`,
+                );
+            } else {
+                assert.ok(
+                    callback.notCalled,
+                    `onUpdateURL callback not called on transiton from ${testCase.previousURL} to ${testCase.newURL}`,
+                );
+            }
+        }
+    });
+});


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[EMB-123] some really great stuff`
-->

## Purpose
When you go to a URL like /guid/#summary, the viewport should scroll to the element with id="summary" once the app has rendered.

This was previously implemented, but was only tested at `localhost:4200` and broke when the app is proxied through our web server. Trailing slashes :(
<!-- Describe the purpose of your changes. -->

## Summary of Changes
- Refactor our `HistoryLocation` to be more idiomatic/readable/testable, so the time I spent understanding "why" doesn't go to waste.
- Fix and test handling of trailing slashes.
<!-- Briefly describe or list your changes. -->

## Side Effects
n/a
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## Feature Flags
n/a
<!--
  Please list any feature flags that need to be enabled for these changes to go into effect.
  For each flag, what is the expected behavior with the flag enabled vs disabled?
-->

## QA Notes
Probably easiest to test on the registries overview page:
1. Click on a header in the registration form (e.g. "Summary")
2. Verify that the browser's viewport scrolls to that header, and the URL has the name of the header in the fragment (e.g. `/guid#summary`)
3. Reload the page
4. Repeat step 2 -- should scroll to the same header and have the same fragment
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
-->

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
https://openscience.atlassian.net/browse/EMB-581

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
