### PR TITLE
[no ticket] fix: withdraw registration via pending_withdrawal

### DIFF
--- a/lib/registries/addon/components/registries-states/is-public/component.ts
+++ b/lib/registries/addon/components/registries-states/is-public/component.ts
@@ -19,7 +19,7 @@ export default class RegistrationIsPublic extends Component.extend({
         }
 
         this.node.setProperties({
-            withdrawn: true,
+            pendingWithdrawal: true,
             withdrawalJustification: this.withdrawalJustification,
         });
 


### PR DESCRIPTION
Never set `withdrawn` directly, let the backend handle it.

<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[EMB-123] some really great stuff`
-->

## Purpose
Front-end follow-up to [PLAT-1333](https://openscience.atlassian.net/browse/PLAT-1333)
<!-- Describe the purpose of your changes. -->

## Summary of Changes
When the user triggers a withdrawal, set `pending_withdrawal: true` instead of `withdrawn: true`, since the withdrawal has to be confirmed before it's actually withdrawn.
<!-- Briefly describe or list your changes. -->

## Side Effects
n/a
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## Feature Flags
`ember_registries_detail_page`
<!--
  Please list any feature flags that need to be enabled for these changes to go into effect.
  For each flag, what is the expected behavior with the flag enabled vs disabled?
-->

## QA Notes
Withdrawal should *work*.
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
-->

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
