### PR TITLE
[ENG 473] fix paginated list

### DIFF
--- a/app/settings/account/-components/connected-emails/template.hbs
+++ b/app/settings/account/-components/connected-emails/template.hbs
@@ -1,224 +1,220 @@
-{{#let (component 'paginated-list/has-many') as |HasManyList|}}
-    <Panel
-        data-analytics-scope='Connected emails panel'
-        as |panel|
-    >
-        <panel.heading @title={{t 'settings.account.connected_emails.title'}} />
-        <panel.body>
-            <div local-class='section-container'>
-                <h5 local-class='section-header'>
-                    {{t 'settings.account.connected_emails.primary_email'}}
-                </h5>
-                <div local-class='primary-email'>
-                    {{#if this.loadPrimaryEmail.isRunning}}
-                        <LoadingIndicator local-class='loading-icon' @dark=true @inline=true />
-                    {{else}}
-                        <span data-test-primary-email={{this.loadPrimaryEmail.lastSuccessful.value.emailAddress}}>
-                            {{this.loadPrimaryEmail.lastSuccessful.value.emailAddress}}
-                        </span>
-                    {{/if}}
-                </div>
+<Panel
+    data-analytics-scope='Connected emails panel'
+    as |panel|
+>
+    <panel.heading @title={{t 'settings.account.connected_emails.title'}} />
+    <panel.body>
+        <div local-class='section-container'>
+            <h5 local-class='section-header'>
+                {{t 'settings.account.connected_emails.primary_email'}}
+            </h5>
+            <div local-class='primary-email'>
+                {{#if this.loadPrimaryEmail.isRunning}}
+                    <LoadingIndicator local-class='loading-icon' @dark=true @inline=true />
+                {{else}}
+                    <span data-test-primary-email={{this.loadPrimaryEmail.lastSuccessful.value.emailAddress}}>
+                        {{this.loadPrimaryEmail.lastSuccessful.value.emailAddress}}
+                    </span>
+                {{/if}}
             </div>
-            <div local-class='section-container'>
-                <h5 local-class='section-header'>
-                    {{t 'settings.account.connected_emails.alternate_emails'}}
-                </h5>
-                <span local-class='email-section'>
-                    <HasManyList
-                        local-class='email-list'
-                        @model={{this.currentUser.user}}
-                        @relationshipName='emails'
-                        @bindReload={{action (mut this.reloadAlternateList)}}
-                        @query={{this.alternateQueryParams}}
-                        @usePlaceholders={{false}}
-                        @analyticsScope='Account Settings - Alternate Emails'
-                        as |list|
-                    >
-                        {{#if list.item}}
-                            <list.item as |email|>
-                                <div local-class='email-object' class='clearfix'>
-                                    {{#if (not email)}}
-                                        <ContentPlaceholders as |placeholder|>
-                                            <placeholder.heading @subtitle={{false}} />
-                                        </ContentPlaceholders>
-                                    {{else}}
-                                        <span data-test-alternate-email-item='{{email.emailAddress}}'>
-                                            {{email.emailAddress}}
-                                            <div local-class='options'>
+        </div>
+        <div local-class='section-container'>
+            <h5 local-class='section-header'>
+                {{t 'settings.account.connected_emails.alternate_emails'}}
+            </h5>
+            <span local-class='email-section'>
+                <PaginatedList::HasMany
+                    local-class='email-list'
+                    @model={{this.currentUser.user}}
+                    @relationshipName='emails'
+                    @bindReload={{action (mut this.reloadAlternateList)}}
+                    @query={{this.alternateQueryParams}}
+                    @usePlaceholders={{false}}
+                    @analyticsScope='Account Settings - Alternate Emails'
+                    as |list|
+                >
+                    <list.item as |email|>
+                        <div local-class='email-object' class='clearfix'>
+                            {{#if (not email)}}
+                                <ContentPlaceholders as |placeholder|>
+                                    <placeholder.heading @subtitle={{false}} />
+                                </ContentPlaceholders>
+                            {{else}}
+                                <span data-test-alternate-email-item='{{email.emailAddress}}'>
+                                    {{email.emailAddress}}
+                                    <div local-class='options'>
+                                        <BsButton
+                                            data-test-make-primary
+                                            data-analytics-name='Make primary'
+                                            @onClick={{action this.makePrimary email}}
+                                        >
+                                            {{t 'settings.account.connected_emails.make_primary'}}
+                                        </BsButton>
+                                        <DeleteButton
+                                            data-test-alternate-delete
+                                            @small=true
+                                            @delete={{action this.removeEmail email}}
+                                            @analyticsScope='Settings - Alternate Emails'
+                                            @modalTitle={{t 'settings.account.connected_emails.confirm_delete.title'}}
+                                            @modalBody={{t 'settings.account.connected_emails.confirm_delete.body' emailAddress=email.emailAddress}}
+                                        />
+                                    </div>
+                                </span>
+                            {{/if}}
+                        </div>
+                    </list.item>
+                    <list.empty>
+                        <div local-class='no-object-message' class='clearfix'>
+                            {{t 'settings.account.connected_emails.no_alternate_emails'}}
+                        </div>
+                    </list.empty>
+                </PaginatedList::HasMany>
+            </span>
+        </div>
+        <div local-class='section-container'>
+            <h5 local-class='section-header'>
+                {{t 'settings.account.connected_emails.unconfirmed_emails'}}
+            </h5>
+            <span local-class='email-section'>
+                <PaginatedList::HasMany
+                    local-class='email-list'
+                    @model={{this.currentUser.user}}
+                    @relationshipName='emails'
+                    @bindReload={{action (mut this.reloadUnconfirmedList)}}
+                    @query={{this.unconfirmedQueryParams}}
+                    @usePlaceholders={{false}}
+                    @analyticsScope='Account Settings - Unconfirmed Emails'
+                    as |list|
+                >
+                    <list.item as |email|>
+                        <div local-class='email-object' class='clearfix'>
+                            {{#if (not email)}}
+                                <ContentPlaceholders as |placeholder|>
+                                    <placeholder.heading @subtitle={{false}} />
+                                </ContentPlaceholders>
+                            {{else}}
+                                <span data-test-unconfirmed-email-item={{email.emailAddress}}>
+                                    {{email.emailAddress}}
+                                    <div local-class='options'>
+                                        <BsButton
+                                            data-test-resend-confirmation-button
+                                            data-analytics-name='Resend confirmation'
+                                            @onClick={{action this.toggleMergeModal}}
+                                        >
+                                            {{t 'settings.account.connected_emails.resend_confirmation'}}
+                                        </BsButton>
+                                        <BsModal
+                                            @open={{this.showMergeModal}}
+                                            @tagName='span'
+                                            @onHide={{action this.toggleMergeModal}}
+                                            as |modal|
+                                        >
+                                            <modal.header>
+                                                <h3 class='modal-title'>
+                                                    {{t 'settings.account.connected_emails.resend_confirmation_modal.title'}}
+                                                </h3>
+                                            </modal.header>
+
+                                            <modal.body>
+                                                <p>
+                                                    {{t 'settings.account.connected_emails.resend_confirmation_modal.body' emailAddress=email.emailAddress}}
+                                                </p>
+                                            </modal.body>
+
+                                            <modal.footer
+                                                data-analytics-scope='Merge modal'
+                                            >
                                                 <BsButton
-                                                    data-test-make-primary
-                                                    data-analytics-name='Make primary'
-                                                    @onClick={{action this.makePrimary email}}
-                                                >
-                                                    {{t 'settings.account.connected_emails.make_primary'}}
-                                                </BsButton>
-                                                <DeleteButton
-                                                    data-test-alternate-delete
-                                                    @small=true
-                                                    @delete={{action this.removeEmail email}}
-                                                    @analyticsScope='Settings - Alternate Emails'
-                                                    @modalTitle={{t 'settings.account.connected_emails.confirm_delete.title'}}
-                                                    @modalBody={{t 'settings.account.connected_emails.confirm_delete.body' emailAddress=email.emailAddress}}
-                                                />
-                                            </div>
-                                        </span>
-                                    {{/if}}
-                                </div>
-                            </list.item>
-                        {{else}}
-                            <div local-class='no-object-message' class='clearfix'>
-                                {{t 'settings.account.connected_emails.no_alternate_emails'}}
-                            </div>
-                        {{/if}}
-                    </HasManyList>
-                </span>
-            </div>
-            <div local-class='section-container'>
-                <h5 local-class='section-header'>
-                    {{t 'settings.account.connected_emails.unconfirmed_emails'}}
-                </h5>
-                <span local-class='email-section'>
-                    <HasManyList
-                        local-class='email-list'
-                        @model={{this.currentUser.user}}
-                        @relationshipName='emails'
-                        @bindReload={{action (mut this.reloadUnconfirmedList)}}
-                        @query={{this.unconfirmedQueryParams}}
-                        @usePlaceholders={{false}}
-                        @analyticsScope='Account Settings - Unconfirmed Emails'
-                        as |list|
-                    >
-                        {{#if list.item}}
-                            <list.item as |email|>
-                                <div local-class='email-object' class='clearfix'>
-                                    {{#if (not email)}}
-                                        <ContentPlaceholders as |placeholder|>
-                                            <placeholder.heading @subtitle={{false}} />
-                                        </ContentPlaceholders>
-                                    {{else}}
-                                        <span data-test-unconfirmed-email-item={{email.emailAddress}}>
-                                            {{email.emailAddress}}
-                                            <div local-class='options'>
-                                                <BsButton
-                                                    data-test-resend-confirmation-button
-                                                    data-analytics-name='Resend confirmation'
+                                                    data-test-close-modal
+                                                    data-analytics-name='Close modal'
                                                     @onClick={{action this.toggleMergeModal}}
-                                                >
-                                                    {{t 'settings.account.connected_emails.resend_confirmation'}}
-                                                </BsButton>
-                                                <BsModal
-                                                    @open={{this.showMergeModal}}
-                                                    @tagName='span'
-                                                    @onHide={{action this.toggleMergeModal}}
-                                                    as |modal|
-                                                >
-                                                    <modal.header>
-                                                        <h3 class='modal-title'>
-                                                            {{t 'settings.account.connected_emails.resend_confirmation_modal.title'}}
-                                                        </h3>
-                                                    </modal.header>
-
-                                                    <modal.body>
-                                                        <p>
-                                                            {{t 'settings.account.connected_emails.resend_confirmation_modal.body' emailAddress=email.emailAddress}}
-                                                        </p>
-                                                    </modal.body>
-
-                                                    <modal.footer
-                                                        data-analytics-scope='Merge modal'
-                                                    >
-                                                        <BsButton
-                                                            data-test-close-modal
-                                                            data-analytics-name='Close modal'
-                                                            @onClick={{action this.toggleMergeModal}}
-                                                            @defaultText={{t 'general.cancel'}}
-                                                        />
-                                                        <BsButton
-                                                            data-test-resend-confirmation
-                                                            data-analytics-name='Resend confirmation'
-                                                            @type='primary'
-                                                            @onClick={{action this.resendConfirmation email}}
-                                                            @defaultText={{t 'settings.account.connected_emails.resend_confirmation_modal.resend_button'}}
-                                                        />
-                                                    </modal.footer>
-                                                </BsModal>
-                                                <DeleteButton
-                                                    @small=true
-                                                    @delete={{action this.removeEmail email}}
-                                                    @analyticsScope='Settings - Unconfirmed Emails'
-                                                    @modalTitle={{t 'settings.account.connected_emails.confirm_delete.title'}}
-                                                    @modalBody={{t 'settings.account.connected_emails.confirm_delete.body' emailAddress=email.emailAddress}}
+                                                    @defaultText={{t 'general.cancel'}}
                                                 />
-                                            </div>
-                                        </span>
-                                    {{/if}}
-                                </div>
-                            </list.item>
-                        {{else}}
-                            <div local-class='no-object-message' class='clearfix'>
-                                {{t 'settings.account.connected_emails.no_unconfirmed_emails'}}
-                            </div>
-                        {{/if}}
-                    </HasManyList>
-                </span>
-                <p local-class='merge-explanation'>
-                    {{t 'settings.account.connected_emails.merge_explanation'}}
-                </p>
-                <ValidatedModelForm
-                    data-analytics-scope='Add email form'
-                    @onSave={{action this.onSave}}
-                    @onError={{action this.onError}}
-                    @modelName='userEmail'
-                    @modelProperties={{this.modelProperties}}
-                    @recreateModel={{true}}
-                    as |form|
+                                                <BsButton
+                                                    data-test-resend-confirmation
+                                                    data-analytics-name='Resend confirmation'
+                                                    @type='primary'
+                                                    @onClick={{action this.resendConfirmation email}}
+                                                    @defaultText={{t 'settings.account.connected_emails.resend_confirmation_modal.resend_button'}}
+                                                />
+                                            </modal.footer>
+                                        </BsModal>
+                                        <DeleteButton
+                                            @small=true
+                                            @delete={{action this.removeEmail email}}
+                                            @analyticsScope='Settings - Unconfirmed Emails'
+                                            @modalTitle={{t 'settings.account.connected_emails.confirm_delete.title'}}
+                                            @modalBody={{t 'settings.account.connected_emails.confirm_delete.body' emailAddress=email.emailAddress}}
+                                        />
+                                    </div>
+                                </span>
+                            {{/if}}
+                        </div>
+                    </list.item>
+                    <list.empty>
+                        <div local-class='no-object-message' class='clearfix'>
+                            {{t 'settings.account.connected_emails.no_unconfirmed_emails'}}
+                        </div>
+                    </list.empty>
+                </PaginatedList::HasMany>
+            </span>
+            <p local-class='merge-explanation'>
+                {{t 'settings.account.connected_emails.merge_explanation'}}
+            </p>
+            <ValidatedModelForm
+                data-analytics-scope='Add email form'
+                @onSave={{action this.onSave}}
+                @onError={{action this.onError}}
+                @modelName='userEmail'
+                @modelProperties={{this.modelProperties}}
+                @recreateModel={{true}}
+                as |form|
+            >
+                <form.text
+                    data-test-add-email
+                    @local-class='input-form'
+                    @valuePath='emailAddress'
+                    @placeholder={{t 'settings.account.connected_emails.placeholder_text'}}
+                    @ariaLabel={{t 'settings.account.connected_emails.placeholder_text'}}
+                />
+                <BsButton
+                    data-test-add-email-button
+                    data-analytics-name='add email'
+                    @buttonType='submit'
+                    @local-class='add-email-button'
                 >
-                    <form.text
-                        data-test-add-email
-                        @local-class='input-form'
-                        @valuePath='emailAddress'
-                        @placeholder={{t 'settings.account.connected_emails.placeholder_text'}}
-                        @ariaLabel={{t 'settings.account.connected_emails.placeholder_text'}}
+                    {{t 'settings.account.connected_emails.add_email'}}
+                </BsButton>
+            </ValidatedModelForm>
+            <BsModal
+                @open={{this.showAddModal}}
+                @tagName='span'
+                @onHide={{action this.toggleAddModal}}
+                as |modal|
+            >
+                <modal.header>
+                    <h3 class='modal-title'>
+                        {{t 'settings.account.connected_emails.add_email_modal.title'}}
+                    </h3>
+                </modal.header>
+
+                <modal.body>
+                    <p>
+                        {{t 'settings.account.connected_emails.add_email_modal.body' emailAddress=this.lastUserEmail}}
+                    </p>
+                </modal.body>
+
+                <modal.footer
+                    data-analytics-scope='Add email modal'
+                >
+                    <BsButton
+                        data-test-close-modal
+                        data-analytics-name='Close modal'
+                        @onClick={{action this.toggleAddModal}}
+                        @defaultText={{t 'general.close'}}
                     />
-                    <BsButton 
-                        data-test-add-email-button
-                        data-analytics-name='add email'
-                        @buttonType='submit'
-                        @local-class='add-email-button'
-                    >
-                        {{t 'settings.account.connected_emails.add_email'}}
-                    </BsButton>
-                </ValidatedModelForm>
-                <BsModal
-                    @open={{this.showAddModal}}
-                    @tagName='span'
-                    @onHide={{action this.toggleAddModal}}
-                    as |modal|
-                >
-                    <modal.header>
-                        <h3 class='modal-title'>
-                            {{t 'settings.account.connected_emails.add_email_modal.title'}}
-                        </h3>
-                    </modal.header>
-
-                    <modal.body>
-                        <p>
-                            {{t 'settings.account.connected_emails.add_email_modal.body' emailAddress=this.lastUserEmail}}
-                        </p>
-                    </modal.body>
-
-                    <modal.footer
-                        data-analytics-scope='Add email modal'
-                    >
-                        <BsButton
-                            data-test-close-modal
-                            data-analytics-name='Close modal'
-                            @onClick={{action this.toggleAddModal}}
-                            @defaultText={{t 'general.close'}}
-                        />
-                    </modal.footer>
-                </BsModal>
-            </div>
-        </panel.body>
-    </Panel>
-{{/let}}
+                </modal.footer>
+            </BsModal>
+        </div>
+    </panel.body>
+</Panel>

--- a/lib/osf-components/addon/components/node-list/template.hbs
+++ b/lib/osf-components/addon/components/node-list/template.hbs
@@ -1,18 +1,16 @@
-<ul class='list-group'>
-    {{#paginated-list/has-many
-        modelTaskInstance=@modelTaskInstance
-        relationshipName=@relationshipName
-        query=this.queryParams
-        bindReload=this.bindReload
-        as |pr|
-    }}
-        <pr.item as |node|>
-            <NodeCard
-                @node={{node}}
-                @showTags={{@showTags}}
-            />
-        </pr.item>
+<PaginatedList::HasMany
+    @modelTaskInstance={{@modelTaskInstance}}
+    @relationshipName={{@relationshipName}}
+    @query={{this.queryParams}}
+    @bindReload={{this.bindReload}}
+    as |list|
+>
+    <list.item as |node|>
+        <NodeCard
+            @node={{node}}
+            @showTags={{@showTags}}
+        />
+    </list.item>
 
-        {{yield (hash empty=pr.empty)}}
-    {{/paginated-list/has-many}}
-</ul>
+    {{yield (hash empty=list.empty)}}
+</PaginatedList::HasMany>

--- a/lib/osf-components/addon/components/paginated-list/layout/template.hbs
+++ b/lib/osf-components/addon/components/paginated-list/layout/template.hbs
@@ -1,48 +1,43 @@
-<ul class='list-group m-md'>
-    {{yield (hash
-        header=(component 'paginated-list/x-header')
-    )}}
-    {{#if this.loading}}
-        {{#if this.placeholderCount}}
+{{#if this.errorShown}}
+    <p>{{t 'osf-components.paginated-list.error'}}</p>
+{{else if (or @items.length (and this.loading this.placeholderCount))}}
+    <ul class='list-group m-md'>
+        {{yield (hash
+            header=(component 'paginated-list/x-header')
+        )}}
+        {{#if this.loading}}
             {{#each (range 1 this.placeholderCount)}}
                 {{yield (hash
                     item=(component 'paginated-list/x-item')
                     doReload=(action @doReload)
                 )}}
             {{/each}}
+        {{else if @items.length}}
+            {{#each @items as |item index|}}
+                {{#unless item.isDeleted}}
+                    {{yield (hash
+                        item=(component 'paginated-list/x-item' item=item index=index)
+                        doReload=(action @doReload)
+                    )}}
+                {{/unless}}
+            {{/each}}
         {{/if}}
-    {{else if @items.length}}
-        {{#each @items as |item index|}}
-            {{#unless item.isDeleted}}
-                {{yield (hash
-                    item=(component 'paginated-list/x-item' item=item index=index)
-                    doReload=(action @doReload)
-                )}}
-            {{/unless}}
-        {{/each}}
+    </ul>
+    {{#if this.paginatorShown}}
+        <div class='text-center'>
+            {{simple-paginator
+                maxPage=this.maxPage
+                nextPage=(action @next)
+                previousPage=(action @previous)
+                curPage=@page
+            }}
+        </div>
     {{/if}}
-</ul>
-
-{{#if this.loading}}
-    {{#if (not this.placeholderCount)}}
-        {{loading-indicator dark=true}}
-    {{/if}}
-{{else if this.errorShown}}
-    <p>{{t 'osf-components.paginated-list.error'}}</p>
-{{else if (not @items.length)}}
+{{else if this.loading}}
+    {{loading-indicator dark=true}}
+{{else}}
     {{yield (hash
         empty=(component 'paginated-list/x-render')
         doReload=(action @doReload)
     )}}
-{{/if}}
-
-{{#if this.paginatorShown}}
-    <div class='text-center'>
-        {{simple-paginator
-            maxPage=this.maxPage
-            nextPage=(action @next)
-            previousPage=(action @previous)
-            curPage=@page
-        }}
-    </div>
 {{/if}}

--- a/lib/osf-components/package.json
+++ b/lib/osf-components/package.json
@@ -4,6 +4,7 @@
     "ember-addon"
   ],
   "dependencies": {
+    "ember-angle-bracket-invocation-polyfill": "*",
     "ember-bootstrap": "*",
     "ember-bootstrap-datepicker": "*",
     "ember-cli-babel": "*",


### PR DESCRIPTION
## Purpose

The changes made in #667 cause issue with paginated lists. Namely, on Account Settings - Connected Emails, the "empty" message is [always displayed](https://percy.io/Center-for-Open-Science/ember-osf-web/builds/1888952/view/122829898/1280?mode=diff&browser=chrome&snapshot=122829898) (and [displayed twice if there are no alternate or unconfirmed emails](https://percy.io/Center-for-Open-Science/ember-osf-web/builds/1888952/view/122829884/1280?mode=diff&browser=chrome&snapshot=122829884)). [Extra space was also injected when the list was empty](https://percy.io/Center-for-Open-Science/ember-osf-web/builds/1888952/view/122829058/1280?mode=diff&browser=chrome&snapshot=122829058) in most invocations of paginated-list.

## Summary of Changes

* in the `connected-emails` component, use the `empty` closure component instead of an `if` block (this fixes the `empty` component duplicate rendering)
* restructure the `paginated-list/layout` template to only render a `ul` when it will render a list. (this fixes the `empty` block being pushed down due to margins around an empty `ul`)
* remove extraneous `ul` from `node-list` (`paginated-list` already renders a `ul`)

## Side Effects

It's possible that these changes could cause some uses of paginated-list to have increased or decreased margin. I spot-checked all invocations against `master`, but it's possible I missed something.

## Feature Flags

n/a

## QA Notes

Devs will QA this.

## Ticket

https://openscience.atlassian.net/browse/ENG-473

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(this is just restoring previous functionality)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
