### PR TITLE
[ENG-456] connected identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Models:
     - `meeting` - for OSF Meetings
+    - `external-identity` - for connected identities
 - Adapters:
     - `meeting` - in private namespace
+    - `external-identity` - for connected identities
 - Serializers:
     - `meeting`
+    - `external-identity` - for connected identities
 - Routes:
     - `meetings` - parent route for meetings
         - `meetings.index` - meetings landing page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         - `meetings-list`
         - `meetings-hero-banner`
         - `meetings-footer`
+        - `connected-identities`
     - Unit:
         - `leaf-vals` utility
 - Mirage:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `paginated-list/x-header` - a paginated list header closure component
     - `meetings/index/components/meetings-hero-banner` - meetings landing page hero banner
     - `meetings/index/components/meetings-footer` - meetings landing page footer
+    - `settings/account/-components/connected-identities` - connected identities component
 - Utilities:
     - `leaf-vals` - get values of all leaves in an object tree
 - Tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `meeting` factory
     - private `meetings` endpoint
     - meetings scenario
+    - `external-identities` factory and endpoint
+    - add `external-identities` to settings scenario
 
 ### Changed
 - Components:

--- a/app/adapters/external-identity.ts
+++ b/app/adapters/external-identity.ts
@@ -1,0 +1,13 @@
+import OsfAdapter from './osf-adapter';
+
+export default class ExternalIdentityAdapter extends OsfAdapter {
+    pathForType(_: string) {
+        return 'users/me/settings/identities';
+    }
+}
+
+declare module 'ember-data/types/registries/adapter' {
+    export default interface AdapterRegistry {
+        'external-identity': ExternalIdentityAdapter;
+    } // eslint-disable-line semi
+}

--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -1548,6 +1548,22 @@ export default {
                     placeholder: 'Verify password',
                 },
             },
