### PR TITLE
[EMB-562] Add editable license field

### DIFF
--- a/app/adapters/registration-provider.ts
+++ b/app/adapters/registration-provider.ts
@@ -1,6 +1,6 @@
 import OsfAdapter from './osf-adapter';
 
-export default class RegistryProviderAdapter extends OsfAdapter {
+export default class RegistrationProviderAdapter extends OsfAdapter {
     pathForType(_: string): string {
         return 'providers/registries';
     }
@@ -8,6 +8,6 @@ export default class RegistryProviderAdapter extends OsfAdapter {
 
 declare module 'ember-data/types/registries/adapter' {
     export default interface AdapterRegistry {
-        'registry-provider': RegistryProviderAdapter;
+        'registration-provider': RegistrationProviderAdapter;
     } // eslint-disable-line semi
 }

--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -1115,6 +1115,13 @@ export default {
             create_doi_header: 'Are you sure you want to create a DOI for this registration?',
             create_doi_text: 'A DOI is persistent and will always resolve to this page.',
             no_doi: 'No DOI assigned',
+            add_license: 'Add license',
+            edit_license: {
+                success: 'License successfully updated',
+                error: 'Unable to update license',
+            },
+            select_license: 'Select license',
+            no_matches: 'No matches found',
             save_category: {
                 error: 'Unable to save category',
             },

--- a/app/models/registration-provider.ts
+++ b/app/models/registration-provider.ts
@@ -4,13 +4,13 @@ import DS from 'ember-data';
 import ProviderModel from './provider';
 import RegistrationModel from './registration';
 
-export default class RegistryProviderModel extends ProviderModel {
+export default class RegistrationProviderModel extends ProviderModel {
     @hasMany('registration', { inverse: 'provider' })
     registrations!: DS.PromiseManyArray<RegistrationModel>;
 }
 
 declare module 'ember-data/types/registries/model' {
     export default interface ModelRegistry {
-        'registry-provider': RegistryProviderModel;
+        'registration-provider': RegistrationProviderModel;
     } // eslint-disable-line semi
 }

--- a/app/models/registration.ts
+++ b/app/models/registration.ts
@@ -1,13 +1,14 @@
 import { attr, belongsTo, hasMany } from '@ember-decorators/data';
 import { computed } from '@ember-decorators/object';
+import { buildValidations, validator } from 'ember-cp-validations';
 import DS from 'ember-data';
 
 import CommentModel from './comment';
 import ContributorModel from './contributor';
 import InstitutionModel from './institution';
 import NodeModel from './node';
+import RegistrationProviderModel from './registration-provider';
 import RegistrationSchemaModel, { RegistrationMetadata } from './registration-schema';
-import RegistryProviderModel from './registry-provider';
 import UserModel from './user';
 
 export enum RegistrationState {
@@ -20,7 +21,23 @@ export enum RegistrationState {
     PendingEmbargoTermination = 'PendingEmbargoTermination',
 }
 
-export default class RegistrationModel extends NodeModel.extend() {
+const Validations = buildValidations({
+    license: [
+        validator('presence', {
+            presence: true,
+        }),
+    ],
+    nodeLicense: [
+        validator('presence', {
+            presence: true,
+        }),
+        validator('node-license', {
+            on: 'license',
+        }),
+    ],
+});
+
+export default class RegistrationModel extends NodeModel.extend(Validations) {
     @attr('date') dateRegistered!: Date;
     @attr('boolean') pendingRegistrationApproval!: boolean;
     @attr('boolean') archiving!: boolean;
@@ -60,8 +77,8 @@ export default class RegistrationModel extends NodeModel.extend() {
     @belongsTo('user', { inverse: null })
     registeredBy!: DS.PromiseObject<UserModel> & UserModel;
 
-    @belongsTo('registry-provider', { inverse: 'registrations' })
-    provider!: DS.PromiseObject<RegistryProviderModel> & RegistryProviderModel;
+    @belongsTo('registration-provider', { inverse: 'registrations' })
+    provider!: DS.PromiseObject<RegistrationProviderModel> & RegistrationProviderModel;
 
     @hasMany('contributor', { inverse: 'node' })
     contributors!: DS.PromiseManyArray<ContributorModel>;
@@ -76,7 +93,7 @@ export default class RegistrationModel extends NodeModel.extend() {
     parent!: DS.PromiseObject<RegistrationModel> & RegistrationModel;
 
     @belongsTo('registration', { inverse: null })
-    root!: DS.PromiseObject<NodeModel> & NodeModel;
+    root!: DS.PromiseObject<RegistrationModel> & RegistrationModel;
 
     @hasMany('registration', { inverse: 'parent' })
     children!: DS.PromiseManyArray<RegistrationModel>;

--- a/app/serializers/registration-provider.ts
+++ b/app/serializers/registration-provider.ts
@@ -1,0 +1,10 @@
+import OsfSerializer from './osf-serializer';
+
+export default class RegistrationProviderSerializer extends OsfSerializer {
+}
+
+declare module 'ember-data/types/registries/serializer' {
+    export default interface SerializerRegistry {
+        'registration-provider': RegistrationProviderSerializer;
+    } // eslint-disable-line semi
+}

--- a/app/services/theme.ts
+++ b/app/services/theme.ts
@@ -9,12 +9,12 @@ import defaultTo from 'ember-osf-web/utils/default-to';
 
 const { defaultProvider, assetsPrefix } = config;
 
-type ProviderType = 'collection' | 'preprint' | 'registry';
+type ProviderType = 'collection' | 'preprint' | 'registration';
 
 interface Setting {
     assetPath: string;
     routePath: string;
-    model: 'collection-provider' | 'preprint-provider' | 'registry-provider';
+    model: 'collection-provider' | 'preprint-provider' | 'registration-provider';
 }
 
 const settings: { [P in ProviderType]: Setting } = {
@@ -28,10 +28,10 @@ const settings: { [P in ProviderType]: Setting } = {
         routePath: 'preprints',
         model: 'preprint-provider',
     },
-    registry: {
+    registration: {
         assetPath: 'registries-assets',
         routePath: 'registries',
-        model: 'registry-provider',
+        model: 'registration-provider',
     },
 };
 

--- a/lib/osf-components/addon/components/editable-field/license-manager/component.ts
+++ b/lib/osf-components/addon/components/editable-field/license-manager/component.ts
@@ -1,0 +1,141 @@
+import { tagName } from '@ember-decorators/component';
+import { action, computed } from '@ember-decorators/object';
+import { alias, and, not, sort } from '@ember-decorators/object/computed';
+import { service } from '@ember-decorators/service';
+import Component from '@ember/component';
+import { task, timeout } from 'ember-concurrency';
+import DS from 'ember-data';
+import I18N from 'ember-i18n/services/i18n';
+import Toast from 'ember-toastr/services/toast';
+
+import { layout } from 'ember-osf-web/decorators/component';
+import License from 'ember-osf-web/models/license';
+import { NodeLicense } from 'ember-osf-web/models/node';
+import { QueryHasManyResult } from 'ember-osf-web/models/osf-model';
+import Registration from 'ember-osf-web/models/registration';
+import Analytics from 'ember-osf-web/services/analytics';
+
+import template from './template';
+
+export interface LicenseManager {
+    queryLicenses: () => void;
+    onSave: () => void;
+    onError: () => void;
+    onCancel: () => void;
+    changeLicense: () => void;
+    registration: Registration;
+    requiredFields: string[];
+    selectedLicense: License;
+    licensesAcceptable: License[];
+}
+
+@tagName('')
+@layout(template)
+export default class LicenseManagerComponent extends Component.extend({
+    queryLicenses: task(function *(this: LicenseManagerComponent, name?: string) {
+        if (this.licensesAcceptable && this.licensesAcceptable.length) {
+            if (name) {
+                yield timeout(500);
+            }
+
+            const licensesAcceptable = this.licensesAcceptable
+                .filter(license => license.get('name').includes(name || ''));
+
+            this.setProperties({ licensesAcceptable });
+            return licensesAcceptable;
+        }
+        return undefined;
+    }).on('didReceiveAttrs').restartable(),
+    getAllProviderLicenses: task(function *(this: LicenseManagerComponent) {
+        const provider = yield this.node.provider;
+
+        if (!provider) {
+            return;
+        }
+
+        const providerLicenses: QueryHasManyResult<License> = yield provider
+            .queryHasMany('licensesAcceptable', {
+                page: { size: 20 },
+            });
+
+        this.setProperties({
+            licensesAcceptable: providerLicenses,
+            currentLicense: yield this.node.license,
+            currentNodeLicense: { ...this.node.nodeLicense },
+        });
+    }).on('init'),
+}) {
+    // required
+    node!: Registration;
+
+    // private
+    @service analytics!: Analytics;
+    @service i18n!: I18N;
+    @service store!: DS.Store;
+    @service toast!: Toast;
+
+    requestedEditMode: boolean = false;
+
+    showText: boolean = false;
+    licensesAcceptable!: QueryHasManyResult<License>;
+    helpLink: string = 'http://help.osf.io/m/60347/l/611430-licensing';
+    currentLicense!: License;
+    currentNodeLicense!: NodeLicense;
+
+    @alias('node.userHasAdminPermission') userCanEdit!: boolean;
+    @and('userCanEdit', 'requestedEditMode') inEditMode!: boolean;
+    @alias('node.license') selectedLicense!: License;
+    @not('currentLicense') fieldIsEmpty!: License;
+
+    @sort('selectedLicense.requiredFields', (a: string, b: string) => +(a > b))
+    requiredFields!: string[];
+
+    @computed('fieldIsEmpty', 'userCanEdit')
+    get shouldShowField() {
+        return this.userCanEdit || !this.fieldIsEmpty;
+    }
+
+    @action
+    startEditing() {
+        this.set('requestedEditMode', true);
+    }
+
+    @action
+    cancel() {
+        this.set('requestedEditMode', false);
+    }
+
+    reset() {
+        this.node.setProperties({
+            license: this.currentLicense,
+            nodeLicense: { ...this.currentNodeLicense },
+        });
+    }
+
+    @action
+    changeLicense(selected: License) {
+        this.set('selectedLicense', selected);
+        this.node.setNodeLicenseDefaults(selected.requiredFields);
+    }
+
+    @action
+    onSave() {
+        this.toast.success(this.i18n.t('registries.registration_metadata.edit_license.success'));
+        this.setProperties({
+            currentLicense: this.selectedLicense,
+            currentNodeLicense: { ...this.node.nodeLicense },
+        });
+        this.set('requestedEditMode', false);
+    }
+
+    @action
+    onError() {
+        this.toast.error(this.i18n.t('registries.registration_metadata.edit_license.error'));
+    }
+
+    @action
+    onCancel() {
+        this.reset();
+        this.set('requestedEditMode', false);
+    }
+}

--- a/lib/osf-components/addon/components/editable-field/license-manager/template.hbs
+++ b/lib/osf-components/addon/components/editable-field/license-manager/template.hbs
@@ -1,0 +1,19 @@
+{{yield (hash
+    save=(perform this.save)
+    cancel=(action this.cancel)
+    fieldIsEmpty=this.fieldIsEmpty
+    emptyFieldText=(t 'registries.registration_metadata.no_license')
+    startEditing=(action this.startEditing)
+    inEditMode=this.inEditMode
+    userCanEdit=this.userCanEdit
+    shouldShowField=this.shouldShowField
+    queryLicenses=(perform this.queryLicenses)
+    registration=this.node
+    onSave=(action this.onSave)
+    onError=(action this.onError)
+    onCancel=(action this.onCancel)
+    changeLicense=(action this.changeLicense)
+    requiredFields=this.requiredFields
+    selectedLicense=this.selectedLicense
+    licensesAcceptable=this.licensesAcceptable
+)}}

--- a/lib/osf-components/addon/components/validated-input/power-select/component.ts
+++ b/lib/osf-components/addon/components/validated-input/power-select/component.ts
@@ -2,6 +2,7 @@ import { action } from '@ember-decorators/object';
 import DS, { AttributesFor } from 'ember-data';
 
 import { layout } from 'ember-osf-web/decorators/component';
+import defaultTo from 'ember-osf-web/utils/default-to';
 
 import BaseValidatedComponent from '../base-component';
 import template from './template';
@@ -17,6 +18,10 @@ export default class ValidatedPowerSelect<M extends DS.Model> extends BaseValida
     options: any[] = this.options;
     searchEnabled?: boolean = this.searchEnabled;
     placeholder?: string = this.placeholder;
+
+    // Set renderInPlace to true when <powerselect> is rendered in <bsModal>
+    // BsModal has z-index 1050 while power-select has 1000.
+    renderInPlace?: boolean = defaultTo(this.renderInPlace, false);
 
     @action
     powerSelectChanged(value: string) {

--- a/lib/osf-components/addon/components/validated-input/power-select/template.hbs
+++ b/lib/osf-components/addon/components/validated-input/power-select/template.hbs
@@ -16,6 +16,7 @@
         @disabled={{this.disabled}}
         @searchEnabled={{this.searchEnabled}}
         @placeholder={{this.placeholder}}
+        @renderInPlace={{this.renderInPlace}}
         as |option|
     >
         {{yield option}}

--- a/lib/osf-components/app/components/editable-field/license-manager/component.js
+++ b/lib/osf-components/app/components/editable-field/license-manager/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/editable-field/license-manager/component';

--- a/lib/registries/addon/components/license-viewer/component.ts
+++ b/lib/registries/addon/components/license-viewer/component.ts
@@ -1,0 +1,8 @@
+import Component from '@ember/component';
+
+import { layout } from 'ember-osf-web/decorators/component';
+import styles from './styles';
+import template from './template';
+
+@layout(template, styles)
+export default class LicenseViewer extends Component {}

--- a/lib/registries/addon/components/license-viewer/styles.scss
+++ b/lib/registries/addon/components/license-viewer/styles.scss
@@ -1,0 +1,4 @@
+.LinkButton {
+    padding: 0;
+    border: 0;
+}

--- a/lib/registries/addon/components/license-viewer/template.hbs
+++ b/lib/registries/addon/components/license-viewer/template.hbs
@@ -1,0 +1,33 @@
+<OsfButton
+  data-analytics-name='View license'
+  local-class='LinkButton'
+  @type='link'
+  @onClick={{action (mut this.shouldShowLicense) true}}
+>
+    {{@manager.registration.license.name}}
+</OsfButton>
+
+<BsModal
+    @onHidden={{action (mut this.shouldShowLicense) false}}
+    @open={{this.shouldShowLicense}}
+    as |modal|
+>
+    <modal.header>
+        <h4 class='modal-title'>
+            {{t 'registries.registration_metadata.license'}}
+        </h4>
+    </modal.header>
+    <modal.body>
+        {{#if @manager.registration.license.url}}
+            <p>
+                <OsfLink
+                    data-analytics-name='License URL'
+                    @href={{@manager.registration.license.url}}
+                >
+                    {{@manager.registration.license.name}}
+                </OsfLink>
+            </p>
+        {{/if}}
+        <LicenseText @node={{@manager.registration}} />
+    </modal.body>
+</BsModal>

--- a/lib/registries/addon/components/registries-license-picker/component.ts
+++ b/lib/registries/addon/components/registries-license-picker/component.ts
@@ -1,0 +1,113 @@
+import { action } from '@ember-decorators/object';
+import { alias, sort } from '@ember-decorators/object/computed';
+import { service } from '@ember-decorators/service';
+import Component from '@ember/component';
+import { task, timeout } from 'ember-concurrency';
+import DS from 'ember-data';
+import I18N from 'ember-i18n/services/i18n';
+import Toast from 'ember-toastr/services/toast';
+
+import { layout } from 'ember-osf-web/decorators/component';
+import License from 'ember-osf-web/models/license';
+import { QueryHasManyResult } from 'ember-osf-web/models/osf-model';
+import Registration from 'ember-osf-web/models/registration';
+import Analytics from 'ember-osf-web/services/analytics';
+import defaultTo from 'ember-osf-web/utils/default-to';
+import styles from './styles';
+import template from './template';
+
+@layout(template, styles)
+export default class RegistriesLicensePicker extends Component.extend({
+    queryLicenses: task(function *(this: RegistriesLicensePicker, name?: string) {
+        if (!(this.providerLicenses && this.providerLicenses.length)) {
+            return;
+        }
+
+        if (name) {
+            yield timeout(500);
+        }
+
+        const licensesAcceptable = this.providerLicenses
+            .filter(license => license.get('name').includes(name || ''));
+
+        this.setProperties({ licensesAcceptable });
+        this.registration.notifyPropertyChange('license');
+
+        return licensesAcceptable;
+    }).on('didReceiveAttrs').restartable(),
+    getAllProviderLicenses: task(function *(this: RegistriesLicensePicker) {
+        const provider = yield this.registration.provider;
+        if (!provider) {
+            return;
+        }
+        const providerLicenses: QueryHasManyResult<License> = yield provider
+            .queryHasMany('licensesAcceptable', {
+                page: { size: 20 },
+            });
+
+        this.setProperties({ providerLicenses });
+    }).on('init'),
+}) {
+    // Required
+    editMode: boolean = defaultTo(this.editMode, false);
+    registration!: Registration;
+
+    // Private
+    @service analytics!: Analytics;
+    @service i18n!: I18N;
+    @service store!: DS.Store;
+    @service toast!: Toast;
+
+    showText: boolean = false;
+    providerLicenses!: QueryHasManyResult<License>;
+    licensesAcceptable!: QueryHasManyResult<License>;
+    helpLink: string = 'http://help.osf.io/m/60347/l/611430-licensing';
+    currentLicense = this.registration.license.content as License;
+
+    @alias('registration.license') selectedLicense!: License;
+
+    @sort('selectedLicense.requiredFields', (a: string, b: string) => +(a > b))
+    requiredFields!: string[];
+
+    reset(this: RegistriesLicensePicker) {
+        this.registration.set('license', this.currentLicense);
+    }
+
+    @action
+    changeLicense(this: RegistriesLicensePicker, selected: License) {
+        this.set('selectedLicense', selected);
+        this.registration.setNodeLicenseDefaults(selected.requiredFields);
+    }
+
+    @action
+    notify(this: RegistriesLicensePicker) {
+        this.registration.notifyPropertyChange('nodeLicense');
+    }
+
+    @action
+    onHideModal() {
+        const licenseChanged = this.currentLicense !== this.registration.license;
+        if (licenseChanged || this.registration.hasDirtyAttributes) {
+            this.reset();
+        }
+        this.set('editMode', false);
+    }
+
+    @action
+    onSave() {
+        this.toast.success(this.i18n.t('registries.registration_metadata.edit_license.success'));
+        this.set('currentLicense', this.selectedLicense);
+        this.set('editMode', false);
+    }
+
+    @action
+    onError() {
+        this.toast.error(this.i18n.t('registries.registration_metadata.edit_license.error'));
+        this.set('editMode', false);
+    }
+
+    @action
+    onCancel() {
+        this.reset();
+    }
+}

--- a/lib/registries/addon/components/registries-license-picker/component.ts
+++ b/lib/registries/addon/components/registries-license-picker/component.ts
@@ -1,113 +1,15 @@
-import { action } from '@ember-decorators/object';
-import { alias, sort } from '@ember-decorators/object/computed';
-import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
-import { task, timeout } from 'ember-concurrency';
-import DS from 'ember-data';
-import I18N from 'ember-i18n/services/i18n';
-import Toast from 'ember-toastr/services/toast';
 
 import { layout } from 'ember-osf-web/decorators/component';
-import License from 'ember-osf-web/models/license';
-import { QueryHasManyResult } from 'ember-osf-web/models/osf-model';
-import Registration from 'ember-osf-web/models/registration';
-import Analytics from 'ember-osf-web/services/analytics';
-import defaultTo from 'ember-osf-web/utils/default-to';
+import { LicenseManager } from 'osf-components/components/editable-field/license-manager/component';
+
 import styles from './styles';
 import template from './template';
 
 @layout(template, styles)
-export default class RegistriesLicensePicker extends Component.extend({
-    queryLicenses: task(function *(this: RegistriesLicensePicker, name?: string) {
-        if (!(this.providerLicenses && this.providerLicenses.length)) {
-            return;
-        }
-
-        if (name) {
-            yield timeout(500);
-        }
-
-        const licensesAcceptable = this.providerLicenses
-            .filter(license => license.get('name').includes(name || ''));
-
-        this.setProperties({ licensesAcceptable });
-        this.registration.notifyPropertyChange('license');
-
-        return licensesAcceptable;
-    }).on('didReceiveAttrs').restartable(),
-    getAllProviderLicenses: task(function *(this: RegistriesLicensePicker) {
-        const provider = yield this.registration.provider;
-        if (!provider) {
-            return;
-        }
-        const providerLicenses: QueryHasManyResult<License> = yield provider
-            .queryHasMany('licensesAcceptable', {
-                page: { size: 20 },
-            });
-
-        this.setProperties({ providerLicenses });
-    }).on('init'),
-}) {
-    // Required
-    editMode: boolean = defaultTo(this.editMode, false);
-    registration!: Registration;
-
-    // Private
-    @service analytics!: Analytics;
-    @service i18n!: I18N;
-    @service store!: DS.Store;
-    @service toast!: Toast;
+export default class RegistriesLicensePicker extends Component {
+    manager!: LicenseManager;
 
     showText: boolean = false;
-    providerLicenses!: QueryHasManyResult<License>;
-    licensesAcceptable!: QueryHasManyResult<License>;
     helpLink: string = 'http://help.osf.io/m/60347/l/611430-licensing';
-    currentLicense = this.registration.license.content as License;
-
-    @alias('registration.license') selectedLicense!: License;
-
-    @sort('selectedLicense.requiredFields', (a: string, b: string) => +(a > b))
-    requiredFields!: string[];
-
-    reset(this: RegistriesLicensePicker) {
-        this.registration.set('license', this.currentLicense);
-    }
-
-    @action
-    changeLicense(this: RegistriesLicensePicker, selected: License) {
-        this.set('selectedLicense', selected);
-        this.registration.setNodeLicenseDefaults(selected.requiredFields);
-    }
-
-    @action
-    notify(this: RegistriesLicensePicker) {
-        this.registration.notifyPropertyChange('nodeLicense');
-    }
-
-    @action
-    onHideModal() {
-        const licenseChanged = this.currentLicense !== this.registration.license;
-        if (licenseChanged || this.registration.hasDirtyAttributes) {
-            this.reset();
-        }
-        this.set('editMode', false);
-    }
-
-    @action
-    onSave() {
-        this.toast.success(this.i18n.t('registries.registration_metadata.edit_license.success'));
-        this.set('currentLicense', this.selectedLicense);
-        this.set('editMode', false);
-    }
-
-    @action
-    onError() {
-        this.toast.error(this.i18n.t('registries.registration_metadata.edit_license.error'));
-        this.set('editMode', false);
-    }
-
-    @action
-    onCancel() {
-        this.reset();
-    }
 }

--- a/lib/registries/addon/components/registries-license-picker/styles.scss
+++ b/lib/registries/addon/components/registries-license-picker/styles.scss
@@ -1,0 +1,26 @@
+.Controls {
+    display: flex;
+    margin-top: 10px;
+
+    .Save {
+        margin-right: 15px;
+        font-weight: 600;
+        margin-right: 10px;
+        border: 0;
+
+        &:hover,
+        &:active,
+        &:focus {
+            background-color: $secondary-blue;
+        }
+    }
+}
+
+.LinkButton {
+    padding: 0;
+    border: 0;
+}
+
+.small {
+    font-size: 85%;
+}

--- a/lib/registries/addon/components/registries-license-picker/styles.scss
+++ b/lib/registries/addon/components/registries-license-picker/styles.scss
@@ -1,18 +1,8 @@
 .Controls {
-    display: flex;
     margin-top: 10px;
 
-    .Save {
-        margin-right: 15px;
-        font-weight: 600;
+    button:first-child {
         margin-right: 10px;
-        border: 0;
-
-        &:hover,
-        &:active,
-        &:focus {
-            background-color: $secondary-blue;
-        }
     }
 }
 

--- a/lib/registries/addon/components/registries-license-picker/template.hbs
+++ b/lib/registries/addon/components/registries-license-picker/template.hbs
@@ -1,132 +1,91 @@
-{{#if this.registration.license}}
-    <OsfButton
-        data-analytics-name='View license'
-        local-class='LinkButton'
-        @type='link'
-        @onClick={{action (mut this.shouldShowLicense) true}}
+{{#if @manager.inEditMode}}
+    <ValidatedModelForm
+        data-test-license-edit-form
+        @model={{@manager.registration}}
+        @onSave={{@manager.onSave}}
+        @onError={{@manager.onError}}
+        as |form|
     >
-        {{this.registration.license.name}}
-    </OsfButton>
-
-    {{#if this.shouldShowLicense}}
-        <BsModal
-            @onHide={{action (mut this.shouldShowLicense) false}}
-            as |modal|
+        <form.select
+            data-analytics-category='text'
+            data-analytics-name='Select license'
+            data-test-select-license
+            @valuePath='license'
+            @search={{action @manager.queryLicenses}}
+            @selected={{@manager.selectedLicense}}
+            @options={{@manager.licensesAcceptable}}
+            @onchange={{@manager.changeLicense}}
+            @noMatchesMessage={{t 'registries.registration_metadata.no_matches'}}
+            @placeholder={{t 'registries.registration_metadata.add_license'}}
+            @renderInPlace={{true}}
+            as |license|
         >
-            <modal.header>
-                <h4 class='modal-title'>
-                    {{t 'registries.registration_metadata.license'}}
-                </h4>
-            </modal.header>
-            <modal.body>
-                {{#if this.registration.license.url}}
-                    <p>
-                        <OsfLink
-                            data-analytics-name='License URL'
-                            @href={{this.registration.license.url}}
-                        >
-                            {{this.registration.license.name}}
-                        </OsfLink>
-                    </p>
-                {{/if}}
-                <LicenseText @node={{this.registration}} />
-            </modal.body>
-        </BsModal>
-    {{/if}}
-{{else}}
-    {{t 'registries.registration_metadata.no_license'}}
-{{/if}}
+            {{license.name}}
+        </form.select>
 
-{{#if this.editMode}}
-    <BsModal @onHide={{action this.onHideModal}} as |modal|>
-        <modal.header>
-            <h4 class='modal-title'>
-                {{t 'registries.registration_metadata.select_license'}}
-            </h4>
-        </modal.header>
-        <modal.body>
-            <ValidatedModelForm
-              @model={{this.registration}}
-              @onSave={{action this.onSave}}
-              @onError={{action this.onError}}
-              as |form|>
-                <form.select
-                    @valuePath='license'
-                    @search={{perform this.queryLicenses}}
-                    @selected={{this.selectedLicense}}
-                    @options={{this.licensesAcceptable}}
-                    @onchange={{action this.changeLicense}}
-                    @noMatchesMessage={{t 'registries.registration_metadata.no_matches'}}
-                    @placeholder={{t 'registries.registration_metadata.add_license'}}
-                    @renderInPlace={{true}}
-                    as |license|
-                >
-                    {{license.name}}
-                </form.select>
+        <div local-class='small help-link'>
+            <OsfLink
+                @target='_blank'
+                @rel='noopener'
+                @href={{this.helpLink}}
+            >
+                {{t 'app_components.license_picker.faq'}}
+            </OsfLink>
+        </div>
 
-                <div local-class='small help-link'>
-                    <OsfLink
-                        @target='_blank'
-                        @rel='noopener'
-                        @href={{this.helpLink}}
-                    >
-                        {{t 'app_components.license_picker.faq'}}
-                    </OsfLink>
-                </div>
+        {{#if @manager.selectedLicense}}
+            {{#if @manager.requiredFields}}
+                <br>
+            {{/if}}
 
-                {{#if this.selectedLicense}}
-                    {{#if this.requiredFields}}
-                        <br>
-                    {{/if}}
-
-                    <form.custom @valuePath='nodeLicense'>
-                        {{#each this.requiredFields as |key|}}
-                            <br>
-                            <label for='nodeLicense-{{key}}'>{{t (concat 'app_components.license_picker.fields.' key)}}</label>
-                            <br>
+            <form.custom @valuePath='nodeLicense'>
+                {{#each @manager.requiredFields as |key|}}
+                    <div class='form-group'>
+                        <label>
+                            {{t (concat 'app_components.license_picker.fields.' key)}}
                             {{input
                                 class='form-control'
-                                id=(concat 'nodeLicense-' key)
-                                value=(mut (get this.registration.nodeLicense key))
-                                input=(action 'notify')
-                                placeholder='Required'
+                                value=(mut (get @manager.registration.nodeLicense key))
+                                placeholder=(t 'general.required')
+                                data-test-required-field=key
                             }}
-                        {{/each}}
-                    </form.custom>
-
-                    <OsfButton
-                        @type='link'
-                        @onClick={{action (mut this.showText) (not this.showText)}}
-                        local-class='LinkButton small'
-                    >
-                        {{t (concat 'app_components.license_picker.' (if this.showText 'hide' 'show'))}}
-                    </OsfButton>
-
-                    {{#if this.showText}}
-                        <LicenseText @node={{this.registration}} />
-                    {{/if}}
-
-                    <div local-class='Controls'>
-                        <OsfButton
-                            @type='primary'
-                            @buttonType='submit'
-                            @disabled={{form.submitting}}
-                            @size='sm'
-                            local-class='Save'
-                        >
-                            {{t 'general.save'}}
-                        </OsfButton>
-                        <OsfButton
-                            @type='default'
-                            @disabled={{form.submitting}}
-                            @onClick={{action this.onCancel}}
-                            @size='sm'
-                        >
-                            {{t 'general.cancel'}}
-                        </OsfButton>
+                        </label>
                     </div>
-                {{/if}}
-            </ValidatedModelForm>
-        </modal.body>
-    </BsModal>
+                {{/each}}
+            </form.custom>
+
+            <OsfButton
+                @type='link'
+                @onClick={{action (mut this.showText) (not this.showText)}}
+                local-class='LinkButton small'
+            >
+                {{t (concat 'app_components.license_picker.' (if this.showText 'hide' 'show'))}}
+            </OsfButton>
+
+            {{#if this.showText}}
+                <LicenseText @node={{@manager.registration}} />
+            {{/if}}
+
+            <div local-class='Controls'>
+                <OsfButton
+                    data-analytics-name='Save license'
+                    data-test-save-license
+                    @type='primary'
+                    @buttonType='submit'
+                    @disabled={{form.disabled}}
+                    @size='sm'
+                >
+                    {{t 'general.save'}}
+                </OsfButton>
+                <OsfButton
+                    @type='default'
+                    @disabled={{form.disabled}}
+                    @onClick={{action @manager.onCancel}}
+                    @size='sm'
+                >
+                    {{t 'general.cancel'}}
+                </OsfButton>
+            </div>
+        {{/if}}
+    </ValidatedModelForm>
 {{/if}}

--- a/lib/registries/addon/components/registries-license-picker/template.hbs
+++ b/lib/registries/addon/components/registries-license-picker/template.hbs
@@ -1,0 +1,132 @@
+{{#if this.registration.license}}
+    <OsfButton
+        data-analytics-name='View license'
+        local-class='LinkButton'
+        @type='link'
+        @onClick={{action (mut this.shouldShowLicense) true}}
+    >
+        {{this.registration.license.name}}
+    </OsfButton>
+
+    {{#if this.shouldShowLicense}}
+        <BsModal
+            @onHide={{action (mut this.shouldShowLicense) false}}
+            as |modal|
+        >
+            <modal.header>
+                <h4 class='modal-title'>
+                    {{t 'registries.registration_metadata.license'}}
+                </h4>
+            </modal.header>
+            <modal.body>
+                {{#if this.registration.license.url}}
+                    <p>
+                        <OsfLink
+                            data-analytics-name='License URL'
+                            @href={{this.registration.license.url}}
+                        >
+                            {{this.registration.license.name}}
+                        </OsfLink>
+                    </p>
+                {{/if}}
+                <LicenseText @node={{this.registration}} />
+            </modal.body>
+        </BsModal>
+    {{/if}}
+{{else}}
+    {{t 'registries.registration_metadata.no_license'}}
+{{/if}}
+
+{{#if this.editMode}}
+    <BsModal @onHide={{action this.onHideModal}} as |modal|>
+        <modal.header>
+            <h4 class='modal-title'>
+                {{t 'registries.registration_metadata.select_license'}}
+            </h4>
+        </modal.header>
+        <modal.body>
+            <ValidatedModelForm
+              @model={{this.registration}}
+              @onSave={{action this.onSave}}
+              @onError={{action this.onError}}
+              as |form|>
+                <form.select
+                    @valuePath='license'
+                    @search={{perform this.queryLicenses}}
+                    @selected={{this.selectedLicense}}
+                    @options={{this.licensesAcceptable}}
+                    @onchange={{action this.changeLicense}}
+                    @noMatchesMessage={{t 'registries.registration_metadata.no_matches'}}
+                    @placeholder={{t 'registries.registration_metadata.add_license'}}
+                    @renderInPlace={{true}}
+                    as |license|
+                >
+                    {{license.name}}
+                </form.select>
+
+                <div local-class='small help-link'>
+                    <OsfLink
+                        @target='_blank'
+                        @rel='noopener'
+                        @href={{this.helpLink}}
+                    >
+                        {{t 'app_components.license_picker.faq'}}
+                    </OsfLink>
+                </div>
+
+                {{#if this.selectedLicense}}
+                    {{#if this.requiredFields}}
+                        <br>
+                    {{/if}}
+
+                    <form.custom @valuePath='nodeLicense'>
+                        {{#each this.requiredFields as |key|}}
+                            <br>
+                            <label for='nodeLicense-{{key}}'>{{t (concat 'app_components.license_picker.fields.' key)}}</label>
+                            <br>
+                            {{input
+                                class='form-control'
+                                id=(concat 'nodeLicense-' key)
+                                value=(mut (get this.registration.nodeLicense key))
+                                input=(action 'notify')
+                                placeholder='Required'
+                            }}
+                        {{/each}}
+                    </form.custom>
+
+                    <OsfButton
+                        @type='link'
+                        @onClick={{action (mut this.showText) (not this.showText)}}
+                        local-class='LinkButton small'
+                    >
+                        {{t (concat 'app_components.license_picker.' (if this.showText 'hide' 'show'))}}
+                    </OsfButton>
+
+                    {{#if this.showText}}
+                        <LicenseText @node={{this.registration}} />
+                    {{/if}}
+
+                    <div local-class='Controls'>
+                        <OsfButton
+                            @type='primary'
+                            @buttonType='submit'
+                            @disabled={{form.submitting}}
+                            @size='sm'
+                            local-class='Save'
+                        >
+                            {{t 'general.save'}}
+                        </OsfButton>
+                        <OsfButton
+                            @type='default'
+                            @disabled={{form.submitting}}
+                            @onClick={{action this.onCancel}}
+                            @size='sm'
+                        >
+                            {{t 'general.cancel'}}
+                        </OsfButton>
+                    </div>
+                {{/if}}
+            </ValidatedModelForm>
+        </modal.body>
+    </BsModal>
+{{/if}}

--- a/lib/registries/addon/components/registries-metadata/styles.scss
+++ b/lib/registries/addon/components/registries-metadata/styles.scss
@@ -5,8 +5,3 @@
 .Field:first-child h4 {
     margin-top: 0;
 }
-
-.LinkButton {
-    padding: 0;
-    border: 0;
-}

--- a/lib/registries/addon/components/registries-metadata/template.hbs
+++ b/lib/registries/addon/components/registries-metadata/template.hbs
@@ -138,45 +138,19 @@
         </div>
 
         <div local-class='Field'>
-            <h4>{{t 'registries.registration_metadata.license'}}</h4>
-            {{#if this.registration.license}}
-                <OsfButton
-                    data-analytics-name='View license'
-                    local-class='LinkButton'
-                    @type='link'
-                    @onClick={{action (mut this.shouldShowLicense) true}}
-                >
-                    {{this.registration.license.name}}
-                </OsfButton>
-                {{#if this.shouldShowLicense}}
-                    <BsModal
-                        @onHide={{action (mut this.shouldShowLicense) false}}
-                        as |modal|
-                    >
-                        <modal.header>
-                            <h4 class='modal-title'>
-                                {{t 'registries.registration_metadata.license'}}
-                            </h4>
-                        </modal.header>
-                        <modal.body>
-                            {{#if this.registration.license.url}}
-                                <p>
-                                    <OsfLink
-                                        data-analytics-name='License URL'
-                                        @href={{this.registration.license.url}}
-                                    >
-                                        {{this.registration.license.name}}
-                                    </OsfLink>
-                                </p>
-                            {{/if}}
-                            <LicenseText @node={{this.registration}} />
-                        </modal.body>
-                    </BsModal>
-                {{/if}}
-            {{else}}
-                {{t 'registries.registration_metadata.no_license'}}
-            {{/if}}
+            <EditableField
+                data-analytics-scope='License'
+                @registration={{this.registration}}
+                @title={{t 'registries.registration_metadata.license'}}
+            as |editable|>
+                <RegistriesLicensePicker
+                    data-analytics-scope='Registries overview'
+                    @registration={{this.registration}}
+                    @editMode={{editable.showEditable}}
+                />
+            </EditableField>
         </div>
+
         <div local-class='Field'>
             <EditableField::TagsManager @registration={{this.registration}} as |tagsManager|>
                 <EditableField

--- a/lib/registries/addon/components/registries-metadata/template.hbs
+++ b/lib/registries/addon/components/registries-metadata/template.hbs
@@ -138,17 +138,25 @@
         </div>
 
         <div local-class='Field'>
-            <EditableField
-                data-analytics-scope='License'
-                @registration={{this.registration}}
-                @title={{t 'registries.registration_metadata.license'}}
-            as |editable|>
-                <RegistriesLicensePicker
-                    data-analytics-scope='Registries overview'
-                    @registration={{this.registration}}
-                    @editMode={{editable.showEditable}}
-                />
-            </EditableField>
+            <div local-class='Field'>
+                <EditableField::LicenseManager @node={{this.registration}} as |licenseManager|>
+                    <EditableField
+                        data-analytics-scope='License'
+                        @manager={{licenseManager}}
+                        @title={{t 'registries.registration_metadata.license'}}
+                        @name='license'
+                        @hasCustomButtons={{true}}
+                        as |field|
+                    >
+                        <field.edit>
+                            <RegistriesLicensePicker @manager={{licenseManager}} />
+                        </field.edit>
+                        <field.display>
+                            <LicenseViewer @manager={{licenseManager}} />
+                        </field.display>
+                    </EditableField>
+                </EditableField::LicenseManager>
+            </div>
         </div>
 
         <div local-class='Field'>

--- a/lib/registries/addon/overview/route.ts
+++ b/lib/registries/addon/overview/route.ts
@@ -83,7 +83,7 @@ export default class Overview extends GuidRoute {
     }
 
     include() {
-        return ['registration_schema', 'bibliographic_contributors', 'identifiers', 'root'];
+        return ['registration_schema', 'bibliographic_contributors', 'identifiers', 'root', 'provider'];
     }
 
     adapterOptions() {

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -134,6 +134,12 @@ export default function(this: Server) {
     osfNestedResource(this, 'user', 'quickfiles', { only: ['index', 'show'] });
 
     osfResource(this, 'preprint-provider', { path: '/providers/preprints' });
+    osfResource(this, 'registration-provider', { path: '/providers/registrations' });
+    osfNestedResource(this, 'registration-provider', 'licensesAcceptable', {
+        only: ['index'],
+        path: '/providers/registrations/:parentID/licenses/',
+        relatedModelName: 'license',
+    });
 
     // Waterbutler namespace
     this.namespace = '/wb';

--- a/mirage/factories/registration.ts
+++ b/mirage/factories/registration.ts
@@ -80,7 +80,6 @@ export default NodeFactory.extend<MirageRegistration & RegistrationTraits>({
     id: guid('registration'),
     afterCreate(newReg, server) {
         guidAfterCreate(newReg, server);
-
         if (newReg.parent) {
             newReg.update({
                 dateRegistered: newReg.parent.dateRegistered,
@@ -105,6 +104,12 @@ export default NodeFactory.extend<MirageRegistration & RegistrationTraits>({
             newReg.update({
                 registrationSchema,
                 registeredMeta: createRegistrationMetadata(registrationSchema, true),
+            });
+        }
+
+        if (!newReg.provider) {
+            newReg.update({
+                provider: server.schema.registrationProviders.find('osf'),
             });
         }
     },

--- a/mirage/fixtures/registration-providers.ts
+++ b/mirage/fixtures/registration-providers.ts
@@ -1,0 +1,43 @@
+import RegistrationProvider from 'ember-osf-web/models/registration-provider';
+
+import { randomGravatar } from '../utils';
+
+function randomAssets() {
+    return {
+        square_color_no_transparent: randomGravatar(100),
+    };
+}
+
+interface MirageRegistrationProvider extends RegistrationProvider {
+    licensesAcceptableIds: string[];
+}
+
+const registrationProviders: Array<Partial<MirageRegistrationProvider>> = [
+    {
+        id: 'osf',
+        name: 'OSF Registries',
+        description: 'The open registries network',
+        allowSubmissions: true,
+        assets: randomAssets(),
+        licensesAcceptableIds: [
+            '5c252c8e0989e100220edb70',
+            '5c252c8e0989e100220edb7a',
+            '5c252c8e0989e100220edb76',
+            '5c252c8e0989e100220edb74',
+            '5c252c8e0989e100220edb71',
+            '5c252c8e0989e100220edb75',
+            '5c252c8e0989e100220edb73',
+            '5c252c8e0989e100220edb7b',
+            '5c252c8e0989e100220edb7f',
+            '5c252c8e0989e100220edb7e',
+            '5c252c8e0989e100220edb72',
+            '5c252c8e0989e100220edb6f',
+            '5c252c8e0989e100220edb7d',
+            '5c252c8e0989e100220edb7c',
+            '5c252c8e0989e100220edb6e',
+            '5c252c8e0989e100220edb78',
+        ],
+    },
+];
+
+export default registrationProviders;

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -56,7 +56,7 @@ function registrationScenario(
         linkedNodes: server.createList('node', 2),
         linkedRegistrations: server.createList('registration', 2),
         currentUserPermissions: Object.values(Permission),
-}, 'withContributors', 'withComments', 'withAffiliatedInstitutions');
+    }, 'withContributors', 'withComments', 'withAffiliatedInstitutions');
 
     // Current user Bookmarks collection
     server.create('collection', { title: 'Bookmarks', bookmarks: true });

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -56,7 +56,7 @@ function registrationScenario(
         linkedNodes: server.createList('node', 2),
         linkedRegistrations: server.createList('registration', 2),
         currentUserPermissions: Object.values(Permission),
-    }, 'withContributors', 'withComments', 'withLicense', 'withAffiliatedInstitutions');
+}, 'withContributors', 'withComments', 'withAffiliatedInstitutions');
 
     // Current user Bookmarks collection
     server.create('collection', { title: 'Bookmarks', bookmarks: true });
@@ -164,6 +164,7 @@ export default function(server: Server) {
     server.loadFixtures('regions');
     server.loadFixtures('preprint-providers');
     server.loadFixtures('licenses');
+    server.loadFixtures('registration-providers');
 
     const userTraits = !mirageScenarios.includes('loggedIn') ? [] :
         [

--- a/mirage/serializers/registration-provider.ts
+++ b/mirage/serializers/registration-provider.ts
@@ -1,0 +1,21 @@
+import { ModelInstance } from 'ember-cli-mirage';
+import config from 'ember-get-config';
+import RegistrationProvider from 'ember-osf-web/models/registration-provider';
+import ApplicationSerializer from './application';
+
+const { OSF: { apiUrl } } = config;
+
+export default class RegistrationProviderSerializer extends ApplicationSerializer<RegistrationProvider> {
+    buildRelationships(model: ModelInstance<RegistrationProvider>) {
+        return {
+            licensesAcceptable: {
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/providers/registrations/${model.id}/licenses/`,
+                        meta: {},
+                    },
+                },
+            },
+        };
+    }
+}

--- a/mirage/serializers/registration.ts
+++ b/mirage/serializers/registration.ts
@@ -10,6 +10,7 @@ const { OSF: { apiUrl } } = config;
 
 interface RegistrationAttrs extends NodeAttrs {
     registeredFromId: ID | null;
+    providerId: ID | null;
 }
 
 type MirageRegistration = Registration & { attrs: RegistrationAttrs };
@@ -122,6 +123,22 @@ export default class RegistrationSerializer extends ApplicationSerializer<Mirage
                 },
             },
         };
+        if (model.attrs.providerId) {
+            const { providerId } = model.attrs;
+            relationships.provider = {
+                data: {
+                    id: providerId,
+                    type: 'registration-providers',
+                },
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/providers/registrations/${providerId}/`,
+                        meta: {},
+                    },
+                },
+            };
+        }
+
         if (model.attrs.parentId !== null) {
             const { parentId } = model.attrs;
             relationships.parent = {


### PR DESCRIPTION
## Purpose

Add editable license field

## Summary of Changes

- Rename `registry-provider` to `registration-provider`
- Add `<RegistriesLicensePicker>` component
- Update mirage setup
- Fix `<LicenseText>` component to display to wrap text correctly.

## Side Effects

## Feature Flags

`ember_registries_detail_page`

## QA Notes

## Ticket

[[EMB-562]](https://openscience.atlassian.net/browse/EMB-562)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`
