### PR TITLE
[ENG-184] Tooltip positioning fix

### DIFF
--- a/app/styles/_global.scss
+++ b/app/styles/_global.scss
@@ -5,7 +5,7 @@
 html,
 body,
 body > :global(.ember-view) {
-    height: 100%;
+    min-height: 100%;
 }
 
 :global(#toast-container) > div { // stylelint-disable-line selector-max-id

--- a/lib/osf-components/addon/components/copyable-text/template.hbs
+++ b/lib/osf-components/addon/components/copyable-text/template.hbs
@@ -9,13 +9,12 @@
         aria-label={{t 'osf-components.copyable-text.copyToClipboard'}}
     >
         {{fa-icon 'copy'}}
-        {{#if this.showTooltip}}
-            <BsTooltip
-                @visible={{true}}
-            >
-                {{t 'osf-components.copyable-text.copied'}}
-            </BsTooltip>
-        {{/if}}
+        <BsTooltip
+            @triggerEvents=''
+            @visible={{this.showTooltip}}
+        >
+            {{t 'osf-components.copyable-text.copied'}}
+        </BsTooltip>
     </CopyButton>
 </span>
 <input


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[EMB-123] some really great stuff`
-->

## Purpose
Tooltips on the citation widget show up in the wrong place:
![Kapture 2019-03-29 at 13 12 19](https://user-images.githubusercontent.com/6776190/55250332-56331780-5224-11e9-97c4-89f68f9a793b.gif)

<!-- Describe the purpose of your changes. -->

## Summary of Changes
Turns out, the tooltip's location is limited to the `body` element, and we style `body` to be exactly the height of the browser viewport. This means that when you need to scroll down to see the button, the tooltip will pop up higher on the page:
![Kapture 2019-03-29 at 11 41 57](https://user-images.githubusercontent.com/6776190/55250632-04d75800-5225-11e9-8731-3f53d251f57f.gif)

Replacing `body`'s `height` with `min-height` solves this problem while preserving the "footer at the bottom" behavior that motivated that style in the first place.

While investigating, I noticed the tooltip acting weird in a distracting way as the mouse moves. Made it not react to mouse events, so it always stays up for 3 seconds after you click, then disappears.

<!-- Briefly describe or list your changes. -->

## Side Effects
If there's anywhere we depend on `body` being *smaller* than the content of the page... well, we should be ashamed of ourselves. I haven't found anything like that, and consider it very unlikely.
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## Feature Flags

<!--
  Please list any feature flags that need to be enabled for these changes to go into effect.
  For each flag, what is the expected behavior with the flag enabled vs disabled?
-->

## QA Notes
When you click the "copy" button, the tooltip should be right where you'd expect it.
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
-->

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
https://openscience.atlassian.net/browse/ENG-184

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
