### PR TITLE
refactor: use padding instead of negative margins to prevent overlap

### DIFF
--- a/app/settings/account/-components/connected-emails/styles.scss
+++ b/app/settings/account/-components/connected-emails/styles.scss
@@ -24,34 +24,38 @@
     margin-top: 8px;
 }
 
-.email-section {
-    :global(.list-group-item):last-of-type > .email-object {
-        border-bottom: 0;
+.email-list {
+    ul {
+        margin: 0;
     }
-}
 
-.email-list ul {
-    margin: 0;
-
-    & > li {
+    li {
         border: 0;
         padding: 0;
         margin-bottom: 0;
+
+        &:last-of-type > .email-object {
+            border-bottom: 0;
+        }
     }
 }
 
 .email-object {
     border-bottom: 1px solid $color-border-gray;
-    padding: 20px 8px 13px;
+    padding: 13px 8px;
 }
 
 .no-object-message {
-    padding: 20px 8px 13px;
+    padding: 13px 8px;
+}
+
+.email-address {
+    display: inline-block;
+    padding: 7px 0;
 }
 
 .options {
     margin-right: 0;
-    margin-top: -8px;
     float: right;
 }
 

--- a/app/settings/account/-components/connected-emails/template.hbs
+++ b/app/settings/account/-components/connected-emails/template.hbs
@@ -22,142 +22,144 @@
             <h5 local-class='section-header'>
                 {{t 'settings.account.connected_emails.alternate_emails'}}
             </h5>
-            <span local-class='email-section'>
-                <PaginatedList::HasMany
-                    local-class='email-list'
-                    @model={{this.currentUser.user}}
-                    @relationshipName='emails'
-                    @bindReload={{action (mut this.reloadAlternateList)}}
-                    @query={{this.alternateQueryParams}}
-                    @usePlaceholders={{false}}
-                    @analyticsScope='Account Settings - Alternate Emails'
-                    as |list|
-                >
-                    <list.item as |email|>
-                        <div local-class='email-object' class='clearfix'>
-                            {{#if (not email)}}
-                                <ContentPlaceholders as |placeholder|>
-                                    <placeholder.heading @subtitle={{false}} />
-                                </ContentPlaceholders>
-                            {{else}}
-                                <span data-test-alternate-email-item='{{email.emailAddress}}'>
+            <PaginatedList::HasMany
+                local-class='email-list'
+                @model={{this.currentUser.user}}
+                @relationshipName='emails'
+                @bindReload={{action (mut this.reloadAlternateList)}}
+                @query={{this.alternateQueryParams}}
+                @usePlaceholders={{false}}
+                @analyticsScope='Account Settings - Alternate Emails'
+                as |list|
+            >
+                <list.item as |email|>
+                    <div local-class='email-object' class='clearfix'>
+                        {{#if (not email)}}
+                            <ContentPlaceholders as |placeholder|>
+                                <placeholder.heading @subtitle={{false}} />
+                            </ContentPlaceholders>
+                        {{else}}
+                            <div data-test-alternate-email-item='{{email.emailAddress}}'>
+                                <div local-class='email-address'>
                                     {{email.emailAddress}}
-                                    <div local-class='options'>
-                                        <BsButton
-                                            data-test-make-primary
-                                            data-analytics-name='Make primary'
-                                            @onClick={{action this.makePrimary email}}
-                                        >
-                                            {{t 'settings.account.connected_emails.make_primary'}}
-                                        </BsButton>
-                                        <DeleteButton
-                                            data-test-alternate-delete
-                                            @small=true
-                                            @delete={{action this.removeEmail email}}
-                                            @analyticsScope='Settings - Alternate Emails'
-                                            @modalTitle={{t 'settings.account.connected_emails.confirm_delete.title'}}
-                                            @modalBody={{t 'settings.account.connected_emails.confirm_delete.body' emailAddress=email.emailAddress}}
-                                        />
-                                    </div>
-                                </span>
-                            {{/if}}
-                        </div>
-                    </list.item>
-                    <list.empty>
-                        <div local-class='no-object-message' class='clearfix'>
-                            {{t 'settings.account.connected_emails.no_alternate_emails'}}
-                        </div>
-                    </list.empty>
-                </PaginatedList::HasMany>
-            </span>
+                                </div>
+                                <div local-class='options'>
+                                    <OsfButton
+                                        data-test-make-primary
+                                        data-analytics-name='Make primary'
+                                        @onClick={{action this.makePrimary email}}
+                                    >
+                                        {{t 'settings.account.connected_emails.make_primary'}}
+                                    </OsfButton>
+                                    <DeleteButton
+                                        data-test-alternate-delete
+                                        @small=true
+                                        @delete={{action this.removeEmail email}}
+                                        @analyticsScope='Settings - Alternate Emails'
+                                        @modalTitle={{t 'settings.account.connected_emails.confirm_delete.title'}}
+                                        @modalBody={{t 'settings.account.connected_emails.confirm_delete.body' emailAddress=email.emailAddress}}
+                                    />
+                                </div>
+                            </div>
+                        {{/if}}
+                    </div>
+                </list.item>
+                <list.empty>
+                    <div local-class='no-object-message' class='clearfix'>
+                        {{t 'settings.account.connected_emails.no_alternate_emails'}}
+                    </div>
+                </list.empty>
+            </PaginatedList::HasMany>
         </div>
         <div local-class='section-container'>
             <h5 local-class='section-header'>
                 {{t 'settings.account.connected_emails.unconfirmed_emails'}}
             </h5>
-            <span local-class='email-section'>
-                <PaginatedList::HasMany
-                    local-class='email-list'
-                    @model={{this.currentUser.user}}
-                    @relationshipName='emails'
-                    @bindReload={{action (mut this.reloadUnconfirmedList)}}
-                    @query={{this.unconfirmedQueryParams}}
-                    @usePlaceholders={{false}}
-                    @analyticsScope='Account Settings - Unconfirmed Emails'
-                    as |list|
-                >
-                    <list.item as |email|>
-                        <div local-class='email-object' class='clearfix'>
-                            {{#if (not email)}}
-                                <ContentPlaceholders as |placeholder|>
-                                    <placeholder.heading @subtitle={{false}} />
-                                </ContentPlaceholders>
-                            {{else}}
-                                <span data-test-unconfirmed-email-item={{email.emailAddress}}>
+            <PaginatedList::HasMany
+                local-class='email-list'
+                @model={{this.currentUser.user}}
+                @relationshipName='emails'
+                @bindReload={{action (mut this.reloadUnconfirmedList)}}
+                @query={{this.unconfirmedQueryParams}}
+                @usePlaceholders={{false}}
+                @analyticsScope='Account Settings - Unconfirmed Emails'
+                as |list|
+            >
+                <list.item as |email|>
+                    <div local-class='email-object' class='clearfix'>
+                        {{#if (not email)}}
+                            <ContentPlaceholders as |placeholder|>
+                                <placeholder.heading @subtitle={{false}} />
+                            </ContentPlaceholders>
+                        {{else}}
+                            <div data-test-unconfirmed-email-item={{email.emailAddress}}>
+                                <div local-class='email-address'>
                                     {{email.emailAddress}}
-                                    <div local-class='options'>
-                                        <BsButton
-                                            data-test-resend-confirmation-button
-                                            data-analytics-name='Resend confirmation'
-                                            @onClick={{action this.toggleMergeModal}}
-                                        >
-                                            {{t 'settings.account.connected_emails.resend_confirmation'}}
-                                        </BsButton>
-                                        <BsModal
-                                            @open={{this.showMergeModal}}
-                                            @tagName='span'
-                                            @onHide={{action this.toggleMergeModal}}
-                                            as |modal|
-                                        >
-                                            <modal.header>
-                                                <h3 class='modal-title'>
-                                                    {{t 'settings.account.connected_emails.resend_confirmation_modal.title'}}
-                                                </h3>
-                                            </modal.header>
+                                </div>
+                                <div local-class='options'>
+                                    <OsfButton
+                                        data-test-resend-confirmation-button
+                                        data-analytics-name='Resend confirmation'
+                                        @onClick={{action this.toggleMergeModal}}
+                                    >
+                                        {{t 'settings.account.connected_emails.resend_confirmation'}}
+                                    </OsfButton>
+                                    <BsModal
+                                        @open={{this.showMergeModal}}
+                                        @tagName='span'
+                                        @onHide={{action this.toggleMergeModal}}
+                                        as |modal|
+                                    >
+                                        <modal.header>
+                                            <h3 class='modal-title'>
+                                                {{t 'settings.account.connected_emails.resend_confirmation_modal.title'}}
+                                            </h3>
+                                        </modal.header>
 
-                                            <modal.body>
-                                                <p>
-                                                    {{t 'settings.account.connected_emails.resend_confirmation_modal.body' emailAddress=email.emailAddress}}
-                                                </p>
-                                            </modal.body>
+                                        <modal.body>
+                                            <p>
+                                                {{t 'settings.account.connected_emails.resend_confirmation_modal.body' emailAddress=email.emailAddress}}
+                                            </p>
+                                        </modal.body>
 
-                                            <modal.footer
-                                                data-analytics-scope='Merge modal'
+                                        <modal.footer
+                                            data-analytics-scope='Merge modal'
+                                        >
+                                            <OsfButton
+                                                data-test-close-modal
+                                                data-analytics-name='Close modal'
+                                                @onClick={{action this.toggleMergeModal}}
                                             >
-                                                <BsButton
-                                                    data-test-close-modal
-                                                    data-analytics-name='Close modal'
-                                                    @onClick={{action this.toggleMergeModal}}
-                                                    @defaultText={{t 'general.cancel'}}
-                                                />
-                                                <BsButton
-                                                    data-test-resend-confirmation
-                                                    data-analytics-name='Resend confirmation'
-                                                    @type='primary'
-                                                    @onClick={{action this.resendConfirmation email}}
-                                                    @defaultText={{t 'settings.account.connected_emails.resend_confirmation_modal.resend_button'}}
-                                                />
-                                            </modal.footer>
-                                        </BsModal>
-                                        <DeleteButton
-                                            @small=true
-                                            @delete={{action this.removeEmail email}}
-                                            @analyticsScope='Settings - Unconfirmed Emails'
-                                            @modalTitle={{t 'settings.account.connected_emails.confirm_delete.title'}}
-                                            @modalBody={{t 'settings.account.connected_emails.confirm_delete.body' emailAddress=email.emailAddress}}
-                                        />
-                                    </div>
-                                </span>
-                            {{/if}}
-                        </div>
-                    </list.item>
-                    <list.empty>
-                        <div local-class='no-object-message' class='clearfix'>
-                            {{t 'settings.account.connected_emails.no_unconfirmed_emails'}}
-                        </div>
-                    </list.empty>
-                </PaginatedList::HasMany>
-            </span>
+                                                {{t 'general.cancel'}}
+                                            </OsfButton>
+                                            <OsfButton
+                                                data-test-resend-confirmation
+                                                data-analytics-name='Resend confirmation'
+                                                @type='primary'
+                                                @onClick={{action this.resendConfirmation email}}
+                                            >
+                                                {{t 'settings.account.connected_emails.resend_confirmation_modal.resend_button'}}
+                                            </OsfButton>
+                                        </modal.footer>
+                                    </BsModal>
+                                    <DeleteButton
+                                        @small=true
+                                        @delete={{action this.removeEmail email}}
+                                        @analyticsScope='Settings - Unconfirmed Emails'
+                                        @modalTitle={{t 'settings.account.connected_emails.confirm_delete.title'}}
+                                        @modalBody={{t 'settings.account.connected_emails.confirm_delete.body' emailAddress=email.emailAddress}}
+                                    />
+                                </div>
+                            </div>
+                        {{/if}}
+                    </div>
+                </list.item>
+                <list.empty>
+                    <div local-class='no-object-message' class='clearfix'>
+                        {{t 'settings.account.connected_emails.no_unconfirmed_emails'}}
+                    </div>
+                </list.empty>
+            </PaginatedList::HasMany>
             <p local-class='merge-explanation'>
                 {{t 'settings.account.connected_emails.merge_explanation'}}
             </p>
@@ -177,14 +179,14 @@
                     @placeholder={{t 'settings.account.connected_emails.placeholder_text'}}
                     @ariaLabel={{t 'settings.account.connected_emails.placeholder_text'}}
                 />
-                <BsButton
+                <OsfButton
                     data-test-add-email-button
                     data-analytics-name='add email'
                     @buttonType='submit'
                     @local-class='add-email-button'
                 >
                     {{t 'settings.account.connected_emails.add_email'}}
-                </BsButton>
+                </OsfButton>
             </ValidatedModelForm>
             <BsModal
                 @open={{this.showAddModal}}
@@ -207,12 +209,13 @@
                 <modal.footer
                     data-analytics-scope='Add email modal'
                 >
-                    <BsButton
+                    <OsfButton
                         data-test-close-modal
                         data-analytics-name='Close modal'
                         @onClick={{action this.toggleAddModal}}
-                        @defaultText={{t 'general.close'}}
-                    />
+                    >
+                        {{t 'general.close'}}
+                    </OsfButton>
                 </modal.footer>
             </BsModal>
         </div>


### PR DESCRIPTION
## Purpose

use padding instead of negative margins to prevent overlap

## Summary of Changes

* use padding instead of negative margins to prevent overlap
* use `OsfButton`
* remove unnecessary tags

## Side Effects

None expected

## Feature Flags

`ember_user_settings_account_page`

## QA Notes

Should fix issue where buttons overlap email addresses on very small screens.

## Ticket

https://openscience.atlassian.net/browse/ENG-578

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
