### PR TITLE
[EMB-442] Fix overview toolbar bugs

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -191,7 +191,7 @@ module.exports = function(environment) {
         },
         social: {
             twitter: {
-                viaHandle: '@OSFramework',
+                viaHandle: 'OSFramework',
             },
         },
         signUpPolicy: {

--- a/lib/registries/addon/components/registries-banner/component.ts
+++ b/lib/registries/addon/components/registries-banner/component.ts
@@ -43,26 +43,26 @@ const { OSF: { url: baseURL } } = config;
 export default class RegistriesBanner extends Component {
     @service i18n!: I18N;
 
-    @alias('node.embargoEndDate') endEmbargoDate!: string;
+    @alias('registration.embargoEndDate') endEmbargoDate!: string;
 
     // Required
-    node!: RegistrationModel;
+    registration!: RegistrationModel;
 
     // Optional
     dismissible?: boolean = defaultTo(this.dismissible, false);
     type?: string = defaultTo(this.type, 'info');
 
-    @computed('node.state')
+    @computed('registration.state')
     get stateBanner(this: RegistriesBanner) {
-        return stateToBannerMap[this.node.state];
+        return stateToBannerMap[this.registration.state];
     }
 
-    @computed('node.registeredFrom.id')
+    @computed('registration.registeredFrom.id')
     get projectUrl(this: RegistriesBanner) {
-        if (!this.node) {
+        if (!this.registration) {
             return;
         }
-        const registeredFromId = this.node.registeredFrom.get('id');
+        const registeredFromId = this.registration.registeredFrom.get('id');
         return registeredFromId && pathJoin(baseURL, registeredFromId);
     }
 }

--- a/lib/registries/addon/components/registries-banner/template.hbs
+++ b/lib/registries/addon/components/registries-banner/template.hbs
@@ -1,5 +1,5 @@
 {{#if (and this.stateBanner.text this.stateBanner.type) }}
-    <div local-class='Banner' data-test-banner={{@node.state}}>
+    <div local-class='Banner' data-test-banner={{@registration.state}}>
         <BsAlert @dismissible={{this.dismissible}} @type={{this.stateBanner.type}}>
             <div class='text-center'>
                 {{t this.stateBanner.text embargoEndDate=(moment-format this.registration.embargoEndDate 'MMMM D, YYYY') projectUrl=this.projectUrl}}

--- a/lib/registries/addon/components/registries-banner/template.hbs
+++ b/lib/registries/addon/components/registries-banner/template.hbs
@@ -2,7 +2,7 @@
     <div local-class='Banner' data-test-banner={{@registration.state}}>
         <BsAlert @dismissible={{this.dismissible}} @type={{this.stateBanner.type}}>
             <div class='text-center'>
-                {{t this.stateBanner.text embargoEndDate=(moment-format this.registration.embargoEndDate 'MMMM D, YYYY') projectUrl=this.projectUrl}}
+                {{t this.stateBanner.text embargoEndDate=(moment-format @registration.embargoEndDate 'MMMM D, YYYY') projectUrl=this.projectUrl}}
             </div>
         </BsAlert>
     </div>

--- a/lib/registries/addon/components/registries-overview-menu/component.ts
+++ b/lib/registries/addon/components/registries-overview-menu/component.ts
@@ -14,14 +14,14 @@ import template from './template';
 @layout(template, styles)
 export default class RegistriesOverviewMenu extends Component.extend({
     forkRegistration: task(function *(this: RegistriesOverviewMenu, closeDropdown: () => void) {
-        if (!this.node) {
+        if (!this.registration) {
             return;
         }
 
         closeDropdown();
 
         try {
-            yield this.node.makeFork();
+            yield this.registration.makeFork();
         } catch (e) {
             this.toast.error(this.i18n.t('registries.overview.fork.error'));
             throw e;
@@ -39,10 +39,10 @@ export default class RegistriesOverviewMenu extends Component.extend({
 
     registrationURL!: string;
 
-    node!: RegistrationModel;
+    registration!: RegistrationModel;
 
-    @computed('node.state')
+    @computed('registration.state')
     get isWithdrawn(this: RegistriesOverviewMenu): boolean {
-        return this.node.state === RegistrationState.Withdrawn;
+        return this.registration.state === RegistrationState.Withdrawn;
     }
 }

--- a/lib/registries/addon/components/registries-overview-menu/template.hbs
+++ b/lib/registries/addon/components/registries-overview-menu/template.hbs
@@ -41,8 +41,8 @@
         </div>
         <div data-test-social-sharing-button class='btn-group' role='group' aria-label={{t 'general.share'}}>
             {{#sharing-icons/dropdown
-                title=@registration.title
-                description=@registration.description
+                title=@node.title
+                description=@node.description
                 hyperlink=@registrationURL
                 showBookmark=true
                 showText=true

--- a/lib/registries/addon/components/registries-overview-menu/template.hbs
+++ b/lib/registries/addon/components/registries-overview-menu/template.hbs
@@ -1,6 +1,6 @@
 <div class='btn-group pull-right' role='group' aria-label={{t 'registries.overview.aria_labels.main'}}>
     <div class='btn-group' role='group'>
-        <RegistriesStates @node={{this.node}} />
+        <RegistriesStates @registration={{this.registration}} />
     </div>
     {{#unless this.isWithdrawn}}
         <div class='btn-group' role='group'>
@@ -21,7 +21,7 @@
                             <OsfLink
                                 data-analytics-name='Go to forks page'
                                 @route='guid-registration.forks'
-                                @models={{array this.node.id}}
+                                @models={{array @registration.id}}
                             >
                                 {{t 'registries.overview.view_forks'}}
                             </OsfLink>
@@ -41,12 +41,12 @@
         </div>
         <div data-test-social-sharing-button class='btn-group' role='group' aria-label={{t 'general.share'}}>
             {{#sharing-icons/dropdown
-                title=@node.title
-                description=@node.description
+                title=@registration.title
+                description=@registration.description
                 hyperlink=@registrationURL
                 showBookmark=true
                 showText=true
-                node=this.node
+                registration=@registration
                 as |dd|}}
                 {{#dd.trigger local-class='Menu__button'}}
                     <OsfButton

--- a/lib/registries/addon/components/registries-states/actions-trigger/component.ts
+++ b/lib/registries/addon/components/registries-states/actions-trigger/component.ts
@@ -36,14 +36,14 @@ export default class ActionsTrigger extends Component {
       @not('media.isDesktop') showMobileView!: boolean;
 
       isDisabled?: boolean = defaultTo(this.isDisabled, false);
-      node!: RegistrationModel;
+      registration!: RegistrationModel;
 
-      @computed('node.state')
+      @computed('registration.state')
       get registrationState(this: ActionsTrigger): object {
-          if (this.node.state.includes('pending')) {
+          if (this.registration.state.includes('pending')) {
               return StateToIconMap.pending;
           }
-          return StateToIconMap[this.node.state];
+          return StateToIconMap[this.registration.state];
       }
 
       @computed('isDisabled', 'showMobileView')

--- a/lib/registries/addon/components/registries-states/actions-trigger/template.hbs
+++ b/lib/registries/addon/components/registries-states/actions-trigger/template.hbs
@@ -1,6 +1,6 @@
 <OsfButton
     data-analytics-name='Expand admin action'
-    data-analytics-extra={{concat 'Current state: ' @node.state}}
+    data-analytics-extra={{concat 'Current state: ' @registration.state}}
     @type='default'
     @class={{local-class this.buttonClass}}
 >

--- a/lib/registries/addon/components/registries-states/component.ts
+++ b/lib/registries/addon/components/registries-states/component.ts
@@ -8,11 +8,11 @@ import template from './template';
 
 @layout(template, styles)
 export default class RegistriesStates extends Component {
-    node!: RegistrationModel;
+    registration!: RegistrationModel;
 
-    @computed('node.userHasAdminPermission', 'node.state', 'node.isRoot')
+    @computed('registration.userHasAdminPermission', 'registration.state', 'registration.isRoot')
     get isDisabled(this: RegistriesStates): boolean {
-        return (!this.node.isRoot || !this.node.userHasAdminPermission ||
-            !([RegistrationState.Public, RegistrationState.Embargoed].includes(this.node.state)));
+        return (!this.registration.isRoot || !this.registration.userHasAdminPermission ||
+            !([RegistrationState.Public, RegistrationState.Embargoed].includes(this.registration.state)));
     }
 }

--- a/lib/registries/addon/components/registries-states/is-embargoed/component.ts
+++ b/lib/registries/addon/components/registries-states/is-embargoed/component.ts
@@ -12,14 +12,14 @@ import template from './template';
 @layout(template)
 export default class RegistrationIsEmbargoed extends Component.extend({
     endEmbargo: task(function *(this: RegistrationIsEmbargoed) {
-        if (!this.node) {
+        if (!this.registration) {
             return;
         }
 
-        this.node.set('public', true);
+        this.registration.set('public', true);
 
         try {
-            yield this.node.save();
+            yield this.registration.save();
         } catch (e) {
             this.toast.error(this.i18n.t('registries.overview.embargoed.action_error'));
         }
@@ -32,7 +32,7 @@ export default class RegistrationIsEmbargoed extends Component.extend({
     @service i18n!: I18N;
     @service toast!: Toast;
 
-    node!: Registration;
+    registration!: Registration;
     closeDropdown?: () => void;
     showModal?: boolean = false;
 

--- a/lib/registries/addon/components/registries-states/is-public/component.ts
+++ b/lib/registries/addon/components/registries-states/is-public/component.ts
@@ -14,17 +14,17 @@ import template from './template';
 @layout(template, styles)
 export default class RegistrationIsPublic extends Component.extend({
     submitWithdrawal: task(function *(this: RegistrationIsPublic) {
-        if (!this.node && !this.withdrawalJustification) {
+        if (!this.registration && !this.withdrawalJustification) {
             return;
         }
 
-        this.node.setProperties({
+        this.registration.setProperties({
             pendingWithdrawal: true,
             withdrawalJustification: this.withdrawalJustification,
         });
 
         try {
-            yield this.node.save();
+            yield this.registration.save();
         } catch (e) {
             this.toast.error(this.i18n.t('registries.overview.withdraw.error'));
             throw e;
@@ -40,7 +40,7 @@ export default class RegistrationIsPublic extends Component.extend({
     @service i18n!: I18N;
     @service toast!: Toast;
 
-    node!: Registration;
+    registration!: Registration;
 
     scientistName?: string;
     scientistNameInput?: string = '';

--- a/lib/registries/addon/components/registries-states/template.hbs
+++ b/lib/registries/addon/components/registries-states/template.hbs
@@ -1,15 +1,15 @@
 {{#if this.isDisabled}}
-    {{registries-states/actions-trigger node=@node isDisabled=true}}
+    {{registries-states/actions-trigger registration=@registration isDisabled=true}}
 {{else}}
     <ResponsiveDropdown as |dd|>
         {{#dd.trigger local-class='Menu__button'}}
-            {{registries-states/actions-trigger isOpen=dd.isOpen node=@node}}
+            {{registries-states/actions-trigger isOpen=dd.isOpen registration=@registration}}
         {{/dd.trigger}}
         {{#dd.content local-class='States'}}
-            {{#if (eq this.node.state 'public')}}
-                {{registries-states/is-public node=@node closeDropdown=dd.close}}
+            {{#if (eq this.registration.state 'public')}}
+                {{registries-states/is-public registration=@registration closeDropdown=dd.close}}
             {{else}}
-                {{registries-states/is-embargoed node=@node closeDropdown=dd.close}}
+                {{registries-states/is-embargoed registration=@registration closeDropdown=dd.close}}
             {{/if}}
         {{/dd.content}}
     </ResponsiveDropdown>

--- a/lib/registries/addon/components/sharing-icons/component.ts
+++ b/lib/registries/addon/components/sharing-icons/component.ts
@@ -1,5 +1,6 @@
 import { computed } from '@ember-decorators/object';
 import Component from '@ember/component';
+import config from 'ember-get-config';
 
 import { layout } from 'ember-osf-web/decorators/component';
 import defaultTo from 'ember-osf-web/utils/default-to';
@@ -22,7 +23,7 @@ export default class SharingIcons extends Component {
         const queryParams = {
             url: this.hyperlink,
             text: this.title,
-            via: 'OSFramework',
+            via: config.social.twitter.viaHandle,
         };
         return `https://twitter.com/intent/tweet?${param(queryParams)}`;
     }

--- a/lib/registries/addon/components/sharing-icons/dropdown/component.ts
+++ b/lib/registries/addon/components/sharing-icons/dropdown/component.ts
@@ -15,7 +15,7 @@ import template from './template';
 @tagName('')
 @layout(template, styles)
 export default class SharingIconsDropdown extends Component.extend({
-    bookmark: task(function *(this: SharingIconsDropdown) {
+    bookmark: task(function *(this: SharingIconsDropdown, closeDropdown: () => void) {
         if (!this.bookmarksCollection || !this.node) {
             return;
         }
@@ -41,6 +41,7 @@ export default class SharingIconsDropdown extends Component.extend({
         if (response && response.data) {
             const isBookmarked = Boolean(response.data.find((reg: Registration) => reg.id === this.node.id));
             this.set('isBookmarked', isBookmarked);
+            closeDropdown();
         }
     }).drop(),
     getBookmarksCollection: task(function *(this: SharingIconsDropdown) {

--- a/lib/registries/addon/components/sharing-icons/dropdown/component.ts
+++ b/lib/registries/addon/components/sharing-icons/dropdown/component.ts
@@ -15,8 +15,8 @@ import template from './template';
 @tagName('')
 @layout(template, styles)
 export default class SharingIconsDropdown extends Component.extend({
-    bookmark: task(function *(this: SharingIconsDropdown, closeDropdown: () => void) {
-        if (!this.bookmarksCollection || !this.node) {
+    bookmark: task(function *(this: SharingIconsDropdown) {
+        if (!this.bookmarksCollection || !this.registration) {
             return;
         }
 
@@ -25,11 +25,17 @@ export default class SharingIconsDropdown extends Component.extend({
 
         try {
             if (op === 'remove') {
-                this.bookmarksCollection.linkedRegistrations.removeObject(this.node);
-                response = yield this.bookmarksCollection.deleteM2MRelationship('linkedRegistrations', this.node);
+                this.bookmarksCollection.linkedRegistrations.removeObject(this.registration);
+                response = yield this.bookmarksCollection.deleteM2MRelationship(
+                    'linkedRegistrations',
+                    this.registration,
+                );
             } else {
-                this.bookmarksCollection.linkedRegistrations.pushObject(this.node);
-                response = yield this.bookmarksCollection.createM2MRelationship('linkedRegistrations', this.node);
+                this.bookmarksCollection.linkedRegistrations.pushObject(this.registration);
+                response = yield this.bookmarksCollection.createM2MRelationship(
+                    'linkedRegistrations',
+                    this.registration,
+                );
             }
         } catch (e) {
             this.toast.error(this.i18n.t(`registries.overview.update_bookmarks.${op}.error`));
@@ -39,9 +45,8 @@ export default class SharingIconsDropdown extends Component.extend({
         this.toast.success(this.i18n.t(`registries.overview.update_bookmarks.${op}.success`));
 
         if (response && response.data) {
-            const isBookmarked = Boolean(response.data.find((reg: Registration) => reg.id === this.node.id));
+            const isBookmarked = Boolean(response.data.find((reg: Registration) => reg.id === this.registration.id));
             this.set('isBookmarked', isBookmarked);
-            closeDropdown();
         }
     }).drop(),
     getBookmarksCollection: task(function *(this: SharingIconsDropdown) {
@@ -56,7 +61,7 @@ export default class SharingIconsDropdown extends Component.extend({
         this.set('bookmarksCollection', collections.firstObject);
 
         const bookmarkedRegs = yield this.bookmarksCollection.linkedRegistrations;
-        const isBookmarked = Boolean(bookmarkedRegs.find((reg: Registration) => reg.id === this.node.id));
+        const isBookmarked = Boolean(bookmarkedRegs.find((reg: Registration) => reg.id === this.registration.id));
 
         this.set('isBookmarked', isBookmarked);
     }).on('init'),
@@ -65,7 +70,7 @@ export default class SharingIconsDropdown extends Component.extend({
     @service toast!: Toast;
     @service i18n!: I18n;
 
-    node!: Registration;
+    registration!: Registration;
     bookmarksCollection!: Collection;
     isBookmarked?: boolean;
 }

--- a/lib/registries/addon/components/sharing-icons/dropdown/template.hbs
+++ b/lib/registries/addon/components/sharing-icons/dropdown/template.hbs
@@ -8,13 +8,14 @@
             @resultId={{@resultId}}
             @parentId={{@parentId}}
             @showText={{@showText}}
+            @closeDropdown={{action dd.close}}
         as |links|>
             <ul local-class='Dropdown__list'>
                 {{#if @showBookmark}}
                     <li role='menuitem' local-class='Dropdown__option'>
                         <OsfButton
                             @type='link'
-                            @onClick={{action (perform this.bookmark)}}
+                            @onClick={{action (perform this.bookmark dd.close)}}
                         >
                             <FaIcon @icon='bookmark' @fixedWidth={{true}} />
                             {{#if this.isBookmarked}}

--- a/lib/registries/addon/components/sharing-icons/dropdown/template.hbs
+++ b/lib/registries/addon/components/sharing-icons/dropdown/template.hbs
@@ -8,14 +8,16 @@
             @resultId={{@resultId}}
             @parentId={{@parentId}}
             @showText={{@showText}}
-            @closeDropdown={{action dd.close}}
         as |links|>
-            <ul local-class='Dropdown__list'>
+            {{! template-lint-disable invalid-interactive }}
+            <ul local-class='Dropdown__list' {{action dd.close preventDefault=false}}>
+                {{! template-lint-enable invalid-interactive }}
                 {{#if @showBookmark}}
                     <li role='menuitem' local-class='Dropdown__option'>
                         <OsfButton
                             @type='link'
-                            @onClick={{action (perform this.bookmark dd.close)}}
+                            @onClick={{action (perform this.bookmark)}}
+                            @bubble={{true}}
                         >
                             <FaIcon @icon='bookmark' @fixedWidth={{true}} />
                             {{#if this.isBookmarked}}

--- a/lib/registries/addon/components/sharing-icons/sharing-anchor/template.hbs
+++ b/lib/registries/addon/components/sharing-icons/sharing-anchor/template.hbs
@@ -1,8 +1,15 @@
 {{#if this.href}}
-    <a data-analytics-name={{@analyticsName}} href={{this.href}}>
+    <OsfLink
+        data-analytics-name={{@analyticsName}}
+        @onClick={{@closeDropdown}}
+        @href={{this.href}}
+        target='_blank'
+        rel='noopener'
+    >
         <FaIcon @icon={{@icon}} @fixedWidth={{true}} />
         {{#if @showText}}
             {{@medium}}
         {{/if}}
-    </a>
+    </OsfLink>
+
 {{/if}}

--- a/lib/registries/addon/components/sharing-icons/sharing-anchor/template.hbs
+++ b/lib/registries/addon/components/sharing-icons/sharing-anchor/template.hbs
@@ -11,5 +11,4 @@
             {{@medium}}
         {{/if}}
     </OsfLink>
-
 {{/if}}

--- a/lib/registries/addon/components/sharing-icons/sharing-anchor/template.hbs
+++ b/lib/registries/addon/components/sharing-icons/sharing-anchor/template.hbs
@@ -1,7 +1,6 @@
 {{#if this.href}}
     <OsfLink
         data-analytics-name={{@analyticsName}}
-        @onClick={{@closeDropdown}}
         @href={{this.href}}
         target='_blank'
         rel='noopener'

--- a/lib/registries/addon/components/sharing-icons/template.hbs
+++ b/lib/registries/addon/components/sharing-icons/template.hbs
@@ -5,6 +5,7 @@
         analyticsName='Share - tweet'
         icon='twitter-square'
         showText=@showText
+        closeDropdown=@closeDropdown
     )
     linkedin=(component 'sharing-icons/sharing-anchor'
         href=this.linkedinHref
@@ -12,6 +13,7 @@
         analyticsName='Share - linkedin'
         icon='linkedin-square'
         showText=@showText
+        closeDropdown=@closeDropdown
     )
     facebook=(component 'sharing-icons/sharing-anchor'
         href=this.facebookHref
@@ -19,6 +21,7 @@
         analyticsName='Share - facebook'
         icon='facebook-square'
         showText=@showText
+        closeDropdown=@closeDropdown
     )
     email=(component 'sharing-icons/sharing-anchor'
         href=this.emailHref
@@ -26,6 +29,7 @@
         analyticsName='Share - email'
         icon='envelope'
         showText=@showText
+        closeDropdown=@closeDropdown
     )) as |links|}}
     {{#if (has-block)}}
         {{yield links}}

--- a/lib/registries/addon/components/sharing-icons/template.hbs
+++ b/lib/registries/addon/components/sharing-icons/template.hbs
@@ -5,7 +5,6 @@
         analyticsName='Share - tweet'
         icon='twitter-square'
         showText=@showText
-        closeDropdown=@closeDropdown
     )
     linkedin=(component 'sharing-icons/sharing-anchor'
         href=this.linkedinHref
@@ -13,7 +12,6 @@
         analyticsName='Share - linkedin'
         icon='linkedin-square'
         showText=@showText
-        closeDropdown=@closeDropdown
     )
     facebook=(component 'sharing-icons/sharing-anchor'
         href=this.facebookHref
@@ -21,7 +19,6 @@
         analyticsName='Share - facebook'
         icon='facebook-square'
         showText=@showText
-        closeDropdown=@closeDropdown
     )
     email=(component 'sharing-icons/sharing-anchor'
         href=this.emailHref
@@ -29,7 +26,6 @@
         analyticsName='Share - email'
         icon='envelope'
         showText=@showText
-        closeDropdown=@closeDropdown
     )) as |links|}}
     {{#if (has-block)}}
         {{yield links}}

--- a/lib/registries/addon/overview/controller.ts
+++ b/lib/registries/addon/overview/controller.ts
@@ -33,15 +33,11 @@ export default class Overview extends Controller {
 
     @alias('model.taskInstance.value') registration?: Registration;
     @not('registration') loading!: boolean;
+    @not('media.isDesktop') showMobileView!: boolean;
 
     @computed('registration.id')
     get registrationURL() {
         return this.registration && pathJoin(baseURL, `${this.registration.id}`);
-    }
-
-    @computed('media.isDesktop', 'registration.withdrawn')
-    get showMobileView() {
-        return !this.media.isDesktop && this.registration && !this.registration.withdrawn;
     }
 
     @computed('media.{isMobile,isTablet,isDesktop}')

--- a/lib/registries/addon/overview/route.ts
+++ b/lib/registries/addon/overview/route.ts
@@ -14,8 +14,6 @@ import MetaTags, { HeadTagDef } from 'ember-osf-web/services/meta-tags';
 import Ready from 'ember-osf-web/services/ready';
 import pathJoin from 'ember-osf-web/utils/path-join';
 
-const { assetsPrefix } = config;
-
 export default class Overview extends GuidRoute {
     @service analytics!: Analytics;
     @service router!: RouterService;
@@ -34,7 +32,7 @@ export default class Overview extends GuidRoute {
             const institutions = yield registration.loadAll('affiliatedInstitutions');
             const license = yield registration.license;
 
-            const image = `${assetsPrefix}engines-dist/registries/assets/img/osf-sharing.png`;
+            const image = 'engines-dist/registries/assets/img/osf-sharing.png';
 
             const metaTagsData = {
                 title: registration.title,

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -4,7 +4,7 @@
     </div>
 {{else}}
     {{title this.registration.title}}
-    <RegistriesBanner @node={{this.registration}} />
+    <RegistriesBanner @registration={{this.registration}} />
     <div local-class='TitleBackground'>
         <Container>
             <div local-class='Container'>

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -66,7 +66,7 @@
             </div>
         {{/let}}
     {{else}}
-        {{#if this.showMobileView}}
+        {{#if (and this.showMobileView (not this.registration.withdrawn))}}
             <Navbar as |nav|>
                 <nav.bordered-section>
 

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -16,15 +16,15 @@
                         <h1 data-test-registration-title>{{this.registration.title}}</h1>
                     </div>
                 </div>
-                {{#unless this.showMobileView}}
+                {{#if (not (or this.registration.withdrawn this.showMobileView))}}
                     <div local-class='Toolbar' data-analytics-scope='Registries Overview Toolbar'>
                         <RegistriesOverviewMenu
                             @registrationURL={{this.registrationURL}}
                             @forksCount={{this.forksCount}}
-                            @node={{this.registration}}
+                            @registration={{this.registration}}
                         />
                     </div>
-                {{/unless}}
+                {{/if}}
             </div>
         </Container>
     </div>
@@ -80,7 +80,7 @@
 
                 </nav.bordered-section>
                 <nav.bordered-section>
-                    <RegistriesStates @node={{this.registration}} />
+                    <RegistriesStates @registration={{this.registration}} />
 
                     <nav.buttons.default @onclick={{action 'toggleMetadata'}}>
                         {{nav.icon 'info-circle'}}
@@ -92,7 +92,7 @@
                         hyperlink=this.registrationURL
                         showText=true
                         showBookmark=true
-                        node=this.registration
+                        registration=this.registration
                         as |dd|}}
                         {{#dd.trigger}}
                             <nav.buttons.default>

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -1,7 +1,7 @@
 import { Server } from 'ember-cli-mirage';
 import config from 'ember-get-config';
 
-import { updateBookmarks } from './views/collection';
+import { bookmarksRegistrationAdd, bookmarksRegistrationDelete } from './views/collection';
 import { reportDelete } from './views/comment';
 import { createDeveloperApp, resetClientSecret } from './views/developer-app';
 import { createFork, createRegistrationFork } from './views/fork';
@@ -100,10 +100,18 @@ export default function(this: Server) {
     osfResource(this, 'registration-schema', { path: '/schemas/registrations' });
 
     osfResource(this, 'collection');
-    osfNestedResource(this, 'collection', 'linkedRegistrations', { only: ['index'] });
-
-    this.post('/collections/:id/relationships/linked_registrations', updateBookmarks);
-    this.del('/collections/:id/relationships/linked_registrations', updateBookmarks);
+    osfNestedResource(this, 'collection', 'linkedRegistrations', {
+        only: ['index'],
+        path: '/collections/:parentID/linked_registrations',
+    });
+    osfNestedResource(this, 'collection', 'linkedRegistrations', {
+        only: ['create', 'delete'],
+        path: '/collections/:parentID/relationships/linked_registrations',
+        views: {
+            create: bookmarksRegistrationAdd,
+            delete: bookmarksRegistrationDelete,
+        },
+    });
 
     osfResource(this, 'scope', { only: ['index', 'show'] });
     osfResource(this, 'region', { only: ['index', 'show'] });

--- a/mirage/views/collection.ts
+++ b/mirage/views/collection.ts
@@ -1,18 +1,21 @@
 import { HandlerContext, Schema } from 'ember-cli-mirage';
 
-export function updateBookmarks(
-    this: HandlerContext,
-    schema: Schema,
-    request: any,
-) {
-    const { id: collId } = this.request.params;
-    const { data: [{ id: regId, type }] } = JSON.parse(request.requestBody);
+export function bookmarksRegistrationAdd(this: HandlerContext, schema: Schema) {
+    const { parentID: collId } = this.request.params;
+    const { data: [{ id: regId, type }] } = JSON.parse(this.request.requestBody);
     const bookmarksColl = schema.collections.find(collId);
 
-    const existingLinkedRegistrations: string[] = bookmarksColl.linkedRegistrations.models.mapBy('id');
-    const linkedRegistrations = request.method === 'POST' ?
-        [regId, ...existingLinkedRegistrations] :
-        existingLinkedRegistrations.splice(existingLinkedRegistrations.indexOf(regId), 1);
+    const existingLinkedRegistrations: Array<string|number> = bookmarksColl.linkedRegistrations.models.mapBy('id');
+    const linkedRegistrations = [regId, ...existingLinkedRegistrations];
 
     return { data: linkedRegistrations.map(id => ({ id, type })) };
+}
+
+export function bookmarksRegistrationDelete(this: HandlerContext, schema: Schema) {
+    const { id: regId, parentID } = this.request.params;
+    const bookmarksColl = schema.collections.find(parentID);
+    const existingLinkedRegistrations: Array<string|number> = bookmarksColl.linkedRegistrations.models.mapBy('id');
+    const linkedRegistrations = existingLinkedRegistrations.splice(existingLinkedRegistrations.indexOf(regId), 1);
+
+    return { data: linkedRegistrations.map(id => ({ id, type: 'registrations' })) };
 }

--- a/tests/acceptance/guid-file/file-detail-test.ts
+++ b/tests/acceptance/guid-file/file-detail-test.ts
@@ -182,7 +182,7 @@ module('Acceptance | guid file', hooks => {
             assert.dom('[data-test-twitter-link]')
                 .hasAttribute(
                     'href',
-                    `${twitter}${file.name}&url=${encodedOsfUrl}${file.guid}&via=%40OSFramework`,
+                    `${twitter}${file.name}&url=${encodedOsfUrl}${file.guid}&via=${config.social.twitter.viaHandle}`,
                 );
             assert.dom('[data-test-facebook-link]')
                 .hasAttribute(

--- a/tests/engines/registries/acceptance/overview/overview-test.ts
+++ b/tests/engines/registries/acceptance/overview/overview-test.ts
@@ -1,7 +1,4 @@
-import {
-    // faker,
-    ModelInstance,
-} from 'ember-cli-mirage';
+import { ModelInstance } from 'ember-cli-mirage';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import config from 'ember-get-config';
 import { TestContext } from 'ember-test-helpers';
@@ -178,7 +175,7 @@ module('Registries | Acceptance | overview.overview', hooks => {
         assertHeadMetaTags(assert, 'dateRegistered', moment(reg.dateRegistered).format('YYYY-MM-DD'));
         assertHeadMetaTags(assert, 'dateModified', moment(reg.dateModified).format('YYYY-MM-DD'));
         assertHeadMetaTags(assert, 'url', pathJoin(config.OSF.url, reg.id as string));
-        assertHeadMetaTags(assert, 'image', `${config.assetsPrefix}engines-dist/registries/assets/img/osf-sharing.png`);
+        assertHeadMetaTags(assert, 'image', 'engines-dist/registries/assets/img/osf-sharing.png');
         assertHeadMetaTags(assert, 'tags', reg.tags);
         assertHeadMetaTags(assert, 'contributors', reg.contributors.models.mapBy('users.fullName'));
         assertHeadMetaTags(assert, 'affiliatedInstitutions', affiliatedInstitutions.mapBy('name'), true);


### PR DESCRIPTION
## Purpose

Fix issues with social sharing links.
Fix image url og tag


## Summary of Changes
 - og:image tag had a bad url. Do not append `assetsPrefix` on the image asset location url.
 - Upon clicking a link in the sharing links on the overview toolbar, the dropdown closes.
 - sharing links on the overview toolbar had `undefined` in the share url as registration title and description were being retrieved on `node` while `registration` is passed in.
 - registries banner `embargoEnddate` was wrong.

## Side Effects

N/A

## Feature Flags

`ember_registries_detail_page`

## QA Notes

On the overview menu, expand the social sharing dropdown.
Click on linkedin, facebook (if any), twitter make sure, you will be take to share post
page on the platform, make sure that the osf logo image, registration title show.

## Ticket

[EMB-442](https://openscience.atlassian.net/browse/EMB-442)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
