### PR TITLE
[ENG-458][ENG-544][ENG-545][ENG-550] VOL followup

### DIFF
--- a/app/application/controller.ts
+++ b/app/application/controller.ts
@@ -19,6 +19,15 @@ export default class Application extends Controller {
     @service theme!: Theme;
     @service features!: Features;
 
+    queryParams = [{
+        viewOnlyToken: {
+            as: 'view_only',
+            // scope needs the literal type `'controller'`, not just `string`
+            scope: 'controller' as 'controller',
+        },
+    }];
+    viewOnlyToken = '';
+
     @alias(`features.${camelize(verifyEmailModals)}`)
     shouldShowVerifyEmailModals!: boolean;
 

--- a/app/application/route.ts
+++ b/app/application/route.ts
@@ -28,7 +28,6 @@ export default class ApplicationRoute extends Route.extend(
 
     queryParams = {
         viewOnlyToken: {
-            as: 'view_only',
             refreshModel: true,
         },
     };

--- a/app/services/current-user.ts
+++ b/app/services/current-user.ts
@@ -9,7 +9,7 @@ import Session from 'ember-simple-auth/services/session';
 import RSVP from 'rsvp';
 
 import User from 'ember-osf-web/models/user';
-import { addQueryParam } from 'ember-osf-web/utils/param';
+import { addQueryParam } from 'ember-osf-web/utils/url-parts';
 
 const {
     OSF: {

--- a/app/utils/param.ts
+++ b/app/utils/param.ts
@@ -3,28 +3,3 @@ export default function param(params: Record<string, string>) {
         entry => entry.map(comp => encodeURIComponent(comp)).join('='),
     ).join('&');
 }
-
-function deserializeQueryString(queryString: string): Record<string, string> {
-    return queryString.split('&').reduce(
-        (acc, q) => {
-            if (q) {
-                const [key, val] = q.split('=');
-                acc[key] = val;
-            }
-            return acc;
-        },
-        {} as Record<string, string>,
-    );
-}
-
-export function addQueryParam(url: string, key: string, value: string): string {
-    const [, path, queryString, fragment] = url.match(
-        /^([^?#]+)(?:\?([^#]+))?(?:#(.+))?$/,
-    ) as Array<string | undefined>;
-    const queryParams = {
-        ...deserializeQueryString(queryString || ''),
-        [key]: value,
-    };
-    const newUrl = `${path}?${param(queryParams)}`;
-    return fragment ? `${newUrl}#${fragment}` : newUrl;
-}

--- a/app/utils/url-parts.ts
+++ b/app/utils/url-parts.ts
@@ -1,0 +1,61 @@
+import param from './param';
+import pathJoin from './path-join';
+
+interface UrlParts {
+    path: string;
+    queryString?: string;
+    fragment?: string;
+}
+
+export function splitUrl(url: string): UrlParts {
+    const [, path, queryString, fragment] = url.match(
+        /^([^?#]+)(?:\?([^#]+))?(?:#(.+))?$/,
+    ) as Array<string | undefined>;
+
+    return {
+        path: path || '',
+        queryString,
+        fragment,
+    };
+}
+
+export function joinUrl({ path, queryString, fragment }: UrlParts): string {
+    const pathAndQuery = queryString ? `${path}?${queryString}` : path;
+    return fragment ? `${pathAndQuery}#${fragment}` : pathAndQuery;
+}
+
+function deserializeQueryString(queryString: string): Record<string, string> {
+    return queryString.split('&').reduce(
+        (acc, q) => {
+            if (q) {
+                const [key, val] = q.split('=');
+                acc[key] = val;
+            }
+            return acc;
+        },
+        {} as Record<string, string>,
+    );
+}
+
+export function addQueryParam(url: string, key: string, value: string): string {
+    const { path, queryString, fragment } = splitUrl(url);
+
+    const queryParams = {
+        ...deserializeQueryString(queryString || ''),
+        [key]: value,
+    };
+    return joinUrl({
+        path,
+        queryString: param(queryParams),
+        fragment,
+    });
+}
+
+export function addPathSegment(url: string, segment: string): string {
+    const { path, queryString, fragment } = splitUrl(url);
+    return joinUrl({
+        path: pathJoin(path, segment),
+        queryString,
+        fragment,
+    });
+}

--- a/lib/osf-components/addon/components/banners/view-only-link/component.ts
+++ b/lib/osf-components/addon/components/banners/view-only-link/component.ts
@@ -19,6 +19,6 @@ export default class BannersViewOnlyLink extends Component {
 
     @action
     stopViewOnly() {
-        this.router.transitionTo('home', { queryParams: { view_only: undefined } });
+        this.router.transitionTo('home', { queryParams: { view_only: '' } });
     }
 }

--- a/lib/osf-components/addon/components/citation-viewer/component.ts
+++ b/lib/osf-components/addon/components/citation-viewer/component.ts
@@ -9,7 +9,7 @@ import Node from 'ember-osf-web/models/node';
 import Preprint from 'ember-osf-web/models/preprint';
 import CurrentUser from 'ember-osf-web/services/current-user';
 import getRelatedHref from 'ember-osf-web/utils/get-related-href';
-import pathJoin from 'ember-osf-web/utils/path-join';
+import { addPathSegment } from 'ember-osf-web/utils/url-parts';
 import { SingleResourceDocument } from 'osf-api';
 
 import template from './template';
@@ -29,10 +29,13 @@ const defaultCitations: DefaultCitation[] = [
 function citationUrl(citable: Node | Preprint, citationStyleId: string) {
     const relatedHref = getRelatedHref(citable.links.relationships!.citation);
 
-    return pathJoin(
-        relatedHref!,
+    if (!relatedHref) {
+        throw Error('Error getting citation URL');
+    }
+
+    return addPathSegment(
+        relatedHref,
         citationStyleId,
-        '/',
     );
 }
 

--- a/lib/osf-components/addon/components/osf-link/component.ts
+++ b/lib/osf-components/addon/components/osf-link/component.ts
@@ -9,7 +9,7 @@ import config from 'ember-get-config';
 
 import CurrentUser from 'ember-osf-web/services/current-user';
 import defaultTo from 'ember-osf-web/utils/default-to';
-import { addQueryParam } from 'ember-osf-web/utils/param';
+import { addQueryParam } from 'ember-osf-web/utils/url-parts';
 
 import template from './template';
 

--- a/lib/osf-components/addon/components/osf-navbar/x-links/hyper-link/x-anchor/component.ts
+++ b/lib/osf-components/addon/components/osf-navbar/x-links/hyper-link/x-anchor/component.ts
@@ -6,7 +6,7 @@ import config from 'ember-get-config';
 
 import { layout } from 'ember-osf-web/decorators/component';
 import CurrentUser from 'ember-osf-web/services/current-user';
-import { addQueryParam } from 'ember-osf-web/utils/param';
+import { addQueryParam } from 'ember-osf-web/utils/url-parts';
 import template from './template';
 
 const {

--- a/lib/registries/addon/components/registration-form-view/component.ts
+++ b/lib/registries/addon/components/registration-form-view/component.ts
@@ -46,9 +46,9 @@ export class Answerable {
         return new Answerable(
             question.type,
             question.format,
-            fixAnswerValue(answer.value as string | string[]),
+            answer ? fixAnswerValue(answer.value as string | string[]) : '',
             Boolean(question.required),
-            (answer.extra && answer.extra.length) ? answer.extra : {},
+            (answer && answer.extra && answer.extra.length) ? answer.extra : {},
             question.description,
         );
     }

--- a/lib/registries/addon/components/registries-metadata/template.hbs
+++ b/lib/registries/addon/components/registries-metadata/template.hbs
@@ -176,20 +176,22 @@
                 </field.display>
             </EditableField>
         </div>
-        <div local-class='Field'>
-            <h4>{{t 'registries.registration_metadata.citation'}}</h4>
-            <OsfButton
-                data-analytics-name='{{if this.expandCitations 'Collapse' 'Expand'}} citations'
-                local-class='LinkButton'
-                @type='link'
-                @onClick={{action (mut this.expandCitations) (not this.expandCitations)}}
-            >
-                {{this.registrationDisplayUrl}}
-                <FaIcon @icon={{if this.expandCitations 'caret-up' 'caret-down'}} />
-            </OsfButton>
-            {{#if this.expandCitations}}
-                <CitationViewer @citable={{this.registration}} />
-            {{/if}}
-        </div>
+        {{#unless this.registration.isAnonymous}}
+            <div local-class='Field'>
+                <h4>{{t 'registries.registration_metadata.citation'}}</h4>
+                <OsfButton
+                    data-analytics-name='{{if this.expandCitations 'Collapse' 'Expand'}} citations'
+                    local-class='LinkButton'
+                    @type='link'
+                    @onClick={{action (mut this.expandCitations) (not this.expandCitations)}}
+                >
+                    {{this.registrationDisplayUrl}}
+                    <FaIcon @icon={{if this.expandCitations 'caret-up' 'caret-down'}} />
+                </OsfButton>
+                {{#if this.expandCitations}}
+                    <CitationViewer @citable={{this.registration}} />
+                {{/if}}
+            </div>
+        {{/unless}}
     {{/if}}
 </div>

--- a/mirage/factories/node.ts
+++ b/mirage/factories/node.ts
@@ -16,6 +16,7 @@ export interface MirageNode extends Node {
 
 export interface NodeTraits {
     anonymized: Trait;
+    currentUserAdmin: Trait;
     withContributors: Trait;
     withRegistrations: Trait;
     withDraftRegistrations: Trait;
@@ -156,6 +157,10 @@ export default Factory.extend<MirageNode & NodeTraits>({
                 nodes: [node],
             });
         },
+    }),
+
+    currentUserAdmin: trait<MirageNode>({
+        currentUserPermissions: Object.values(Permission),
     }),
 
     anonymized: trait<MirageNode>({

--- a/mirage/factories/node.ts
+++ b/mirage/factories/node.ts
@@ -11,9 +11,11 @@ export interface MirageNode extends Node {
     affiliatedInstitutionIds: string[] | number[];
     regionId: string | number;
     lastLogged: Date | string;
+    _anonymized: boolean;
 }
 
 export interface NodeTraits {
+    anonymized: Trait;
     withContributors: Trait;
     withRegistrations: Trait;
     withDraftRegistrations: Trait;
@@ -73,6 +75,7 @@ export default Factory.extend<MirageNode & NodeTraits>({
     nodeLicense: null,
     public: true,
     tags: faker.lorem.words(5).split(' '),
+    _anonymized: false,
 
     withContributors: trait<MirageNode>({
         afterCreate(node, server) {
@@ -153,6 +156,10 @@ export default Factory.extend<MirageNode & NodeTraits>({
                 nodes: [node],
             });
         },
+    }),
+
+    anonymized: trait<MirageNode>({
+        _anonymized: true,
     }),
 });
 

--- a/mirage/factories/utils.ts
+++ b/mirage/factories/utils.ts
@@ -34,6 +34,8 @@ export function guidAfterCreate(newObj: ModelInstance, server: Server) {
     });
 }
 
+const anonymizedQuestions = ['Authors'];
+
 function fakeAnswer(question: Question | Subquestion, answerIfRequired: boolean): Answer<any> {
     const answer: Answer<any> = {
         comments: [],
@@ -86,11 +88,15 @@ function fakeAnswer(question: Question | Subquestion, answerIfRequired: boolean)
 export function createRegistrationMetadata(
     registrationSchema: ModelInstance<MirageRegistrationSchema>,
     answerAllRequired = false,
+    anonymized = false,
 ) {
     const registrationMetadata: RegistrationMetadata = {};
     if (registrationSchema.schemaNoConflict) {
         registrationSchema.schemaNoConflict.pages.forEach(page =>
             page.questions.forEach(question => {
+                if (anonymized && anonymizedQuestions.includes(question.title)) {
+                    return;
+                }
                 if (question.type === 'object' && question.properties) {
                     const value: RegistrationMetadata = { };
                     question.properties.forEach(property => {

--- a/mirage/serializers/application.ts
+++ b/mirage/serializers/application.ts
@@ -2,7 +2,7 @@ import { underscore } from '@ember/string';
 import { Collection, JSONAPISerializer, ModelInstance, Request } from 'ember-cli-mirage';
 import DS, { RelationshipsFor } from 'ember-data';
 import config from 'ember-get-config';
-import { RelatedLinkMeta, Relationship } from 'osf-api';
+import { BaseMeta, RelatedLinkMeta, Relationship } from 'osf-api';
 
 const { OSF: { apiUrl } } = config;
 
@@ -43,9 +43,19 @@ export default class ApplicationSerializer<T extends DS.Model> extends JSONAPISe
         return {};
     }
 
+    buildApiMeta(_: ModelInstance<T>): BaseMeta {
+        return {
+            version: '',
+        };
+    }
+
     serialize(model: ModelInstance<T>, request: Request) {
         const json = super.serialize(model, request);
         json.data.links = this.buildNormalLinks(model);
+        json.data.meta = {
+            ...this.buildApiMeta(model),
+            ...(json.data.meta || {}),
+        };
         json.data.relationships = Object
             .entries(this.buildRelationships(model))
             .reduce((acc, [key, value]) => {

--- a/mirage/serializers/node.ts
+++ b/mirage/serializers/node.ts
@@ -9,6 +9,7 @@ export interface NodeAttrs {
     parentId: ID | null;
     rootId: ID | null;
     licenseId: ID | null;
+    _anonymized: boolean;
 }
 
 type MirageNode = Node & { attrs: NodeAttrs };
@@ -161,6 +162,13 @@ export default class NodeSerializer extends ApplicationSerializer<MirageNode> {
         return {
             ...super.buildNormalLinks(model),
             html: `/${model.id}/`,
+        };
+    }
+
+    buildApiMeta(model: ModelInstance<MirageNode>) {
+        return {
+            ...super.buildApiMeta(model),
+            ...(model.attrs._anonymized ? { anonymous: true } : {}),
         };
     }
 }

--- a/tests/acceptance/guid-file/file-detail-test.ts
+++ b/tests/acceptance/guid-file/file-detail-test.ts
@@ -113,12 +113,12 @@ module('Acceptance | guid file', hooks => {
                     user: currentUser,
                 },
             );
-            await visit(`--file/${fileOne.id}`);
-            assert.equal(currentURL(), `--file/${fileOne.guid}`);
+            await visit(`/--file/${fileOne.id}`);
+            assert.equal(currentURL(), `/--file/${fileOne.guid}`);
             assert.dom('[data-test-file-title-header]').containsText(fileOne.name);
             assert.dom(`[data-test-file-item-link="${fileTwo.name}"]`).exists();
             await click(`[data-test-file-item-link="${fileTwo.name}"]`);
-            assert.equal(currentURL(), `/--file/${fileTwo.guid}?show=view`);
+            assert.equal(currentURL(), `/--file/${fileTwo.guid}`);
             assert.dom('[data-test-file-title-header]').containsText(fileTwo.name);
         });
 
@@ -309,12 +309,12 @@ module('Acceptance | guid file', hooks => {
                     user: otherUser,
                 },
             );
-            await visit(`--file/${fileOne.id}`);
-            assert.equal(currentURL(), `--file/${fileOne.guid}`);
+            await visit(`/--file/${fileOne.id}`);
+            assert.equal(currentURL(), `/--file/${fileOne.guid}`);
             assert.dom('[data-test-file-title-header]').containsText(fileOne.name);
             assert.dom(`[data-test-file-item-link="${fileTwo.name}"]`).exists();
             await click(`[data-test-file-item-link="${fileTwo.name}"]`);
-            assert.equal(currentURL(), `/--file/${fileTwo.guid}?show=view`);
+            assert.equal(currentURL(), `/--file/${fileTwo.guid}`);
             assert.dom('[data-test-file-title-header]').containsText(fileTwo.name);
         });
 

--- a/tests/acceptance/new-home-test.ts
+++ b/tests/acceptance/new-home-test.ts
@@ -56,6 +56,6 @@ module('Acceptance | new home page test', hooks => {
         await visit('/new-home');
 
         await click('[data-test-get-started-button]');
-        assert.equal(currentURL(), '/register?campaign=&next=');
+        assert.equal(currentURL(), '/register');
     });
 });

--- a/tests/acceptance/view-only-link-test.ts
+++ b/tests/acceptance/view-only-link-test.ts
@@ -1,10 +1,10 @@
 import { Request } from 'ember-cli-mirage';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import config from 'ember-get-config';
-import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 import { click, currentURL, visit } from 'ember-osf-web/tests/helpers';
+import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
 
 const {
     OSF: {
@@ -14,7 +14,7 @@ const {
 } = config;
 
 module('Acceptance | view-only-links', hooks => {
-    setupApplicationTest(hooks);
+    setupEngineApplicationTest(hooks, 'registries');
     setupMirage(hooks);
 
     test('View-only links', async assert => {
@@ -122,5 +122,17 @@ module('Acceptance | view-only-links', hooks => {
 
         assert.equal(currentURL(), '/');
         assert.dom('[data-test-view-normally]').doesNotExist();
+    });
+
+    test('Transition from project to registration does not add bad VOL', async assert => {
+        const mirageProject = server.create('node', 'currentUserAdmin');
+        const mirageRegistration = server.create('registration', {
+            registeredFrom: mirageProject,
+        }, 'currentUserAdmin');
+
+        await visit(`/${mirageProject.id}/registrations`);
+        await click('[data-test-node-card-heading] a');
+
+        assert.equal(currentURL(), `/--registries/${mirageRegistration.id}`, 'URL does not have view_only');
     });
 });

--- a/tests/engines/registries/acceptance/overview/view-only-link-test.ts
+++ b/tests/engines/registries/acceptance/overview/view-only-link-test.ts
@@ -1,0 +1,39 @@
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { module, test } from 'qunit';
+
+import { createRegistrationMetadata } from 'ember-osf-web/mirage/factories/utils';
+import { visit } from 'ember-osf-web/tests/helpers';
+import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
+
+module('Registries | Acceptance | overview.view-only-link', hooks => {
+    setupEngineApplicationTest(hooks, 'registries');
+    setupMirage(hooks);
+
+    hooks.beforeEach(() => {
+        server.loadFixtures('registration-schemas');
+    });
+
+    test('anonymized registered_meta should not break everything', async assert => {
+        server.create('root', 'withAnonymizedVOL');
+        const viewOnlyToken = 'thisisatoken';
+
+        const registrationSchema = server.schema.registrationSchemas.find('prereg_challenge');
+        const mirageReg = server.create('registration', {
+            registrationSchema,
+            registeredMeta: createRegistrationMetadata(registrationSchema, true, true),
+            pendingRegistrationApproval: true,
+            public: false,
+        });
+
+        await visit(`/${mirageReg.id}?view_only=${viewOnlyToken}`);
+
+        assert.dom('[data-test-form-section]').exists({ count: 7 });
+        const assertTitle = assert.dom('#study-information\\.title p');
+        assertTitle.exists({ count: 1 });
+        assertTitle.hasAnyText();
+
+        const assertAuthors = assert.dom('#study-information\\.authors p');
+        assertAuthors.exists({ count: 1 });
+        assertAuthors.hasText('', 'Authors question empty');
+    });
+});

--- a/tests/unit/utils/param-test.ts
+++ b/tests/unit/utils/param-test.ts
@@ -1,4 +1,4 @@
-import param, { addQueryParam } from 'ember-osf-web/utils/param';
+import param from 'ember-osf-web/utils/param';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | param', () => {
@@ -26,43 +26,5 @@ module('Unit | Utility | param', () => {
             }),
             'foo%2Fbar=boo%2Choo',
         );
-    });
-
-    test('addQueryParam', assert => {
-        const testCases = [
-            {
-                initial: 'https://osf.io/',
-                key: 'foo',
-                val: 'bar',
-                expected: 'https://osf.io/?foo=bar',
-            },
-            {
-                initial: 'https://osf.io/?blah=blee',
-                key: 'foo',
-                val: 'bar',
-                expected: 'https://osf.io/?blah=blee&foo=bar',
-            },
-            {
-                initial: 'https://osf.io/?aoeu=aoeu&blah=blee#hahafragment',
-                key: 'foo',
-                val: 'bar',
-                expected: 'https://osf.io/?aoeu=aoeu&blah=blee&foo=bar#hahafragment',
-            },
-            {
-                initial: 'https://osf.io/#hahafragment',
-                key: 'foo',
-                val: 'bar',
-                expected: 'https://osf.io/?foo=bar#hahafragment',
-            },
-        ];
-
-        for (const testCase of testCases) {
-            const actual = addQueryParam(
-                testCase.initial,
-                testCase.key,
-                testCase.val,
-            );
-            assert.equal(actual, testCase.expected, 'addQueryParam added query param');
-        }
     });
 });

--- a/tests/unit/utils/url-parts-test.ts
+++ b/tests/unit/utils/url-parts-test.ts
@@ -1,0 +1,143 @@
+import { addPathSegment, addQueryParam, joinUrl, splitUrl } from 'ember-osf-web/utils/url-parts';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | url-parts', () => {
+    test('splitUrl and joinUrl', assert => {
+        const testCases = [
+            {
+                input: 'https://osf.io/',
+                expected: {
+                    path: 'https://osf.io/',
+                    queryString: undefined,
+                    fragment: undefined,
+                },
+            },
+            {
+                input: 'https://osf.io/?blah=blee',
+                expected: {
+                    path: 'https://osf.io/',
+                    queryString: 'blah=blee',
+                    fragment: undefined,
+                },
+            },
+            {
+                input: 'https://osf.io/?aoeu=aoeu&blah=blee#hahafragment',
+                expected: {
+                    path: 'https://osf.io/',
+                    queryString: 'aoeu=aoeu&blah=blee',
+                    fragment: 'hahafragment',
+                },
+            },
+            {
+                input: 'https://osf.io/#hahafragment',
+                expected: {
+                    path: 'https://osf.io/',
+                    queryString: undefined,
+                    fragment: 'hahafragment',
+                },
+            },
+            {
+                input: '/?aoeu=aoeu&blah=blee#hahafragment',
+                expected: {
+                    path: '/',
+                    queryString: 'aoeu=aoeu&blah=blee',
+                    fragment: 'hahafragment',
+                },
+            },
+            {
+                input: '/some/path/#hahafragment',
+                expected: {
+                    path: '/some/path/',
+                    queryString: undefined,
+                    fragment: 'hahafragment',
+                },
+            },
+            {
+                input: '/#hahafragment',
+                expected: {
+                    path: '/',
+                    queryString: undefined,
+                    fragment: 'hahafragment',
+                },
+            },
+        ];
+
+        for (const testCase of testCases) {
+            const actual = splitUrl(testCase.input);
+            assert.deepEqual(actual, testCase.expected, 'splitUrl split the URL');
+            const rejoined = joinUrl(actual);
+            assert.equal(rejoined, testCase.input, 'joinUrl rejoins to the same URL');
+        }
+    });
+
+    test('addQueryParam', assert => {
+        const testCases = [
+            {
+                initial: 'https://osf.io/',
+                key: 'foo',
+                val: 'bar',
+                expected: 'https://osf.io/?foo=bar',
+            },
+            {
+                initial: 'https://osf.io/?blah=blee',
+                key: 'foo',
+                val: 'bar',
+                expected: 'https://osf.io/?blah=blee&foo=bar',
+            },
+            {
+                initial: 'https://osf.io/?aoeu=aoeu&blah=blee#hahafragment',
+                key: 'foo',
+                val: 'bar',
+                expected: 'https://osf.io/?aoeu=aoeu&blah=blee&foo=bar#hahafragment',
+            },
+            {
+                initial: 'https://osf.io/#hahafragment',
+                key: 'foo',
+                val: 'bar',
+                expected: 'https://osf.io/?foo=bar#hahafragment',
+            },
+        ];
+
+        for (const testCase of testCases) {
+            const actual = addQueryParam(
+                testCase.initial,
+                testCase.key,
+                testCase.val,
+            );
+            assert.equal(actual, testCase.expected, 'addQueryParam added query param');
+        }
+    });
+
+    test('addPathSegment', assert => {
+        const testCases = [
+            {
+                initial: 'https://osf.io/',
+                segment: 'foo',
+                expected: 'https://osf.io/foo',
+            },
+            {
+                initial: 'https://osf.io/?blah=blee',
+                segment: 'foo',
+                expected: 'https://osf.io/foo?blah=blee',
+            },
+            {
+                initial: 'https://osf.io/woo/?aoeu=aoeu&blah=blee#hahafragment',
+                segment: 'foo',
+                expected: 'https://osf.io/woo/foo?aoeu=aoeu&blah=blee#hahafragment',
+            },
+            {
+                initial: 'https://osf.io/#hahafragment',
+                segment: 'foo/blah/boo',
+                expected: 'https://osf.io/foo/blah/boo#hahafragment',
+            },
+        ];
+
+        for (const testCase of testCases) {
+            const actual = addPathSegment(
+                testCase.initial,
+                testCase.segment,
+            );
+            assert.equal(actual, testCase.expected, 'addPathSegment added a path segment');
+        }
+    });
+});


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[EMB-123] some really great stuff`
-->

## Purpose
Fix some VOL bugs
<!-- Describe the purpose of your changes. -->

## Summary of Changes
- Anonymized registration forms might be missing answers to questions. Update `registration-form-view` parser to handle missing answers gracefully.
- New util: `addPathSegment` for adding a segment to a URL's path
  - Consolidated utils for manipulating URL parts in `utils/url-parts`
- Update `citation-viewer` to behave correctly with view-only links
  - use `addPathSegment` to build URL with `view_only` query param
  - hide citation widget for anonymized view
- Add a non-`undefined` default value for the `view_only` query param
- Update mirage to handle AVOLs *slightly* more true-to-life

## Side Effects
For some reason, adding a default value for `view_only` also fixed a long-standing bug on `guid-file` and a shorter-standing one on `new-home`: query params were sometimes displayed in the URL when they have default values, which shouldn't happen.
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## Feature Flags

<!--
  Please list any feature flags that need to be enabled for these changes to go into effect.
  For each flag, what is the expected behavior with the flag enabled vs disabled?
-->

## QA Notes
In addition to the issues in the tickets, this inadvertently fixes some strange query parameter behavior across the app. In short, when a query parameter has its default value (usually an empty string), it is not supposed to show up in the URL. This should not affect anything, but is worth at least spot checking. A good one is the quickfile detail page:

- Go to a quickfile guid (I'll use `abcde`), check that the url is `/abcde`
- Click around with "view", "edit", and "revisions", check they all work and have the correct URLs:
  - revisions: `/abcde?show=revisions`
  - view & edit split: `/abcde?show=view_edit`
  - just edit: `/abcde?show=edit`
  - just view: `/abcde`
- Click another file in the quickfile list. The URL should be `/fghjk`, without `?show=view`
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
-->

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
https://openscience.atlassian.net/browse/ENG-458
https://openscience.atlassian.net/browse/ENG-544
https://openscience.atlassian.net/browse/ENG-545
https://openscience.atlassian.net/browse/ENG-550

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
