### PR TITLE
[ENG-448][ENG-447] Fix password-strength-bar double validation message and failure to display message for weak passwords

### DIFF
--- a/app/settings/account/-components/change-password/component.ts
+++ b/app/settings/account/-components/change-password/component.ts
@@ -1,5 +1,4 @@
-import { computed } from '@ember-decorators/object';
-import { alias } from '@ember-decorators/object/computed';
+import { alias, not, or } from '@ember-decorators/object/computed';
 import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
 import PasswordStrength from 'ember-cli-password-strength/services/password-strength';
@@ -37,22 +36,24 @@ export default class ChangePasswordPane extends Component.extend({
         this.currentUser.logout();
     }),
 }) {
-    // Private parameters
-    userPassword: UserPassword;
-    didValidate = false;
-    newPassword = '';
-
+    // Private properties
     @service currentUser!: CurrentUser;
     @service i18n!: I18N;
     @service passwordStrength!: PasswordStrength;
     @service toast!: Toast;
     @service store!: DS.Store;
+
+    userPassword: UserPassword;
+    didValidate = false;
+    @not('didValidate') didNotValidate!: boolean;
+
     @alias('currentUser.user') user!: User;
 
-    @computed('userPassword.validations.attrs.{newPassword,existingPassword,confirmPassword}.isValidating')
-    get shouldShowMessage() {
-        return Boolean(!this.userPassword.validations.attrs.newPassword.message);
-    }
+    @or(
+        'didNotValidate',
+        'userPassword.validations.attrs.newPassword.{message,isValidating}',
+    )
+    shouldHideStrengthBarMessage!: boolean;
 
     constructor(...args: any[]) {
         super(...args);

--- a/app/settings/account/-components/change-password/component.ts
+++ b/app/settings/account/-components/change-password/component.ts
@@ -1,3 +1,4 @@
+import { computed } from '@ember-decorators/object';
 import { alias } from '@ember-decorators/object/computed';
 import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
@@ -47,6 +48,11 @@ export default class ChangePasswordPane extends Component.extend({
     @service toast!: Toast;
     @service store!: DS.Store;
     @alias('currentUser.user') user!: User;
+
+    @computed('userPassword.validations.attrs.{newPassword,existingPassword,confirmPassword}.isValidating')
+    get shouldShowMessage() {
+        return Boolean(!this.userPassword.validations.attrs.newPassword.message);
+    }
 
     constructor(...args: any[]) {
         super(...args);

--- a/app/settings/account/-components/change-password/template.hbs
+++ b/app/settings/account/-components/change-password/template.hbs
@@ -30,6 +30,7 @@
                     data-test-strength-bar
                     @password={{this.userPassword.newPassword}}
                     @model={{this.userPassword}}
+                    @shouldShowMessage={{this.shouldShowMessage}}
                 />
                 <ValidatedTextInput
                     data-test-confirm-password

--- a/app/settings/account/-components/change-password/template.hbs
+++ b/app/settings/account/-components/change-password/template.hbs
@@ -29,8 +29,7 @@
                 <PasswordStrengthBar
                     data-test-strength-bar
                     @password={{this.userPassword.newPassword}}
-                    @model={{this.userPassword}}
-                    @shouldShowMessage={{this.shouldShowMessage}}
+                    @shouldShowMessages={{not this.shouldHideStrengthBarMessage}}
                 />
                 <ValidatedTextInput
                     data-test-confirm-password

--- a/lib/osf-components/addon/components/password-strength-bar/component.ts
+++ b/lib/osf-components/addon/components/password-strength-bar/component.ts
@@ -54,7 +54,7 @@ export default class PasswordStrengthBar extends Component.extend({
         return this.strength && this.strength.score >= this.minStrength;
     }
 
-    @computed('strength', 'strength.{feedback.warning,score}', 'valid')
+    @computed('strength', 'strength.feedback.warning', 'valid')
     get message() {
         if (this.strength) {
             if (this.strength.feedback.warning) {

--- a/lib/osf-components/addon/components/password-strength-bar/component.ts
+++ b/lib/osf-components/addon/components/password-strength-bar/component.ts
@@ -8,6 +8,7 @@ import { task, timeout } from 'ember-concurrency';
 import I18n from 'ember-i18n/services/i18n';
 import { layout } from 'ember-osf-web/decorators/component';
 import UserPassword from 'ember-osf-web/models/user-password';
+import defaultTo from 'ember-osf-web/utils/default-to';
 
 import styles from './styles';
 import template from './template';
@@ -28,15 +29,17 @@ export default class PasswordStrengthBar extends Component.extend({
     password!: string;
     model!: UserPassword;
 
+    // Optional parameters
+    shouldShowMessage: boolean = defaultTo(this.shouldShowMessage, true);
+
     // Private parameters
     @service i18n!: I18n;
     @service passwordStrength!: PasswordStrength;
     message: string = '';
-    shouldShowMessage: boolean = false;
     @alias('model.validations.attrs.newPassword.message')
         hasValidationMessage!: boolean;
     @alias('model.validations.attrs.newPassword.isValidating')
-        isValidating!: boolean;
+       isValidating!: boolean;
 
     @computed('password',
         'strength.{lastSuccessful,lastSuccessful.value,lastSuccessful.value.score}',
@@ -45,7 +48,6 @@ export default class PasswordStrengthBar extends Component.extend({
     get progress() {
         const { lastSuccessful } = this.strength;
         if (lastSuccessful && lastSuccessful.value && !this.isValidating) {
-            this.set('shouldShowMessage', !this.hasValidationMessage);
             this.set('message', lastSuccessful.value.feedback.warning);
         }
         return this.password && lastSuccessful ? 1 + lastSuccessful.value.score : 0;

--- a/lib/osf-components/addon/components/password-strength-bar/component.ts
+++ b/lib/osf-components/addon/components/password-strength-bar/component.ts
@@ -2,20 +2,26 @@ import { computed } from '@ember-decorators/object';
 import { alias } from '@ember-decorators/object/computed';
 import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
-
 import PasswordStrength from 'ember-cli-password-strength/services/password-strength';
 import { task, timeout } from 'ember-concurrency';
 import I18n from 'ember-i18n/services/i18n';
+
 import { layout } from 'ember-osf-web/decorators/component';
-import UserPassword from 'ember-osf-web/models/user-password';
 import defaultTo from 'ember-osf-web/utils/default-to';
 
 import styles from './styles';
 import template from './template';
 
+interface Strength {
+    score: number;
+    feedback: {
+        warning: string;
+    };
+}
+
 @layout(template, styles)
 export default class PasswordStrengthBar extends Component.extend({
-    strength: task(function *(this: PasswordStrengthBar, value: string) {
+    checkStrength: task(function *(this: PasswordStrengthBar, value: string) {
         if (!value) {
             return 0;
         }
@@ -27,30 +33,38 @@ export default class PasswordStrengthBar extends Component.extend({
 }) {
     // Required parameters
     password!: string;
-    model!: UserPassword;
 
     // Optional parameters
-    shouldShowMessage: boolean = defaultTo(this.shouldShowMessage, true);
+    shouldShowMessages: boolean = defaultTo(this.shouldShowMessages, true);
+    minStrength: number = defaultTo(this.minStrength, 2);
 
-    // Private parameters
+    // Private properties
     @service i18n!: I18n;
     @service passwordStrength!: PasswordStrength;
-    message: string = '';
-    @alias('model.validations.attrs.newPassword.message')
-        hasValidationMessage!: boolean;
-    @alias('model.validations.attrs.newPassword.isValidating')
-       isValidating!: boolean;
 
-    @computed('password',
-        'strength.{lastSuccessful,lastSuccessful.value,lastSuccessful.value.score}',
-        'hasValidationMessage',
-        'isValidating')
+    @alias('checkStrength.lastSuccessful.value') strength?: Strength;
+
+    @computed('password', 'strength', 'strength.score')
     get progress() {
-        const { lastSuccessful } = this.strength;
-        if (lastSuccessful && lastSuccessful.value && !this.isValidating) {
-            this.set('message', lastSuccessful.value.feedback.warning);
+        return this.password && this.strength ? 1 + this.strength.score : 0;
+    }
+
+    @computed('strength', 'strength.score', 'minStrength')
+    get valid() {
+        return this.strength && this.strength.score >= this.minStrength;
+    }
+
+    @computed('strength', 'strength.{feedback.warning,score}', 'valid')
+    get message() {
+        if (this.strength) {
+            if (this.strength.feedback.warning) {
+                return this.strength.feedback.warning;
+            }
+            if (!this.valid) {
+                return 'Password is too weak.';
+            }
         }
-        return this.password && lastSuccessful ? 1 + lastSuccessful.value.score : 0;
+        return '';
     }
 
     @computed('progress')
@@ -72,6 +86,6 @@ export default class PasswordStrengthBar extends Component.extend({
     }
 
     didUpdateAttrs() {
-        this.strength.perform(this.password);
+        this.checkStrength.perform(this.password);
     }
 }

--- a/lib/osf-components/addon/components/password-strength-bar/template.hbs
+++ b/lib/osf-components/addon/components/password-strength-bar/template.hbs
@@ -1,5 +1,5 @@
-{{#if (and @shouldShowMessage this.message)}}
-    <div class='text-danger col-xs-12' local-class='warning-message'>
+{{#if (and @shouldShowMessages this.message)}}
+    <div class='{{if this.valid 'text-warning' 'text-danger'}} col-xs-12' local-class='warning-message'>
         {{this.message}}
     </div>
 {{/if}}

--- a/lib/osf-components/addon/components/password-strength-bar/template.hbs
+++ b/lib/osf-components/addon/components/password-strength-bar/template.hbs
@@ -1,4 +1,4 @@
-{{#if (and this.shouldShowMessage this.message)}}
+{{#if (and @shouldShowMessage this.message)}}
     <div class='text-danger col-xs-12' local-class='warning-message'>
         {{this.message}}
     </div>

--- a/tests/integration/routes/settings/account/-components/change-password-test.ts
+++ b/tests/integration/routes/settings/account/-components/change-password-test.ts
@@ -6,7 +6,7 @@ import { module, test } from 'qunit';
 import { click } from 'ember-osf-web/tests/helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | routes | settings | profile | name | -components | citation-preview', hooks => {
+module('Integration | routes | settings | account | -components | change-password', hooks => {
     setupRenderingTest(hooks);
 
     test('it renders', async assert => {


### PR DESCRIPTION
## Purpose

To remove double validation messages on the `password-strength-bar` and always provide a message when the password does not pass validation.

## Summary of Changes

- Move logic from the `password-strength-bar` to the `change-password` widget.
- Refactor logic to determine when to show the `password-strength-bar`'s message.
- Add a message to be shown when password strength is weak, but the checker does not provide a warning.
- Display `password-strength-bar` with the `warning` color (orange) when validation passes, but the password is mediocre.

## Side Effects

`N/A`

## Feature Flags

`N/A`

## QA Notes

This should fix the double validation messages on the `password-strength-bar`.  Please make sure that it works when editing the `new password` field as well as when editing the `existing password` field.

This also add a validation message to be displayed when the password is too weak, but the strength checker does not provide a particular reason. Additionally, when the password strength is high enough to pass validation, but the strength checker provides a warning that the password is not of high strength, the message will be shown in orange (instead of red) to match the password strength bar and not make it look like there is a validation error.

## Ticket

https://openscience.atlassian.net/browse/ENG-448
https://openscience.atlassian.net/browse/ENG-447

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
