### PR TITLE
Initialize all feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `get-started-button` - a button that takes you to the '/register' page.
     - `search-bar` - a search bar component that takes you to the search page.
     - `new-home/-components/hero-banner` - a banner to be used on the logged-out homepage.
+- Utilities:
+    - `leaf-vals` - get values of all leaves in an object tree
 - Tests:
     - Acceptance:
         - `new-home`
@@ -21,10 +23,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         - `get-started-button`
         - `search-bar`
         - `hero-banner`
+    - Unit:
+        - `leaf-vals` utility
 
 ### Changed
 - Components:
     - `osf-navbar` - detect active OSF service for any non-engine service
+- Authenticators:
+    - `osf-cookie` - initialize any disabled feature flags found in config
 
 ## [19.4.0] - 2019-04-25
 ### Added

--- a/app/utils/leaf-vals.ts
+++ b/app/utils/leaf-vals.ts
@@ -1,0 +1,9 @@
+/*
+ * Get values of all leaves in an object tree.
+ */
+export default function leafVals(obj: object): any[] {
+    return Object.values(obj).reduce(
+        (acc: any[], val: any) => acc.concat(typeof val === 'object' ? leafVals(val) : val),
+        [],
+    );
+}

--- a/tests/unit/utils/leaf-vals-test.ts
+++ b/tests/unit/utils/leaf-vals-test.ts
@@ -1,0 +1,78 @@
+import { module, test } from 'qunit';
+
+import leafVals from 'ember-osf-web/utils/leaf-vals';
+
+const TEST_CASES = [{
+    name: 'empty object',
+    input: {},
+    output: [],
+}, {
+    name: 'simple object with single value',
+    input: {
+        foo: 'bar',
+    },
+    output: ['bar'],
+}, {
+    name: 'simple object with multiple values',
+    input: {
+        foo: 'bar',
+        baz: 'qux',
+    },
+    output: ['bar', 'qux'],
+}, {
+    name: 'one-level object',
+    input: {
+        foo: {
+            a: 'bar',
+            b: 'baz',
+        },
+    },
+    output: ['bar', 'baz'],
+}, {
+    name: 'multiple one-level objects',
+    input: {
+        foo: {
+            a: 'bar',
+            b: 'baz',
+        },
+        qux: {
+            a: 'corge',
+            b: 'grault',
+        },
+    },
+    output: ['bar', 'baz', 'corge', 'grault'],
+}, {
+    name: 'mixed simple and one-level object',
+    input: {
+        foo: {
+            a: 'bar',
+            b: 'baz',
+        },
+        qux: 'corge',
+    },
+    output: ['bar', 'baz', 'corge'],
+}, {
+    name: 'mixed simple, one, and multi-level objects',
+    input: {
+        foo: {
+            a: 'bar',
+            b: {
+                c: 'baz',
+            },
+        },
+        qux: {
+            a: 'corge',
+            b: 'grault',
+        },
+        garply: 'waldo',
+    },
+    output: ['bar', 'baz', 'corge', 'grault', 'waldo'],
+}];
+
+module('Unit | Utility | leafvals', () => {
+    test('leafVals returns all values for leaves in an object tree', assert => {
+        for (const testCase of TEST_CASES) {
+            assert.deepEqual(leafVals(testCase.input), testCase.output, `Test case: ${testCase.name}`);
+        }
+    });
+});


### PR DESCRIPTION
## Purpose

The API only lists enabled feature flags and thus disabled flags are not initialized in `ember-feature-flags`. Initializing disabled feature flags found in config makes them available in the dev banner features tab so that they can be enabled from here for testing.

## Summary of Changes

### Added
- Utilities:
    - `leaf-vals` - get values of all leaves in an object tree
- Tests:
    - Unit:
        - `leaf-vals` utility

### Changed
- Authenticators:
    - `osf-cookie` - initialize any disabled feature flags found in config

## Side Effects

None expected

## Feature Flags

It initializes them.

## QA Notes

No QA needed, but this will make some things easier to test.

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
