### PR TITLE
[EMB-587] Fix displaying files names in form view

### DIFF
--- a/lib/registries/addon/components/registration-form-view/component.ts
+++ b/lib/registries/addon/components/registration-form-view/component.ts
@@ -28,7 +28,7 @@ export class Answerable {
             question.type,
             question.format,
             answer.value as string,
-            (answer.extra && answer.extra.length) ? answer.extra[0] : {},
+            (answer.extra && answer.extra.length) ? answer.extra : {},
         );
     }
 

--- a/lib/registries/addon/components/registration-form-view/x-file/component.ts
+++ b/lib/registries/addon/components/registration-form-view/x-file/component.ts
@@ -4,10 +4,11 @@ import Component from '@ember/component';
 
 import { layout } from 'ember-osf-web/decorators/component';
 import { Answerable } from '../component';
+import styles from './styles';
 import template from './template';
 
 @tagName('')
-@layout(template)
+@layout(template, styles)
 export default class ViewFile extends Component {
     static positionalParams = ['part'];
 

--- a/lib/registries/addon/components/registration-form-view/x-file/styles.scss
+++ b/lib/registries/addon/components/registration-form-view/x-file/styles.scss
@@ -1,0 +1,14 @@
+.Files {
+    display: flex;
+    flex-direction: column;
+
+    a {
+        color: $primary-blue;
+
+        &:hover,
+        &:focus {
+            color: $secondary-blue;
+            text-decoration: none;
+        }
+    }
+}

--- a/lib/registries/addon/components/registration-form-view/x-file/template.hbs
+++ b/lib/registries/addon/components/registration-form-view/x-file/template.hbs
@@ -1,13 +1,9 @@
-{{#if this.fileList.length}}
-    <ul>
-        {{#each this.fileList as |file|}}
-            <li>
-                <a href={{file.viewUrl}}>
-                    {{file.selectedFileName}}
-                </a>
-            </li>
-        {{/each}}
-    </ul>
-{{else}}
-    {{t 'registries.overview.form_view.no_files'}}
-{{/if}}
+<div local-class='Files'>
+    {{#each this.fileList as |file|}}
+        <OsfLink @href={{file.viewUrl}}>
+            {{file.selectedFileName}}
+        </OsfLink>
+    {{else}}
+        {{t 'registries.overview.form_view.no_files'}}
+    {{/each}}
+</div>


### PR DESCRIPTION
## Purpose

Registries overview: 
Fix: uploaded files are not displayed on the registration form view 

## Summary of Changes 
<img width="638" alt="screen shot 2019-02-26 at 3 35 02 pm" src="https://user-images.githubusercontent.com/4511563/53445057-b17fa900-39dd-11e9-99d5-638f20def07c.png">

## Side Effects

N/A

## Feature Flags

N/A

## QA Notes

Register a project using a schema that required file uploads such as Registered Reports,
make sure the file names are displayed on the registration overview

## Ticket

[EMB-587](https://openscience.atlassian.net/browse/EMB-587)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`