### PR TITLE
[ENG-473] add meetings mirage scenario to default

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -34,6 +34,7 @@ const {
         'loggedIn',
         'dashboard',
         'settings',
+        'meetings',
     ],
     OAUTH_SCOPES: scope,
     OSF_STATUS_COOKIE: statusCookie = 'osf_status',


### PR DESCRIPTION
## Purpose

Add the meetings scenario to the default list of enabled mirage scenarios for testing.

## Summary of Changes

Add the meetings scenario to the default list of enabled mirage scenarios for testing.

## Side Effects

None.

## Feature Flags

n/a

## QA Notes

This will enable testing of the meetings list at: https://centerforopenscience.github.io/ember-osf-web/meetings

## Ticket

https://openscience.atlassian.net/browse/ENG-473

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~ *(minor default config change)*
- [ ] ~~changes described in `CHANGELOG.md`~~ *(minor default config change)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
