### PR TITLE
fix: add dateWithdrawn attribute to registration model and factory

### DIFF
--- a/app/models/registration.ts
+++ b/app/models/registration.ts
@@ -29,6 +29,7 @@ export default class RegistrationModel extends NodeModel.extend() {
     @attr('boolean') pendingEmbargoApproval!: boolean;
     @attr('boolean') pendingEmbargoTerminationApproval!: boolean;
     @attr('boolean') withdrawn!: boolean;
+    @attr('date') dateWithdrawn!: Date | null;
     @attr('fixstring') withdrawalJustification?: string;
     @attr('boolean') pendingWithdrawal!: boolean;
     @attr('fixstring') registrationSupplement?: string;

--- a/mirage/factories/registration.ts
+++ b/mirage/factories/registration.ts
@@ -106,6 +106,7 @@ export default NodeFactory.extend<MirageRegistration & RegistrationTraits>({
     embargoEndDate: null,
     pendingEmbargoApproval: false,
     withdrawn: false,
+    dateWithdrawn: null,
     pendingWithdrawal: false,
     pendingEmbargoTerminationApproval: false,
 


### PR DESCRIPTION
## Purpose

https://percy.io/Center-for-Open-Science/ember-osf-web/builds/1780593/view/115932618/1280?browser=chrome&mode=diff alerted me (🎉for Percy!) to an issue where the "Date withdrawn" was always the current date, even after this was fixed to always use a date in the past:
https://github.com/CenterForOpenScience/ember-osf-web/blob/58a002a789c1c3b1e7bafb08a375981ff854a7ba/mirage/factories/registration.ts#L51-L53
This turns out to be because the `registration` model did not even have a `dateWithdrawn` attribute.

## Summary of Changes

* add `dateWithdrawn` attribute to `registration` model
* initialize `dateWithdrawn` to `null` in the `registration` mirage factory

## Side Effects

None.

## Feature Flags

n/a

## QA Notes

n/a

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
