### PR TITLE
[ENG-473] fix registrations tab paginated list

### DIFF
--- a/app/guid-node/registrations/styles.scss
+++ b/app/guid-node/registrations/styles.scss
@@ -1,5 +1,6 @@
 .RegistrationsContainer {
     margin-top: 15px;
+    margin-bottom: 15px;
 }
 
 .RegistrationsPane {

--- a/app/guid-node/registrations/template.hbs
+++ b/app/guid-node/registrations/template.hbs
@@ -47,29 +47,27 @@
                         @title={{t 'node.registrations.draft_registrations'}}
                     >
                         <div class='row' local-class='RegistrationsPane' data-test-draft-registrations-pane>
-                            <ul class='list-group'>
-                                {{#paginated-list/has-many
-                                    data-analytics-scope='Project Draft Registrations'
-                                    modelTaskInstance=this.model.taskInstance
-                                    relationshipName='draftRegistrations'
-                                    bindReload=(action (mut this.reloadDrafts))
-                                    query=this.draftsQueryParams
-                                    as |list|
-                                }}
-                                    <list.item as |draftRegistration|>
-                                        <DraftRegistrationCard
-                                            @draftRegistration={{draftRegistration}}
-                                            @onDelete={{action list.doReload 1}} 
-                                        />
-                                    </list.item>
+                            <PaginatedList::HasMany
+                                data-analytics-scope='Project Draft Registrations'
+                                @modelTaskInstance={{this.model.taskInstance}}
+                                @relationshipName='draftRegistrations'
+                                @bindReload={{action (mut this.reloadDrafts)}}
+                                @query={{this.draftsQueryParams}}
+                                as |list|
+                            >
+                                <list.item as |draftRegistration|>
+                                    <DraftRegistrationCard
+                                        @draftRegistration={{draftRegistration}}
+                                        @onDelete={{action list.doReload 1}}
+                                    />
+                                </list.item>
 
-                                    <list.empty>
-                                        <p>{{t 'node.registrations.no_drafts'}}</p>
-                                        <p>{{t 'node.registrations.start_new'}}</p>
-                                        <p>{{t 'node.registrations.learn_more' learnMoreLink='https://openscience.zendesk.com/hc/en-us/articles/360019930893'}}</p>
-                                    </list.empty>
-                                {{/paginated-list/has-many}}
-                            </ul>
+                                <list.empty>
+                                    <p>{{t 'node.registrations.no_drafts'}}</p>
+                                    <p>{{t 'node.registrations.start_new'}}</p>
+                                    <p>{{t 'node.registrations.learn_more' learnMoreLink='https://openscience.zendesk.com/hc/en-us/articles/360019930893'}}</p>
+                                </list.empty>
+                            </PaginatedList::HasMany>
                         </div>
                     </tab.pane>
                 {{/if}}
@@ -171,7 +169,7 @@
                                     {{t 'node.registrations.prereg_modal.info' learnMoreLink=this.preregLinks.learnMore}}
                                 </p>
                                 <ol class='PreRegChallengeModal__list'>
-                                    {{t 
+                                    {{t
                                         'node.registrations.prereg_modal.list'
                                         eligibleJournalLink=this.preregLinks.eligibleJournal
                                         embargoedCountriesLink=this.preregLinks.embargoedCountries


### PR DESCRIPTION
## Purpose

#671 [was successful](https://percy.io/Center-for-Open-Science/ember-osf-web/builds/1895204) in restoring almost all of the paginated list formatting to match what is on `master`, but one small issue with the bottom margin on the registrations tab registration list [persists](https://percy.io/Center-for-Open-Science/ember-osf-web/builds/1895204/view/123256124/1280?mode=diff&browser=chrome&snapshot=123256124). This PR solves this by removing the extraneous `ul` wrapper from the draft registrations list (which was adding a 15px bottom margin in the wrong place) and instead adding a 15px bottom margin to the whole registration tab container.

## Summary of Changes

*  remove extraneous `ul` wrapper on draft registrations list
* add 15px bottom margin to registrations container

## Side Effects

None expected.

## Feature Flags

n/a

## QA Notes

n/a

## Ticket

https://openscience.atlassian.net/browse/ENG-473

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~ *(visual regression, tested by Percy)*
- [ ] ~~changes described in `CHANGELOG.md`~~ *(fixing regression in unreleased code)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
