### PR TITLE
[EMB-572] Password widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         - `circle` - a placeholder for circlular elements
 - Routes:
     - `new-home` - new logged out home page route
+    - `settings/account/change-password` - Panel for changing a user's password
+    - `password-strength-bar` - Shows the strength of a given password
 
 ### Changed
 - Components

--- a/app/adapters/user-password.ts
+++ b/app/adapters/user-password.ts
@@ -1,6 +1,26 @@
+// import DS from 'ember-data';
+import config from 'ember-get-config';
+
 import OsfAdapter from './osf-adapter';
 
+const {
+    OSF: {
+        apiUrl: host,
+        apiNamespace: namespace,
+    },
+} = config;
+
 export default class UserPasswordAdapter extends OsfAdapter {
+    host = host;
+    namespace = namespace;
+
+    urlForCreateRecord(): string {
+        // modelName = modelName;
+        // snapshot = snapshot;
+        return 'hello';
+        // const userID = snapshot.user.id;
+        // return `${host}/${namespace}/users/${userID}/settings/password/`;
+    }
 }
 
 declare module 'ember-data/types/registries/adapter' {

--- a/app/adapters/user-password.ts
+++ b/app/adapters/user-password.ts
@@ -10,13 +10,12 @@ const {
 } = config;
 
 export default class UserPasswordAdapter extends OsfAdapter {
-    host = host;
-    namespace = namespace;
-
     urlForCreateRecord(): string {
         let userID = '';
         if (this.currentUser && this.currentUser.user && this.currentUser.user.id) {
             userID = this.currentUser.user.id;
+        } else {
+            throw Error('Must provide valid user');
         }
         return `${host}/${namespace}/users/${userID}/settings/password/`;
     }

--- a/app/adapters/user-password.ts
+++ b/app/adapters/user-password.ts
@@ -1,0 +1,10 @@
+import OsfAdapter from './osf-adapter';
+
+export default class UserPasswordAdapter extends OsfAdapter {
+}
+
+declare module 'ember-data/types/registries/adapter' {
+    export default interface AdapterRegistry {
+        'user-password': UserPasswordAdapter;
+    } // eslint-disable-line semi
+}

--- a/app/adapters/user-password.ts
+++ b/app/adapters/user-password.ts
@@ -11,13 +11,10 @@ const {
 
 export default class UserPasswordAdapter extends OsfAdapter {
     urlForCreateRecord(): string {
-        let userID = '';
         if (this.currentUser && this.currentUser.user && this.currentUser.user.id) {
-            userID = this.currentUser.user.id;
-        } else {
-            throw Error('Must provide valid user');
+            return `${host}/${namespace}/users/${this.currentUser.user.id}/settings/password/`;
         }
-        return `${host}/${namespace}/users/${userID}/settings/password/`;
+        throw Error('Must provide valid user');
     }
 }
 

--- a/app/adapters/user-password.ts
+++ b/app/adapters/user-password.ts
@@ -1,4 +1,3 @@
-// import DS from 'ember-data';
 import config from 'ember-get-config';
 
 import OsfAdapter from './osf-adapter';
@@ -15,11 +14,11 @@ export default class UserPasswordAdapter extends OsfAdapter {
     namespace = namespace;
 
     urlForCreateRecord(): string {
-        // modelName = modelName;
-        // snapshot = snapshot;
-        return 'hello';
-        // const userID = snapshot.user.id;
-        // return `${host}/${namespace}/users/${userID}/settings/password/`;
+        let userID = '';
+        if (this.currentUser && this.currentUser.user && this.currentUser.user.id) {
+            userID = this.currentUser.user.id;
+        }
+        return `${host}/${namespace}/users/${userID}/settings/password/`;
     }
 }
 

--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -1471,6 +1471,7 @@ export default {
                 title: 'Change password',
                 updateButton: 'Update password',
                 updateFail: 'Error updating password',
+                updateSuccess: 'Successfully changed password',
                 currentPassword: {
                     placeholder: 'Old password',
                 },

--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -1467,6 +1467,20 @@ export default {
                 update_fail: 'Unable to update email',
                 update_success: 'Email updated',
             },
+            changePassword: {
+                title: 'Change password',
+                updateButton: 'Update password',
+                currentPassword: {
+                    placeholder: 'Old password',
+                },
+                newPassword: {
+                    placeholder: 'New password',
+                },
+                confirmPassword: {
+                    title: 'Confirm new password',
+                    placeholder: 'Verify password',
+                },
+            },
         },
         addons: {
             title: 'Configure add-on accounts',

--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -1470,6 +1470,8 @@ export default {
             changePassword: {
                 title: 'Change password',
                 updateButton: 'Update password',
+                incorrectPassword: 'Old password does not match current password',
+                updateFail: 'Error updating password',
                 currentPassword: {
                     placeholder: 'Old password',
                 },

--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -1470,7 +1470,6 @@ export default {
             changePassword: {
                 title: 'Change password',
                 updateButton: 'Update password',
-                incorrectPassword: 'Old password does not match current password',
                 updateFail: 'Error updating password',
                 currentPassword: {
                     placeholder: 'Old password',

--- a/app/models/user-password.ts
+++ b/app/models/user-password.ts
@@ -20,15 +20,15 @@ const Validations = buildValidations({
             min: 2,
         }),
         validator('mismatch', {
+            messageKey: 'validationErrors.password_old',
             on: 'currentPassword',
-            message: 'New password must not match current password',
         }),
     ],
     confirmPassword: [
         validator('presence', true),
         validator('confirmation', {
+            messageKey: 'validationErrors.password_match',
             on: 'password',
-            message: 'Passwords must match',
         }),
     ],
 }, {

--- a/app/models/user-password.ts
+++ b/app/models/user-password.ts
@@ -1,0 +1,46 @@
+import { attr } from '@ember-decorators/data';
+import { buildValidations, validator } from 'ember-cp-validations';
+import DS from 'ember-data';
+
+const { Model } = DS;
+
+const Validations = buildValidations({
+    currentPassword: [
+        validator('presence', true),
+    ],
+    newPassword: [
+        validator('presence', true),
+        validator('length', {
+            max: 255,
+            min: 8,
+        }),
+        validator('password-strength', {
+            min: 2,
+        }),
+        validator('mismatch', {
+            on: 'currentPassword',
+            message: 'New password must not match current password',
+        }),
+    ],
+    confirmPassword: [
+        validator('presence', true),
+        validator('confirmation', {
+            on: 'newPassword',
+            message: 'Passwords must match',
+        }),
+    ],
+}, {
+    debounce: 500,
+});
+
+export default class UserPasswordModel extends Model.extend(Validations) {
+    @attr('string') currentPassword!: string;
+    @attr('string') newPassword!: string;
+    @attr('string') confirmPassword!: string;
+}
+
+declare module 'ember-data/types/registries/model' {
+    export default interface ModelRegistry {
+        'user-password': UserPasswordModel;
+    } // eslint-disable-line semi
+}

--- a/app/models/user-password.ts
+++ b/app/models/user-password.ts
@@ -31,6 +31,8 @@ const Validations = buildValidations({
             message: 'Passwords must match',
         }),
     ],
+}, {
+    debounce: 500,
 });
 
 export default class UserPasswordModel extends Model.extend(Validations) {

--- a/app/models/user-password.ts
+++ b/app/models/user-password.ts
@@ -31,8 +31,6 @@ const Validations = buildValidations({
             message: 'Passwords must match',
         }),
     ],
-}, {
-    debounce: 500,
 });
 
 export default class UserPasswordModel extends Model.extend(Validations) {

--- a/app/models/user-password.ts
+++ b/app/models/user-password.ts
@@ -27,7 +27,7 @@ const Validations = buildValidations({
     confirmPassword: [
         validator('presence', true),
         validator('confirmation', {
-            on: 'newPassword',
+            on: 'password',
             message: 'Passwords must match',
         }),
     ],

--- a/app/models/user-password.ts
+++ b/app/models/user-password.ts
@@ -1,6 +1,8 @@
-import { attr } from '@ember-decorators/data';
+import { attr, belongsTo } from '@ember-decorators/data';
 import { buildValidations, validator } from 'ember-cp-validations';
 import DS from 'ember-data';
+
+import UserModel from './user';
 
 const { Model } = DS;
 
@@ -8,7 +10,7 @@ const Validations = buildValidations({
     currentPassword: [
         validator('presence', true),
     ],
-    newPassword: [
+    password: [
         validator('presence', true),
         validator('length', {
             max: 255,
@@ -35,8 +37,11 @@ const Validations = buildValidations({
 
 export default class UserPasswordModel extends Model.extend(Validations) {
     @attr('string') currentPassword!: string;
-    @attr('string') newPassword!: string;
+    @attr('string') password!: string;
     @attr('string') confirmPassword!: string;
+
+    @belongsTo('user')
+    user!: UserModel;
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/models/user-password.ts
+++ b/app/models/user-password.ts
@@ -7,10 +7,10 @@ import UserModel from './user';
 const { Model } = DS;
 
 const Validations = buildValidations({
-    currentPassword: [
+    existingPassword: [
         validator('presence', true),
     ],
-    password: [
+    newPassword: [
         validator('presence', true),
         validator('length', {
             max: 255,
@@ -21,14 +21,14 @@ const Validations = buildValidations({
         }),
         validator('mismatch', {
             messageKey: 'validationErrors.password_old',
-            on: 'currentPassword',
+            on: 'existingPassword',
         }),
     ],
     confirmPassword: [
         validator('presence', true),
         validator('confirmation', {
             messageKey: 'validationErrors.password_match',
-            on: 'password',
+            on: 'newPassword',
         }),
     ],
 }, {
@@ -36,8 +36,8 @@ const Validations = buildValidations({
 });
 
 export default class UserPasswordModel extends Model.extend(Validations) {
-    @attr('string') currentPassword!: string;
-    @attr('string') password!: string;
+    @attr('string') existingPassword!: string;
+    @attr('string') newPassword!: string;
     @attr('string') confirmPassword!: string;
 
     @belongsTo('user')

--- a/app/serializers/user-password.ts
+++ b/app/serializers/user-password.ts
@@ -1,0 +1,10 @@
+import OsfSerializer from './osf-serializer';
+
+export default class UserPasswordSerializer extends OsfSerializer {
+}
+
+declare module 'ember-data/types/registries/serializer' {
+    export default interface SerializerRegistry {
+        'user-password': UserPasswordSerializer;
+    } // eslint-disable-line semi
+}

--- a/app/settings/account/-components/change-password/component.ts
+++ b/app/settings/account/-components/change-password/component.ts
@@ -24,6 +24,7 @@ export default class ChangePasswordPane extends Component.extend({
 
         try {
             yield this.userPassword.save();
+            location.reload();
         } catch (e) {
             this.toast.error(errorMessage);
         } finally {

--- a/app/settings/account/-components/change-password/component.ts
+++ b/app/settings/account/-components/change-password/component.ts
@@ -1,0 +1,65 @@
+import { action } from '@ember-decorators/object';
+import { alias, and } from '@ember-decorators/object/computed';
+import { service } from '@ember-decorators/service';
+import Component from '@ember/component';
+import PasswordStrength from 'ember-cli-password-strength/services/password-strength';
+import { task } from 'ember-concurrency';
+import DS from 'ember-data';
+import I18N from 'ember-i18n/services/i18n';
+import Toast from 'ember-toastr/services/toast';
+
+import User from 'ember-osf-web/models/user';
+import UserPassword from 'ember-osf-web/models/user-password';
+import CurrentUser from 'ember-osf-web/services/current-user';
+
+export default class ChangePasswordPane extends Component.extend({
+    submitTask: task(function *(this: ChangePasswordPane) {
+        const { validations } = yield this.userPassword.validate();
+        this.set('didValidate', true);
+
+        if (!validations.isValid) {
+            return;
+        }
+
+        try {
+            yield this.userPassword.save();
+        } catch (e) {
+            return;
+        }
+
+        this.set('hasSubmitted', true);
+    }),
+}) {
+    // Private parameters
+    userPassword!: UserPassword;
+    hasSubmitted: boolean = false;
+    didValidate = false;
+
+    @service currentUser!: CurrentUser;
+    @service i18n!: I18N;
+    @service passwordStrength!: PasswordStrength;
+    @service toast!: Toast;
+    @service store!: DS.Store;
+    @alias('currentUser.user') user!: User;
+
+    @alias('userPassword.validations.attrs') a!: object;
+
+    @and(
+        'a.newPassword.isValid',
+    ) formIsValid!: boolean;
+
+    init() {
+        this.set('userPassword', this.store.createRecord('user-password'));
+        return super.init();
+    }
+
+    @action
+    submit() {
+        this.submitTask.perform();
+    }
+
+    @action
+    updateError() {
+        return false;
+    }
+}

--- a/app/settings/account/-components/change-password/component.ts
+++ b/app/settings/account/-components/change-password/component.ts
@@ -35,6 +35,7 @@ export default class ChangePasswordPane extends Component.extend({
     userPassword!: UserPassword;
     hasSubmitted: boolean = false;
     didValidate = false;
+    newPassword = '';
 
     @service currentUser!: CurrentUser;
     @service i18n!: I18N;
@@ -51,11 +52,5 @@ export default class ChangePasswordPane extends Component.extend({
     @action
     submit() {
         this.submitTask.perform();
-    }
-
-    @action
-    updateError() {
-        const errorMessage = this.i18n.t('settings.account.changePassword.incorrectPassword');
-        return this.toast.error(errorMessage);
     }
 }

--- a/app/settings/account/-components/change-password/component.ts
+++ b/app/settings/account/-components/change-password/component.ts
@@ -28,12 +28,12 @@ export default class ChangePasswordPane extends Component.extend({
             return;
         }
         this.userPassword.unloadRecord();
-        this.currentUser.logout();
         this.toast.success(successMessage);
         const { timeOut, hideDuration } = window.toastr.options;
         if (timeOut && hideDuration) {
-            yield timeout(timeOut + hideDuration);
+            yield timeout(Number(timeOut) + Number(hideDuration));
         }
+        this.currentUser.logout();
     }),
 }) {
     // Private parameters
@@ -50,6 +50,8 @@ export default class ChangePasswordPane extends Component.extend({
 
     constructor(...args: any[]) {
         super(...args);
+
+        // creates a fake id because ember data expects one
         const id = Math.floor(Math.random() * 1000000);
         this.userPassword = this.store.createRecord('user-password', { id });
     }

--- a/app/settings/account/-components/change-password/component.ts
+++ b/app/settings/account/-components/change-password/component.ts
@@ -30,7 +30,7 @@ export default class ChangePasswordPane extends Component.extend({
         this.userPassword.unloadRecord();
         this.toast.success(successMessage);
         const { timeOut, hideDuration } = window.toastr.options;
-        if (timeOut && hideDuration) {
+        if (typeof timeOut !== 'undefined' && typeof hideDuration !== 'undefined') {
             yield timeout(Number(timeOut) + Number(hideDuration));
         }
         this.currentUser.logout();

--- a/app/settings/account/-components/change-password/component.ts
+++ b/app/settings/account/-components/change-password/component.ts
@@ -25,15 +25,14 @@ export default class ChangePasswordPane extends Component.extend({
         try {
             yield this.userPassword.save();
         } catch (e) {
-            return this.toast.error(errorMessage);
+            this.toast.error(errorMessage);
+        } finally {
+            this.userPassword.unloadRecord();
         }
-
-        this.set('hasSubmitted', true);
     }),
 }) {
     // Private parameters
     userPassword!: UserPassword;
-    hasSubmitted: boolean = false;
     didValidate = false;
     newPassword = '';
 
@@ -45,7 +44,7 @@ export default class ChangePasswordPane extends Component.extend({
     @alias('currentUser.user') user!: User;
 
     init() {
-        this.set('userPassword', this.store.createRecord('user-password'));
+        this.set('userPassword', this.store.createRecord('user-password', { id: '123te' }));
         return super.init();
     }
 

--- a/app/settings/account/-components/change-password/component.ts
+++ b/app/settings/account/-components/change-password/component.ts
@@ -1,5 +1,5 @@
 import { action } from '@ember-decorators/object';
-import { alias, and } from '@ember-decorators/object/computed';
+import { alias } from '@ember-decorators/object/computed';
 import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
 import PasswordStrength from 'ember-cli-password-strength/services/password-strength';
@@ -14,6 +14,7 @@ import CurrentUser from 'ember-osf-web/services/current-user';
 
 export default class ChangePasswordPane extends Component.extend({
     submitTask: task(function *(this: ChangePasswordPane) {
+        const errorMessage = this.i18n.t('settings.account.changePassword.updateFail');
         const { validations } = yield this.userPassword.validate();
         this.set('didValidate', true);
 
@@ -24,7 +25,7 @@ export default class ChangePasswordPane extends Component.extend({
         try {
             yield this.userPassword.save();
         } catch (e) {
-            return;
+            return this.toast.error(errorMessage);
         }
 
         this.set('hasSubmitted', true);
@@ -42,12 +43,6 @@ export default class ChangePasswordPane extends Component.extend({
     @service store!: DS.Store;
     @alias('currentUser.user') user!: User;
 
-    @alias('userPassword.validations.attrs') a!: object;
-
-    @and(
-        'a.newPassword.isValid',
-    ) formIsValid!: boolean;
-
     init() {
         this.set('userPassword', this.store.createRecord('user-password'));
         return super.init();
@@ -60,6 +55,7 @@ export default class ChangePasswordPane extends Component.extend({
 
     @action
     updateError() {
-        return false;
+        const errorMessage = this.i18n.t('settings.account.changePassword.incorrectPassword');
+        return this.toast.error(errorMessage);
     }
 }

--- a/app/settings/account/-components/change-password/template.hbs
+++ b/app/settings/account/-components/change-password/template.hbs
@@ -25,12 +25,12 @@
                 data-test-new-password
                 @password={{true}}
                 @model={{this.userPassword}}
-                @valuePath='newPassword'
+                @valuePath='password'
                 @shouldShowMessages={{this.didValidate}}
                 @placeholder={{t 'settings.account.changePassword.newPassword.placeholder'}}
                 @ariaLabel={{t 'settings.account.changePassword.newPassword.placeholder'}}
             />
-            <PasswordStrengthBar @password={{this.userPassword.newPassword}} />
+            <PasswordStrengthBar @password={{this.userPassword.password}} />
             <label>{{t 'settings.account.changePassword.confirmPassword.title'}}</label>
             <form.text
                 data-test-confirm-password

--- a/app/settings/account/-components/change-password/template.hbs
+++ b/app/settings/account/-components/change-password/template.hbs
@@ -4,50 +4,48 @@
 >
     <panel.heading @title={{t 'settings.account.changePassword.title'}} />
     <panel.body data-analytics-scope='Change password panel'>
-        <form
-            {{action 'submit' on='submit'}}
-        >
-            {{! template-lint-disable no-implicit-this }}
-            {{validated-input/text
-                data-test-current-password
-                label=(t 'settings.account.changePassword.currentPassword.placeholder')
-                password=true
-                model=this.userPassword
-                valuePath='existingPassword'
-                shouldShowMessages=this.didValidate
-                placeholder=(t 'settings.account.changePassword.currentPassword.placeholder')
-                ariaLabel=(t 'settings.account.changePassword.currentPassword.placeholder')
-            }}
-            {{validated-input/text
-                data-test-new-password
-                label=(t 'settings.account.changePassword.newPassword.placeholder')
-                password=true
-                model=this.userPassword
-                valuePath='newPassword'
-                shouldShowMessages=this.didValidate
-                placeholder=(t 'settings.account.changePassword.newPassword.placeholder')
-                ariaLabel=(t 'settings.account.changePassword.newPassword.placeholder')
-            }}
-            <PasswordStrengthBar
-                @password={{this.userPassword.newPassword}}
-                @model={{this.userPassword}}
-            />
-            {{validated-input/text
-                data-test-confirm-password
-                label=(t 'settings.account.changePassword.confirmPassword.title')
-                password=true
-                model=this.userPassword
-                valuePath='confirmPassword'
-                shouldShowMessages=this.didValidate
-                placeholder=(t 'settings.account.changePassword.confirmPassword.placeholder')
-                ariaLabel=(t 'settings.account.changePassword.confirmPassword.placeholder')
-            }}
-            {{! template-lint-enable no-implicit-this }}
+        <form>
+            {{#let (component 'validated-input/text') as |ValidatedTextInput| }}
+                <ValidatedTextInput
+                    data-test-current-password
+                    @label={{t 'settings.account.changePassword.currentPassword.placeholder'}}
+                    @password={{true}}
+                    @model={{this.userPassword}}
+                    @valuePath='existingPassword'
+                    @shouldShowMessages={{this.didValidate}}
+                    @placeholder={{t 'settings.account.changePassword.currentPassword.placeholder'}}
+                    @ariaLabel={{t 'settings.account.changePassword.currentPassword.placeholder'}}
+                />
+                <ValidatedTextInput
+                    data-test-new-password
+                    @label={{t 'settings.account.changePassword.newPassword.placeholder'}}
+                    @password={{true}}
+                    @model={{this.userPassword}}
+                    @valuePath='newPassword'
+                    @shouldShowMessages={{this.didValidate}}
+                    @placeholder={{t 'settings.account.changePassword.newPassword.placeholder'}}
+                    @ariaLabel={{t 'settings.account.changePassword.newPassword.placeholder'}}
+                />
+                <PasswordStrengthBar
+                    @password={{this.userPassword.newPassword}}
+                    @model={{this.userPassword}}
+                />
+                <ValidatedTextInput
+                    data-test-confirm-password
+                    @label={{t 'settings.account.changePassword.confirmPassword.title'}}
+                    @password={{true}}
+                    @model={{this.userPassword}}
+                    @valuePath='confirmPassword'
+                    @shouldShowMessages={{this.didValidate}}
+                    @placeholder={{t 'settings.account.changePassword.confirmPassword.placeholder'}}
+                    @ariaLabel={{t 'settings.account.changePassword.confirmPassword.placeholder'}}
+                />
+            {{/let}}
             <OsfButton
                 data-test-update-password-button
                 data-analytics-name='Submit'
                 @buttonType='submit'
-                @onClick={{action this.submit}}
+                @onClick={{perform this.submitTask}}
             >
                 {{t 'settings.account.changePassword.updateButton'}}
             </OsfButton>

--- a/app/settings/account/-components/change-password/template.hbs
+++ b/app/settings/account/-components/change-password/template.hbs
@@ -4,7 +4,7 @@
 >
     <panel.heading @title={{t 'settings.account.changePassword.title'}} />
     <panel.body data-analytics-scope='Change password panel'>
-        <form>
+        <form data-test-password-form>
             {{#let (component 'validated-input/text') as |ValidatedTextInput| }}
                 <ValidatedTextInput
                     data-test-current-password
@@ -27,6 +27,7 @@
                     @ariaLabel={{t 'settings.account.changePassword.newPassword.placeholder'}}
                 />
                 <PasswordStrengthBar
+                    data-test-strength-bar
                     @password={{this.userPassword.newPassword}}
                     @model={{this.userPassword}}
                 />

--- a/app/settings/account/-components/change-password/template.hbs
+++ b/app/settings/account/-components/change-password/template.hbs
@@ -4,52 +4,53 @@
 >
     <panel.heading @title={{t 'settings.account.changePassword.title'}} />
     <panel.body data-analytics-scope='Change password panel'>
-        <ValidatedModelForm
-            @onSave={{action this.submit}}
-            @onError={{action this.updateError}}
-            @model={{this.userPassword}}
-            as |form|
+        <form
+            {{action 'submit' on='submit'}}
         >
             <label>{{t 'settings.account.changePassword.currentPassword.placeholder'}}</label>
-            <form.text
+            {{! template-lint-disable no-implicit-this }}
+            {{validated-input/text
                 data-test-current-password
-                @password={{true}}
-                @model={{this.userPassword}}
-                @valuePath='currentPassword'
-                @shouldShowMessages={{this.didValidate}}
-                @placeholder={{t 'settings.account.changePassword.currentPassword.placeholder'}}
-                @ariaLabel={{t 'settings.account.changePassword.currentPassword.placeholder'}}
-            />
+                password=true
+                model=this.userPassword
+                valuePath='currentPassword'
+                shouldShowMessages=this.didValidate
+                placeholder=(t 'settings.account.changePassword.currentPassword.placeholder')
+                ariaLabel=(t 'settings.account.changePassword.currentPassword.placeholder')
+            }}
             <label>{{t 'settings.account.changePassword.newPassword.placeholder'}}</label>
-            <form.text
+            {{validated-input/text
                 data-test-new-password
-                @password={{true}}
-                @model={{this.userPassword}}
-                @valuePath='password'
-                @placeholder={{t 'settings.account.changePassword.newPassword.placeholder'}}
-                @ariaLabel={{t 'settings.account.changePassword.newPassword.placeholder'}}
-            />
+                password=true
+                model=this.userPassword
+                valuePath='password'
+                shouldShowMessages=this.didValidate
+                placeholder=(t 'settings.account.changePassword.newPassword.placeholder')
+                ariaLabel=(t 'settings.account.changePassword.newPassword.placeholder')
+            }}
             <PasswordStrengthBar
-                @password={{form.changeset.password}}
-                @model={{form.changeset}}
+                @password={{this.userPassword.password}}
+                @model={{this.userPassword}}
             />
             <label>{{t 'settings.account.changePassword.confirmPassword.title'}}</label>
-            <form.text
+            {{validated-input/text
                 data-test-confirm-password
-                @password={{true}}
-                @model={{this.userPassword}}
-                @valuePath='confirmPassword'
-                @shouldShowMessages={{this.didValidate}}
-                @placeholder={{t 'settings.account.changePassword.confirmPassword.placeholder'}}
-                @ariaLabel={{t 'settings.account.changePassword.confirmPassword.placeholder'}}
-            />
+                password=true
+                model=this.userPassword
+                valuePath='confirmPassword'
+                shouldShowMessages=this.didValidate
+                placeholder=(t 'settings.account.changePassword.confirmPassword.placeholder')
+                ariaLabel=(t 'settings.account.changePassword.confirmPassword.placeholder')
+            }}
+            {{! template-lint-enable no-implicit-this }}
             <OsfButton
                 data-test-update-password-button
                 data-analytics-name='Submit'
-                type='submit'
+                @buttonType='submit'
+                @onClick={{action this.submit}}
             >
                 {{t 'settings.account.changePassword.updateButton'}}
             </OsfButton>
-        </ValidatedModelForm>
+        </form>
     </panel.body>
 </Panel>

--- a/app/settings/account/-components/change-password/template.hbs
+++ b/app/settings/account/-components/change-password/template.hbs
@@ -13,7 +13,7 @@
                 label=(t 'settings.account.changePassword.currentPassword.placeholder')
                 password=true
                 model=this.userPassword
-                valuePath='currentPassword'
+                valuePath='existingPassword'
                 shouldShowMessages=this.didValidate
                 placeholder=(t 'settings.account.changePassword.currentPassword.placeholder')
                 ariaLabel=(t 'settings.account.changePassword.currentPassword.placeholder')
@@ -23,13 +23,13 @@
                 label=(t 'settings.account.changePassword.newPassword.placeholder')
                 password=true
                 model=this.userPassword
-                valuePath='password'
+                valuePath='newPassword'
                 shouldShowMessages=this.didValidate
                 placeholder=(t 'settings.account.changePassword.newPassword.placeholder')
                 ariaLabel=(t 'settings.account.changePassword.newPassword.placeholder')
             }}
             <PasswordStrengthBar
-                @password={{this.userPassword.password}}
+                @password={{this.userPassword.newPassword}}
                 @model={{this.userPassword}}
             />
             {{validated-input/text

--- a/app/settings/account/-components/change-password/template.hbs
+++ b/app/settings/account/-components/change-password/template.hbs
@@ -7,10 +7,10 @@
         <form
             {{action 'submit' on='submit'}}
         >
-            <label>{{t 'settings.account.changePassword.currentPassword.placeholder'}}</label>
             {{! template-lint-disable no-implicit-this }}
             {{validated-input/text
                 data-test-current-password
+                label=(t 'settings.account.changePassword.currentPassword.placeholder')
                 password=true
                 model=this.userPassword
                 valuePath='currentPassword'
@@ -18,9 +18,9 @@
                 placeholder=(t 'settings.account.changePassword.currentPassword.placeholder')
                 ariaLabel=(t 'settings.account.changePassword.currentPassword.placeholder')
             }}
-            <label>{{t 'settings.account.changePassword.newPassword.placeholder'}}</label>
             {{validated-input/text
                 data-test-new-password
+                label=(t 'settings.account.changePassword.newPassword.placeholder')
                 password=true
                 model=this.userPassword
                 valuePath='password'
@@ -32,9 +32,9 @@
                 @password={{this.userPassword.password}}
                 @model={{this.userPassword}}
             />
-            <label>{{t 'settings.account.changePassword.confirmPassword.title'}}</label>
             {{validated-input/text
                 data-test-confirm-password
+                label=(t 'settings.account.changePassword.confirmPassword.title')
                 password=true
                 model=this.userPassword
                 valuePath='confirmPassword'

--- a/app/settings/account/-components/change-password/template.hbs
+++ b/app/settings/account/-components/change-password/template.hbs
@@ -30,9 +30,8 @@
                 @ariaLabel={{t 'settings.account.changePassword.newPassword.placeholder'}}
             />
             <PasswordStrengthBar
-                @password={{this.userPassword.password}}
-                @model={{this.userPassword}}
-                @valuePath='password'
+                @password={{form.changeset.password}}
+                @model={{form.changeset}}
             />
             <label>{{t 'settings.account.changePassword.confirmPassword.title'}}</label>
             <form.text

--- a/app/settings/account/-components/change-password/template.hbs
+++ b/app/settings/account/-components/change-password/template.hbs
@@ -26,11 +26,14 @@
                 @password={{true}}
                 @model={{this.userPassword}}
                 @valuePath='password'
-                @shouldShowMessages={{this.didValidate}}
                 @placeholder={{t 'settings.account.changePassword.newPassword.placeholder'}}
                 @ariaLabel={{t 'settings.account.changePassword.newPassword.placeholder'}}
             />
-            <PasswordStrengthBar @password={{this.userPassword.password}} />
+            <PasswordStrengthBar
+                @password={{this.userPassword.password}}
+                @model={{this.userPassword}}
+                @valuePath='password'
+            />
             <label>{{t 'settings.account.changePassword.confirmPassword.title'}}</label>
             <form.text
                 data-test-confirm-password

--- a/app/settings/account/-components/change-password/template.hbs
+++ b/app/settings/account/-components/change-password/template.hbs
@@ -1,0 +1,53 @@
+<Panel
+    data-test-change-password-panel
+    as |panel|
+>
+    <panel.heading @title={{t 'settings.account.changePassword.title'}} />
+    <panel.body data-analytics-scope='Change password panel'>
+        <ValidatedModelForm
+            @onSave={{action this.submit}}
+            @onError={{action this.updateError}}
+            @model={{this.userPassword}}
+            as |form|
+        >
+            <label>{{t 'settings.account.changePassword.currentPassword.placeholder'}}</label>
+            <form.text
+                data-test-current-password
+                @password={{true}}
+                @model={{this.userPassword}}
+                @valuePath='currentPassword'
+                @shouldShowMessages={{this.didValidate}}
+                @placeholder={{t 'settings.account.changePassword.currentPassword.placeholder'}}
+                @ariaLabel={{t 'settings.account.changePassword.currentPassword.placeholder'}}
+            />
+            <label>{{t 'settings.account.changePassword.newPassword.placeholder'}}</label>
+            <form.text
+                data-test-new-password
+                @password={{true}}
+                @model={{this.userPassword}}
+                @valuePath='newPassword'
+                @shouldShowMessages={{this.didValidate}}
+                @placeholder={{t 'settings.account.changePassword.newPassword.placeholder'}}
+                @ariaLabel={{t 'settings.account.changePassword.newPassword.placeholder'}}
+            />
+            <PasswordStrengthBar @password={{this.userPassword.newPassword}} />
+            <label>{{t 'settings.account.changePassword.confirmPassword.title'}}</label>
+            <form.text
+                data-test-confirm-password
+                @password={{true}}
+                @model={{this.userPassword}}
+                @valuePath='confirmPassword'
+                @shouldShowMessages={{this.didValidate}}
+                @placeholder={{t 'settings.account.changePassword.confirmPassword.placeholder'}}
+                @ariaLabel={{t 'settings.account.changePassword.confirmPassword.placeholder'}}
+            />
+            <OsfButton
+                data-test-update-password-button
+                data-analytics-name='Submit'
+                type='submit'
+            >
+                {{t 'settings.account.changePassword.updateButton'}}
+            </OsfButton>
+        </ValidatedModelForm>
+    </panel.body>
+</Panel>

--- a/app/settings/account/template.hbs
+++ b/app/settings/account/template.hbs
@@ -2,6 +2,7 @@
 {{! template-lint-disable no-implicit-this }}
 {{settings/account/-components/connected-emails}}
 {{settings/account/-components/default-region}}
+{{settings/account/-components/change-password}}
 {{settings/account/-components/security}}
 {{settings/account/-components/request-export}}
 {{settings/account/-components/request-deactivation}}

--- a/lib/osf-components/addon/components/password-strength-bar/component.ts
+++ b/lib/osf-components/addon/components/password-strength-bar/component.ts
@@ -1,0 +1,60 @@
+import { computed } from '@ember-decorators/object';
+import { service } from '@ember-decorators/service';
+import Component from '@ember/component';
+
+import PasswordStrength from 'ember-cli-password-strength/services/password-strength';
+import { task, timeout } from 'ember-concurrency';
+import { layout } from 'ember-osf-web/decorators/component';
+import UserPassword from 'ember-osf-web/models/user-password';
+
+import styles from './styles';
+import template from './template';
+
+@layout(template, styles)
+export default class PasswordStrengthBar extends Component {
+    // Required parameters
+    password!: UserPassword;
+
+    // Private parameters
+    @service passwordStrength!: PasswordStrength;
+    message: string = '';
+
+    strength = task(function *(this: PasswordStrengthBar, value: string) {
+        if (!value) {
+            return 0;
+        }
+
+        yield timeout(250);
+
+        return yield this.passwordStrength.strength(value);
+    }).restartable();
+
+    @computed('password', 'strength.lastSuccessful.value.score')
+    get progress(this: PasswordStrengthBar): number {
+        const { lastSuccessful } = this.strength;
+        if (lastSuccessful && lastSuccessful.value) {
+            this.set('message', lastSuccessful.value.feedback.warning);
+        }
+        return this.password && lastSuccessful ? 1 + lastSuccessful.value.score : 0;
+    }
+
+    @computed('progress')
+    get progressStyle(): string {
+        switch (this.progress) {
+        case 1:
+        case 2:
+            return 'danger';
+        case 3:
+            return 'warning';
+        case 4:
+        case 5:
+            return 'success';
+        default:
+            return 'none';
+        }
+    }
+
+    didUpdateAttrs(this: PasswordStrengthBar) {
+        this.strength.perform(this.get('password'));
+    }
+}

--- a/lib/osf-components/addon/components/password-strength-bar/component.ts
+++ b/lib/osf-components/addon/components/password-strength-bar/component.ts
@@ -33,9 +33,9 @@ export default class PasswordStrengthBar extends Component.extend({
     @service passwordStrength!: PasswordStrength;
     message: string = '';
     shouldShowMessage: boolean = false;
-    @alias('model.validations.attrs.password.message')
+    @alias('model.validations.attrs.newPassword.message')
         hasValidationMessage!: boolean;
-    @alias('model.validations.attrs.password.isValidating')
+    @alias('model.validations.attrs.newPassword.isValidating')
         isValidating!: boolean;
 
     @computed('password', 'strength.lastSuccessful.value.score', 'hasValidationMessage')

--- a/lib/osf-components/addon/components/password-strength-bar/component.ts
+++ b/lib/osf-components/addon/components/password-strength-bar/component.ts
@@ -18,6 +18,7 @@ export default class PasswordStrengthBar extends Component {
     // Private parameters
     @service passwordStrength!: PasswordStrength;
     message: string = '';
+    strengthMessage: string = '';
 
     strength = task(function *(this: PasswordStrengthBar, value: string) {
         if (!value) {
@@ -42,12 +43,19 @@ export default class PasswordStrengthBar extends Component {
     get progressStyle(): string {
         switch (this.progress) {
         case 1:
+            this.set('strengthMessage', 'Very weak');
+            return 'danger';
         case 2:
+            this.set('strengthMessage', 'Weak');
             return 'danger';
         case 3:
+            this.set('strengthMessage', 'So-so');
             return 'warning';
         case 4:
+            this.set('strengthMessage', 'Good');
+            return 'success';
         case 5:
+            this.set('strengthMessage', 'Great!');
             return 'success';
         default:
             return 'none';

--- a/lib/osf-components/addon/components/password-strength-bar/component.ts
+++ b/lib/osf-components/addon/components/password-strength-bar/component.ts
@@ -1,8 +1,8 @@
 import { computed } from '@ember-decorators/object';
-import { alias } from '@ember-decorators/object/computed';
 import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
 
+import { ChangesetDef } from 'ember-changeset/types';
 import PasswordStrength from 'ember-cli-password-strength/services/password-strength';
 import { task, timeout } from 'ember-concurrency';
 import { layout } from 'ember-osf-web/decorators/component';
@@ -15,7 +15,7 @@ import template from './template';
 export default class PasswordStrengthBar extends Component {
     // Required parameters
     password!: UserPassword;
-    model!: UserPassword;
+    model!: ChangesetDef;
     valuePath!: string;
 
     // Private parameters
@@ -23,8 +23,6 @@ export default class PasswordStrengthBar extends Component {
     message: string = '';
     strengthMessage: string = '';
     shouldShowMessage: boolean = false;
-    @alias('model.validations.attrs.password.message')
-    hasValidationMessage!: boolean;
 
     strength = task(function *(this: PasswordStrengthBar, value: string) {
         if (!value) {
@@ -36,11 +34,11 @@ export default class PasswordStrengthBar extends Component {
         return yield this.passwordStrength.strength(value);
     }).restartable();
 
-    @computed('password', 'strength.lastSuccessful.value.score', 'model.validations.attrs.password.message')
+    @computed('password', 'strength.lastSuccessful.value.score', 'model.password.isValidating')
     get progress(this: PasswordStrengthBar): number {
         const { lastSuccessful } = this.strength;
-        if (lastSuccessful && lastSuccessful.value && !this.model.validations.attrs.password.isValidating) {
-            this.set('shouldShowMessage', !this.hasValidationMessage);
+        if (lastSuccessful && lastSuccessful.value && !this.model.get('password.isValidating')) {
+            this.set('shouldShowMessage', !this.model.get('errors')[0]);
             this.set('message', lastSuccessful.value.feedback.warning);
         }
         return this.password && lastSuccessful ? 1 + lastSuccessful.value.score : 0;

--- a/lib/osf-components/addon/components/password-strength-bar/component.ts
+++ b/lib/osf-components/addon/components/password-strength-bar/component.ts
@@ -1,8 +1,8 @@
 import { computed } from '@ember-decorators/object';
+import { alias } from '@ember-decorators/object/computed';
 import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
 
-import { ChangesetDef } from 'ember-changeset/types';
 import PasswordStrength from 'ember-cli-password-strength/services/password-strength';
 import { task, timeout } from 'ember-concurrency';
 import { layout } from 'ember-osf-web/decorators/component';
@@ -15,14 +15,15 @@ import template from './template';
 export default class PasswordStrengthBar extends Component {
     // Required parameters
     password!: UserPassword;
-    model!: ChangesetDef;
-    valuePath!: string;
+    model!: UserPassword;
 
     // Private parameters
     @service passwordStrength!: PasswordStrength;
     message: string = '';
     strengthMessage: string = '';
     shouldShowMessage: boolean = false;
+    @alias('model.validations.attrs.password.message')
+    hasValidationMessage!: boolean;
 
     strength = task(function *(this: PasswordStrengthBar, value: string) {
         if (!value) {
@@ -34,11 +35,11 @@ export default class PasswordStrengthBar extends Component {
         return yield this.passwordStrength.strength(value);
     }).restartable();
 
-    @computed('password', 'strength.lastSuccessful.value.score', 'model.password.isValidating')
-    get progress(this: PasswordStrengthBar): number {
+    @computed('password', 'strength.lastSuccessful.value.score', 'model.validations.attrs.password.message')
+    get progress(this: PasswordStrengthBar) {
         const { lastSuccessful } = this.strength;
-        if (lastSuccessful && lastSuccessful.value && !this.model.get('password.isValidating')) {
-            this.set('shouldShowMessage', !this.model.get('errors')[0]);
+        if (lastSuccessful && lastSuccessful.value && !this.model.validations.attrs.password.isValidating) {
+            this.set('shouldShowMessage', !this.hasValidationMessage);
             this.set('message', lastSuccessful.value.feedback.warning);
         }
         return this.password && lastSuccessful ? 1 + lastSuccessful.value.score : 0;
@@ -68,6 +69,6 @@ export default class PasswordStrengthBar extends Component {
     }
 
     didUpdateAttrs(this: PasswordStrengthBar) {
-        this.strength.perform(this.get('password'));
+        this.get('strength').perform(this.get('password'));
     }
 }

--- a/lib/osf-components/addon/components/password-strength-bar/component.ts
+++ b/lib/osf-components/addon/components/password-strength-bar/component.ts
@@ -25,7 +25,7 @@ export default class PasswordStrengthBar extends Component.extend({
     }).restartable(),
 }) {
     // Required parameters
-    password!: UserPassword;
+    password!: string;
     model!: UserPassword;
 
     // Private parameters
@@ -38,8 +38,11 @@ export default class PasswordStrengthBar extends Component.extend({
     @alias('model.validations.attrs.newPassword.isValidating')
         isValidating!: boolean;
 
-    @computed('password', 'strength.lastSuccessful.value.score', 'hasValidationMessage')
-    get progress(this: PasswordStrengthBar) {
+    @computed('password',
+        'strength.{lastSuccessful,lastSuccessful.value,lastSuccessful.value.score}',
+        'hasValidationMessage',
+        'isValidating')
+    get progress() {
         const { lastSuccessful } = this.strength;
         if (lastSuccessful && lastSuccessful.value && !this.isValidating) {
             this.set('shouldShowMessage', !this.hasValidationMessage);
@@ -66,7 +69,7 @@ export default class PasswordStrengthBar extends Component.extend({
         }
     }
 
-    didUpdateAttrs(this: PasswordStrengthBar) {
-        this.strength.perform(this.get('password'));
+    didUpdateAttrs() {
+        this.strength.perform(this.password);
     }
 }

--- a/lib/osf-components/addon/components/password-strength-bar/styles.scss
+++ b/lib/osf-components/addon/components/password-strength-bar/styles.scss
@@ -22,5 +22,6 @@
 }
 
 .warning-message {
-    margin-bottom: 10px;
+    padding: 0 !important;
+    margin: -10px 0 10px;
 }

--- a/lib/osf-components/addon/components/password-strength-bar/styles.scss
+++ b/lib/osf-components/addon/components/password-strength-bar/styles.scss
@@ -10,11 +10,17 @@
     }
 }
 
-.createPassword:global(.progress) {
-    height: inherit;
-    margin-bottom: 15px;
+.create-password {
+    margin: 5px 0;
 }
 
-.warningMessage {
+.create-password:global(.progress) {
+    height: 10px;
+    margin-bottom: 15px;
+    padding-left: 0;
+    padding-right: 0;
+}
+
+.warning-message {
     margin-bottom: 10px;
 }

--- a/lib/osf-components/addon/components/password-strength-bar/styles.scss
+++ b/lib/osf-components/addon/components/password-strength-bar/styles.scss
@@ -1,24 +1,19 @@
-@for $i from 0 through 5 {
-    :global(.progress-bar-#{$i}) {
-        width: #{$i * 20%} !important;
-    }
-}
-
-@each $class, $color in $progress-bar-bg-bright {
-    :global(.progress-bar-#{$class}) {
-        background-color: $color;
-    }
-}
-
-.create-password {
-    margin: 5px 0;
-}
-
 .create-password:global(.progress) {
+    margin: 5px 0 15px;
     height: 10px;
-    margin-bottom: 15px;
     padding-left: 0;
     padding-right: 0;
+    @for $i from 0 through 5 {
+        :global(.progress-bar-#{$i}) {
+            width: #{$i * 20%} !important;
+        }
+    }
+    
+    @each $class, $color in $progress-bar-bg-bright {
+        :global(.progress-bar-#{$class}) {
+            background-color: $color;
+        }
+    }
 }
 
 .warning-message {

--- a/lib/osf-components/addon/components/password-strength-bar/styles.scss
+++ b/lib/osf-components/addon/components/password-strength-bar/styles.scss
@@ -1,0 +1,20 @@
+@for $i from 0 through 5 {
+    :global(.progress-bar-#{$i}) {
+        width: #{$i * 20%} !important;
+    }
+}
+
+@each $class, $color in $progress-bar-bg-bright {
+    :global(.progress-bar-#{$class}) {
+        background-color: $color;
+    }
+}
+
+.createPassword:global(.progress) {
+    height: inherit;
+    margin-bottom: 15px;
+}
+
+.warningMessage {
+    margin-bottom: 10px;
+}

--- a/lib/osf-components/addon/components/password-strength-bar/template.hbs
+++ b/lib/osf-components/addon/components/password-strength-bar/template.hbs
@@ -12,7 +12,7 @@
             {{this.strengthMessage}}
         </div>
     </div>
-    {{#if this.message}}
+    {{#if (and this.message this.shouldShowMessage)}}
         <div class='text-danger col-xs-12' local-class='warning-message'>
             {{this.message}}
         </div>

--- a/lib/osf-components/addon/components/password-strength-bar/template.hbs
+++ b/lib/osf-components/addon/components/password-strength-bar/template.hbs
@@ -1,0 +1,16 @@
+{{! template-lint-enable no-implicit-this }}
+<div class='row' hidden={{not this.progress}}>
+    <div class='col-xs-12'>
+        <div class='progress' local-class='createPassword'>
+            <div
+                class='progress-bar progress-bar-sm progress-bar-{{this.progress}} progress-bar-{{this.progressStyle}}'
+                role='progressbar'>
+            </div>
+        </div>
+        {{#if this.message}}
+            <div class='text-danger' local-class='warningMessage'>
+                {{this.message}}
+            </div>
+        {{/if}}
+    </div>
+</div>

--- a/lib/osf-components/addon/components/password-strength-bar/template.hbs
+++ b/lib/osf-components/addon/components/password-strength-bar/template.hbs
@@ -7,6 +7,7 @@
     <div class='col-xs-12' local-class='bar-container'>
         <div class='progress col-xs-12' local-class='create-password'>
             <div
+                data-test-password-color-bar
                 class='progress-bar progress-bar-sm progress-bar-{{this.progress}} progress-bar-{{this.progressStyle}}'
                 role='progressbar'>
             </div>

--- a/lib/osf-components/addon/components/password-strength-bar/template.hbs
+++ b/lib/osf-components/addon/components/password-strength-bar/template.hbs
@@ -1,4 +1,9 @@
 {{! template-lint-enable no-implicit-this }}
+{{#if (and this.shouldShowMessage this.message)}}
+    <div class='text-danger col-xs-12' local-class='warning-message'>
+        {{this.message}}
+    </div>
+{{/if}}
 <div data-test-password-bar class='row' hidden={{not this.progress}}>
     <div class='col-xs-12' local-class='bar-container'>
         <div class='progress col-xs-9' local-class='create-password'>
@@ -12,9 +17,4 @@
             {{this.strengthMessage}}
         </div>
     </div>
-    {{#if (and this.message this.shouldShowMessage)}}
-        <div class='text-danger col-xs-12' local-class='warning-message'>
-            {{this.message}}
-        </div>
-    {{/if}}
 </div>

--- a/lib/osf-components/addon/components/password-strength-bar/template.hbs
+++ b/lib/osf-components/addon/components/password-strength-bar/template.hbs
@@ -1,4 +1,3 @@
-{{! template-lint-enable no-implicit-this }}
 {{#if (and this.shouldShowMessage this.message)}}
     <div class='text-danger col-xs-12' local-class='warning-message'>
         {{this.message}}

--- a/lib/osf-components/addon/components/password-strength-bar/template.hbs
+++ b/lib/osf-components/addon/components/password-strength-bar/template.hbs
@@ -6,15 +6,11 @@
 {{/if}}
 <div data-test-password-bar class='row' hidden={{not this.progress}}>
     <div class='col-xs-12' local-class='bar-container'>
-        <div class='progress col-xs-9' local-class='create-password'>
+        <div class='progress col-xs-12' local-class='create-password'>
             <div
-                local-class='strength-bar'
                 class='progress-bar progress-bar-sm progress-bar-{{this.progress}} progress-bar-{{this.progressStyle}}'
                 role='progressbar'>
             </div>
-        </div>
-        <div local-class='strength-message' class='col-xs-3 text-{{this.progressStyle}}'>
-            {{this.strengthMessage}}
         </div>
     </div>
 </div>

--- a/lib/osf-components/addon/components/password-strength-bar/template.hbs
+++ b/lib/osf-components/addon/components/password-strength-bar/template.hbs
@@ -1,16 +1,20 @@
 {{! template-lint-enable no-implicit-this }}
-<div class='row' hidden={{not this.progress}}>
-    <div class='col-xs-12'>
-        <div class='progress' local-class='createPassword'>
+<div data-test-password-bar class='row' hidden={{not this.progress}}>
+    <div class='col-xs-12' local-class='bar-container'>
+        <div class='progress col-xs-9' local-class='create-password'>
             <div
+                local-class='strength-bar'
                 class='progress-bar progress-bar-sm progress-bar-{{this.progress}} progress-bar-{{this.progressStyle}}'
                 role='progressbar'>
             </div>
         </div>
-        {{#if this.message}}
-            <div class='text-danger' local-class='warningMessage'>
-                {{this.message}}
-            </div>
-        {{/if}}
+        <div local-class='strength-message' class='col-xs-3 text-{{this.progressStyle}}'>
+            {{this.strengthMessage}}
+        </div>
     </div>
+    {{#if this.message}}
+        <div class='text-danger col-xs-12' local-class='warning-message'>
+            {{this.message}}
+        </div>
+    {{/if}}
 </div>

--- a/lib/osf-components/app/components/password-strength-bar/component.js
+++ b/lib/osf-components/app/components/password-strength-bar/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/password-strength-bar/component';

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -14,6 +14,7 @@ import { rootDetail } from './views/root';
 import { createToken } from './views/token';
 import { createEmails, updateEmails } from './views/update-email';
 import { userNodeList } from './views/user';
+import { updatePassword } from './views/user-password';
 import * as userSettings from './views/user-setting';
 import * as wb from './views/wb';
 
@@ -115,6 +116,7 @@ export default function(this: Server) {
     this.patch('/users/:parentID/settings/emails/:emailID/', updateEmails);
     this.post('/users/:parentID/settings/emails/', createEmails);
     this.post('/users/:id/settings/export', userSettings.requestExport);
+    this.post('/users/:parentID/settings/password/', updatePassword);
 
     this.get('/users/:id/nodes', userNodeList);
     osfNestedResource(this, 'user', 'quickfiles', { only: ['index', 'show'] });

--- a/mirage/views/user-password.ts
+++ b/mirage/views/user-password.ts
@@ -2,10 +2,10 @@ import { HandlerContext, Response } from 'ember-cli-mirage';
 
 export function updatePassword(this: HandlerContext) {
     const attrs = this.normalizedRequestAttrs('user-password');
-    const currentPassword = 'oldpassword';
+    const existingPassword = 'oldpassword';
 
-    if (attrs.currentPassword !== undefined) {
-        if (attrs.currentPassword === currentPassword) {
+    if (attrs.existingPassword !== undefined) {
+        if (attrs.existingPassword === existingPassword) {
             return new Response(204, undefined, undefined);
         }
         return new Response(409, { 'Content-Type': 'application/vnd.api+json' }, {

--- a/mirage/views/user-password.ts
+++ b/mirage/views/user-password.ts
@@ -1,0 +1,13 @@
+import { HandlerContext } from 'ember-cli-mirage';
+
+export function updatePassword(this: HandlerContext) {
+    const attrs = this.normalizedRequestAttrs('userSetting');
+    const currentPassword = 'oldpassword';
+
+    if (attrs.password !== undefined) {
+        if (attrs.password === currentPassword) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/mirage/views/user-password.ts
+++ b/mirage/views/user-password.ts
@@ -6,15 +6,14 @@ export function updatePassword(this: HandlerContext) {
 
     if (attrs.currentPassword !== undefined) {
         if (attrs.currentPassword === currentPassword) {
-            return new Response(204, {}, undefined);
-        } else {
-            return new Response(409, { 'Content-Type': 'application/vnd.api+json' }, {
-                errors: [{
-                    status: 409,
-                    detail: 'Passwords do not match.',
-                }],
-            });
+            return new Response(204, undefined, undefined);
         }
+        return new Response(409, { 'Content-Type': 'application/vnd.api+json' }, {
+            errors: [{
+                status: 409,
+                detail: 'Old password is invalid.',
+            }],
+        });
     }
     return new Response(400, { 'Content-Type': 'application/vnd.api+json' }, {
         errors: [{

--- a/mirage/views/user-password.ts
+++ b/mirage/views/user-password.ts
@@ -1,13 +1,25 @@
-import { HandlerContext } from 'ember-cli-mirage';
+import { HandlerContext, Response } from 'ember-cli-mirage';
 
 export function updatePassword(this: HandlerContext) {
-    const attrs = this.normalizedRequestAttrs('userSetting');
+    const attrs = this.normalizedRequestAttrs('user-password');
     const currentPassword = 'oldpassword';
 
-    if (attrs.password !== undefined) {
-        if (attrs.password === currentPassword) {
-            return true;
+    if (attrs.currentPassword !== undefined) {
+        if (attrs.currentPassword === currentPassword) {
+            return new Response(204, {}, undefined);
+        } else {
+            return new Response(409, { 'Content-Type': 'application/vnd.api+json' }, {
+                errors: [{
+                    status: 409,
+                    detail: 'Passwords do not match.',
+                }],
+            });
         }
     }
-    return false;
+    return new Response(400, { 'Content-Type': 'application/vnd.api+json' }, {
+        errors: [{
+            status: 400,
+            detail: 'Password must not be blank.',
+        }],
+    });
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@types/rsvp": "^4.0.1",
     "@types/sanitize-html": "^1.14.0",
     "@types/sinon": "^5.0.1",
+    "@types/toastr": "^2.1.36",
     "@typescript-eslint/eslint-plugin": "^1.3.0",
     "bootstrap-sass": "^3.3.7",
     "broccoli-asset-rev": "^2.7.0",

--- a/tests/acceptance/settings/account/change-password-test.ts
+++ b/tests/acceptance/settings/account/change-password-test.ts
@@ -1,0 +1,52 @@
+import { currentURL, fillIn, settled, visit } from '@ember/test-helpers';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { TestContext } from 'ember-test-helpers';
+import { module, skip, test } from 'qunit';
+
+import { click, setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
+
+module('Acceptance | settings/account | change password', hooks => {
+    setupOSFApplicationTest(hooks);
+    setupMirage(hooks);
+
+    // Changing password works
+    skip('it works', async function(this: TestContext, assert) {
+        // Currently doesn't work.
+        // Will need to revist later, might need to install addons to get to work
+        server.create('user', 'loggedIn', 'withSettings');
+
+        await visit('/settings/account');
+        assert.ok(true);
+
+        const currentPassword = 'oldpassword';
+        const newPassword = 'oldpassword239901abc';
+        await fillIn('[data-test-current-password] input', currentPassword);
+        await fillIn('[data-test-new-password] input', newPassword);
+        await fillIn('[data-test-confirm-password] input', newPassword);
+
+        await click('[data-test-update-password-button]');
+        settled().then(() => {
+            assert.ok(true);
+        });
+    });
+
+    // Changing password fails with wrong current password
+    test('wrong current password', async assert => {
+        server.create('user', 'loggedIn', 'withSettings');
+
+        await visit('/settings/account');
+
+        const currentPassword = 'wrongPassword';
+        const newPassword = 'oldpassword239901abc';
+
+        await fillIn('[data-test-current-password] input', currentPassword);
+        await fillIn('[data-test-new-password] input', newPassword);
+        await fillIn('[data-test-confirm-password] input', newPassword);
+
+        await click('[data-test-update-password-button]');
+        const root = server.schema.roots.first();
+        assert.ok(root.currentUser);
+        assert.equal(currentURL(), '/settings/account');
+    });
+});

--- a/tests/integration/components/password-strength-bar/component-test.ts
+++ b/tests/integration/components/password-strength-bar/component-test.ts
@@ -1,0 +1,26 @@
+import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+
+module('Integration | Component | password-strength-bar', hooks => {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function(assert) {
+        // Set any properties with this.set('myProperty', 'value');
+        // Handle any actions with this.set('myAction', function(val) { ... });
+
+        await render(hbs`{{password-strength-bar}}`);
+
+        assert.dom(this.element).hasText('');
+
+        // Template block usage:
+        await render(hbs`
+            {{#password-strength-bar}}
+                template block text
+            {{/password-strength-bar}}
+        `);
+
+        assert.dom(this.element).hasText('template block text');
+    });
+});

--- a/tests/integration/components/password-strength-bar/component-test.ts
+++ b/tests/integration/components/password-strength-bar/component-test.ts
@@ -1,10 +1,21 @@
-import { render } from '@ember/test-helpers';
+import { render, settled } from '@ember/test-helpers';
+import { Server } from 'ember-cli-mirage';
 import { setupRenderingTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
 
+import { startMirage } from 'ember-osf-web/initializers/ember-cli-mirage';
+
+type Context = TestContext & { server: Server };
+
 module('Integration | Component | password-strength-bar', hooks => {
     setupRenderingTest(hooks);
+
+    hooks.beforeEach(function(this: Context) {
+        this.server = startMirage();
+        this.store = this.owner.lookup('service:store');
+    });
 
     test('it renders', async function(assert) {
         this.set('password', 'testPassword');
@@ -12,5 +23,71 @@ module('Integration | Component | password-strength-bar', hooks => {
         await render(hbs`<PasswordStrengthBar @password={{this.password}}/>`);
 
         assert.dom('[data-test-password-bar]').exists('Password-bar renders');
+    });
+
+    test('very weak password', async function(assert) {
+        this.set('password', '');
+
+        await render(hbs`<PasswordStrengthBar @password={{this.password}}/>`);
+
+        this.set('password', 'abc');
+
+        assert.dom('[data-test-password-bar]').exists('Password-bar renders');
+
+        settled().then(() => {
+            assert.dom('[data-test-password-color-bar]').hasClass('progress-bar-danger');
+        });
+    });
+
+    test('weak password', async function(assert) {
+        this.set('password', '');
+
+        await render(hbs`<PasswordStrengthBar @password={{this.password}}/>`);
+
+        this.set('password', 'abcs');
+
+        assert.dom('[data-test-password-bar]').exists('Password-bar renders');
+
+        settled().then(() => {
+            assert.dom('[data-test-password-color-bar]').hasClass('progress-bar-danger');
+        });
+    });
+
+    test('so-so password', async function(assert) {
+        this.set('password', '');
+
+        await render(hbs`<PasswordStrengthBar @password={{this.password}}/>`);
+
+        this.set('password', 'abcstest');
+
+        assert.dom('[data-test-password-bar]').exists('Password-bar renders');
+
+        settled().then(() => {
+            assert.dom('[data-test-password-color-bar]').hasClass('progress-bar-warning');
+        });
+    });
+
+    test('good password', async function(assert) {
+        this.set('password', '');
+
+        await render(hbs`<PasswordStrengthBar @password={{this.password}}/>`);
+
+        this.set('password', 'testpassword12310');
+
+        settled().then(() => {
+            assert.dom('[data-test-password-color-bar]').hasClass('progress-bar-success');
+        });
+    });
+
+    test('great password', async function(assert) {
+        this.set('password', '');
+
+        await render(hbs`<PasswordStrengthBar @password={{this.password}}/>`);
+
+        this.set('password', 'testpassword12310abc');
+
+        settled().then(() => {
+            assert.dom('[data-test-password-color-bar]').hasClass('progress-bar-success');
+        });
     });
 });

--- a/tests/integration/components/password-strength-bar/component-test.ts
+++ b/tests/integration/components/password-strength-bar/component-test.ts
@@ -7,20 +7,10 @@ module('Integration | Component | password-strength-bar', hooks => {
     setupRenderingTest(hooks);
 
     test('it renders', async function(assert) {
-        // Set any properties with this.set('myProperty', 'value');
-        // Handle any actions with this.set('myAction', function(val) { ... });
+        this.set('password', 'testPassword');
 
-        await render(hbs`{{password-strength-bar}}`);
+        await render(hbs`<PasswordStrengthBar @password={{this.password}}/>`);
 
-        assert.dom(this.element).hasText('');
-
-        // Template block usage:
-        await render(hbs`
-            {{#password-strength-bar}}
-                template block text
-            {{/password-strength-bar}}
-        `);
-
-        assert.dom(this.element).hasText('template block text');
+        assert.dom('[data-test-password-bar]').exists('Password-bar renders');
     });
 });

--- a/tests/integration/routes/settings/account/-components/change-password-test.ts
+++ b/tests/integration/routes/settings/account/-components/change-password-test.ts
@@ -1,0 +1,100 @@
+import { fillIn, render, settled } from '@ember/test-helpers';
+import { percySnapshot } from 'ember-percy';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import { click } from 'ember-osf-web/tests/helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | routes | settings | profile | name | -components | citation-preview', hooks => {
+    setupRenderingTest(hooks);
+
+    test('it renders', async assert => {
+        await render(hbs`{{settings/account/-components/change-password}}`);
+
+        assert.dom('[data-test-change-password-panel]').exists('Password section renders');
+        assert.dom('[data-test-password-form]').exists('Password form renders');
+        await percySnapshot(assert);
+    });
+
+    // Validation works
+    test('validation works', async assert => {
+        await render(hbs`{{settings/account/-components/change-password}}`);
+
+        const oldPassword = 'oldPassword1234';
+        const newPassword = 'newPassword1234';
+        const confirmPassword = 'newPassword123410abcd';
+
+        assert.dom('[data-test-change-password-panel]').exists('Password section renders');
+        assert.dom('[data-test-password-form]').exists('Password form renders');
+
+        await click('[data-test-update-password-button]');
+        await percySnapshot(assert);
+
+        // Check that validations are for empty fields
+        settled().then(() => {
+            assert.dom('[data-test-current-password] div[class*="help-block"]')
+                .exists('Validation works for old password');
+            assert.dom('[data-test-new-password] div[class*="help-block"]').exists('Validation works for new password');
+            assert.dom('[data-test-confirm-password] div[class*="help-block"]')
+                .exists('Validation works for confirm password');
+        });
+
+        await fillIn('[data-test-current-password] input', oldPassword);
+        await fillIn('[data-test-new-password] input', oldPassword);
+        await fillIn('[data-test-confirm-password] input', confirmPassword);
+
+        // Check:
+        // 1.) Old password no longer has a validation message
+        // 2.) New password has a validation error for matching old password
+        // 3.) Confirm password has a validation error for not matching new password
+        settled().then(() => {
+            assert.dom('[data-test-current-password] div[class*="help-block"]')
+                .doesNotExist('No error validations on old password');
+            assert.dom('[data-test-new-password] div[class*="help-block"]')
+                .matchesText('Your new password cannot be the same as your old password.');
+            assert.dom('[data-test-confirm-password] div[class*="help-block"]').matchesText('Passwords must match.');
+        });
+
+        await fillIn('[data-test-new-password] input', newPassword);
+
+        // Check:
+        // 1.) New password no longer has validation error for matching old password
+        // 2.) Confirm password still has a validation error for not matching new password
+        settled().then(() => {
+            assert.dom('[data-test-new-password] div[class*="help-block"]')
+                .doesNotExist('No error validations on new password');
+            assert.dom('[data-test-confirm-password] div[class*="help-block"]').matchesText('Passwords must match.');
+        });
+
+        await fillIn('[data-test-confirm-password] input', newPassword);
+
+        // Check:
+        // 1.) Confirm password no longer has validation error
+        settled().then(() => {
+            assert.dom('[data-test-new-password] div[class*="help-block"]')
+                .doesNotExist('No error validations on current password');
+        });
+    });
+
+    // Check validation double message for new password
+    test('double validation messages do not appear', async assert => {
+        await render(hbs`{{settings/account/-components/change-password}}`);
+
+        await click('[data-test-update-password-button]');
+
+        settled().then(() => {
+            assert.dom('[data-test-new-password] div[class*="help-block"]').matchesText("This field can't be blank.");
+        });
+
+        await fillIn('[data-test-new-password] input', 'abcabcab');
+
+        settled().then(() => {
+            // Check to make sure that when both the validation and password suggestion would return an string,
+            // only one is shown
+            assert.dom('[data-test-new-password] div[class*="help-block"]')
+                .matchesText('Repeats like "abcabcabc" are only slightly harder to guess than "abc"');
+            assert.dom('[data-test-new-password] div[class*="help-block"]').exists({ count: 1 });
+        });
+    });
+});

--- a/types/ember-toastr/index.d.ts
+++ b/types/ember-toastr/index.d.ts
@@ -1,23 +1,6 @@
 declare module 'ember-toastr/services/toast' {
     import Service from '@ember/service';
-
-    interface ToastOptions {
-        closeButton: boolean;
-        debug: boolean;
-        newestOnTop: boolean;
-        progressBar: boolean;
-        positionClass: string;
-        preventDuplicates: boolean;
-        showDuration: number;
-        hideDuration: number;
-        timeOut: number;
-        extendedTimeOut: number;
-        showEasing: string;
-        hideEasing: string;
-        showMethod: string;
-        hideMethod: string;
-        tapToDismiss: boolean;
-    }
+    import { ToastOptions } from '@types/toastr';
 
     export default class Toast extends Service {
         error(message: string, title?: string, options?: Partial<ToastOptions>): void;
@@ -25,4 +8,8 @@ declare module 'ember-toastr/services/toast' {
         success(message: string, title?: string, options?: Partial<ToastOptions>): void;
         warning(message: string, title?: string, options?: Partial<ToastOptions>): void;
     }
+}
+
+interface Window {
+    toastr: Toastr;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1362,6 +1362,13 @@
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.2.tgz#a811b8c18e2babab7d542b3365887ae2e4d9de47"
   integrity sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==
 
+"@types/toastr@^2.1.36":
+  version "2.1.36"
+  resolved "https://registry.yarnpkg.com/@types/toastr/-/toastr-2.1.36.tgz#6b692ec384147324cffe13892e9e5b26bd1e69e7"
+  integrity sha512-mz4eBVCNrH0AyGpt+6DLl/xE+CPrSqMfQs/cMTAGJl8W9W375DNOTYOon1GsuSJqVU1QqZ4jCuARzo4TNQNrDg==
+  dependencies:
+    "@types/jquery" "*"
+
 "@typescript-eslint/eslint-plugin@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.3.0.tgz#e64c859a3eec10d96731eb5f72b5f48796a2f9ad"


### PR DESCRIPTION
## Purpose

Adds the password widget to the account settings page

## Summary of Changes

- create `password-widget` component
- create `password-strength-bar` component

The password widget:
<img width="855" alt="screen shot 2019-02-26 at 11 47 35 am" src="https://user-images.githubusercontent.com/19379783/53430480-981a3500-39bc-11e9-86c5-81026aafae1b.png">

If there are validations that need to be met on the new password, it will show:
<img width="833" alt="screen shot 2019-02-26 at 11 48 43 am" src="https://user-images.githubusercontent.com/19379783/53430491-9cdee900-39bc-11e9-8402-90c732b2bddd.png">

Otherwise it will give hints:
<img width="838" alt="screen shot 2019-02-26 at 11 49 16 am" src="https://user-images.githubusercontent.com/19379783/53430532-b122e600-39bc-11e9-9c22-b193c3d60029.png">

### Password Strength

There are 5 different statuses that can show for the password strength bar:

Very weak:
<img width="712" alt="screen shot 2019-02-26 at 11 52 59 am" src="https://user-images.githubusercontent.com/19379783/53430721-1545aa00-39bd-11e9-9177-692764e4eccd.png">


Weak:
<img width="693" alt="screen shot 2019-02-26 at 11 53 29 am" src="https://user-images.githubusercontent.com/19379783/53431159-f562b600-39bd-11e9-8126-5ea87524d4f7.png">


So-so:
<img width="829" alt="screen shot 2019-02-26 at 11 59 54 am" src="https://user-images.githubusercontent.com/19379783/53431203-0ca1a380-39be-11e9-865f-b097c532ce13.png">


Good:
<img width="829" alt="screen shot 2019-02-26 at 12 00 18 pm" src="https://user-images.githubusercontent.com/19379783/53431234-1aefbf80-39be-11e9-84f8-b54a08ca588d.png">


Great!:
<img width="816" alt="screen shot 2019-02-26 at 12 00 42 pm" src="https://user-images.githubusercontent.com/19379783/53431259-2a6f0880-39be-11e9-8f5d-90b115d5d619.png">


## Side Effects

N/A

## Feature Flags

N/A

## QA Notes

- This will affect the account settings page.

- There are two different validations for the 'New Password' field that are combined into one message.  If the actual form field isn't valid, it will show what the user needs for it to be valid (at least 8 characters, can't be the same as what's entered in the 'Current Password').  If the validations requirements are met for that field, it will show password strength hints.  These don't necessarily affect whether or not the user can update the password, but it will give helpful hints to make the password stronger.

## Ticket

https://openscience.atlassian.net/browse/EMB-572

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
