### PR TITLE
[MAIN] Refactor.registries.states

### DIFF
--- a/app/models/registration.ts
+++ b/app/models/registration.ts
@@ -11,13 +11,13 @@ import RegistryProviderModel from './registry-provider';
 import UserModel from './user';
 
 export enum RegistrationState {
-    Embargoed = 'embargoed',
-    Public = 'public',
-    Withdrawn = 'withdrawn',
-    PendingRegistration = 'pendingRegistrationApproval',
-    PendingWithdrawal = 'pendingWithdrawal',
-    PendingEmbargo = 'pendingEmbargoApproval',
-    PendingEmbargoTermination = 'pendingEmbargoTerminationApproval',
+    embargoed = 'embargoed',
+    public = 'public',
+    withdrawn = 'withdrawn',
+    pendingRegistrationApproval = 'pendingRegistrationApproval',
+    pendingWithdrawal = 'pendingWithdrawal',
+    pendingEmbargoApproval = 'pendingEmbargoApproval',
+    pendingEmbargoTerminationApproval = 'pendingEmbargoTerminationApproval',
 }
 
 export default class RegistrationModel extends NodeModel.extend() {
@@ -44,15 +44,12 @@ export default class RegistrationModel extends NodeModel.extend() {
         'pendingEmbargoApproval', 'pendingEmbargoTerminationApproval',
         'pendingWithdrawal')
     get state(): RegistrationState {
-        return (
-            (this.pendingRegistrationApproval && RegistrationState.PendingRegistration) ||
-            (this.pendingEmbargoApproval && RegistrationState.PendingEmbargo) ||
-            (this.pendingEmbargoTerminationApproval && RegistrationState.PendingEmbargoTermination) ||
-            (this.pendingWithdrawal && RegistrationState.PendingWithdrawal) ||
-            (this.withdrawn && RegistrationState.Withdrawn) ||
-            (this.embargoed && RegistrationState.Embargoed) ||
-            RegistrationState.Public
-        );
+        const stateMap = this.registrationStateMap();
+        const currentState: any = Object.keys(stateMap)
+            .filter((key: string) => stateMap[key])
+            .map(activeState => activeState)[0];
+
+        return currentState || RegistrationState.public;
     }
 
     @belongsTo('node', { inverse: 'registrations' })
@@ -84,6 +81,26 @@ export default class RegistrationModel extends NodeModel.extend() {
 
     @hasMany('institution', { inverse: 'registrations' })
     affiliatedInstitutions!: DS.PromiseManyArray<InstitutionModel> | InstitutionModel[];
+
+    registrationStateMap(): any {
+        const {
+            pendingRegistrationApproval,
+            pendingEmbargoApproval,
+            pendingEmbargoTerminationApproval,
+            pendingWithdrawal,
+            withdrawn,
+            embargoed,
+        } = this;
+
+        return {
+            pendingRegistrationApproval,
+            pendingEmbargoApproval,
+            pendingEmbargoTerminationApproval,
+            pendingWithdrawal,
+            withdrawn,
+            embargoed,
+        };
+    }
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/models/registration.ts
+++ b/app/models/registration.ts
@@ -44,10 +44,9 @@ export default class RegistrationModel extends NodeModel.extend() {
         'pendingEmbargoApproval', 'pendingEmbargoTerminationApproval',
         'pendingWithdrawal')
     get state(): RegistrationState {
-        const stateMap = this.registrationStateMap();
+        const stateMap: any = this.registrationStateMap();
         const currentState: any = Object.keys(stateMap)
-            .filter((key: string) => stateMap[key])
-            .map(activeState => activeState)[0];
+            .filter(key => stateMap[key])[0];
 
         return currentState || RegistrationState.Public;
     }
@@ -82,7 +81,7 @@ export default class RegistrationModel extends NodeModel.extend() {
     @hasMany('institution', { inverse: 'registrations' })
     affiliatedInstitutions!: DS.PromiseManyArray<InstitutionModel> | InstitutionModel[];
 
-    registrationStateMap(): any {
+    registrationStateMap(): Record<RegistrationState, boolean> {
         const {
             pendingRegistrationApproval,
             pendingEmbargoApproval,
@@ -100,6 +99,7 @@ export default class RegistrationModel extends NodeModel.extend() {
             PendingWithdrawal: pendingWithdrawal,
             Withdrawn: withdrawn,
             Embargoed: embargo,
+            Public: !pendingWithdrawal,
         };
     }
 }

--- a/app/models/registration.ts
+++ b/app/models/registration.ts
@@ -45,8 +45,9 @@ export default class RegistrationModel extends NodeModel.extend() {
         'pendingWithdrawal')
     get state(): RegistrationState {
         const stateMap: any = this.registrationStateMap();
-        const currentState: any = Object.keys(stateMap)
-            .filter(key => stateMap[key])[0];
+        const currentState: RegistrationState = Object.keys(stateMap)
+            .filter(active => stateMap[active])
+            .map(key => RegistrationState[key as keyof typeof RegistrationState])[0];
 
         return currentState || RegistrationState.Public;
     }

--- a/app/models/registration.ts
+++ b/app/models/registration.ts
@@ -11,13 +11,13 @@ import RegistryProviderModel from './registry-provider';
 import UserModel from './user';
 
 export enum RegistrationState {
-    embargoed = 'embargoed',
-    public = 'public',
-    withdrawn = 'withdrawn',
-    pendingRegistrationApproval = 'pendingRegistrationApproval',
-    pendingWithdrawal = 'pendingWithdrawal',
-    pendingEmbargoApproval = 'pendingEmbargoApproval',
-    pendingEmbargoTerminationApproval = 'pendingEmbargoTerminationApproval',
+    Embargoed = 'Embargoed',
+    Public = 'Public',
+    Withdrawn = 'Withdrawn',
+    PendingRegistration = 'PendingRegistration',
+    PendingWithdrawal = 'PendingWithdrawal',
+    PendingEmbargo = 'PendingEmbargo',
+    PendingEmbargoTermination = 'PendingEmbargoTermination',
 }
 
 export default class RegistrationModel extends NodeModel.extend() {
@@ -49,7 +49,7 @@ export default class RegistrationModel extends NodeModel.extend() {
             .filter((key: string) => stateMap[key])
             .map(activeState => activeState)[0];
 
-        return currentState || RegistrationState.public;
+        return currentState || RegistrationState.Public;
     }
 
     @belongsTo('node', { inverse: 'registrations' })
@@ -91,14 +91,15 @@ export default class RegistrationModel extends NodeModel.extend() {
             withdrawn,
             embargoed,
         } = this;
+        const embargo = embargoed && !pendingEmbargoTerminationApproval;
 
         return {
-            pendingRegistrationApproval,
-            pendingEmbargoApproval,
-            pendingEmbargoTerminationApproval,
-            pendingWithdrawal,
-            withdrawn,
-            embargoed,
+            PendingRegistration: pendingRegistrationApproval,
+            PendingEmbargo: pendingEmbargoApproval,
+            PendingEmbargoTermination: pendingEmbargoTerminationApproval,
+            PendingWithdrawal: pendingWithdrawal,
+            Withdrawn: withdrawn,
+            Embargoed: embargo,
         };
     }
 }

--- a/lib/registries/addon/components/registries-banner/component.ts
+++ b/lib/registries/addon/components/registries-banner/component.ts
@@ -13,28 +13,28 @@ import styles from './styles';
 import template from './template';
 
 const stateToBannerMap: Record<RegistrationState, {text: string, type: string}> = {
-    pendingRegistrationApproval: {
+    PendingRegistration: {
         text: 'registries.overview.pendingRegistrationApproval.banner',
         type: 'info',
     },
-    pendingWithdrawal: {
+    PendingWithdrawal: {
         text: 'registries.overview.pendingWithdrawal.banner',
         type: 'info',
     },
-    pendingEmbargoApproval: {
+    PendingEmbargo: {
         text: 'registries.overview.pendingEmbargoApproval.banner',
         type: 'info',
     },
-    pendingEmbargoTerminationApproval: {
+    PendingEmbargoTermination: {
         text: 'registries.overview.pendingEmbargoTerminationApproval.banner',
         type: 'danger',
     },
-    embargoed: {
+    Embargoed: {
         text: 'registries.overview.embargoed.banner',
         type: 'danger',
     },
-    public: { text: '', type: '' },
-    withdrawn: { text: '', type: '' },
+    Public: { text: '', type: '' },
+    Withdrawn: { text: '', type: '' },
 };
 
 const { OSF: { url: baseURL } } = config;

--- a/lib/registries/addon/components/registries-banner/component.ts
+++ b/lib/registries/addon/components/registries-banner/component.ts
@@ -12,31 +12,6 @@ import pathJoin from 'ember-osf-web/utils/path-join';
 import styles from './styles';
 import template from './template';
 
-const stateToBannerMap: Record<RegistrationState, {text: string, type: string}> = {
-    PendingRegistration: {
-        text: 'registries.overview.pendingRegistrationApproval.banner',
-        type: 'info',
-    },
-    PendingWithdrawal: {
-        text: 'registries.overview.pendingWithdrawal.banner',
-        type: 'info',
-    },
-    PendingEmbargo: {
-        text: 'registries.overview.pendingEmbargoApproval.banner',
-        type: 'info',
-    },
-    PendingEmbargoTermination: {
-        text: 'registries.overview.pendingEmbargoTerminationApproval.banner',
-        type: 'danger',
-    },
-    Embargoed: {
-        text: 'registries.overview.embargoed.banner',
-        type: 'danger',
-    },
-    Public: { text: '', type: '' },
-    Withdrawn: { text: '', type: '' },
-};
-
 const { OSF: { url: baseURL } } = config;
 
 @layout(template, styles)
@@ -54,7 +29,47 @@ export default class RegistriesBanner extends Component {
 
     @computed('registration.state')
     get stateBanner(this: RegistriesBanner) {
-        return stateToBannerMap[this.registration.state];
+        const {
+            registration,
+        } = this;
+        const {
+            PendingRegistration,
+            PendingWithdrawal,
+            PendingEmbargo,
+            PendingEmbargoTermination,
+            Embargoed,
+        } = RegistrationState;
+        const banner = { text: '', type: '' };
+
+        switch (registration.state) {
+        case PendingRegistration:
+            return {
+                text: 'registries.overview.pendingRegistrationApproval.banner',
+                type: 'info',
+            };
+        case PendingWithdrawal:
+            return {
+                text: 'registries.overview.pendingWithdrawal.banner',
+                type: 'info',
+            };
+        case PendingEmbargo:
+            return {
+                text: 'registries.overview.pendingEmbargoApproval.banner',
+                type: 'info',
+            };
+        case PendingEmbargoTermination:
+            return {
+                text: 'registries.overview.pendingEmbargoTerminationApproval.banner',
+                type: 'danger',
+            };
+        case Embargoed:
+            return {
+                text: 'registries.overview.embargoed.banner',
+                type: 'danger',
+            };
+        default:
+            return banner;
+        }
     }
 
     @computed('registration.registeredFrom.id')

--- a/lib/registries/addon/components/registries-overview-menu/component.ts
+++ b/lib/registries/addon/components/registries-overview-menu/component.ts
@@ -43,6 +43,6 @@ export default class RegistriesOverviewMenu extends Component.extend({
 
     @computed('registration.state')
     get isWithdrawn(this: RegistriesOverviewMenu): boolean {
-        return this.registration.state === RegistrationState.withdrawn;
+        return this.registration.state === RegistrationState.Withdrawn;
     }
 }

--- a/lib/registries/addon/components/registries-overview-menu/component.ts
+++ b/lib/registries/addon/components/registries-overview-menu/component.ts
@@ -43,6 +43,6 @@ export default class RegistriesOverviewMenu extends Component.extend({
 
     @computed('registration.state')
     get isWithdrawn(this: RegistriesOverviewMenu): boolean {
-        return this.registration.state === RegistrationState.Withdrawn;
+        return this.registration.state === RegistrationState.withdrawn;
     }
 }

--- a/lib/registries/addon/components/registries-states/actions-trigger/component.ts
+++ b/lib/registries/addon/components/registries-states/actions-trigger/component.ts
@@ -5,29 +5,10 @@ import Component from '@ember/component';
 import Media from 'ember-responsive';
 
 import { layout } from 'ember-osf-web/decorators/component';
-import RegistrationModel from 'ember-osf-web/models/registration';
+import RegistrationModel, { RegistrationState } from 'ember-osf-web/models/registration';
 import defaultTo from 'ember-osf-web/utils/default-to';
 import styles from './styles';
 import template from './template';
-
-const StateToIconMap: Record<string, { text: string, icon: string }> = {
-    public: {
-        text: 'registries.overview.public.state',
-        icon: 'eye',
-    },
-    pending: {
-        text: 'registries.overview.pending.state',
-        icon: 'hourglass-o',
-    },
-    embargoed: {
-        text: 'registries.overview.embargoed.state',
-        icon: 'lock',
-    },
-    withdrawn: {
-        text: 'registries.overview.withdrawn.state',
-        icon: 'ban',
-    },
-};
 
 @layout(template, styles)
 export default class ActionsTrigger extends Component {
@@ -40,10 +21,41 @@ export default class ActionsTrigger extends Component {
 
       @computed('registration.state')
       get registrationState(this: ActionsTrigger): object {
-          if (this.registration.state.includes('pending')) {
-              return StateToIconMap.pending;
+          const { registration } = this;
+          const {
+              PendingRegistration,
+              PendingWithdrawal,
+              PendingEmbargo,
+              PendingEmbargoTermination,
+              Withdrawn,
+              Embargoed,
+          } = RegistrationState;
+
+          switch (registration.state) {
+          case PendingRegistration:
+          case PendingWithdrawal:
+          case PendingEmbargo:
+          case PendingEmbargoTermination:
+              return {
+                  text: 'registries.overview.pending.state',
+                  icon: 'hourglass-o',
+              };
+          case Withdrawn:
+              return {
+                  text: 'registries.overview.withdrawn.state',
+                  icon: 'ban',
+              };
+          case Embargoed:
+              return {
+                  text: 'registries.overview.embargoed.state',
+                  icon: 'lock',
+              };
+          default:
+              return {
+                  text: 'registries.overview.public.state',
+                  icon: 'eye',
+              };
           }
-          return StateToIconMap[this.registration.state];
       }
 
       @computed('isDisabled', 'showMobileView')

--- a/lib/registries/addon/components/registries-states/component.ts
+++ b/lib/registries/addon/components/registries-states/component.ts
@@ -13,6 +13,6 @@ export default class RegistriesStates extends Component {
     @computed('registration.userHasAdminPermission', 'registration.state', 'registration.isRoot')
     get isDisabled(this: RegistriesStates): boolean {
         return (!this.registration.isRoot || !this.registration.userHasAdminPermission ||
-            !([RegistrationState.Public, RegistrationState.Embargoed].includes(this.registration.state)));
+            !([RegistrationState.public, RegistrationState.embargoed].includes(this.registration.state)));
     }
 }

--- a/lib/registries/addon/components/registries-states/component.ts
+++ b/lib/registries/addon/components/registries-states/component.ts
@@ -9,6 +9,7 @@ import template from './template';
 @layout(template, styles)
 export default class RegistriesStates extends Component {
     registration!: RegistrationModel;
+    public!: RegistrationState.Public;
 
     @computed('registration.userHasAdminPermission', 'registration.state', 'registration.isRoot')
     get isDisabled(this: RegistriesStates): boolean {

--- a/lib/registries/addon/components/registries-states/component.ts
+++ b/lib/registries/addon/components/registries-states/component.ts
@@ -13,6 +13,6 @@ export default class RegistriesStates extends Component {
     @computed('registration.userHasAdminPermission', 'registration.state', 'registration.isRoot')
     get isDisabled(this: RegistriesStates): boolean {
         return (!this.registration.isRoot || !this.registration.userHasAdminPermission ||
-            !([RegistrationState.public, RegistrationState.embargoed].includes(this.registration.state)));
+            !([RegistrationState.Public, RegistrationState.Embargoed].includes(this.registration.state)));
     }
 }

--- a/lib/registries/addon/components/registries-states/template.hbs
+++ b/lib/registries/addon/components/registries-states/template.hbs
@@ -6,7 +6,7 @@
             {{registries-states/actions-trigger isOpen=dd.isOpen registration=@registration}}
         {{/dd.trigger}}
         {{#dd.content local-class='States'}}
-            {{#if (eq this.registration.state 'public')}}
+            {{#if (eq this.registration.state this.public)}}
                 {{registries-states/is-public registration=@registration closeDropdown=dd.close}}
             {{else}}
                 {{registries-states/is-embargoed registration=@registration closeDropdown=dd.close}}

--- a/tests/engines/registries/acceptance/overview/overview-test.ts
+++ b/tests/engines/registries/acceptance/overview/overview-test.ts
@@ -72,7 +72,7 @@ module('Registries | Acceptance | overview.overview', hooks => {
 
             await visit(`/${this.registration.id}/`);
 
-            assert.dom('[data-test-banner="embargoed"]').isVisible();
+            assert.dom('[data-test-banner="Embargoed"]').isVisible();
             assert.dom('[data-test-registration-title]').isVisible();
         });
 
@@ -84,7 +84,7 @@ module('Registries | Acceptance | overview.overview', hooks => {
 
             await visit(`/${this.registration.id}/`);
 
-            assert.dom('[data-test-banner="embargoed"]').isVisible();
+            assert.dom('[data-test-banner="Embargoed"]').isVisible();
             assert.dom('[data-test-registration-title]').isVisible();
         });
 

--- a/tests/unit/models/registration-test.ts
+++ b/tests/unit/models/registration-test.ts
@@ -58,7 +58,7 @@ module('Unit | Model | registration', hooks => {
         assert.equal(model.get('state'), 'Embargoed');
     });
 
-    test('state returns pendingEmbargoTerminationApproval if both it and embargo true', function(assert) {
+    test('state returns pendingEmbargoTerminationApproval if both it and embargo are true', function(assert) {
         const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
         model.set('embargoed', true);
         model.set('pendingEmbargoTerminationApproval', true);
@@ -66,7 +66,7 @@ module('Unit | Model | registration', hooks => {
         assert.equal(model.get('state'), 'PendingEmbargoTermination');
     });
 
-    test('state returns pendingEmbargoTerminationApproval if both it and embargo true', function(assert) {
+    test('state returns pendingWithdrawal if both it and public are true', function(assert) {
         const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
         model.set('public', true);
         model.set('pendingWithdrawal', true);

--- a/tests/unit/models/registration-test.ts
+++ b/tests/unit/models/registration-test.ts
@@ -66,6 +66,14 @@ module('Unit | Model | registration', hooks => {
         assert.equal(model.get('state'), 'PendingEmbargoTermination');
     });
 
+    test('state returns pendingEmbargoTerminationApproval if both it and embargo true', function(assert) {
+        const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
+        model.set('public', true);
+        model.set('pendingWithdrawal', true);
+
+        assert.equal(model.get('state'), 'PendingWithdrawal');
+    });
+
     test('state updates when the model changes', function(assert) {
         const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
         model.set('embargoed', true);

--- a/tests/unit/models/registration-test.ts
+++ b/tests/unit/models/registration-test.ts
@@ -10,60 +10,68 @@ module('Unit | Model | registration', hooks => {
         assert.ok(!!model);
     });
 
-    test('registraiton state selects public as default', function(assert) {
+    test('state selects public as default', function(assert) {
         const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
 
-        assert.equal(model.get('state'), 'public');
+        assert.equal(model.get('state'), 'Public');
     });
 
-    test('registration state returns pendingRegistrationApproval if field is true', function(assert) {
+    test('state returns pendingRegistrationApproval if field is true', function(assert) {
         const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
         model.set('pendingRegistrationApproval', true);
 
-        assert.equal(model.get('state'), 'pendingRegistrationApproval');
+        assert.equal(model.get('state'), 'PendingRegistration');
     });
 
-    test('registration state returns pendingEmbargoApproval if field is true', function(assert) {
+    test('state returns pendingEmbargoApproval if field is true', function(assert) {
         const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
         model.set('pendingEmbargoApproval', true);
 
-        assert.equal(model.get('state'), 'pendingEmbargoApproval');
+        assert.equal(model.get('state'), 'PendingEmbargo');
     });
 
-    test('registration state return pendingEmbargoTerminationApproval if field is true', function(assert) {
+    test('state return pendingEmbargoTerminationApproval if field is true', function(assert) {
         const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
         model.set('pendingEmbargoTerminationApproval', true);
 
-        assert.equal(model.get('state'), 'pendingEmbargoTerminationApproval');
+        assert.equal(model.get('state'), 'PendingEmbargoTermination');
     });
 
-    test('registartion state returns pendingWithdrawal if field is true', function(assert) {
+    test('state returns pendingWithdrawal if field is true', function(assert) {
         const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
         model.set('pendingWithdrawal', true);
 
-        assert.equal(model.get('state'), 'pendingWithdrawal');
+        assert.equal(model.get('state'), 'PendingWithdrawal');
     });
 
-    test('registartion state returns withdrawn if field is true', function(assert) {
+    test('state returns withdrawn if field is true', function(assert) {
         const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
         model.set('withdrawn', true);
 
-        assert.equal(model.get('state'), 'withdrawn');
+        assert.equal(model.get('state'), 'Withdrawn');
     });
 
-    test('registration state returns embargoed if field is true', function(assert) {
+    test('state returns embargoed if field is true', function(assert) {
         const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
         model.set('embargoed', true);
 
-        assert.equal(model.get('state'), 'embargoed');
+        assert.equal(model.get('state'), 'Embargoed');
     });
 
-    test('registration state updates when the model changes', function(assert) {
+    test('state returns pendingEmbargoTerminationApproval if both it and embargo true', function(assert) {
         const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
         model.set('embargoed', true);
-        assert.equal(model.get('state'), 'embargoed');
+        model.set('pendingEmbargoTerminationApproval', true);
+
+        assert.equal(model.get('state'), 'PendingEmbargoTermination');
+    });
+
+    test('state updates when the model changes', function(assert) {
+        const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
+        model.set('embargoed', true);
+        assert.equal(model.get('state'), 'Embargoed');
 
         model.set('withdrawn', true);
-        assert.equal(model.get('state'), 'withdrawn');
+        assert.equal(model.get('state'), 'Withdrawn');
     });
 });

--- a/tests/unit/models/registration-test.ts
+++ b/tests/unit/models/registration-test.ts
@@ -10,55 +10,55 @@ module('Unit | Model | registration', hooks => {
         assert.ok(!!model);
     });
 
-    test('it selects public as default state', function(assert) {
+    test('registraiton state selects public as default', function(assert) {
         const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
 
         assert.equal(model.get('state'), 'public');
     });
 
-    test('it returns pendingRegistrationApproval if field is true', function(assert) {
+    test('registration state returns pendingRegistrationApproval if field is true', function(assert) {
         const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
         model.set('pendingRegistrationApproval', true);
 
         assert.equal(model.get('state'), 'pendingRegistrationApproval');
     });
 
-    test('it returns pendingEmbargoApproval if field is true', function(assert) {
+    test('registration state returns pendingEmbargoApproval if field is true', function(assert) {
         const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
         model.set('pendingEmbargoApproval', true);
 
         assert.equal(model.get('state'), 'pendingEmbargoApproval');
     });
 
-    test('it returns pendingEmbargoTerminationApproval if field is true', function(assert) {
+    test('registration state return pendingEmbargoTerminationApproval if field is true', function(assert) {
         const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
         model.set('pendingEmbargoTerminationApproval', true);
 
         assert.equal(model.get('state'), 'pendingEmbargoTerminationApproval');
     });
 
-    test('it returns pendingWithdrawal if field is true', function(assert) {
+    test('registartion state returns pendingWithdrawal if field is true', function(assert) {
         const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
         model.set('pendingWithdrawal', true);
 
         assert.equal(model.get('state'), 'pendingWithdrawal');
     });
 
-    test('it returns withdrawn if field is true', function(assert) {
+    test('registartion state returns withdrawn if field is true', function(assert) {
         const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
         model.set('withdrawn', true);
 
         assert.equal(model.get('state'), 'withdrawn');
     });
 
-    test('it returns embargoed if field is true', function(assert) {
+    test('registration state returns embargoed if field is true', function(assert) {
         const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
         model.set('embargoed', true);
 
         assert.equal(model.get('state'), 'embargoed');
     });
 
-    test('it updates registrations state when the model changes', function(assert) {
+    test('registration state updates when the model changes', function(assert) {
         const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
         model.set('embargoed', true);
         assert.equal(model.get('state'), 'embargoed');

--- a/tests/unit/models/registration-test.ts
+++ b/tests/unit/models/registration-test.ts
@@ -57,4 +57,13 @@ module('Unit | Model | registration', hooks => {
 
         assert.equal(model.get('state'), 'embargoed');
     });
+
+    test('it updates registrations state when the model changes', function(assert) {
+        const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
+        model.set('embargoed', true);
+        assert.equal(model.get('state'), 'embargoed');
+
+        model.set('withdrawn', true);
+        assert.equal(model.get('state'), 'withdrawn');
+    });
 });

--- a/tests/unit/models/registration-test.ts
+++ b/tests/unit/models/registration-test.ts
@@ -9,4 +9,52 @@ module('Unit | Model | registration', hooks => {
         const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
         assert.ok(!!model);
     });
+
+    test('it selects public as default state', function(assert) {
+        const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
+
+        assert.equal(model.get('state'), 'public');
+    });
+
+    test('it returns pendingRegistrationApproval if field is true', function(assert) {
+        const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
+        model.set('pendingRegistrationApproval', true);
+
+        assert.equal(model.get('state'), 'pendingRegistrationApproval');
+    });
+
+    test('it returns pendingEmbargoApproval if field is true', function(assert) {
+        const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
+        model.set('pendingEmbargoApproval', true);
+
+        assert.equal(model.get('state'), 'pendingEmbargoApproval');
+    });
+
+    test('it returns pendingEmbargoTerminationApproval if field is true', function(assert) {
+        const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
+        model.set('pendingEmbargoTerminationApproval', true);
+
+        assert.equal(model.get('state'), 'pendingEmbargoTerminationApproval');
+    });
+
+    test('it returns pendingWithdrawal if field is true', function(assert) {
+        const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
+        model.set('pendingWithdrawal', true);
+
+        assert.equal(model.get('state'), 'pendingWithdrawal');
+    });
+
+    test('it returns withdrawn if field is true', function(assert) {
+        const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
+        model.set('withdrawn', true);
+
+        assert.equal(model.get('state'), 'withdrawn');
+    });
+
+    test('it returns embargoed if field is true', function(assert) {
+        const model = run(() => this.owner.lookup('service:store').createRecord('registration'));
+        model.set('embargoed', true);
+
+        assert.equal(model.get('state'), 'embargoed');
+    });
 });


### PR DESCRIPTION
## Purpose

To refactor and add tests to the registry model state function. 

## Summary of Changes

1) Add tests around the function to guarantee functionality.
2) Refactor state function.

## Design Doc

### Reason
To refactor this function I ideally wanted to get rid of the complex if statement. Main reasons for this is that is first hard to read / reason about what's going on and changing it could cause it to break. It is also packing a lot of logic into a relatively small space that also increases the complexity of understanding.

### Design
The current function basically acts as a hash map. It maps a boolean value to a RegistrationState and then, if the bool is true, it returns that value. It is also doing the if / or statements within each hashmap section so there's a bit of a mixing of this hashmap with the various if logic.

So I basically made this hashmap explicit by creating a hashmap of the values inside the registrationStateMap() which is basically just `{ 'stateKey': 'stateValue' }`.

I then separated this hashmap (the data) from the logic and then created an operation that simply filters out which value is true and returns that key. We then use this key as the state registration is currently in.

### Downsides
It's slightly more verbose because we have to create the mapped object - it's easy to reason about, however.

## Side Effects

Just a refactor - same functionality as before