### PR TITLE
[EMB-576] Better mirage schema types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         - traits now take a type argument (the model they are a trait for) which results in proper typing for
           `afterCreate(model, server)` without requiring manual typing of its args.
         - the `afterCreate` method of mirage factories is typed similarly to trait's `afterCreate`
-        - mirage model class methods now take a type argument and their return value will be properly typed.
-          (e.g `server.schema.users.find<User>()` will return `ModelInstance<User>`)
+        - `normalizedRequestAttrs()` now requires the model name to be passed to ensure type safety
 - Services
     - `analytics` - allow toast-on-click to be used in production builds (when enabled in dev banner)
 - Components

--- a/mirage/factories/collection.ts
+++ b/mirage/factories/collection.ts
@@ -13,3 +13,9 @@ export default Factory.extend<Collection>({
     dateModified: faker.date.past(2),
     bookmarks: faker.random.boolean(),
 });
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        collections: Collection;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/comment-report.ts
+++ b/mirage/factories/comment-report.ts
@@ -1,21 +1,19 @@
 import { association, Factory, faker } from 'ember-cli-mirage';
 
-import Comment from 'ember-osf-web/models/comment';
 import CommentReport from 'ember-osf-web/models/comment-report';
 
-import { Root } from './root';
 import { guid } from './utils';
 
 export default Factory.extend<CommentReport>({
     id: guid('comment-report'),
     afterCreate(commentReport, server) {
-        const root = server.schema.roots.first<Root>();
+        const root = server.schema.roots.first();
         const reporter = (!root || faker.random.boolean()) ? server.create('user').id : root.currentUser!.id;
         commentReport.update({
             reporter,
         });
 
-        const comment = server.schema.comments.find<Comment>(commentReport.comment.id);
+        const comment = server.schema.comments.find(commentReport.comment.id);
         if (comment) {
             comment.update({
                 isAbuse: true,
@@ -28,3 +26,9 @@ export default Factory.extend<CommentReport>({
 
     comment: association() as CommentReport['comment'],
 });
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        commentReports: CommentReport;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/comment.ts
+++ b/mirage/factories/comment.ts
@@ -67,3 +67,9 @@ export default Factory.extend<Comment & CommentTraits>({
         },
     }),
 });
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        comments: Comment;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/contributor.ts
+++ b/mirage/factories/contributor.ts
@@ -13,3 +13,9 @@ export default Factory.extend<Contributor>({
     node: association() as Contributor['node'],
     users: association() as Contributor['users'],
 });
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        contributors: Contributor;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/developer-app.ts
+++ b/mirage/factories/developer-app.ts
@@ -26,3 +26,9 @@ export default Factory.extend<DeveloperApp>({
         return faker.random.uuid();
     },
 });
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        developerApps: DeveloperApp;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/draft-registration.ts
+++ b/mirage/factories/draft-registration.ts
@@ -35,3 +35,9 @@ export default Factory.extend<DraftRegistration & DraftRegistrationTraits>({
         },
     }),
 });
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        draftRegistrations: DraftRegistration;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/file.ts
+++ b/mirage/factories/file.ts
@@ -47,3 +47,9 @@ export default Factory.extend<File>({
         return faker.random.number(1000000000);
     },
 });
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        files: File;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/identifier.ts
+++ b/mirage/factories/identifier.ts
@@ -8,3 +8,9 @@ export default Factory.extend<Identifier>({
         return faker.fake('10.5555/{{company.bsNoun}}');
     },
 });
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        identifierss: Identifier;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/institution.ts
+++ b/mirage/factories/institution.ts
@@ -17,3 +17,9 @@ export default Factory.extend<Institution>({
         };
     },
 });
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        institutions: Institution;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/node.ts
+++ b/mirage/factories/node.ts
@@ -2,10 +2,8 @@ import { capitalize } from '@ember/string';
 import { Collection, Factory, faker, trait, Trait } from 'ember-cli-mirage';
 
 import Identifier from 'ember-osf-web/models/identifier';
-import License from 'ember-osf-web/models/license';
 import Node from 'ember-osf-web/models/node';
 import { Permission } from 'ember-osf-web/models/osf-model';
-import RegistrationSchema from 'ember-osf-web/models/registration-schema';
 
 import { guid, guidAfterCreate } from './utils';
 
