### PR TITLE
[No ticket] Bump OSF api version: 2.8 -> 2.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - Using new `click` handler everywhere in main app to verify `data-analytics-name` usage
 - Travis
     - Use a production build for handbook
+- OSF API
+    - Bump version from 2.8 to 2.14
 
 ### Removed
 - Components:

--- a/config/environment.js
+++ b/config/environment.js
@@ -40,7 +40,7 @@ const {
     OSF_COOKIE_DOMAIN: cookieDomain = 'localhost',
     OSF_URL: url = 'http://localhost:5000/',
     OSF_API_URL: apiUrl = 'http://localhost:8000',
-    OSF_API_VERSION: apiVersion = '2.8',
+    OSF_API_VERSION: apiVersion = '2.13',
     OSF_RENDER_URL: renderUrl = 'http://localhost:7778/render',
     OSF_FILE_URL: waterbutlerUrl = 'http://localhost:7777/',
     OSF_HELP_URL: helpUrl = 'http://localhost:4200/help',

--- a/config/environment.js
+++ b/config/environment.js
@@ -40,7 +40,7 @@ const {
     OSF_COOKIE_DOMAIN: cookieDomain = 'localhost',
     OSF_URL: url = 'http://localhost:5000/',
     OSF_API_URL: apiUrl = 'http://localhost:8000',
-    OSF_API_VERSION: apiVersion = '2.13',
+    OSF_API_VERSION: apiVersion = '2.14',
     OSF_RENDER_URL: renderUrl = 'http://localhost:7778/render',
     OSF_FILE_URL: waterbutlerUrl = 'http://localhost:7777/',
     OSF_HELP_URL: helpUrl = 'http://localhost:4200/help',


### PR DESCRIPTION
## Purpose

- Bump osf api version: 2.8 -> 2.13

## Summary of Changes

## Side Effects

## Feature Flags

## QA Notes

## Ticket

N/A

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
