### PR TITLE
Use deploy key for handbook deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
       if: |
         branch = develop AND \
         type != pull_request AND \
-        repo = CenterForOpenScience/ember-osf-web
+        env(DEPLOY_KEY) IS present
       before_install:
         - curl -o- -L https://yarnpkg.com/install.sh | bash
         - export PATH=$HOME/.yarn/bin:$PATH
@@ -50,16 +50,17 @@ jobs:
         - HANDBOOK_ENABLED=1
         - MIRAGE_ENABLED=1
         - SHOW_DEV_BANNER=1
-        - ROOT_URL=/ember-osf-web/
-        - ASSETS_PREFIX=/ember-osf-web/
         - A11Y_AUDIT=0
         - NODE_OPTIONS=--max-old-space-size=4096
+        - TARGET_BRANCH=gh-pages
       script:
-        - ember build --environment=production && cp dist/index.html dist/404.html
+        - export ROOT_URL="/${TRAVIS_REPO_SLUG##*\/}/"
+        - export ASSETS_PREFIX="${ROOT_URL}"
+        - ember build --environment=production
+        - cp dist/index.html dist/404.html
       deploy:
-        provider: pages
+        provider: script
         skip-cleanup: true
-        github-token: $GH_TOKEN
-        local-dir: dist
+        script: scripts/handbook_deploy.sh
         on:
           branch: develop

--- a/README.md
+++ b/README.md
@@ -86,6 +86,29 @@ The handbook will be available at [http://localhost:4200/handbook](http://localh
 To enable (experimental) auto-generated docs in the handbook, you can also set
 `HANDBOOK_DOC_GENERATION_ENABLED: true` in your local config.
 
+#### Enable handbook on your fork
+
+1. [Generate a deploy key](https://developer.github.com/v3/guides/managing-deploy-keys/)
+  * `ssh-keygen -t rsa -b 4096 -C <your@email.com>`
+  * Enter file in which to save the key (~/.ssh/id_rsa): `~/deploy_key`
+  * Press enter twice for no passphrase
+2. Add the public key in your GitHub repository settings
+  * `cat ~/deploy_key.pub | pbcopy`
+  * Go to `https://github.com/<org>/<repo>/settings/keys/new`
+  * Title: `Travis CI`
+  * Key: paste in the public key
+  * ☑️ Allow write access
+3. Add the base64-encoded private key to Travis CI
+  * `cat ~/deploy_key | base64 | pbcopy`
+  * Go to `https://travis-ci.org/<org>/<repo>/settings`
+  * Under Environment Variables, add
+    * Name: `DEPLOY_KEY`
+    * Value: paste in the private key
+    * 'Leave Display Value in Build log' off
+    * Click Add
+4. Delete the keypair
+  * `rm ~/deploy_key ~/deploy_key.pub`
+
 ### Code Generators
 
 Make use of the many generators for code, try `ember help generate` for more details

--- a/scripts/handbook_deploy.sh
+++ b/scripts/handbook_deploy.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set +x
+echo "${DEPLOY_KEY}" | base64 --decode > deploy_key
+chmod 600 deploy_key
+eval $(ssh-agent -s)
+ssh-add deploy_key
+rm deploy_key
+set -x
+
+REPO=$(git config remote.origin.url)
+SSH_REPO="${REPO/https:\/\/github.com\//git@github.com:}"
+SHA=$(git rev-parse --verify HEAD)
+
+cd dist/
+git init
+git remote add origin "${SSH_REPO}"
+git checkout -b "${TARGET_BRANCH}"
+git config user.name "Travis CI"
+git config user.email "${COMMIT_AUTHOR_EMAIL}"
+git add .
+git commit -m "Deploy to GitHub Pages: ${SHA}"
+git push --force origin ${TARGET_BRANCH}


### PR DESCRIPTION
## Purpose

There was unauthorized use of a personal access token, which has been remediated. Builds on develop are now failing because of this. All of the necessary settings have been updated on GitHub and Travis CI.

Do **not** commit any changes to the Travis CI configuration without DevOps review and approval.

## Summary of Changes

* Update travis config to use a deploy key instead of a personal access token
* Add instructions in the README

## Side Effects

N/A

## Feature Flags

N/A

## QA Notes

N/A

## Ticket

None

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
