### PR TITLE
[fix] Move a_b_testing flag outside of dev environment conditional

### DIFF
--- a/app/authenticators/osf-cookie.ts
+++ b/app/authenticators/osf-cookie.ts
@@ -41,14 +41,15 @@ export default class OsfCookie extends Base {
             );
         }
 
+        //
+        // TODO: create function to initialize all feature flags in config
+        //
+        if (!this.features.flags.includes(ABTesting.homePageVersionB)) {
+            this.features.disable(ABTesting.homePageVersionB);
+        }
+
         if (devMode) {
             this._checkApiVersion();
-            //
-            // TODO: create function to initialize all feature flags in config
-            //
-            if (!this.features.flags.includes(ABTesting.homePageVersionB)) {
-                this.features.disable(ABTesting.homePageVersionB);
-            }
         }
 
         const userData = res.meta.current_user;


### PR DESCRIPTION
## Purpose

The a_b_testing flag for the logged out homepage is currently in a conditional to only show on development environments.

## Summary of Changes

- Move the a_b_testing flag outside of dev conditional so it can be seen in the osf-dev-footer on staging/prod

## Side Effects

N/A

## Feature Flags

N/A

## QA Notes

The flag should show now show up on the feature tab on the osf-dev-footer.  It should work and switch the homepage between versions A and B.

## Ticket

N/A

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
