### PR TITLE
use traits for registration tombstone tests

### DIFF
--- a/tests/engines/registries/acceptance/overview/index-test.ts
+++ b/tests/engines/registries/acceptance/overview/index-test.ts
@@ -98,7 +98,10 @@ module('Registries | Acceptance | overview.index', hooks => {
     });
 
     test('withdrawn tombstone', async function(this: OverviewTestContext, assert: Assert) {
-        this.registration.update('withdrawn', true);
+        this.set('registration', server.create('registration', {
+            registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
+            currentUserPermissions: [Permission.Admin],
+        }, 'withContributors', 'isWithdrawn'));
         const url = `/${this.registration.id}`;
         await visit(url);
         await percySnapshot(assert);
@@ -112,7 +115,10 @@ module('Registries | Acceptance | overview.index', hooks => {
     });
 
     test('archiving tombstone', async function(this: OverviewTestContext, assert: Assert) {
-        this.registration.update('archiving', true);
+        this.set('registration', server.create('registration', {
+            registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
+            currentUserPermissions: [Permission.Admin],
+        }, 'withContributors', 'isArchiving'));
         const url = `/${this.registration.id}`;
         await visit(url);
         await percySnapshot(assert);


### PR DESCRIPTION
## Purpose

The tombstone tests should use traits to get registrations in proper states rather than setting the state manually.

## Summary of Changes

* create registration in mirage with `isWithdrawn` trait for withdrawn tombstone test
* create registration in mirage with `isArchiving ` trait for archiving tombstone test

## Side Effects

none

## Feature Flags

n/a

## QA Notes

n/a

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
