### PR TITLE
Fix registries-navbar join link

### DIFF
--- a/lib/osf-components/addon/components/osf-link/template.hbs
+++ b/lib/osf-components/addon/components/osf-link/template.hbs
@@ -2,7 +2,7 @@
     href={{this._href}}
     target={{this.target}}
     rel={{this.rel}}
-    class={{if this.isActive 'active'}}
+    class='{{this.class}} {{if this.isActive 'active'}}'
     onclick={{action this._onClick}}
     ...attributes
 >

--- a/lib/osf-components/addon/components/osf-navbar/auth-dropdown/component.ts
+++ b/lib/osf-components/addon/components/osf-navbar/auth-dropdown/component.ts
@@ -13,6 +13,7 @@ import { layout } from 'ember-osf-web/decorators/component';
 import User from 'ember-osf-web/models/user';
 import Analytics from 'ember-osf-web/services/analytics';
 import CurrentUser from 'ember-osf-web/services/current-user';
+import cleanURL from 'ember-osf-web/utils/clean-url';
 import defaultTo from 'ember-osf-web/utils/default-to';
 import param from 'ember-osf-web/utils/param';
 import pathJoin from 'ember-osf-web/utils/path-join';
@@ -50,7 +51,7 @@ export class AuthBase extends Component {
 
     @computed('router.currentURL')
     get signUpNext() {
-        return pathJoin(baseUrl, this.router.currentURL);
+        return pathJoin(baseUrl, cleanURL(this.router.currentURL));
     }
 
     @computed('signUpURL', 'signUpNext')

--- a/lib/registries/addon/components/navbar/template.hbs
+++ b/lib/registries/addon/components/navbar/template.hbs
@@ -19,9 +19,9 @@
         )
 
         links=(hash
-            default=(component 'x-dummy' tagName='a' class=(local-class 'Default Link Item'))
-            primary=(component 'x-dummy' tagName='a' class=(local-class 'Primary Link Item'))
-            secondary=(component 'x-dummy' tagName='a' class=(local-class 'Secondary Link Item'))
+            default=(component 'osf-link' class=(local-class 'Default Link Item'))
+            primary=(component 'osf-link' class=(local-class 'Primary Link Item'))
+            secondary=(component 'osf-link' class=(local-class 'Secondary Link Item'))
         )
     )}}
 </nav>

--- a/lib/registries/addon/components/registries-navbar/template.hbs
+++ b/lib/registries/addon/components/registries-navbar/template.hbs
@@ -92,7 +92,8 @@
                 <nav.links.secondary
                     data-test-join='1'
                     data-analytics-name='Sign up'
-                    @href={{this.signUpRoute}}
+                    @route='register'
+                    @queryParams={{this.signUpQueryParams}}
                     @classNames={{local-class 'HideOnMobile'}}
                 >
                     <h4>{{t 'navbar.join'}}</h4>
@@ -177,7 +178,8 @@
                             <OsfLink
                                 data-test-join-mobile
                                 data-analytics-name='Sign up'
-                                @href={{this.signUpRoute}}
+                                @route='register'
+                                @queryParams={{this.signUpQueryParams}}
                             >
                                 <FaIcon @icon='user-plus' @fixedWidth={{true}} />
                                 {{t 'navbar.join'}}


### PR DESCRIPTION
## Purpose

Change the nav links on the registries navbar to use `osf-link` so that they support specifying a route to transition to along with query parameters.

## Summary of Changes

* allow classes to pass-through to `a` tag in `osf-link`
* use `osf-link` for registries nav links
* for the "Join" link, specify the `register` route and query parameters instead of an href
* use the `cleanURL` util to remove any "--" url components (in this case, `/--registries`) from the sign up next url
* fix up `registries-navbar` integration test to work with `osf-link` join

## Side Effects

None expected.

## Feature Flags

n/a

## QA Notes

Should make sure registries nav links have retained desired style and behavior.

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
