### PR TITLE
[ENG-364] Editable category

### DIFF
--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -1077,6 +1077,9 @@ export default {
             tags: 'Tags',
             citation: 'Citation',
             edit_field: 'Edit {{field}}',
+            save_category: {
+                error: 'Unable to save category',
+            },
         },
 
         form_view: {

--- a/app/models/node.ts
+++ b/app/models/node.ts
@@ -68,10 +68,24 @@ export enum NodeType {
     Registration = 'registration',
 }
 
+export enum NodeCategory {
+    Data = 'data',
+    Other = 'other',
+    Project = 'project',
+    Software = 'software',
+    Analysis = 'analysis',
+    Procedure = 'procedure',
+    Hypothesis = 'hypothesis',
+    Uncategorized = 'uncategorized',
+    Communication = 'communication',
+    Instrumentation = 'instrumentation',
+    MethodsAndMeasures = 'methods and measures',
+}
+
 export default class NodeModel extends BaseFileItem.extend(Validations, CollectableValidations) {
     @attr('fixstring') title!: string;
     @attr('fixstring') description!: string;
-    @attr('node-category') category!: string;
+    @attr('node-category') category!: NodeCategory;
     @attr('array') currentUserPermissions!: Permission[];
     @attr('boolean') currentUserIsContributor!: boolean;
     @attr('boolean') fork!: boolean;

--- a/lib/osf-components/addon/components/editable-field/category-manager/component.ts
+++ b/lib/osf-components/addon/components/editable-field/category-manager/component.ts
@@ -1,0 +1,75 @@
+import { tagName } from '@ember-decorators/component';
+import { action, computed } from '@ember-decorators/object';
+import { alias } from '@ember-decorators/object/computed';
+import { service } from '@ember-decorators/service';
+import Component from '@ember/component';
+import { task } from 'ember-concurrency';
+import I18N from 'ember-i18n/services/i18n';
+import Toast from 'ember-toastr/services/toast';
+
+import { layout } from 'ember-osf-web/decorators/component';
+import Node, { NodeCategory } from 'ember-osf-web/models/node';
+import template from './template';
+
+export interface CategoryManager {
+    save: () => void;
+    selectedCategory: NodeCategory;
+    category: NodeCategory;
+    inEditMode: boolean;
+}
+
+@tagName('')
+@layout(template)
+export default class CategoryManagerComponent extends Component.extend({
+    save: task(function *(this: CategoryManagerComponent) {
+        this.node.set('category', this.selectedCategory);
+        try {
+            yield this.node.save();
+            this.set('inEditMode', false);
+        } catch (e) {
+            this.toast.error(this.i18n.t('registries.node_metadata.save_category.error'));
+            throw e;
+        }
+    }),
+}) {
+    // required
+    node!: Node;
+
+    // private
+    @service i18n!: I18N;
+    @service toast!: Toast;
+
+    inEditMode: boolean = false;
+    fieldIsEmpty = false;
+    selectedCategory!: NodeCategory;
+
+    @alias('node.userHasAdminPermission') userCanEdit!: boolean;
+    @alias('node.category') category!: boolean;
+
+    didReceiveAttrs() {
+        if (this.node) {
+            this.setProperties({ selectedCategory: this.node.category });
+        }
+    }
+
+    @computed('fieldIsEmpty', 'userCanEdit')
+    get shouldShowField() {
+        return this.userCanEdit || !this.fieldIsEmpty;
+    }
+
+    @action
+    startEditing() {
+        this.set('inEditMode', true);
+    }
+
+    @action
+    onSelect(category: NodeCategory) {
+        this.set('selectedCategory', category);
+    }
+
+    @action
+    cancel() {
+        this.set('selectedCategory', this.node.category);
+        this.set('inEditMode', false);
+    }
+}

--- a/lib/osf-components/addon/components/editable-field/category-manager/template.hbs
+++ b/lib/osf-components/addon/components/editable-field/category-manager/template.hbs
@@ -1,15 +1,12 @@
 {{yield (hash
     save=(perform this.save)
     cancel=(action this.cancel)
-    addInstitution=(action this.addInstitution)
-    removeInstitution=(action this.removeInstitution)
+    onSelect=(action this.onSelect)
     fieldIsEmpty=this.fieldIsEmpty
-    emptyFieldText=this.emptyFieldText
-    affiliatedList=this.affiliatedList
-    reloadList=this.reloadList
     startEditing=(action this.startEditing)
     inEditMode=this.inEditMode
     userCanEdit=this.userCanEdit
     shouldShowField=this.shouldShowField
-    bindReload=(action (mut this.reloadList))
+    selectedCategory=this.selectedCategory
+    category=this.category
 )}}

--- a/lib/osf-components/addon/components/editable-field/institutions-manager/component.ts
+++ b/lib/osf-components/addon/components/editable-field/institutions-manager/component.ts
@@ -13,10 +13,17 @@ import Node from 'ember-osf-web/models/node';
 import { QueryHasManyResult } from 'ember-osf-web/models/osf-model';
 import template from './template';
 
+export interface InstitutionsManager {
+    reloadList?: (page?: number) => void;
+    addInstitution: (institution: Institution) => void;
+    removeInstitution: (institution: Institution) => void;
+    affiliatedList: Institution[];
+}
+
 @tagName('')
 @layout(template)
-export default class InstitutionsManager extends Component.extend({
-    loadNodeAffiliatedInstitutions: task(function *(this: InstitutionsManager) {
+export default class InstitutionsManagerComponent extends Component.extend({
+    loadNodeAffiliatedInstitutions: task(function *(this: InstitutionsManagerComponent) {
         if (!this.node) {
             return undefined;
         }
@@ -36,7 +43,7 @@ export default class InstitutionsManager extends Component.extend({
             return false;
         }
     }).on('didReceiveAttrs').restartable(),
-    submitChanges: task(function *(this: InstitutionsManager) {
+    save: task(function *(this: InstitutionsManagerComponent) {
         yield this.node.updateM2MRelationship('affiliatedInstitutions', this.affiliatedList);
         this.setProperties({
             currentAffiliatedList: [...this.affiliatedList],

--- a/lib/osf-components/addon/components/editable-field/tags-manager/component.ts
+++ b/lib/osf-components/addon/components/editable-field/tags-manager/component.ts
@@ -10,12 +10,24 @@ import Registration from 'ember-osf-web/models/registration';
 import pathJoin from 'ember-osf-web/utils/path-join';
 import template from './template';
 
-const { OSF: { url: baseUrl } } = config;
+export interface TagsManager {
+    tags: string[];
+    removeTag: (index: number) => void;
+    addTag: (tag: string) => void;
+    clickTag: (tag: string) => void;
+    readOnly: boolean;
+}
+
+const {
+    OSF: {
+        url: baseUrl,
+    },
+} = config;
 
 @tagName('')
 @layout(template)
-export default class TagsManager extends Component.extend({
-    save: task(function *(this: TagsManager) {
+export default class TagsManagerComponent extends Component.extend({
+    save: task(function *(this: TagsManagerComponent) {
         this.registration.set('tags', [...this.currentTags]);
         yield this.registration.save();
         this.set('requestedEditMode', false);

--- a/lib/osf-components/addon/components/institution-select-list/component.ts
+++ b/lib/osf-components/addon/components/institution-select-list/component.ts
@@ -1,18 +1,11 @@
 import Component from '@ember/component';
 
 import { layout } from 'ember-osf-web/decorators/component';
-import Institution from 'ember-osf-web/models/institution';
 import Node from 'ember-osf-web/models/node';
 import defaultTo from 'ember-osf-web/utils/default-to';
+import { InstitutionsManager } from 'osf-components/components/editable-field/institutions-manager/component';
 import styles from './styles';
 import template from './template';
-
-interface InstitutionsManager {
-    reloadList?: (page?: number) => void;
-    addInstitution: (institution: Institution) => void;
-    removeInstitution: (institution: Institution) => void;
-    affiliatedList: Institution[];
-}
 
 @layout(template, styles)
 export default class InstitutionSelectList extends Component {

--- a/lib/osf-components/addon/components/node-category-picker/component.ts
+++ b/lib/osf-components/addon/components/node-category-picker/component.ts
@@ -1,0 +1,18 @@
+import { computed } from '@ember-decorators/object';
+import Component from '@ember/component';
+
+import { layout } from 'ember-osf-web/decorators/component';
+import { NodeCategory } from 'ember-osf-web/models/node';
+import { CategoryManager } from 'osf-components/components/editable-field/category-manager/component';
+import template from './template';
+
+@layout(template)
+export default class NodeCategoryPicker extends Component {
+    manager!: CategoryManager;
+
+    @computed('manager.selectedCategory')
+    get categories() {
+        return Object.values(NodeCategory)
+            .filter(category => category !== this.manager.selectedCategory);
+    }
+}

--- a/lib/osf-components/addon/components/node-category-picker/template.hbs
+++ b/lib/osf-components/addon/components/node-category-picker/template.hbs
@@ -1,0 +1,14 @@
+{{#if @manager.inEditMode}}
+    <div data-test-select-category>
+        <PowerSelect
+            @options={{this.categories}}
+            @renderInPlace={{true}}
+            @selected={{@manager.selectedCategory}}
+            @onchange={{action @manager.onSelect}}
+            @disabled={{@manager.save.isRunning}}
+            as |category|
+        >
+            <NodeCategory @category={{category}} />
+        </PowerSelect>
+    </div>
+{{/if}}

--- a/lib/osf-components/addon/components/node-category/component.ts
+++ b/lib/osf-components/addon/components/node-category/component.ts
@@ -1,0 +1,39 @@
+import { tagName } from '@ember-decorators/component';
+import { computed } from '@ember-decorators/object';
+import { service } from '@ember-decorators/service';
+import Component from '@ember/component';
+import I18N from 'ember-i18n/services/i18n';
+
+import { layout } from 'ember-osf-web/decorators/component';
+import { NodeCategory } from 'ember-osf-web/models/node';
+import template from './template';
+
+const categoryToIconMap: Record<NodeCategory, string> = {
+    analysis: 'bar-chart',
+    communication: 'comment',
+    data: 'database',
+    hypothesis: 'lightbulb-o',
+    instrumentation: 'flask',
+    'methods and measures': 'pencil',
+    procedure: 'cogs',
+    project: 'cube',
+    software: 'laptop',
+    other: 'th-large',
+    uncategorized: 'circle-o-notch',
+};
+
+@tagName('')
+@layout(template)
+export default class NodeCategoryPicker extends Component {
+    category!: NodeCategory;
+
+    @service i18n!: I18N;
+
+    @computed('category')
+    get currentCategory() {
+        return {
+            text: this.i18n.t(`node_categories.${this.category}`),
+            icon: categoryToIconMap[this.category],
+        };
+    }
+}

--- a/lib/osf-components/addon/components/node-category/template.hbs
+++ b/lib/osf-components/addon/components/node-category/template.hbs
@@ -1,0 +1,4 @@
+<span ...attributes>
+    <FaIcon @icon={{this.currentCategory.icon}} @fixedWidth={{true}} />
+    {{this.currentCategory.text}}
+</span>

--- a/lib/osf-components/app/components/editable-field/category-manager/component.js
+++ b/lib/osf-components/app/components/editable-field/category-manager/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/editable-field/category-manager/component';

--- a/lib/osf-components/app/components/node-category-picker/component.js
+++ b/lib/osf-components/app/components/node-category-picker/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/node-category-picker/component';

--- a/lib/osf-components/app/components/node-category/component.js
+++ b/lib/osf-components/app/components/node-category/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/node-category/component';

--- a/lib/registries/addon/components/registries-metadata/template.hbs
+++ b/lib/registries/addon/components/registries-metadata/template.hbs
@@ -60,14 +60,22 @@
         </div>
     </div>
 
-    {{#if this.registration.category}}
-        <div local-class='Field'>
-            <h4>{{t 'registries.registration_metadata.category'}}</h4>
-            <div data-test-registries-metadata='category'>
-                {{t (concat 'node_categories.' this.registration.category)}}
-            </div>
-        </div>
-    {{/if}}
+    <div local-class='Field'>
+        <EditableField
+            data-analytics-scope='Category'
+            @managerComponent={{component 'editable-field/category-manager' node=this.registration}}
+            @title={{t 'registries.registration_metadata.category'}}
+            @name='category'
+            as |field|
+        >
+            <field.edit>
+                <NodeCategoryPicker @manager={{field.manager}} />
+            </field.edit>
+            <field.display>
+                <NodeCategory @category={{field.manager.category}} />
+            </field.display>
+        </EditableField>
+    </div>
 
     {{#if @extendedFields}}
         <div local-class='Field'>

--- a/lib/registries/addon/components/registries-tags-widget/component.ts
+++ b/lib/registries/addon/components/registries-tags-widget/component.ts
@@ -6,16 +6,9 @@ import { layout } from 'ember-osf-web/decorators/component';
 import Registration from 'ember-osf-web/models/registration';
 import Analytics from 'ember-osf-web/services/analytics';
 import defaultTo from 'ember-osf-web/utils/default-to';
+import { TagsManager } from 'osf-components/components/editable-field/tags-manager/component';
 import styles from './styles';
 import template from './template';
-
-interface TagsManager {
-    tags: string[];
-    removeTag: (index: number) => void;
-    addTag: (tag: string) => void;
-    clickTag: (tag: string) => void;
-    readOnly: boolean;
-}
 
 @layout(template, styles)
 export default class RegistriesTagsWidget extends Component.extend({ styles }) {

--- a/mirage/factories/node.ts
+++ b/mirage/factories/node.ts
@@ -2,7 +2,7 @@ import { capitalize } from '@ember/string';
 import { Collection, Factory, faker, trait, Trait } from 'ember-cli-mirage';
 
 import Identifier from 'ember-osf-web/models/identifier';
-import Node from 'ember-osf-web/models/node';
+import Node, { NodeCategory } from 'ember-osf-web/models/node';
 import { Permission } from 'ember-osf-web/models/osf-model';
 
 import { guid, guidAfterCreate } from './utils';
@@ -32,19 +32,7 @@ export default Factory.extend<MirageNode & NodeTraits>({
         }
     },
 
-    category: faker.list.cycle(
-        'project',
-        'analysis',
-        'communication',
-        'data',
-        'hypothesis',
-        'instrumentation',
-        'methods and measures',
-        'procedure',
-        'project',
-        'software',
-        'other',
-    ),
+    category: faker.random.arrayElement(Object.values(NodeCategory)),
     fork: false,
     currentUserIsContributor: false,
     preprint: false,


### PR DESCRIPTION
## Purpose

Make registration category admin-editable

## Summary of Changes

- Add `node-categories` and `category-manager` component
- Add tests

## Side Effects

## Feature Flags

`ember_registries_detail_page`

## QA Notes

- Only admin should be able to edit registration category
- Make sure all the categories show in the dropdown (except current category which shows
in the dropdown trigger).
- Check for errors upon saving edits.

## Ticket

[ENG-364](https://openscience.atlassian.net/browse/ENG-364)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
