### PR TITLE
[ENG-243] Fix QR code.

### DIFF
--- a/app/models/user-setting.ts
+++ b/app/models/user-setting.ts
@@ -8,7 +8,7 @@ import OsfModel, { OsfLinks } from './osf-model';
 import UserModel from './user';
 
 const Validations = buildValidations({
-    verification: [
+    twoFactorVerification: [
         validator('presence', true),
         validator('number', {
             allowString: true,
@@ -29,7 +29,7 @@ export default class UserSettingModel extends OsfModel.extend(Validations) {
     @attr('boolean') subscribeOsfGeneralEmail!: boolean;
     @attr('boolean') deactivationRequested!: boolean;
     @attr('string') secret!: string;
-    @attr('number') verification?: number;
+    @attr('number') twoFactorVerification?: number;
 
     @belongsTo('user', { inverse: 'settings', async: false })
     user!: UserModel;

--- a/app/settings/account/-components/security/template.hbs
+++ b/app/settings/account/-components/security/template.hbs
@@ -47,7 +47,7 @@
                     <div>
                         <form.text
                             data-test-verification-code-field
-                            @valuePath='verification'
+                            @valuePath='twoFactorVerification'
                             @label={{t 'settings.account.security.enterVerification'}}
                         />
                         {{#if this.showError}}

--- a/app/settings/account/-components/security/template.hbs
+++ b/app/settings/account/-components/security/template.hbs
@@ -32,7 +32,7 @@
                 </p>
                 <QrCode
                     data-test-2f-qr-code
-                    @text={{this.settings.secret}}
+                    @text={{this.keyUri}}
                     @width={{260}}
                     @height={{260}}
                     @correctLevel='L'
@@ -103,6 +103,7 @@
 <BsModal
     data-test-confirm-enable-modal
     @open={{this.showEnableWarning}}
+    @onHide={{action this.hideDialogs}}
     as |modal|
 >
     <modal.header>

--- a/app/settings/account/-components/security/template.hbs
+++ b/app/settings/account/-components/security/template.hbs
@@ -136,6 +136,7 @@
 <BsModal
     data-test-confirm-disable-modal
     @open={{this.showDisableWarning}}
+    @onHide={{action this.hideDialogs}}
     as |modal|
 >
     <modal.header>

--- a/mirage/views/user-setting.ts
+++ b/mirage/views/user-setting.ts
@@ -12,8 +12,8 @@ export function updateUserSetting(this: HandlerContext, schema: Schema, request:
     }
 
     let confirmTwoFactor = twoFactorConfirmed && twoFactorEnabled;
-    if (attrs.verification !== undefined) {
-        if (attrs.verification === 123456) {
+    if (attrs.twoFactorVerification !== undefined) {
+        if (attrs.twoFactorVerification === 123456) {
             if (twoFactorEnabled === true) {
                 confirmTwoFactor = true;
             }


### PR DESCRIPTION
## Purpose

Fix the problem where the QR code is not recognized by 2FA apps such as Authy and Google Authenticator.
Fix the problem where clicking `Enable` after entering the correct verification code doesn't do anything.
Also fix the problem where configure button is disabled after clicking the close button on top right of the modal.

## Summary of Changes

According to [Google Authenticator's doc](https://github.com/google/google-authenticator/wiki/Key-Uri-Format), the QR code should encode a URI in this format:
`otpauth://TYPE/LABEL?PARAMETERS`
In our case, the `TYPE` should be `totp`, the `LABEL` should be `OSF:<primary-email-address>` and `PARAMETERS` should be `secret=<secret>`.

Changes the `verification` field on `user-settings` model to `twoFactorVerification`, because the API expects `two_factor_verification` to be the key in the payload. (See [here](https://github.com/CenterForOpenScience/osf.io/blob/88d5aa9848603e382480600ca5726038f251cac2/api/users/serializers.py#L542))

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
https://openscience.atlassian.net/browse/ENG-243

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