@@ -93,7 +91,7 @@ export default Factory.extend<MirageNode & NodeTraits>({
                     category: node.category,
                     title: node.title,
                     registrationSchema: faker.random.arrayElement(
-                        server.schema.registrationSchemas.all<RegistrationSchema>().models,
+                        server.schema.registrationSchemas.all().models,
                     ),
                 });
                 node.contributors.models.forEach(contributor =>
@@ -109,7 +107,7 @@ export default Factory.extend<MirageNode & NodeTraits>({
                 branchedFrom: node,
                 initiator: node.contributors.models[0].users,
                 registrationSchema: faker.random.arrayElement(
-                    server.schema.registrationSchemas.all<RegistrationSchema>().models,
+                    server.schema.registrationSchemas.all().models,
                 ),
             });
         },
@@ -126,7 +124,7 @@ export default Factory.extend<MirageNode & NodeTraits>({
 
     withLicense: trait<MirageNode>({
         afterCreate(node, server) {
-            const license = faker.random.arrayElement(server.schema.licenses.all<License>().models);
+            const license = faker.random.arrayElement(server.schema.licenses.all().models);
             node.license = license; // eslint-disable-line no-param-reassign
             node.save();
         },
@@ -136,5 +134,11 @@ export default Factory.extend<MirageNode & NodeTraits>({
 declare module 'ember-cli-mirage/types/registries/model' {
     export default interface MirageModelRegistry {
         node: MirageNode;
+    } // eslint-disable-line semi
+}
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        nodes: MirageNode;
     } // eslint-disable-line semi
 }

--- a/mirage/factories/region.ts
+++ b/mirage/factories/region.ts
@@ -11,3 +11,9 @@ export default Factory.extend<RegionModel>({
         return faker.address.country();
     },
 });
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        regions: RegionModel;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/registration-schema.ts
+++ b/mirage/factories/registration-schema.ts
@@ -2,8 +2,7 @@ import { Factory, faker } from 'ember-cli-mirage';
 
 import RegistrationSchema from 'ember-osf-web/models/registration-schema';
 
-export interface MirageRegistrationSchema extends
-    Pick<RegistrationSchema, Exclude<keyof RegistrationSchema, 'schema'>> {
+export interface MirageRegistrationSchema extends RegistrationSchema {
     schemaNoConflict?: RegistrationSchema['schema'];
 }
 
@@ -32,5 +31,11 @@ export default Factory.extend<MirageRegistrationSchema>({
 declare module 'ember-cli-mirage/types/registries/model' {
     export default interface MirageModelRegistry {
         'registration-schema': MirageRegistrationSchema;
+    } // eslint-disable-line semi
+}
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        registrationSchemas: MirageRegistrationSchema;
     } // eslint-disable-line semi
 }

--- a/mirage/factories/registration.ts
+++ b/mirage/factories/registration.ts
@@ -155,3 +155,9 @@ declare module 'ember-cli-mirage/types/registries/model' {
         registration: MirageRegistration;
     } // eslint-disable-line semi
 }
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        registrations: MirageRegistration;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/root.ts
+++ b/mirage/factories/root.ts
@@ -54,3 +54,9 @@ declare module 'ember-cli-mirage/types/registries/model' {
         root: Root;
     } // eslint-disable-line semi
 }
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        roots: Root;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/scope.ts
+++ b/mirage/factories/scope.ts
@@ -11,3 +11,9 @@ export default Factory.extend<Scope>({
         return faker.lorem.sentence();
     },
 });
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        scopes: Scope;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/token.ts
+++ b/mirage/factories/token.ts
@@ -1,9 +1,9 @@
 import { Factory, faker } from 'ember-cli-mirage';
 
-import Scope from 'ember-osf-web/models/scope';
 import Token from 'ember-osf-web/models/token';
 
 export interface MirageToken extends Token {
+    tokenId: string;
     scopeIds: string[];
 }
 
@@ -17,7 +17,7 @@ export default Factory.extend<MirageToken>({
     },
 
     afterCreate(token, server) {
-        const scope = server.schema.scopes.first<Scope>() || server.create('scope');
+        const scope = server.schema.scopes.first() || server.create('scope');
         token.update('scopeIds', [scope.id]);
     },
 });