+            connected_identities: {
+                title: 'Connected identities',
+                description: 'Connected identities allow you to log in to the OSF via a third-party service.<br>You can revoke these authorizations here.',
+                no_identities: 'You have not authorized any external services to log in to the OSF.',
+                status: {
+                    verified: 'Verified',
+                    pending: 'Pending',
+                },
+                confirm_remove: {
+                    title: 'Remove authorization?',
+                    body: 'Are you sure you want to remove this authorization?',
+                    confirm_button_text: 'Remove',
+                },
+                remove_fail: 'Revocation request failed. Please contact <a href="mailto:{{supportEmail}}">{{supportEmail}}</a> if the problem persists.',
+                remove_success: 'You have revoked this connected identity.',
+            },
         },
         addons: {
             title: 'Configure add-on accounts',

--- a/app/models/external-identity.ts
+++ b/app/models/external-identity.ts
@@ -1,0 +1,20 @@
+import { attr } from '@ember-decorators/data';
+
+import OsfModel from './osf-model';
+
+export enum Status {
+    Create = 'CREATE',
+    Link = 'LINK',
+    Verified = 'VERIFIED',
+}
+
+export default class ExternalIdentityModel extends OsfModel {
+    @attr('string') status!: Status;
+    @attr('string') externalId!: string;
+}
+
+declare module 'ember-data/types/registries/model' {
+    export default interface ModelRegistry {
+        'external-identity': ExternalIdentityModel;
+    } // eslint-disable-line semi
+}

--- a/app/serializers/external-identity.ts
+++ b/app/serializers/external-identity.ts
@@ -1,0 +1,10 @@
+import OsfSerializer from './osf-serializer';
+
+export default class ExternalIdentitySerializer extends OsfSerializer {
+}
+
+declare module 'ember-data/types/registries/serializer' {
+    export default interface SerializerRegistry {
+        'external-identity': ExternalIdentitySerializer;
+    } // eslint-disable-line semi
+}

--- a/app/settings/account/-components/connected-identities/component.ts
+++ b/app/settings/account/-components/connected-identities/component.ts
@@ -1,0 +1,39 @@
+import { tagName } from '@ember-decorators/component';
+import { service } from '@ember-decorators/service';
+import Component from '@ember/component';
+import { task } from 'ember-concurrency';
+import config from 'ember-get-config';
+import I18N from 'ember-i18n/services/i18n';
+import Toast from 'ember-toastr/services/toast';
+
+import ExternalIdentity from 'ember-osf-web/models/external-identity';
+
+const { support: { supportEmail } } = config;
+
+@tagName('')
+export default class ConnectedIdentities extends Component.extend({
+    removeIdentityTask: task(function *(this: ConnectedIdentities, identity: ExternalIdentity) {
+        if (!identity) {
+            return undefined;
+        }
+
+        try {
+            yield identity.destroyRecord();
+        } catch (e) {
+            this.toast.error(this.i18n.t('settings.account.connected_identities.remove_fail', { supportEmail }));
+            return false;
+        }
+        this.reloadIdentitiesList();
+        this.toast.success(this.i18n.t('settings.account.connected_identities.remove_success'));
+        return true;
+    }),
+}) {
+    // Private properties
+    @service i18n!: I18N;
+    @service toast!: Toast;
+    reloadIdentitiesList!: (page?: number) => void; // bound by paginated-list
+
+    removeIdentity(identity: ExternalIdentity) {
+        this.removeIdentityTask.perform(identity);
+    }
+}

--- a/app/settings/account/-components/connected-identities/styles.scss
+++ b/app/settings/account/-components/connected-identities/styles.scss
@@ -1,0 +1,26 @@
+.description-list-separator {
+    margin-bottom: 10px;
+}
+
+.identities-list ul {
+    margin: 0;
+
+    & > li {
+        border: 0;
+        padding: 10px;
+
+        &:hover {
+            background-color: #e6e6e6;
+        }
+    }
+}
+
+.delete-button {
+    margin-top: -2px;
+    float: right;
+    clear: right;
+
+    & > button {
+        padding: 0;
+    }
+}

--- a/app/settings/account/-components/connected-identities/template.hbs
+++ b/app/settings/account/-components/connected-identities/template.hbs
@@ -1,0 +1,51 @@
+<Panel
+    data-test-connected-identities-panel
+    data-analytics-scope='Connected identities panel'
+    as |panel|
+>
+    <panel.heading @title={{t 'settings.account.connected_identities.title'}} />
+    <panel.body>
+        <p data-test-connected-identities-description>
+            {{t 'settings.account.connected_identities.description'}}
+        </p>
+        <hr local-class='description-list-separator'>
+        <PaginatedList::All
+            data-test-connected-identities-list
+            local-class='identities-list'
+            @modelName='external-identity'
+            @bindReload={{action (mut this.reloadIdentitiesList)}}
+            as |list|
+        >
+            <list.item as |identity|>
+                {{#if (not identity)}}
+                    <ContentPlaceholders as |placeholder|>
+                        <placeholder.heading @subtitle={{false}} />
+                    </ContentPlaceholders>
+                {{else}}
+                    <span data-test-connected-identities-item='{{identity.id}}'>
+                        {{identity.id}}: {{identity.externalId}}
+                        (
+                        {{#if (eq identity.status 'VERIFIED')}}
+                            {{t 'settings.account.connected_identities.status.verified'}}
+                        {{else}}
+                            {{t 'settings.account.connected_identities.status.pending'}}
+                        {{/if}}
+                        )
+                        <DeleteButton
+                            data-test-connected-identities-delete
+                            local-class='delete-button'
+                            @small={{true}}
+                            @delete={{action this.removeIdentity identity}}
+                            @modalTitle={{t 'settings.account.connected_identities.confirm_remove.title'}}
+                            @modalBody={{t 'settings.account.connected_identities.confirm_remove.body' identity=identity}}
+                            @confirmButtonText={{t 'settings.account.connected_identities.confirm_remove.confirm_button_text'}}
+                        />
+                    </span>
+                {{/if}}
+            </list.item>
+            <list.empty>
+                <p>{{t 'settings.account.connected_identities.no_identities'}}</p>
+            </list.empty>
+        </PaginatedList::All>
+    </panel.body>
+</Panel>

--- a/app/settings/account/template.hbs
+++ b/app/settings/account/template.hbs
@@ -1,8 +1,7 @@
 {{title (t 'settings.account.title')}}
-{{! template-lint-disable no-implicit-this }}
-{{settings/account/-components/connected-emails}}
-{{settings/account/-components/default-region}}
-{{settings/account/-components/change-password}}
-{{settings/account/-components/security}}
-{{settings/account/-components/request-deactivation}}
-{{! template-lint-enable no-implicit-this }}
+<Settings::Account::-Components::ConnectedEmails />
+<Settings::Account::-Components::DefaultRegion />
+<Settings::Account::-Components::ConnectedIdentities />
+<Settings::Account::-Components::ChangePassword />
+<Settings::Account::-Components::Security />
+<Settings::Account::-Components::RequestDeactivation />

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -123,6 +123,11 @@ export default function(this: Server) {
     this.post('/users/:id/settings/export', userSettings.requestExport);
     this.post('/users/:parentID/settings/password/', updatePassword);
 
+    osfResource(this, 'external-identity', {
+        path: '/users/me/settings/identities',
+        only: ['index', 'delete'],
+    });
+
     this.get('/users/:id/nodes', userNodeList);
     osfNestedResource(this, 'user', 'quickfiles', { only: ['index', 'show'] });
 

--- a/mirage/factories/external-identity.ts
+++ b/mirage/factories/external-identity.ts
@@ -1,0 +1,63 @@
+import { Factory, faker, trait, Trait } from 'ember-cli-mirage';
+
+import ExternalIdentity, { Status } from 'ember-osf-web/models/external-identity';
+
+export interface ExternalIdentityTraits {
+    withStatusVerified: Trait;
+    withStatusLink: Trait;
+    withStatusCreate: Trait;
+}
+
+function orcidPart() {
+    return faker.random.number(9999).toString().padStart(4, '0');
+}
+
+export default Factory.extend<ExternalIdentity & ExternalIdentityTraits>({
+    id(index: number) {
+        return `${faker.hacker.abbreviation()}${index}`;
+    },
+    status() {
+        return faker.random.arrayElement([
+            Status.Verified,
+            Status.Create,
+            Status.Link,
+        ]);
+    },
+    externalId() {
+        return faker.internet.email();
+    },
+    afterCreate(identity) {
+        if (identity.id === 'ORCID') {
+            // eslint-disable-next-line no-param-reassign
+            identity.externalId = `0000-0001-${orcidPart()}-${orcidPart()}`;
+            identity.save();
+        }
+    },
+    withStatusVerified: trait<ExternalIdentity>({
+        afterCreate(identity) {
+            // eslint-disable-next-line no-param-reassign
+            identity.status = Status.Verified;
+            identity.save();
+        },
+    }),
+    withStatusLink: trait<ExternalIdentity>({
+        afterCreate(identity) {
+            // eslint-disable-next-line no-param-reassign
+            identity.status = Status.Link;
+            identity.save();
+        },
+    }),
+    withStatusCreate: trait<ExternalIdentity>({
+        afterCreate(identity) {
+            // eslint-disable-next-line no-param-reassign
+            identity.status = Status.Create;
+            identity.save();
+        },
+    }),
+});
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        externalIdentity: ExternalIdentity;
+    } // eslint-disable-line semi
+}

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -143,6 +143,8 @@ function settingsScenario(server: Server, currentUser: ModelInstance<User>) {
     server.createList('token', 23);
     server.createList('scope', 5);
     server.createList('developer-app', 12);
+    server.create('external-identity', { id: 'ORCID' }, 'withStatusVerified');
+    server.createList('external-identity', 10);
 }
 
 function meetingsScenario(server: Server) {

--- a/mirage/serializers/external-identity.ts
+++ b/mirage/serializers/external-identity.ts
@@ -1,0 +1,16 @@
+import { ModelInstance } from 'ember-cli-mirage';
+import config from 'ember-get-config';
+
+import ExternalIdentity from 'ember-osf-web/models/external-identity';
+
+import ApplicationSerializer from './application';
+
+const { OSF: { apiUrl } } = config;
+
+export default class ExternalIdentitySerializer extends ApplicationSerializer<ExternalIdentity> {
+    buildNormalLinks(model: ModelInstance<ExternalIdentity>) {
+        return {
+            self: `${apiUrl}/v2/users/me/settings/identities/${model.id}`,
+        };
+    }
+}

--- a/tests/integration/routes/settings/account/-components/connected-identities-test.ts
+++ b/tests/integration/routes/settings/account/-components/connected-identities-test.ts
@@ -1,0 +1,146 @@
+import { render } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { t } from 'ember-i18n/test-support';
+import { percySnapshot } from 'ember-percy';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+
+import { click } from 'ember-osf-web/tests/helpers';
+
+module('Integration | routes | settings | account | -components | connected-identities', hooks => {
+    setupRenderingTest(hooks);
+    setupMirage(hooks);
+
+    test('no connected identities', async assert => {
+        await render(hbs`{{settings/account/-components/connected-identities}}`);
+
+        assert.dom('[data-test-connected-identities-panel]')
+            .exists('Connected identities section renders');
+        assert.dom('[data-test-connected-identities-panel] [data-test-panel-heading]')
+            .hasText(
+                t('settings.account.connected_identities.title').toString(),
+                'title is correct',
+            );
+        assert.dom('[data-test-connected-identities-description]')
+            .hasText(
+                t('settings.account.connected_identities.description').toString().replace(/(<([^>]+)>)/ig, ''),
+                'description is correct',
+            );
+        assert.dom('[data-test-connected-identities-item').doesNotExist(
+            'no identities in the list',
+        );
+        assert.dom('[data-test-connected-identities-list]')
+            .hasText(
+                t('settings.account.connected_identities.no_identities').toString(),
+                'list displays text for no identities',
+            );
+        await percySnapshot(assert);
+    });
+
+    test('identity statuses', async assert => {
+        const identity1 = server.create('external-identity', 'withStatusVerified');
+        const identity2 = server.create('external-identity', 'withStatusCreate');
+        const identity3 = server.create('external-identity', 'withStatusLink');
+
+        await render(hbs`{{settings/account/-components/connected-identities}}`);
+
+        const verified = t('settings.account.connected_identities.status.verified');
+        assert.dom(`[data-test-connected-identities-item=${identity1.id}]`).exists(
+            { count: 1 },
+            'identity1 is in the list',
+        );
+        assert.dom(`[data-test-connected-identities-item=${identity1.id}]`)
+            .hasText(
+                `${identity1.id}: ${identity1.externalId} ( ${verified} )`,
+                'list displays expected text for identity with status: VERIFIED',
+            );
+
+        const pending = t('settings.account.connected_identities.status.pending');
+        assert.dom(`[data-test-connected-identities-item=${identity2.id}]`).exists(
+            { count: 1 },
+            'identity2 is in the list',
+        );
+        assert.dom(`[data-test-connected-identities-item=${identity2.id}]`)
+            .hasText(
+                `${identity2.id}: ${identity2.externalId} ( ${pending} )`,
+                'list displays expected text for identity with status: CREATE',
+            );
+        assert.dom(`[data-test-connected-identities-item=${identity3.id}]`).exists(
+            { count: 1 },
+            'identity3 is in the list',
+        );
+        assert.dom(`[data-test-connected-identities-item=${identity3.id}]`)
+            .hasText(
+                `${identity3.id}: ${identity3.externalId} ( ${pending} )`,
+                'list displays expected text for identity with status: LINK',
+            );
+
+        await percySnapshot(assert);
+    });
+
+    test('pagination', async assert => {
+        server.createList('external-identity', 12);
+
+        await render(hbs`{{settings/account/-components/connected-identities}}`);
+
+        assert.dom('[data-test-connected-identities-item]').exists(
+            { count: 10 },
+            'ten identities on the first page',
+        );
+        await percySnapshot(assert);
+
+        await click('[data-test-next-page-button]');
+        assert.dom('[data-test-connected-identities-item]').exists(
+            { count: 2 },
+            'two identites on the second page',
+        );
+        await percySnapshot(assert);
+    });
+
+    test('remove identity', async assert => {
+        const identities = server.createList('external-identity', 12);
+        const identity = identities[2];
+
+        await render(hbs`{{settings/account/-components/connected-identities}}`);
+
+        assert.dom(`[data-test-connected-identities-item=${identity.id}]`).exists(
+            { count: 1 },
+            'expected identity is in the list',
+        );
+        await click(`[data-test-connected-identities-item=${identity.id}] [data-test-delete-button]`);
+        await percySnapshot(assert);
+        await click('[data-test-cancel-delete]');
+        assert.dom(`[data-test-connected-identities-item=${identity.id}]`).exists(
+            { count: 1 },
+            'expected identity is still in the list',
+        );
+
+        await click(`[data-test-connected-identities-item=${identity.id}] [data-test-delete-button]`);
+        await click('[data-test-confirm-delete]');
+        assert.dom(`[data-test-connected-identities-item=${identity.id}]`).doesNotExist(
+            'removed identity is no longer in the list',
+        );
+    });
+
+    test('remove last identity', async assert => {
+        const identity = server.create('external-identity');
+
+        await render(hbs`{{settings/account/-components/connected-identities}}`);
+
+        assert.dom(`[data-test-connected-identities-item=${identity.id}]`).exists(
+            { count: 1 },
+            'expected identity is in the list',
+        );
+        await click(`[data-test-connected-identities-item=${identity.id}] [data-test-delete-button]`);
+        await click('[data-test-confirm-delete]');
+        assert.dom(`[data-test-connected-identities-item=${identity.id}]`).doesNotExist(
+            'removed identity is no longer in the list',
+        );
+        assert.dom('[data-test-connected-identities-list]')
+            .hasText(
+                t('settings.account.connected_identities.no_identities').toString(),
+                'list displays text for no identities',
+            );
+    });
+});

--- a/tests/unit/adapters/external-identity-test.ts
+++ b/tests/unit/adapters/external-identity-test.ts
@@ -1,0 +1,11 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Adapter | external-identity', hooks => {
+    setupTest(hooks);
+
+    test('it exists', function(assert) {
+        const adapter = this.owner.lookup('adapter:external-identity');
+        assert.ok(adapter);
+    });
+});

--- a/tests/unit/models/external-identity-test.ts
+++ b/tests/unit/models/external-identity-test.ts
@@ -1,0 +1,12 @@
+import { run } from '@ember/runloop';
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Model | external-identity', hooks => {
+    setupTest(hooks);
+
+    test('it exists', function(assert) {
+        const model = run(() => this.owner.lookup('service:store').createRecord('external-identity'));
+        assert.ok(!!model);
+    });
+});

--- a/tests/unit/serializers/external-identity-test.ts
+++ b/tests/unit/serializers/external-identity-test.ts
@@ -1,0 +1,13 @@
+import { run } from '@ember/runloop';
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Serializer | external-identity', hooks => {
+    setupTest(hooks);
+
+    test('it serializes records', function(assert) {
+        const record = run(() => this.owner.lookup('service:store').createRecord('external-identity'));
+        const serializedRecord = record.serialize();
+        assert.ok(serializedRecord);
+    });
+});


### PR DESCRIPTION
## Purpose

Add a connected identities component to account settings.

![Screen Shot 2019-05-23 at 10 04 26 AM](https://user-images.githubusercontent.com/348630/58259317-4a566400-7d42-11e9-9c46-0b2496dfc3a2.png)

## Summary of Changes

### Added
* `external-identity` model/adapter/serializer
* `connected-identities` component
* `external-identity` mirage things
* integration test for `connected-identities` component
* `connected-identities` component to `settings/account` route (and changed all component invocation int his template to use angle brackets)

## Side Effects

None expected.

## Feature Flags

`ember_user_settings_account_page`

## QA Notes

This component was missing from `/settings/account`. It can be tested on stagings by connecting an ORCID account to an OSF account. ORCID is currently the only external identity available for the OSF, but the component was implemented to support any number of external identities. Once this PR is merged, this functionality can be tested against fake data at: https://centerforopenscience.github.io/ember-osf-web/settings/account

## Ticket

https://openscience.atlassian.net/browse/ENG-456

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
