### PR TITLE
[ENG-564] fix: only show dates when they are defined

### DIFF
--- a/app/meetings/index/-components/meetings-list/template.hbs
+++ b/app/meetings/index/-components/meetings-list/template.hbs
@@ -58,7 +58,9 @@
                     {{meeting.location}}
                 </div>
                 <div data-test-meetings-list-item-date>
-                    {{moment-format meeting.startDate 'MMM DD, YYYY'}} - {{moment-format meeting.endDate 'MMM DD, YYYY'}}
+                    {{if meeting.startDate (moment-format meeting.startDate 'MMM DD, YYYY')}}
+                    {{if (or meeting.startDate meeting.endDate) ' - '}}
+                    {{if meeting.endDate (moment-format meeting.endDate 'MMM DD, YYYY')}}
                 </div>
             {{else}}
                 <div data-test-meetings-list-placeholder-name>


### PR DESCRIPTION
## Purpose

Only show meeting dates when they are defined.

## Summary of Changes

Only show meeting dates when they are defined.

## Side Effects

Should be none.

## Feature Flags

`ember_meetings_page`

## QA Notes

I've implemented this so that the ` - ` separator still displays when only one date is defined so that it is clear which date it is.

## Ticket

https://openscience.atlassian.net/browse/ENG-564

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
