### PR TITLE
[ENG-503] load primary email on init; use component.set() instead of native setter to trigger recompute

### DIFF
--- a/app/settings/account/-components/security/component.ts
+++ b/app/settings/account/-components/security/component.ts
@@ -37,7 +37,7 @@ export default class SecurityPane extends Component.extend({
             'emails',
             { 'filter[primary]': true },
         );
-        this.primaryEmail = emails.length ? emails[0] : undefined;
+        this.set('primaryEmail', emails.length ? emails[0] : undefined);
     }),
 
     saveSettings: task(function *(this: SecurityPane) {
@@ -72,6 +72,7 @@ export default class SecurityPane extends Component.extend({
     init() {
         super.init();
         this.loadSettings.perform();
+        this.loadPrimaryEmail.perform();
     }
 
     hideDialogs() {
@@ -81,7 +82,7 @@ export default class SecurityPane extends Component.extend({
         });
     }
 
-    @computed('this.primaryEmail')
+    @computed('primaryEmail')
     get keyUri() {
         if (this.primaryEmail && this.settings) {
             const keyUri = `otpauth://totp/OSF:${this.primaryEmail.emailAddress}?secret=${this.settings.secret}`;
@@ -94,7 +95,6 @@ export default class SecurityPane extends Component.extend({
     enableTwoFactor() {
         this.set('showError', false);
         this.set('showEnableWarning', true);
-        this.loadPrimaryEmail.perform();
     }
 
     @action

--- a/app/settings/account/-components/security/component.ts
+++ b/app/settings/account/-components/security/component.ts
@@ -23,7 +23,7 @@ export default class SecurityPane extends Component.extend({
         if (!user) {
             return;
         }
-        this.settings = yield user.belongsTo('settings').reload();
+        this.set('settings', yield user.belongsTo('settings').reload());
     }),
 
     loadPrimaryEmail: task(function *(this: SecurityPane) {
@@ -82,7 +82,7 @@ export default class SecurityPane extends Component.extend({
         });
     }
 
-    @computed('primaryEmail')
+    @computed('primaryEmail', 'settings')
     get keyUri() {
         if (this.primaryEmail && this.settings) {
             const keyUri = `otpauth://totp/OSF:${this.primaryEmail.emailAddress}?secret=${this.settings.secret}`;


### PR DESCRIPTION
## Purpose

Currently if you have two factor authentication enabled but not confirmed, the account settings page would not show the QR code for 2FA. The problem lies with the fact that we only load primary emails upon clicking the `Configure` button.

## Summary of Changes

Perform the `loadPrimaryEmail` task in `init()`. Inside the task, use `component.set()` instead of native setters because native setter doesn't trigger recompute of dependent computed properties.

## QA Notes

Enable 2FA on the account settings page but do not confirm. Then refresh the page and make sure the QR code shows up.

## Ticket

https://openscience.atlassian.net/browse/ENG-503

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