@@ -25,5 +25,11 @@ export default Factory.extend<MirageToken>({
 declare module 'ember-cli-mirage/types/registries/model' {
     export default interface MirageModelRegistry {
         token: MirageToken;
+    } // eslint-disable-line semi
+}
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        tokens: MirageToken;
     } // eslint-disable-line semi
 }

--- a/mirage/factories/user-email.ts
+++ b/mirage/factories/user-email.ts
@@ -15,3 +15,9 @@ export default Factory.extend<UserEmail>({
 
     user: association(),
 });
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        userEmails: UserEmail;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/user-setting.ts
+++ b/mirage/factories/user-setting.ts
@@ -31,3 +31,9 @@ declare module 'ember-cli-mirage/types/registries/model' {
         'user-setting': MirageUserSetting;
     } // eslint-disable-line semi
 }
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        userSettings: MirageUserSetting;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/user.ts
+++ b/mirage/factories/user.ts
@@ -1,9 +1,7 @@
 import { association, Factory, faker, trait, Trait } from 'ember-cli-mirage';
 
-import Region from 'ember-osf-web/models/region';
 import User from 'ember-osf-web/models/user';
 
-import { Root } from './root';
 import { guid, guidAfterCreate } from './utils';
 
 export interface MirageUser extends User {
@@ -73,7 +71,7 @@ export default Factory.extend<MirageUser & UserTraits>({
 
     loggedIn: trait<MirageUser>({
         afterCreate(currentUser, server) {
-            const root = server.schema.roots.first<Root>();
+            const root = server.schema.roots.first();
             if (root) {
                 root.update({ currentUser });
             } else {
@@ -114,7 +112,7 @@ export default Factory.extend<MirageUser & UserTraits>({
     }),
     withUsRegion: trait<MirageUser>({
         afterCreate(user, server) {
-            const defaultRegion = server.schema.regions.find<Region>('us');
+            const defaultRegion = server.schema.regions.find('us');
             user.update({ defaultRegion });
         },
     }),
@@ -123,5 +121,11 @@ export default Factory.extend<MirageUser & UserTraits>({
 declare module 'ember-cli-mirage/types/registries/model' {
     export default interface MirageModelRegistry {
         user: MirageUser;
+    } // eslint-disable-line semi
+}
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        users: MirageUser;
     } // eslint-disable-line semi
 }

--- a/mirage/factories/utils.ts
+++ b/mirage/factories/utils.ts
@@ -2,6 +2,7 @@ import { faker, ModelInstance, Server } from 'ember-cli-mirage';
 import SeedRandom from 'seedrandom';
 
 import { GUID_ALPHABET } from 'ember-osf-web/const/guid-alphabet';
+import Guid from 'ember-osf-web/models/guid';
 import { AbstractQuestion, Answer, RegistrationMetadata } from 'ember-osf-web/models/registration-schema';
 
 import { MirageRegistrationSchema } from './registration-schema';
@@ -18,6 +19,12 @@ export function guid(referentType: string) {
 
         return newGuid;
     };
+}
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        guids: Guid;
+    } // eslint-disable-line semi
 }
 
 export function guidAfterCreate(newObj: ModelInstance, server: Server) {

--- a/mirage/fixtures/licenses.ts
+++ b/mirage/fixtures/licenses.ts
@@ -130,3 +130,9 @@ const licenses: Array<Partial<License>> = [
 /* eslint-enable max-len */
 
 export default licenses;
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        licenses: License;
+    } // eslint-disable-line semi
+}

--- a/mirage/helpers.ts
+++ b/mirage/helpers.ts
@@ -1,7 +1,6 @@
 import { faker, ModelAttrs, ModelInstance, Server } from 'ember-cli-mirage';
 
 import DraftRegistration from 'ember-osf-web/models/draft-registration';
-import RegistrationSchema from 'ember-osf-web/models/registration-schema';
 
 import { DraftRegistrationTraits } from './factories/draft-registration';
 import { MirageNode, NodeTraits } from './factories/node';
@@ -19,7 +18,7 @@ export function registerNode(
         title: node.title,
         description: node.description,
         registrationSchema: faker.random.arrayElement(
-            server.schema.registrationSchemas.all<RegistrationSchema>().models,
+            server.schema.registrationSchemas.all().models,
         ),
         ...props,
     }, ...traits);
@@ -52,7 +51,7 @@ export function draftRegisterNode(
         branchedFrom: node,
         initiator: node.contributors.models.length ? node.contributors.models[0].users : undefined,
         registrationSchema: faker.random.arrayElement(
-            server.schema.registrationSchemas.all<RegistrationSchema>().models,
+            server.schema.registrationSchemas.all().models,
         ),
         ...props,
     }, ...traits);

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -2,7 +2,6 @@ import { ModelInstance, Server } from 'ember-cli-mirage';
 import config from 'ember-get-config';
 
 import { Permission } from 'ember-osf-web/models/osf-model';
-import RegistrationSchema from 'ember-osf-web/models/registration-schema';
 import User from 'ember-osf-web/models/user';
 
 import { draftRegisterNodeMultiple, forkNode, registerNodeMultiple } from '../helpers';
@@ -48,7 +47,7 @@ function registrationScenario(server: Server, currentUser: ModelInstance<User>) 
 
     server.create('registration', {
         id: 'decaf',
-        registrationSchema: server.schema.registrationSchemas.find<RegistrationSchema>('prereg_challenge'),
+        registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
         linkedNodes: server.createList('node', 2),
         linkedRegistrations: server.createList('registration', 2),
         root: undefined,

--- a/mirage/views/comment.ts
+++ b/mirage/views/comment.ts
@@ -1,10 +1,8 @@
 import { HandlerContext, ModelInstance, Request, Schema } from 'ember-cli-mirage';
 
-import Comment from 'ember-osf-web/models/comment';
-
 export function reportDelete(this: HandlerContext, schema: Schema, request: Request) {
     const { id, reporter_id: reporterId } = request.params;
-    const comment = schema.comments.find<Comment>(id);
+    const comment = schema.comments.find(id);
     const report = comment.reports.filter((r: ModelInstance) => r.reporter === reporterId).firstObject;
 
     comment.update({

--- a/mirage/views/developer-app.ts
+++ b/mirage/views/developer-app.ts
@@ -1,18 +1,16 @@
 import { faker, HandlerContext, Request, Schema } from 'ember-cli-mirage';
 
-import DeveloperApp from 'ember-osf-web/models/developer-app';
-
 export function createDeveloperApp(this: HandlerContext, schema: Schema) {
     const attrs = {
-        ...this.normalizedRequestAttrs('developerApp'),
+        ...this.normalizedRequestAttrs('developer-app'),
         clientId: faker.internet.ip(),
         clientSecret: faker.random.uuid(),
     };
-    return schema.developerApps.create<DeveloperApp>(attrs);
+    return schema.developerApps.create(attrs);
 }
 
 export function resetClientSecret(this: HandlerContext, schema: Schema, request: Request) {
-    const developerApp = schema.developerApps.find<DeveloperApp>(request.params.id);
+    const developerApp = schema.developerApps.find(request.params.id);
     developerApp.update('clientSecret', faker.random.uuid());
     return this.serialize(developerApp);
 }

--- a/mirage/views/fork.ts
+++ b/mirage/views/fork.ts
@@ -1,13 +1,10 @@
-import { HandlerContext, ModelInstance, Schema } from 'ember-cli-mirage';
-
-import Node from 'ember-osf-web/models/node';
-import Registration from 'ember-osf-web/models/registration';
+import { HandlerContext, Schema } from 'ember-cli-mirage';
 
 export function createFork(this: HandlerContext, schema: Schema) {
     const attrs = this.normalizedRequestAttrs('node');
     const nodeId = attrs.id;
     delete attrs.id;
-    const node = schema.nodes.find(nodeId) as ModelInstance<Node>;
+    const node = schema.nodes.find(nodeId);
     const fork = schema.nodes.create({
         forkedFrom: node,
         category: node.category,
@@ -18,7 +15,7 @@ export function createFork(this: HandlerContext, schema: Schema) {
     });
 
     const userId = schema.roots.first().currentUserId;
-    const currentUser = schema.users.find(userId);
+    const currentUser = schema.users.find(userId!);
     node.contributors.models.forEach(contributor => {
         schema.contributors.create({ node: fork, users: contributor.users });
     });
@@ -31,8 +28,8 @@ export function createRegistrationFork(this: HandlerContext, schema: Schema) {
     const attrs = this.normalizedRequestAttrs('node');
     const registrationId = attrs.id;
     delete attrs.id;
-    const registration = schema.nodes.find(registrationId) as ModelInstance<Registration>;
-    const fork = schema.registrations.create({
+    const registration = schema.registrations.find(registrationId);
+    const fork = schema.nodes.create({
         forkedFrom: registration,
         category: registration.category,
         fork: true,
@@ -42,7 +39,7 @@ export function createRegistrationFork(this: HandlerContext, schema: Schema) {
     });
 
     const userId = schema.roots.first().currentUserId;
-    const currentUser = schema.users.find(userId);
+    const currentUser = schema.users.find(userId!);
     registration.contributors.models.forEach(contributor => {
         schema.contributors.create({ node: fork, users: contributor.users });
     });

--- a/mirage/views/guid.ts
+++ b/mirage/views/guid.ts
@@ -1,13 +1,11 @@
 import { HandlerContext, Request, Response, Schema } from 'ember-cli-mirage';
 
-import Guid from 'ember-osf-web/models/guid';
-
 import { queryParamIsTruthy } from './utils';
 
 export function guidDetail(this: HandlerContext, schema: Schema, request: Request) {
     const { id } = request.params;
     const { resolve } = request.queryParams;
-    const guid = schema.guids.find<Guid>(id);
+    const guid = schema.guids.find(id);
 
     if (!guid) {
         return new Response(404, {}, {

--- a/mirage/views/node.ts
+++ b/mirage/views/node.ts
@@ -1,25 +1,19 @@
 import { HandlerContext, Schema } from 'ember-cli-mirage';
 
-import Contributor from 'ember-osf-web/models/contributor';
-import Node from 'ember-osf-web/models/node';
-import User from 'ember-osf-web/models/user';
-
-import { Root } from '../factories/root';
-
 export function createNode(this: HandlerContext, schema: Schema) {
-    const attrs = this.normalizedRequestAttrs();
+    const attrs = this.normalizedRequestAttrs('node');
     const now = (new Date()).toISOString();
-    const node = schema.nodes.create<Node>({
+    const node = schema.nodes.create({
         ...attrs,
         dateModified: now,
         dateCreated: now,
     });
 
-    const userId = schema.roots.first<Root>().currentUserId;
+    const userId = schema.roots.first().currentUserId;
 
     if (userId) {
-        const currentUser = schema.users.find<User>(userId);
-        schema.contributors.create<Contributor>({ node, users: currentUser, index: 0 });
+        const currentUser = schema.users.find(userId);
+        schema.contributors.create({ node, users: currentUser, index: 0 });
     }
 
     return node;

--- a/mirage/views/registration.ts
+++ b/mirage/views/registration.ts
@@ -1,15 +1,12 @@
 import { HandlerContext, Request, Response, Schema } from 'ember-cli-mirage';
 
-import Registration from 'ember-osf-web/models/registration';
-import RegistrationSchema from 'ember-osf-web/models/registration-schema';
-
 import { process } from './utils';
 
 export function forkRegistration(this: HandlerContext, schema: Schema) {
-    const attrs = this.normalizedRequestAttrs();
-    const forkedFrom = schema.registrations.find<Registration>(attrs.id);
-    const registrationSchema = schema.registrationSchemas.find<RegistrationSchema>('prereg_challenge');
-    const newFork = schema.registrations.create<Registration>({
+    const attrs = this.normalizedRequestAttrs('registration');
+    const forkedFrom = schema.registrations.find(attrs.id);
+    const registrationSchema = schema.registrationSchemas.find('prereg_challenge');
+    const newFork = schema.registrations.create({
         forkedDate: new Date(),
         fork: true,
         forkedFrom,
@@ -21,7 +18,7 @@ export function forkRegistration(this: HandlerContext, schema: Schema) {
 
 export function registrationDetail(this: HandlerContext, schema: Schema, request: Request) {
     const { id } = request.params;
-    const registration = schema.registrations.find<Registration>(id);
+    const registration = schema.registrations.find(id);
 
     if (registration.embargoed && !registration.currentUserPermissions.length) {
         return new Response(404, {}, {

--- a/mirage/views/token.ts
+++ b/mirage/views/token.ts
@@ -1,7 +1,7 @@
 import { faker, HandlerContext, Schema } from 'ember-cli-mirage';
 
 export function createToken(this: HandlerContext, schema: Schema) {
-    const attrs = this.normalizedRequestAttrs();
+    const attrs = this.normalizedRequestAttrs('token');
     const token = schema.tokens.create(attrs);
     token.attrs.tokenId = faker.random.uuid();
     return token;

--- a/mirage/views/update-email.ts
+++ b/mirage/views/update-email.ts
@@ -1,14 +1,11 @@
 import { HandlerContext, Request, Schema } from 'ember-cli-mirage';
 
-import User from 'ember-osf-web/models/user';
-import UserEmail from 'ember-osf-web/models/user-email';
-
 export function updateEmails(this: HandlerContext, schema: Schema, request: Request) {
     const { parentID } = request.params;
     const { emailID } = request.params;
-    const emailList = schema.users.find<User>(parentID).emails;
-    const attrs = this.normalizedRequestAttrs('userEmail');
-    const updatedInfo = schema.userEmails.find<UserEmail>(emailID).update(attrs);
+    const emailList = schema.users.find(parentID).emails;
+    const attrs = this.normalizedRequestAttrs('user-email');
+    const updatedInfo = schema.userEmails.find(emailID).update(attrs);
 
     /*
     // If the user is updating an email to be primary,
@@ -29,8 +26,8 @@ export function updateEmails(this: HandlerContext, schema: Schema, request: Requ
 
 export function createEmails(this: HandlerContext, schema: Schema, request: Request) {
     const { parentID } = request.params;
-    const attrs = this.normalizedRequestAttrs('userEmail');
-    const user = schema.users.find<User>(parentID);
+    const attrs = this.normalizedRequestAttrs('user-email');
+    const user = schema.users.find(parentID);
     /*
     // If the user is adding an email, check if primary.
     // If has primary value use that. Otherwise it's false.

--- a/mirage/views/user-setting.ts
+++ b/mirage/views/user-setting.ts
@@ -1,11 +1,9 @@
 import { HandlerContext, Request, Response, Schema } from 'ember-cli-mirage';
 
-import { MirageUserSetting } from '../factories/user-setting';
-
 export function updateUserSetting(this: HandlerContext, schema: Schema, request: Request) {
-    const attrs = this.normalizedRequestAttrs('userSetting');
+    const attrs = this.normalizedRequestAttrs('user-setting');
     const userId = request.params.parentID;
-    const userSettings = schema.userSettings.findBy<MirageUserSetting>({ userId });
+    const userSettings = schema.userSettings.findBy({ userId });
     const { twoFactorEnabled, twoFactorConfirmed } = userSettings;
     let { secret } = userSettings;
 
@@ -42,7 +40,7 @@ export function updateUserSetting(this: HandlerContext, schema: Schema, request:
 }
 
 export function getUserSetting(this: HandlerContext, schema: Schema, request: Request) {
-    const userSetting = schema.userSettings.findBy<MirageUserSetting>({ userId: request.params.id });
+    const userSetting = schema.userSettings.findBy({ userId: request.params.id });
     const { twoFactorEnabled, twoFactorConfirmed } = userSetting;
     if (twoFactorEnabled && !twoFactorConfirmed) {
         userSetting.secret = 'S3CR3TSHH';

--- a/mirage/views/user.ts
+++ b/mirage/views/user.ts
@@ -1,16 +1,13 @@
 import { HandlerContext, Request, Schema } from 'ember-cli-mirage';
 
-import Contributor from 'ember-osf-web/models/contributor';
-
-import { MirageUser } from '../factories/user';
 import { filter, process } from './utils';
 
 export function userNodeList(this: HandlerContext, schema: Schema, request: Request) {
-    const user = schema.users.find<MirageUser>(request.params.id);
+    const user = schema.users.find(request.params.id);
     const nodes = [];
     const { contributorIds } = user;
     for (const contributorId of contributorIds as string[]) {
-        const { node } = schema.contributors.find<Contributor>(contributorId);
+        const { node } = schema.contributors.find(contributorId);
         if (filter(node, request) && node.modelName === 'node') {
             nodes.push(this.serialize(node).data);
         }

--- a/mirage/views/wb.ts
+++ b/mirage/views/wb.ts
@@ -1,11 +1,9 @@
 import { HandlerContext, Schema } from 'ember-cli-mirage';
 
-import File from 'ember-osf-web/models/file';
-
 export function moveFile(this: HandlerContext, schema: Schema) {
     const fileId = this.request.params.id;
     const nodeId = JSON.parse(this.request.requestBody).resource;
-    const file = schema.files.find<File>(fileId);
+    const file = schema.files.find(fileId);
     file.update({
         userId: null,
         nodeId,
@@ -16,7 +14,7 @@ export function moveFile(this: HandlerContext, schema: Schema) {
 export function renameFile(this: HandlerContext, schema: Schema) {
     const fileId = this.request.params.id;
     const name = JSON.parse(this.request.requestBody).rename;
-    const file = schema.files.find<File>(fileId);
+    const file = schema.files.find(fileId);
     file.update({
         name,
     });
@@ -25,7 +23,7 @@ export function renameFile(this: HandlerContext, schema: Schema) {
 
 export function deleteFile(this: HandlerContext, schema: Schema) {
     const fileId = this.request.params.id;
-    const file = schema.files.find<File>(fileId);
+    const file = schema.files.find(fileId);
     file.destroy();
     return null;
 }

--- a/tests/acceptance/dashboard-test.ts
+++ b/tests/acceptance/dashboard-test.ts
@@ -5,7 +5,6 @@ import { percySnapshot } from 'ember-percy';
 import { selectChoose, selectSearch } from 'ember-power-select/test-support';
 import { module, test } from 'qunit';
 
-import { MirageNode } from 'ember-osf-web/mirage/factories/node';
 import { Permission } from 'ember-osf-web/models/osf-model';
 import { click, setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
 
@@ -288,7 +287,7 @@ module('Acceptance | dashboard', hooks => {
         assert.dom('div[class*="quick-project"]')
             .doesNotIncludeText('You have no projects yet. Create a project with the button on the top right.');
         assert.dom('div[class*="quick-project"]').includesText(title);
-        const newNode = server.schema.nodes.findBy<MirageNode>({ title });
+        const newNode = server.schema.nodes.findBy({ title });
         assert.equal(newNode.attrs.regionId, 'us');
     });
 
@@ -419,7 +418,7 @@ module('Acceptance | dashboard', hooks => {
         await click('[data-test-create-project-submit]');
         await click('[data-test-stay-here]');
 
-        const newNode = server.schema.nodes.findBy<MirageNode>({ title });
+        const newNode = server.schema.nodes.findBy({ title });
         assert.equal(newNode.attrs.description, description);
         assert.equal(newNode.attrs.regionId, 'de-1');
         assert.equal(newNode.attrs.templateFrom, nodeTwo.id);

--- a/tests/acceptance/guid-node/registrations-test.ts
+++ b/tests/acceptance/guid-node/registrations-test.ts
@@ -12,7 +12,6 @@ import {
 import { click, currentURL, setupOSFApplicationTest, visit } from 'ember-osf-web/tests/helpers';
 
 import { Permission } from 'ember-osf-web/models/osf-model';
-import RegistrationSchema from 'ember-osf-web/models/registration-schema';
 
 module('Acceptance | guid-node/registrations', hooks => {
     setupOSFApplicationTest(hooks);
@@ -100,7 +99,7 @@ module('Acceptance | guid-node/registrations', hooks => {
 
         server.loadFixtures('registration-schemas');
         const registrationSchemaName = 'Prereg Challenge';
-        const registrationSchema = server.schema.registrationSchemas.all<RegistrationSchema>().models.filter(schema =>
+        const registrationSchema = server.schema.registrationSchemas.all().models.filter(schema =>
             schema.name === registrationSchemaName)[0];
         const registrationTitle = 'Registration Title';
         const registeredMeta = {
@@ -146,7 +145,7 @@ module('Acceptance | guid-node/registrations', hooks => {
         server.create('contributor', { node, users: contributorUser });
 
         server.loadFixtures('registration-schemas');
-        const registrationSchema = server.schema.registrationSchemas.all<RegistrationSchema>().models[0];
+        const registrationSchema = server.schema.registrationSchemas.all().models[0];
 
         registerNodeMultiple(server, node, 12, { registrationSchema }, 'withArbitraryState');
 
@@ -189,7 +188,7 @@ module('Acceptance | guid-node/registrations', hooks => {
 
         server.loadFixtures('registration-schemas');
 
-        const registrationSchema = server.schema.registrationSchemas.all<RegistrationSchema>().models.filter(schema =>
+        const registrationSchema = server.schema.registrationSchemas.all().models.filter(schema =>
             schema.name === 'Prereg Challenge')[0];
 
         const registrationMetadata = {

--- a/tests/acceptance/guid-user/quickfiles-test.ts
+++ b/tests/acceptance/guid-user/quickfiles-test.ts
@@ -12,7 +12,6 @@ import { selectChoose } from 'ember-power-select/test-support';
 import moment from 'moment';
 import { module, test } from 'qunit';
 
-import Node from 'ember-osf-web/models/node';
 import { Permission } from 'ember-osf-web/models/osf-model';
 import { click, setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
 import pathJoin from 'ember-osf-web/utils/path-join';
@@ -81,7 +80,7 @@ module('Acceptance | Guid User Quickfiles', hooks => {
             await click('[data-test-stay-here]');
             const newFiles = this.element.querySelectorAll('div[class*="file-browser-item"]');
             assert.equal(newFiles.length, files.length - 1);
-            const newNode = server.schema.nodes.findBy<Node>({ title });
+            const newNode = server.schema.nodes.findBy({ title });
             assert.equal(newNode.attrs.public, true, 'Projects created from quickfiles should be public.');
         });
 

--- a/tests/engines/registries/acceptance/overview/index-test.ts
+++ b/tests/engines/registries/acceptance/overview/index-test.ts
@@ -8,7 +8,6 @@ import { module, test } from 'qunit';
 
 import { Permission } from 'ember-osf-web/models/osf-model';
 import Registration from 'ember-osf-web/models/registration';
-import RegistrationSchema from 'ember-osf-web/models/registration-schema';
 import { click, currentURL, visit } from 'ember-osf-web/tests/helpers';
 import { loadEngine, setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
 
@@ -35,7 +34,7 @@ module('Registries | Acceptance | overview.index', hooks => {
         this.set('registration', server.create('registration', {
             archiving: false,
             withdrawn: false,
-            registrationSchema: server.schema.registrationSchemas.find<RegistrationSchema>('prereg_challenge'),
+            registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
             currentUserPermissions: [Permission.Admin],
         }, 'withContributors'));
     });

--- a/tests/engines/registries/acceptance/overview/overview-test.ts
+++ b/tests/engines/registries/acceptance/overview/overview-test.ts
@@ -4,7 +4,6 @@ import { TestContext } from 'ember-test-helpers';
 import { module, test } from 'qunit';
 
 import Registration from 'ember-osf-web/models/registration';
-import RegistrationSchema from 'ember-osf-web/models/registration-schema';
 
 import { visit } from 'ember-osf-web/tests/helpers';
 import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
@@ -20,7 +19,7 @@ module('Registries | Acceptance | overview.overview', hooks => {
     hooks.beforeEach(function(this: OverviewTestContext) {
         server.loadFixtures('registration-schemas');
         const registration = server.create('registration', {
-            registrationSchema: server.schema.registrationSchemas.find<RegistrationSchema>('prereg_challenge'),
+            registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
             embargoed: true,
         });
 

--- a/types/ember-cli-mirage/types/registries/schema.d.ts
+++ b/types/ember-cli-mirage/types/registries/schema.d.ts
@@ -1,0 +1,3 @@
+interface MirageSchemaRegistry {} // tslint:disable-line:no-empty-interface
+
+export default MirageSchemaRegistry;


### PR DESCRIPTION
## Purpose

Improve types for mirage schema such that a type arg is not necessary to get type safety.

## Summary of Changes

- refactor mirage types to use a schema registry to remove the need for type args to model class methods
- require model name to be passed to `normalizedRequestAttrs()` so that it returns properly typed attrs

## Side Effects

n/a

## Feature Flags

n/a

## QA Notes

n/a

## Ticket

https://openscience.atlassian.net/browse/EMB-576

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
