### PR TITLE
[ENG-473] meetings landing page meeting list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Models:
+    - `meeting` - for OSF Meetings
+- Adapters:
+    - `meeting` - in private namespace
+- Serializers:
+    - `meeting`
 - Routes:
     - `meetings` - parent route for meetings
         - `meetings.index` - meetings landing page
@@ -13,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `get-started-button` - a button that takes you to the '/register' page.
     - `search-bar` - a search bar component that takes you to the search page.
     - `new-home/-components/hero-banner` - a banner to be used on the logged-out homepage.
+    - `meetings/index/components/meetings-list` - meetings list for the meetings index page
+    - `paginated-list/x-header` - a paginated list header closure component
 - Utilities:
     - `leaf-vals` - get values of all leaves in an object tree
 - Tests:
@@ -23,12 +31,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         - `get-started-button`
         - `search-bar`
         - `hero-banner`
+        - `meetings-list`
     - Unit:
         - `leaf-vals` utility
+- Mirage:
+    - `meeting` factory
+    - private `meetings` endpoint
+    - meetings scenario
 
 ### Changed
 - Components:
     - `osf-navbar` - detect active OSF service for any non-engine service
+    - `paginated-list`
+        - add ability to provide a header row
+        - add splattributes to item
 - Authenticators:
     - `osf-cookie` - initialize any disabled feature flags found in config
 

--- a/app/adapters/meeting.ts
+++ b/app/adapters/meeting.ts
@@ -1,0 +1,11 @@
+import OsfAdapter from './osf-adapter';
+
+export default class MeetingAdapter extends OsfAdapter {
+    namespace = '_';
+}
+
+declare module 'ember-data/types/registries/adapter' {
+    export default interface AdapterRegistry {
+        meeting: MeetingAdapter;
+    } // eslint-disable-line semi
+}

--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -1223,6 +1223,18 @@ export default {
             fork_registration: 'Fork this registration',
         },
     },
