### PR TITLE
[EMB-565] Allow admin to edit registration tags

### DIFF
--- a/lib/registries/addon/components/registries-metadata/template.hbs
+++ b/lib/registries/addon/components/registries-metadata/template.hbs
@@ -131,8 +131,9 @@
         <div local-class='Field'>
             <h4>{{t 'registries.registration_metadata.tags'}}</h4>
             <TagsWidget
+                data-test-registration-tags
                 @taggable={{this.registration}}
-                @readOnly={{true}}
+                @readOnly={{not this.registration.userHasAdminPermission}}
             />
         </div>
         {{!--

--- a/tests/engines/registries/acceptance/overview/overview-test.ts
+++ b/tests/engines/registries/acceptance/overview/overview-test.ts
@@ -112,6 +112,28 @@ module('Registries | Acceptance | overview.overview', hooks => {
             }
         });
 
+    test('only admin can edit registration tags', async function(this: OverviewTestContext, assert: Assert) {
+        const tags = ['Suspendisse', 'Mauris', 'ipsum', 'facilisis'];
+        const reg = server.create('registration', {
+            registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
+            tags,
+            currentUserPermissions: Object.values(Permission),
+        }, 'withContributors');
+
+        await visit(`/${reg.id}/`);
+
+        assert.dom('[data-test-registration-tags]').isVisible();
+        assert.dom('[data-test-tags-widget-tag-input] input').isVisible();
+        tags.forEach(tag => assert.dom(`[data-test-tags-widget-tag="${tag}"]`).exists());
+
+        reg.update({ currentUserPermissions: [Permission.Read] });
+        await visit(`/${reg.id}/`);
+
+        assert.dom('[data-test-registration-tags]').isVisible();
+        assert.dom('[data-test-tags-widget-tag-input] input').isNotVisible();
+        tags.forEach(tag => assert.dom(`[data-test-tags-widget-tag="${tag}"]`).exists());
+    });
+
     test('Check head meta tags', async assert => {
         const reg = server.create('registration', {
             registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),


### PR DESCRIPTION
## Purpose

 Allow admin to edit registration tags

## Summary of Changes

- Make editable by users with admin permission.
- Add test

## Side Effects

N/A

## Feature Flags

`ember-registries-detail-page`

## QA Notes

## Ticket

[EMB-565](https://openscience.atlassian.net/browse/EMB-565)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
