### PR TITLE
[ENG-470] create meetings index route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Routes:
+    - `meetings` - parent route for meetings
+        - `meetings.index` - meetings landing page
 - Components:
     - `get-started-button` - a button that takes you to the '/register' page.
     - `search-bar` - a search bar component that takes you to the search page.
@@ -13,10 +16,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Tests:
     - Acceptance:
         - `new-home`
+        - `meetings/index`
     - Integration:
         - `get-started-button`
         - `search-bar`
         - `hero-banner`
+
+### Changed
+- Components:
+    - `osf-navbar` - detect active OSF service for any non-engine service
 
 ## [19.4.0] - 2019-04-25
 ### Added

--- a/app/meetings/index/route.ts
+++ b/app/meetings/index/route.ts
@@ -1,0 +1,14 @@
+import { action } from '@ember-decorators/object';
+import { service } from '@ember-decorators/service';
+import Route from '@ember/routing/route';
+
+import Analytics from 'ember-osf-web/services/analytics';
+
+export default class MeetingsIndex extends Route {
+    @service analytics!: Analytics;
+
+    @action
+    didTransition() {
+        this.analytics.trackPage();
+    }
+}

--- a/app/meetings/template.hbs
+++ b/app/meetings/template.hbs
@@ -1,0 +1,3 @@
+<div data-analytics-scope='Meetings'>
+    {{outlet}}
+</div>

--- a/app/router.ts
+++ b/app/router.ts
@@ -120,6 +120,9 @@ Router.map(function() {
         });
     });
     this.route('support');
+    this.route('meetings', function() {
+        this.route('index', { path: '/' }); // Note: this can be removed once another child route exists
+    });
 
     if (collections.enabled) {
         this.mount('collections');

--- a/config/environment.js
+++ b/config/environment.js
@@ -253,6 +253,7 @@ module.exports = function(environment) {
                 'registries.overview.contributors': 'ember_registries_detail_page',
                 'registries.overview.children': 'ember_registries_detail_page',
                 'registries.overview.links': 'ember_registries_detail_page',
+                'meetings.index': 'ember_meetings_page',
             },
             navigation: {
                 institutions: 'institutions_nav_bar',

--- a/lib/osf-components/addon/components/osf-navbar/component.ts
+++ b/lib/osf-components/addon/components/osf-navbar/component.ts
@@ -51,9 +51,18 @@ export default class OsfNavbar extends Component {
     get _activeService() {
         let { activeService } = this;
 
-        // HACK/Special case until institutions are put into an engine
-        if (activeService === OSFService.HOME && this.router.currentRouteName === 'institutions') {
-            activeService = OSFService.INSTITUTIONS;
+        const { currentRouteName } = this.router;
+        if (activeService === OSFService.HOME && currentRouteName) {
+            for (const osfService of OSF_SERVICES) {
+                if (!osfService.route) {
+                    continue;
+                }
+                const routeRegExp = new RegExp(`^${osfService.route}($|\\.)`);
+                if (routeRegExp.test(currentRouteName)) {
+                    activeService = osfService.name as OSFService;
+                    break;
+                }
+            }
         }
 
         return this.services.find(x => x.name === activeService);

--- a/lib/osf-components/addon/components/osf-navbar/component.ts
+++ b/lib/osf-components/addon/components/osf-navbar/component.ts
@@ -31,7 +31,7 @@ export const OSF_SERVICES: ServiceLink[] = [
     { name: OSFService.HOME, route: 'home' },
     { name: OSFService.PREPRINTS, href: `${osfURL}preprints/` },
     { name: OSFService.REGISTRIES, route: 'registries' },
-    { name: OSFService.MEETINGS, href: `${osfURL}meetings/` },
+    { name: OSFService.MEETINGS, route: 'meetings' },
     { name: OSFService.INSTITUTIONS, route: 'institutions' },
 ];
 

--- a/tests/acceptance/meetings/index-test.ts
+++ b/tests/acceptance/meetings/index-test.ts
@@ -1,0 +1,17 @@
+import { currentURL, visit } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { percySnapshot } from 'ember-percy';
+import { module, test } from 'qunit';
+
+import { setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
+
+module('Acceptance | meetings | index', hooks => {
+    setupOSFApplicationTest(hooks);
+    setupMirage(hooks);
+
+    test('meetings index exists', async assert => {
+        await visit('/meetings');
+        assert.equal(currentURL(), '/meetings', "Still at '/meetings'.");
+        await percySnapshot(assert);
+    });
+});


### PR DESCRIPTION
## Purpose

Create meetings index route.

## Summary of Changes

### Added
- Routes:
    - `meetings` - parent route for meetings
        - `meetings.index` - meetings landing page
- Tests:
    - Acceptance:
        - `meetings/index`

### Changed
- Components:
    - `osf-navbar` - detect active OSF service for any non-engine service

## Side Effects

Shouldn’t be any.

## Feature Flags

`ember_meetings_page`

## QA Notes

n/a

## Ticket

https://openscience.atlassian.net/browse/ENG-470

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
