### PR TITLE
[no ticket] 5 little fixes -- registries overview

### DIFF
--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -1120,7 +1120,10 @@ export default {
 
             links: {
                 title: 'Links',
-                no_links: 'This registration has no links.',
+                linked_nodes: 'Linked projects and components',
+                no_linked_nodes: 'This registration has no linked projects or components.',
+                linked_registrations: 'Linked registrations',
+                no_linked_registrations: 'This registration has no linked registrations.',
             },
 
             contributors: {

--- a/app/models/node.ts
+++ b/app/models/node.ts
@@ -224,7 +224,8 @@ export default class NodeModel extends BaseFileItem.extend(Validations, Collecta
 
     @computed('root')
     get isRoot() {
-        return !this.belongsTo('root').id();
+        const rootId = this.belongsTo('root').id();
+        return !rootId || rootId === this.id;
     }
 
     // BaseFileItem override

--- a/lib/registries/addon/components/registries-navbar/template.hbs
+++ b/lib/registries/addon/components/registries-navbar/template.hbs
@@ -162,17 +162,15 @@
                             </OsfLink>
                         </ddm.item>
                         <ddm.item role='menuitem'>
-                            <OsfLink
+                            <OsfButton
                                 data-test-ad-logout
                                 data-analytics-name='Logout'
-                                class='logoutLink'
-                                role='button'
-                                @href='#'
-                                @onclick={{action 'logout'}}
+                                @type='link'
+                                @onClick={{action 'logout'}}
                             >
                                 {{fa-icon 'sign-out' fixedWidth=true}}
                                 {{t 'auth_dropdown.log_out'}}
-                            </OsfLink>
+                            </OsfButton>
                         </ddm.item>
                     </dd.menu>
                 </BsDropdown>

--- a/lib/registries/addon/overview/children/template.hbs
+++ b/lib/registries/addon/overview/children/template.hbs
@@ -1,3 +1,4 @@
+{{title (t 'registries.overview.components.title')}}
 <h3>{{t 'registries.overview.components.title'}}</h3>
 
 {{#paginated-list/has-many

--- a/lib/registries/addon/overview/comments/template.hbs
+++ b/lib/registries/addon/overview/comments/template.hbs
@@ -1,1 +1,2 @@
+{{title (t 'registries.overview.comments.title')}}
 <CommentsList @modelTaskInstance={{this.model.taskInstance}} @relationshipName='comments' />

--- a/lib/registries/addon/overview/links/template.hbs
+++ b/lib/registries/addon/overview/links/template.hbs
@@ -1,5 +1,4 @@
-<h3>{{t 'registries.overview.links.title'}}</h3>
-
+<h3>{{t 'registries.overview.links.linked_nodes'}}</h3>
 {{#paginated-list/has-many
     modelTaskInstance=this.model.taskInstance
     relationshipName='linkedNodes'
@@ -9,6 +8,20 @@
         <NodeCard @node={{child}} />
     {{/list.item}}
     {{#list.empty}}
-        <p>{{t 'registries.overview.links.no_links'}}</p>
+        <p>{{t 'registries.overview.links.no_linked_nodes'}}</p>
+    {{/list.empty}}
+{{/paginated-list/has-many}}
+
+<h3>{{t 'registries.overview.links.linked_registrations'}}</h3>
+{{#paginated-list/has-many
+    modelTaskInstance=this.model.taskInstance
+    relationshipName='linkedRegistrations'
+    as |list|
+}}
+    {{#list.item as |child|}}
+        <NodeCard @node={{child}} />
+    {{/list.item}}
+    {{#list.empty}}
+        <p>{{t 'registries.overview.links.no_linked_registrations'}}</p>
     {{/list.empty}}
 {{/paginated-list/has-many}}

--- a/lib/registries/addon/overview/links/template.hbs
+++ b/lib/registries/addon/overview/links/template.hbs
@@ -1,3 +1,5 @@
+{{title (t 'registries.overview.links.title')}}
+
 <h3>{{t 'registries.overview.links.linked_nodes'}}</h3>
 {{#paginated-list/has-many
     modelTaskInstance=this.model.taskInstance

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -3,6 +3,7 @@
         <LoadingIndicator @dark={{true}} />
     </div>
 {{else}}
+    {{title this.registration.title}}
     <RegistriesBanner @node={{this.registration}} />
     <div local-class='TitleBackground'>
         <Container>

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -50,7 +50,6 @@ function registrationScenario(server: Server, currentUser: ModelInstance<User>) 
         registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
         linkedNodes: server.createList('node', 2),
         linkedRegistrations: server.createList('registration', 2),
-        root: undefined,
         currentUserPermissions: Object.values(Permission),
     }, 'withContributors', 'withComments', 'withDoi', 'withLicense');
     // Current user Bookmarks collection


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[EMB-123] some really great stuff`
-->

## Purpose
Fix a handful of little bugs on the registries overview page that didn't seem worth the overhead of ticketing or reviewing separately.
<!-- Describe the purpose of your changes. -->

## Summary of Changes
- fix `node.isRoot`, which works with mirage but is always `false` with the real API
- fix logout in the registries navbar
- display linked registrations on the "links" page (previously only showed linked projects/components)
- fix an error in the `registrations` mirage scenario
- add page titles to the registries overview page and its subroutes
<!-- Briefly describe or list your changes. -->

## Side Effects
n/a
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## Feature Flags
`ember_registries_detail_page`
<!--
  Please list any feature flags that need to be enabled for these changes to go into effect.
  For each flag, what is the expected behavior with the flag enabled vs disabled?
-->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
-->

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
