### PR TITLE
mirage: make comment dates relative to now

### DIFF
--- a/mirage/factories/comment.ts
+++ b/mirage/factories/comment.ts
@@ -26,10 +26,10 @@ export default Factory.extend<Comment & CommentTraits>({
         return faker.lorem.sentences(faker.random.number({ min: 1, max: 4 }));
     },
     dateCreated() {
-        return faker.date.past(3, new Date(2019, 0, 0));
+        return faker.date.past(3);
     },
     dateModified() {
-        return faker.date.past(3, new Date(2019, 0, 0));
+        return faker.date.past(3);
     },
     modified: false,
     deleted: false,


### PR DESCRIPTION
## Purpose

Make comment dates relative to now since they are always displayed as relative dates. This will eliminate jitter in Percy snapshots as seen [here](https://percy.io/Center-for-Open-Science/ember-osf-web/builds/1973449/view/128309897/1280?mode=diff&browser=chrome&snapshot=128309897).

## Summary of Changes

make created and modified dates relative to now in `comment` mirage factory

## Side Effects

None expected.

## Feature Flags

n/a

## QA Notes

No QA needed.

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