+    meetings: {
+        index: {
+            'meetings-list': {
+                min_5_submissions: 'Only conferences with at least five submissions are displayed.',
+                name: 'Name',
+                submissions: 'Submissions',
+                location: 'Location',
+                date: 'Date',
+                empty: 'No results found for this search term.',
+            },
+        },
+    },
     analytics: {
         pageTitle: '{{nodeTitle}} Analytics',
         forks: 'Forks',

--- a/app/meetings/index/-components/meetings-list/component.ts
+++ b/app/meetings/index/-components/meetings-list/component.ts
@@ -1,0 +1,30 @@
+import { action, computed } from '@ember-decorators/object';
+import Component from '@ember/component';
+import { task, timeout } from 'ember-concurrency';
+
+export default class MeetingsList extends Component.extend({
+    searchMeetings: task(function *(this: MeetingsList, search: string) {
+        yield timeout(500); // debounce
+        this.set('search', search);
+    }).restartable(),
+}) {
+    search?: string;
+    sort?: string;
+
+    @computed('search', 'sort')
+    get query() {
+        const query = {} as Record<string, string>;
+        if (this.search) {
+            query['filter[name]'] = this.search;
+        }
+        if (this.sort) {
+            query.sort = this.sort;
+        }
+        return query;
+    }
+
+    @action
+    sortMeetings(sort: string) {
+        this.set('sort', sort);
+    }
+}

--- a/app/meetings/index/-components/meetings-list/styles.scss
+++ b/app/meetings/index/-components/meetings-list/styles.scss
@@ -1,0 +1,85 @@
+.min_5_submissions {
+    font-size: 85%;
+}
+
+.table {
+    ul {
+        display: table;
+        width: 100%;
+        border: 1px solid #eee;
+        margin: 0;
+        margin-bottom: 15px;
+    }
+
+    li {
+        display: table-row;
+
+        & > div {
+            display: table-cell;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+    }
+}
+
+.search {
+    display: inline-block;
+    width: 100%;
+    background: #efefef;
+    margin: 0 0 10px;
+    padding: 7px;
+
+    input {
+        float: right;
+        width: 100%;
+        padding: 6px 12px;
+        border: 1px solid #ccc;
+
+        &:focus {
+            border-color: #66afe9;
+            outline: 0;
+            box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+        }
+    }
+}
+
+.header > div {
+    padding: 3px 0 7px 5px;
+    font-weight: 700;
+    background: #f5f5f5;
+    border-left: 1px solid #ddd;
+
+    &:first-of-type {
+        border-left: 0;
+    }
+}
+
+.sort-button {
+    display: inline;
+    padding-left: 4px;
+
+    button,
+    button:active,
+    button:focus,
+    button:focus:active,
+    button:hover {
+        padding-top: 0;
+        height: 1em;
+        margin-top: -10px;
+    }
+}
+
+.item > div {
+    padding: 2px 0 4px 5px;
+    border-top: 1px solid #f5f5f5;
+
+    :global(.ember-content-placeholders-text__line) {
+        margin: 2px 0 3px 1px;
+        height: 1em;
+    }
+}
+
+.empty {
+    text-align: center;
+}

--- a/app/meetings/index/-components/meetings-list/template.hbs
+++ b/app/meetings/index/-components/meetings-list/template.hbs
@@ -1,0 +1,66 @@
+<p data-test-meetings-list-min-5 local-class='min_5_submissions'>
+    {{t 'meetings.index.meetings-list.min_5_submissions'}}
+</p>
+
+<div data-test-meetings-list-search local-class='search'>
+    <div class='col-xs-12 col-sm-6 col-sm-offset-6'>
+        {{input
+            type='text'
+            placeholder='Search'
+            key-up=(perform this.searchMeetings)
+        }}
+    </div>
+</div>
+
+<ContentPlaceholders as |placeholder|>
+    <PaginatedList::All
+        data-test-meetings-list-list
+        local-class='table'
+        @modelName='meeting'
+        @query={{this.query}}
+        as |list|
+    >
+        <list.header data-test-meetings-index- local-class='header'>
+            {{#let (component 'sort-button'
+                class=(local-class 'sort-button')
+                sortAction=(action this.sortMeetings)
+                sort=this.sort
+            ) as |SortButton|}}
+                <div data-test-meetings-list-header-name style='width: 45%'>
+                    {{t 'meetings.index.meetings-list.name'}}
+                    <SortButton @sortBy='name' />
+                </div>
+                <div data-test-meetings-list-header-submissions style='width: 15%'>
+                    {{t 'meetings.index.meetings-list.submissions'}}
+                    <SortButton @sortBy='submissions_count' />
+                </div>
+                <div data-test-meetings-list-header-location style='width: 20%'>
+                    {{t 'meetings.index.meetings-list.location'}}
+                    <SortButton @sortBy='location' />
+                </div>
+                <div data-test-meetings-list-header-date style='width: 20%'>
+                    {{t 'meetings.index.meetings-list.date'}}
+                    <SortButton @sortBy='start_date' />
+                </div>
+            {{/let}}
+        </list.header>
+        <list.item local-class='item' as |meeting|>
+            {{#if meeting}}
+                <div data-test-meetings-list-item-name>{{meeting.name}}</div>
+                <div data-test-meetings-list-item-submissions>{{meeting.submissionsCount}}</div>
+                <div data-test-meetings-list-item-location>{{meeting.location}}</div>
+                <div data-test-meetings-list-item-date>
+                    {{moment-format meeting.startDate 'MMM DD, YYYY'}} - {{moment-format meeting.endDate 'MMM DD, YYYY'}}
+                </div>
+            {{else}}
+                <div data-test-meetings-list-placeholder-name>{{placeholder.text lines=1}}</div>
+                <div data-test-meetings-list-placeholder-submissions>{{placeholder.text lines=1}}</div>
+                <div data-test-meetings-list-placeholder-location>{{placeholder.text lines=1}}</div>
+                <div data-test-meetings-list-placeholder-date>{{placeholder.text lines=1}}</div>
+            {{/if}}
+        </list.item>
+        <list.empty data-tests-meetings-list-empty local-class='empty'>
+            {{t 'meetings.index.meetings-list.empty'}}
+        </list.empty>
+    </PaginatedList::All>
+</ContentPlaceholders>

--- a/app/meetings/index/template.hbs
+++ b/app/meetings/index/template.hbs
@@ -1,0 +1,7 @@
+<div class='container'>
+    <div class='row m-v-lg'>
+        <div class='col-md-12'>
+            <Meetings::Index::-Components::MeetingsList />
+        </div>
+    </div>
+</div>

--- a/app/models/meeting.ts
+++ b/app/models/meeting.ts
@@ -1,0 +1,38 @@
+import { attr } from '@ember-decorators/data';
+
+import OsfModel from './osf-model';
+
+export interface FieldNames {
+    /* eslint-disable camelcase */
+    mail_message_body: string;
+    add_submission: string;
+    submission1_plural: string;
+    meeting_title_type: string;
+    mail_subject: string;
+    submission2_plural: string;
+    mail_attachment: string;
+    submission2: string;
+    submission1: string;
+    homepage_link_text: string;
+    /* eslint-enable camelcase */
+}
+
+export default class MeetingModel extends OsfModel {
+    @attr('fixstring') name!: string;
+    @attr('number') submissionsCount!: number;
+    @attr('fixstring') location!: string;
+    @attr('date') startDate!: Date;
+    @attr('date') endDate!: Date;
+    @attr('fixstring') infoUrl!: string;
+    @attr('fixstring') submission1Email!: string;
+    @attr('fixstring') submission2Email!: string;
+    @attr('boolean') active!: boolean;
+    @attr('fixstring') logoUrl!: string;
+    @attr('object') fieldNames!: object;
+}
+
+declare module 'ember-data/types/registries/model' {
+    export default interface ModelRegistry {
+        meeting: MeetingModel;
+    } // eslint-disable-line semi
+}

--- a/app/serializers/meeting.ts
+++ b/app/serializers/meeting.ts
@@ -1,0 +1,10 @@
+import OsfSerializer from './osf-serializer';
+
+export default class MeetingSerializer extends OsfSerializer {
+}
+
+declare module 'ember-data/types/registries/serializer' {
+    export default interface SerializerRegistry {
+        meeting: MeetingSerializer;
+    } // eslint-disable-line semi
+}

--- a/lib/osf-components/addon/components/paginated-list/layout/template.hbs
+++ b/lib/osf-components/addon/components/paginated-list/layout/template.hbs
@@ -1,20 +1,17 @@
-{{#if this.loading}}
-    {{#if this.placeholderCount}}
-        <ul class='list-group m-md'>
+<ul class='list-group m-md'>
+    {{yield (hash
+        header=(component 'paginated-list/x-header')
+    )}}
+    {{#if this.loading}}
+        {{#if this.placeholderCount}}
             {{#each (range 1 this.placeholderCount)}}
                 {{yield (hash
                     item=(component 'paginated-list/x-item')
                     doReload=(action @doReload)
                 )}}
             {{/each}}
-        </ul>
-    {{else}}
-        {{loading-indicator dark=true}}
-    {{/if}}
-{{else if this.errorShown}}
-    <p>{{t 'osf-components.paginated-list.error'}}</p>
-{{else if @items.length}}
-    <ul class='list-group m-md'>
+        {{/if}}
+    {{else if @items.length}}
         {{#each @items as |item index|}}
             {{#unless item.isDeleted}}
                 {{yield (hash
@@ -23,8 +20,16 @@
                 )}}
             {{/unless}}
         {{/each}}
-    </ul>
-{{else}}
+    {{/if}}
+</ul>
+
+{{#if this.loading}}
+    {{#if (not this.placeholderCount)}}
+        {{loading-indicator dark=true}}
+    {{/if}}
+{{else if this.errorShown}}
+    <p>{{t 'osf-components.paginated-list.error'}}</p>
+{{else if (not @items.length)}}
     {{yield (hash
         empty=(component 'paginated-list/x-render')
         doReload=(action @doReload)

--- a/lib/osf-components/addon/components/paginated-list/x-header/component.ts
+++ b/lib/osf-components/addon/components/paginated-list/x-header/component.ts
@@ -1,0 +1,11 @@
+import { tagName } from '@ember-decorators/component';
+import Component from '@ember/component';
+
+import { layout } from 'ember-osf-web/decorators/component';
+
+import template from './template';
+
+@layout(template)
+@tagName('') // No wrapping div
+export default class PaginatedListXHeader extends Component {
+}

--- a/lib/osf-components/addon/components/paginated-list/x-header/template.hbs
+++ b/lib/osf-components/addon/components/paginated-list/x-header/template.hbs
@@ -1,0 +1,3 @@
+<li ...attributes>
+    {{yield}}
+</li>

--- a/lib/osf-components/addon/components/paginated-list/x-item/template.hbs
+++ b/lib/osf-components/addon/components/paginated-list/x-item/template.hbs
@@ -1,3 +1,3 @@
-<li class='list-group-item'>
+<li class='list-group-item' ...attributes>
     {{yield @item @index}}
 </li>

--- a/lib/osf-components/app/components/paginated-list/x-header/component.js
+++ b/lib/osf-components/app/components/paginated-list/x-header/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/paginated-list/x-header/component';

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -146,4 +146,6 @@ export default function(this: Server) {
             id: '',
         },
     }));
+
+    osfResource(this, 'meeting', { only: ['index'] });
 }

--- a/mirage/factories/meeting.ts
+++ b/mirage/factories/meeting.ts
@@ -1,0 +1,40 @@
+import { capitalize } from '@ember/string';
+import { Factory, faker } from 'ember-cli-mirage';
+
+import Meeting from 'ember-osf-web/models/meeting';
+
+export default Factory.extend<Meeting>({
+    name() {
+        return faker.random.arrayElement([
+            faker.company.bs,
+            faker.company.catchPhrase,
+        ])().split(' ').map(word => capitalize(word)).join(' ');
+    },
+    submissionsCount() {
+        return faker.random.number({ min: 5, max: 500 });
+    },
+    location() {
+        return faker.random.arrayElement([
+            `${faker.address.city()}, ${faker.address.stateAbbr()}, USA`,
+            `${faker.address.city()}, ${faker.address.country()}`,
+        ]);
+    },
+    startDate() {
+        return faker.date.past(5, new Date(2020, 0, 0));
+    },
+    endDate() {
+        return faker.date.past(5, new Date(2020, 0, 0));
+    },
+});
+
+declare module 'ember-cli-mirage/types/registries/model' {
+    export default interface MirageModelRegistry {
+        meeting: Meeting;
+    } // eslint-disable-line semi
+}
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        meetings: Meeting;
+    } // eslint-disable-line semi
+}

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -145,6 +145,10 @@ function settingsScenario(server: Server, currentUser: ModelInstance<User>) {
     server.createList('developer-app', 12);
 }
 
+function meetingsScenario(server: Server) {
+    server.createList('meeting', 25);
+}
+
 export default function(server: Server) {
     server.loadFixtures('registration-schemas');
     server.loadFixtures('regions');
@@ -176,6 +180,9 @@ export default function(server: Server) {
     }
     if (mirageScenarios.includes('quickfiles')) {
         quickfilesScenario(server, currentUser);
+    }
+    if (mirageScenarios.includes('meetings')) {
+        meetingsScenario(server);
     }
     if (handbookEnabled) {
         handbookScenario(server, currentUser);

--- a/tests/integration/components/paginated-list/x-header/component-test.ts
+++ b/tests/integration/components/paginated-list/x-header/component-test.ts
@@ -1,0 +1,22 @@
+import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+
+module('Integration | Component | paginated-list/x-header', hooks => {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function(assert) {
+        await render(hbs`<PaginatedList::XItem />`);
+
+        assert.dom(this.element).hasText('');
+
+        await render(hbs`
+            <PaginatedList::XItem>
+                template block text
+            </PaginatedList::XItem>
+        `);
+
+        assert.dom(this.element).hasText('template block text');
+    });
+});

--- a/tests/integration/routes/meetings/index/-components/meetings-list/component-test.ts
+++ b/tests/integration/routes/meetings/index/-components/meetings-list/component-test.ts
@@ -1,0 +1,123 @@
+import { click, render } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+
+module('Integration | routes | meetings | index | -components | meetings-list', hooks => {
+    setupRenderingTest(hooks);
+    setupMirage(hooks);
+
+    test('it renders and paginates', async assert => {
+        server.createList('meeting', 11);
+
+        await render(hbs`<Meetings::Index::-Components::MeetingsList />`);
+
+        assert.dom('[data-test-meetings-list-header-name]')
+            .exists({ count: 1 }, '1 name header');
+        assert.dom('[data-test-meetings-list-header-submissions]')
+            .exists({ count: 1 }, '1 submissions header');
+        assert.dom('[data-test-meetings-list-header-location]')
+            .exists({ count: 1 }, '1 location header');
+        assert.dom('[data-test-meetings-list-header-date]')
+            .exists({ count: 1 }, '1 date header');
+
+        assert.dom('[data-test-meetings-list-item-name]')
+            .exists({ count: 10 }, '10 meetings in the list with a name');
+        assert.dom('[data-test-meetings-list-item-submissions]')
+            .exists({ count: 10 }, '10 meetings in the list with submissions');
+        assert.dom('[data-test-meetings-list-item-location]')
+            .exists({ count: 10 }, '10 meetings in the list with a location');
+        assert.dom('[data-test-meetings-list-item-date]')
+            .exists({ count: 10 }, '10 meetings in the list with dates');
+
+        await click('[data-test-next-page-button]');
+
+        assert.dom('[data-test-meetings-list-item-name]')
+            .exists({ count: 1 }, '1 meeting in the list with a name');
+        assert.dom('[data-test-meetings-list-item-submissions]')
+            .exists({ count: 1 }, '1 meeting in the list with submissions');
+        assert.dom('[data-test-meetings-list-item-location]')
+            .exists({ count: 1 }, '1 meeting in the list with a location');
+        assert.dom('[data-test-meetings-list-item-date]')
+            .exists({ count: 1 }, '1 meeting in the list with dates');
+    });
+
+    test('it searches', async function(assert) {
+        server.create('meeting', { name: 'Meeting A' });
+        server.create('meeting', { name: 'Meeting B' });
+        server.create('meeting', { name: 'Meeting C' });
+
+        this.set('search', 'Meeting B');
+        await render(hbs`<Meetings::Index::-Components::MeetingsList @search={{this.search}} />`);
+
+        assert.dom('[data-test-meetings-list-item-name]')
+            .exists({ count: 1 }, '1 meeting');
+        assert.dom('[data-test-meetings-list-item-name]')
+            .hasText('Meeting B', 'Meeting name matches search term');
+    });
+
+    test('it sorts', async assert => {
+        server.create('meeting', {
+            name: 'Meeting B',
+            submissionsCount: 9,
+            location: 'Place C',
+            startDate: new Date('2003-01-02'),
+        });
+        server.create('meeting', {
+            name: 'Meeting C',
+            submissionsCount: 8,
+            location: 'Place D',
+            startDate: new Date('2001-01-02'),
+        });
+        server.create('meeting', {
+            name: 'Meeting D',
+            submissionsCount: 7,
+            location: 'Place A',
+            startDate: new Date('2000-01-02'),
+        });
+        server.create('meeting', {
+            name: 'Meeting A',
+            submissionsCount: 6,
+            location: 'Place B',
+            startDate: new Date('2002-01-02'),
+        });
+
+        await render(hbs`<Meetings::Index::-Components::MeetingsList />`);
+
+        assert.dom('[data-test-meetings-list-item-name]')
+            .exists({ count: 4 }, '4 meetings');
+
+        await click('[data-test-ascending-sort="name"]');
+        assert.dom('[data-test-meetings-list-item-name]')
+            .hasText('Meeting A', 'Sorts by name ascending');
+
+        await click('[data-test-descending-sort="name"]');
+        assert.dom('[data-test-meetings-list-item-name]')
+            .hasText('Meeting D', 'Sorts by name descending');
+
+        await click('[data-test-ascending-sort="submissions_count"]');
+        assert.dom('[data-test-meetings-list-item-submissions]')
+            .hasText('6', 'Sorts by submissions ascendening');
+
+        await click('[data-test-descending-sort="submissions_count"]');
+        assert.dom('[data-test-meetings-list-item-submissions]')
+            .hasText('9', 'Sorts by submissions descendening');
+
+        await click('[data-test-ascending-sort="location"]');
+        assert.dom('[data-test-meetings-list-item-location]')
+            .hasText('Place A', 'Sorts by location ascendening');
+
+        await click('[data-test-descending-sort="location"]');
+        assert.dom('[data-test-meetings-list-item-location]')
+            .hasText('Place D', 'Sorts by location descendening');
+
+        await click('[data-test-ascending-sort="start_date"]');
+        assert.dom('[data-test-meetings-list-item-date]')
+            .containsText('2000 -', 'Sorts by date ascendening');
+
+        await click('[data-test-descending-sort="start_date"]');
+        assert.dom('[data-test-meetings-list-item-date]')
+            .containsText('2003 -', 'Sorts by date descendening');
+    });
+});

--- a/tests/unit/models/meeting-test.ts
+++ b/tests/unit/models/meeting-test.ts
@@ -1,0 +1,12 @@
+import { run } from '@ember/runloop';
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Model | meeting', hooks => {
+    setupTest(hooks);
+
+    test('it exists', function(assert) {
+        const model = run(() => this.owner.lookup('service:store').createRecord('meeting'));
+        assert.ok(!!model);
+    });
+});


### PR DESCRIPTION
## Purpose

Add the meetings list to the meetings index page.

## Summary of Changes

### Added
- Models:
    - `meeting` - for OSF Meetings
- Adapters:
    - `meeting` - in private namespace
- Serializers:
    - `meeting`
- Components:
    - `meetings/index/components/meetings-list` - meetings list for the meetings index page
- Tests:
    - Integration:
        - `meetings-list
- Mirage:
    - `meeting` factory
    - private `meetings` endpoint
    - meetings scenario

### Changed
 - Components:
     - `osf-navbar` - detect active OSF service for any non-engine service
    - `paginated-list`
    - add ability to provide a header row
    - add splattributes to item

## Side Effects

None expected.

## Feature Flags

`ember_meetings_page`

## QA Notes

Should behave as expected. Search is debounced to avoid an API hit for each letter hit.

## Ticket

https://openscience.atlassian.net/browse/ENG-473

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
