### PR TITLE
[ENG-509] Change styling for sidenav

### DIFF
--- a/lib/registries/addon/components/side-nav/styles.scss
+++ b/lib/registries/addon/components/side-nav/styles.scss
@@ -30,7 +30,7 @@ $width-collapsed: 80px;
         color: $white;
     }
 
-    &:hover h4::before {
+    &:hover * > ::before {
         // Adjusts the white border to not cover the top gray line
         top: 0 !important;
         height: calc(1px + 100%) !important;

--- a/lib/registries/addon/components/side-nav/styles.scss
+++ b/lib/registries/addon/components/side-nav/styles.scss
@@ -30,7 +30,7 @@ $width-collapsed: 80px;
         color: $white;
     }
 
-    &:hover * > ::before {
+    &:hover :global(.SideNav_LabelWrapper)::before {
         // Adjusts the white border to not cover the top gray line
         top: 0 !important;
         height: calc(1px + 100%) !important;

--- a/lib/registries/addon/components/side-nav/styles.scss
+++ b/lib/registries/addon/components/side-nav/styles.scss
@@ -18,7 +18,7 @@ $width-collapsed: 80px;
 
 .Links {
     border-bottom: $alto 1px solid;
-    padding: 15px 0;
+    padding: 15px 10px;
     width: 100%;
 }
 

--- a/lib/registries/addon/components/side-nav/x-link/styles.scss
+++ b/lib/registries/addon/components/side-nav/x-link/styles.scss
@@ -77,28 +77,26 @@ $sidenav-link-height: 40px;
     border-radius: 0 5px 5px 0;
 
     // Cover the border around the h4 to give it the "poke out/through" effect
-    &.LabelWrapper {
-        &::before {
-            position: absolute;
-            z-index: 100;
-            border: solid 1px $white;
-            border-left: 0;
-            border-right: 0;
-            background: transparent;
+    &::before {
+        position: absolute;
+        z-index: 100;
+        border: solid 1px $white;
+        border-left: 0;
+        border-right: 0;
+        background: transparent;
 
-            // Needs to be set to render. Adding content messes things up. Don't do that.
-            content: '';
+        // Needs to be set to render. Adding content messes things up. Don't do that.
+        content: '';
 
-            // Sized and positioned to be 1px larger on all sides
-            // than the h4 to cover the border
-            top: -1px;
-            left: -1px;
-            height: calc(2px + 100%);
+        // Sized and positioned to be 1px larger on all sides
+        // than the h4 to cover the border
+        top: -1px;
+        left: -1px;
+        height: calc(2px + 100%);
 
-            // Matches the width of the parent gutter 
-            // Check the width of the .Collapse:hover .LabelWrapper below)
-            width: 26px;
-        }
+        // Matches the width of the parent gutter 
+        // Check the width of the .Collapse:hover .LabelWrapper below)
+        width: 26px;
     }
 }
 

--- a/lib/registries/addon/components/side-nav/x-link/styles.scss
+++ b/lib/registries/addon/components/side-nav/x-link/styles.scss
@@ -6,7 +6,7 @@ $sidenav-link-height: 40px;
     height: $sidenav-link-height;
     justify-content: space-between;
     width: 100%;
-    padding: 5px 20px;
+    padding: 5px 10px;
     color: $primary-blue;
     outline: 0 !important;
 
@@ -26,11 +26,10 @@ $sidenav-link-height: 40px;
     }
 
     &:global(.active) {
-        color: $white;
-        background-color: $primary-blue;
+        color: $black;
+        background-color: $selected-blue;
         border: $white 1px solid;
-        border-left: 0;
-        border-right: 0;
+        border-radius: 5px;
 
         .Count {
             color: inherit;
@@ -59,10 +58,10 @@ $sidenav-link-height: 40px;
 @mixin hover-poke-through($background-color) {
     position: absolute;
     padding: 11px;
+    padding-left: 0;
     height: $sidenav-link-height;
 
-    top: -20px;
-    left: 28px;
+    top: -10px;
 
     // Forces the label to stay on a single line
     // otherwise it will wrap every letter.
@@ -76,6 +75,9 @@ $sidenav-link-height: 40px;
     border: $alto 1px solid;
     border-left: 0;
 
+    // Round the right corners of the h4 elements
+    border-radius: 0 5px 5px 0;
+
     // Cover the border around the h4 to give it the "poke out/through" effect
     &::before {
         position: absolute;
@@ -83,6 +85,7 @@ $sidenav-link-height: 40px;
         border: $white 1px solid;
         border-left: 0;
         border-right: 0;
+        background: transparent;
 
         // Needs to be set to render. Adding content messes things up. Don't do that.
         content: '';
@@ -93,7 +96,8 @@ $sidenav-link-height: 40px;
         left: -1px;
         height: calc(2px + 100%);
 
-        // Matches the width of the parent gutter
+        // Matches the width of the parent gutter 
+        // Check the width of the .Collapse:hover div below)
         width: 26px;
     }
 }
@@ -110,11 +114,26 @@ $sidenav-link-height: 40px;
         display: none;
     }
 
-    &:hover:global(.active) h4 {
-        @include hover-poke-through($primary-blue);
+    &:hover div {
+        @include hover-poke-through($white);
+        border: 0;
+        left: 28px;
+        padding-right: 0;
+        width: max-content;
     }
 
+    &:hover:global(.active) h4 {
+        @include hover-poke-through($selected-blue);
+        position: relative;
+        top: -21px;
+        padding-left: 11px;
+    }
+    
     &:hover:not(:global(.active)) h4 {
         @include hover-poke-through($white);
+        position: relative;
+        top: -21px;
+        padding-left: 11px;
     }
+
 }

--- a/lib/registries/addon/components/side-nav/x-link/styles.scss
+++ b/lib/registries/addon/components/side-nav/x-link/styles.scss
@@ -26,7 +26,7 @@ $sidenav-link-height: 40px;
     }
 
     &:global(.active) {
-        color: $black;
+        color: $midnight-blue;
         background-color: $selected-blue;
         border: $white 1px solid;
         border-radius: 5px;
@@ -70,35 +70,35 @@ $sidenav-link-height: 40px;
     // Arbitrary number, just needs to be > 1 to avoid
     // overlapping with text and < 100 so the border gets covered by the ::before
     z-index: 10;
-
+    
     background: $background-color;
-    border: $alto 1px solid;
-    border-left: 0;
 
     // Round the right corners of the h4 elements
     border-radius: 0 5px 5px 0;
 
     // Cover the border around the h4 to give it the "poke out/through" effect
-    &::before {
-        position: absolute;
-        z-index: 100;
-        border: $white 1px solid;
-        border-left: 0;
-        border-right: 0;
-        background: transparent;
+    &.LabelWrapper {
+        &::before {
+            position: absolute;
+            z-index: 100;
+            border: solid 1px $white;
+            border-left: 0;
+            border-right: 0;
+            background: transparent;
 
-        // Needs to be set to render. Adding content messes things up. Don't do that.
-        content: '';
+            // Needs to be set to render. Adding content messes things up. Don't do that.
+            content: '';
 
-        // Sized and positioned to be 1px larger on all sides
-        // than the h4 to cover the border
-        top: -1px;
-        left: -1px;
-        height: calc(2px + 100%);
+            // Sized and positioned to be 1px larger on all sides
+            // than the h4 to cover the border
+            top: -1px;
+            left: -1px;
+            height: calc(2px + 100%);
 
-        // Matches the width of the parent gutter 
-        // Check the width of the .Collapse:hover div below)
-        width: 26px;
+            // Matches the width of the parent gutter 
+            // Check the width of the .Collapse:hover .LabelWrapper below)
+            width: 26px;
+        }
     }
 }
 
@@ -114,26 +114,28 @@ $sidenav-link-height: 40px;
         display: none;
     }
 
-    &:hover div {
+    &:hover .LabelWrapper {
         @include hover-poke-through($white);
-        border: 0;
+        border: $alto 1px solid;
+        border-left: 0;
         left: 28px;
         padding-right: 0;
         width: max-content;
     }
 
-    &:hover:global(.active) h4 {
-        @include hover-poke-through($selected-blue);
+    &:hover h4 {
         position: relative;
         top: -21px;
-        padding-left: 11px;
+        padding: 11px;
+        z-index: 10;
+        border-radius: 0 5px 5px 0;
+    }
+
+    &:hover:global(.active) h4 {
+        background: $selected-blue;
     }
     
     &:hover:not(:global(.active)) h4 {
-        @include hover-poke-through($white);
-        position: relative;
-        top: -21px;
-        padding-left: 11px;
+        background: $white;
     }
-
 }

--- a/lib/registries/addon/components/side-nav/x-link/template.hbs
+++ b/lib/registries/addon/components/side-nav/x-link/template.hbs
@@ -8,7 +8,9 @@
     >
         <span local-class='Label'>
             <FaIcon @icon={{@icon}} @fixedWidth={{true}} @class={{local-class 'Icon'}} />
-            <h4>{{@label}}</h4>
+            <div>
+                <h4>{{@label}}</h4>
+            </div>
         </span>
 
         <span local-class='Count'>
@@ -29,7 +31,9 @@
     >
         <span local-class='Label'>
             <FaIcon @icon={{@icon}} @fixedWidth={{true}} @class={{local-class 'Icon'}} />
-            <h4>{{@label}}</h4>
+            <div>
+                <h4>{{@label}}</h4>
+            </div>
         </span>
 
         <span local-class='Count'>

--- a/lib/registries/addon/components/side-nav/x-link/template.hbs
+++ b/lib/registries/addon/components/side-nav/x-link/template.hbs
@@ -8,7 +8,7 @@
     >
         <span local-class='Label'>
             <FaIcon @icon={{@icon}} @fixedWidth={{true}} @class={{local-class 'Icon'}} />
-            <div local-class='LabelWrapper'>
+            <div local-class='LabelWrapper' class='SideNav_LabelWrapper'>
                 <h4>{{@label}}</h4>
             </div>
         </span>

--- a/lib/registries/addon/components/side-nav/x-link/template.hbs
+++ b/lib/registries/addon/components/side-nav/x-link/template.hbs
@@ -8,7 +8,7 @@
     >
         <span local-class='Label'>
             <FaIcon @icon={{@icon}} @fixedWidth={{true}} @class={{local-class 'Icon'}} />
-            <div>
+            <div local-class='LabelWrapper'>
                 <h4>{{@label}}</h4>
             </div>
         </span>
@@ -31,7 +31,7 @@
     >
         <span local-class='Label'>
             <FaIcon @icon={{@icon}} @fixedWidth={{true}} @class={{local-class 'Icon'}} />
-            <div>
+            <div local-class='LabelWrapper'>
                 <h4>{{@label}}</h4>
             </div>
         </span>

--- a/lib/registries/addon/styles/variables.scss
+++ b/lib/registries/addon/styles/variables.scss
@@ -1,9 +1,9 @@
 @import 'app/styles/variables';
 
-$selected-blue: rgba(51, 122, 183, 0.2); // Used to show current page
 $primary-blue: #337ab7; // Links, Icons
 // (AAA) $primary-blue: ##0059a6; // Links, Icons
 $secondary-blue: #15a5eb; // Link Hover
+$selected-blue: rgba($primary-blue, 0.2); // Used to show current page
 
 $midnight-blue: #263947; // Primary Type Color
 $dark-slate-gray: #365063; // Dark Background Color

--- a/lib/registries/addon/styles/variables.scss
+++ b/lib/registries/addon/styles/variables.scss
@@ -1,5 +1,6 @@
 @import 'app/styles/variables';
 
+$selected-blue: rgba(51, 122, 183, 0.2); // Used to show current page
 $primary-blue: #337ab7; // Links, Icons
 // (AAA) $primary-blue: ##0059a6; // Links, Icons
 $secondary-blue: #15a5eb; // Link Hover
@@ -21,5 +22,6 @@ $secondary-red: #fb2424; // Red Hover
 
 $disabled-gray: #a5b3bd; // Disabled button icons
 $white: #fff;
+$black: #000;
 
 $primary-box-shadow: rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[EMB-123] some really great stuff`
-->

## Purpose
Re-style the active route in the sidenav component.
<!-- Describe the purpose of your changes. -->

## Summary of Changes

- Update to side-nav/x-link component so label text is in a wrapper div. 
- Update to CSS to match mockup.

<!-- Briefly describe or list your changes. -->

## Side Effects
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## Feature Flags

<!--
  Please list any feature flags that need to be enabled for these changes to go into effect.
  For each flag, what is the expected behavior with the flag enabled vs disabled?
-->

## QA Notes
Please double-check if it looks acceptable on mobile screens and across browsers. Collapsed behavior should have the labels hidden until hovering over the icons. The text should "poke through" the side-bar. There is an issue in Safari that has been reported here: https://openscience.atlassian.net/browse/EOSF-1053

The active link should be a lighter blue than before, and also have rounded edges with a bit of white-space on the sides.


## Before:
Expanded:
![Screen Shot 2019-06-11 at 11 46 42 AM](https://user-images.githubusercontent.com/51409893/59287006-c60b4880-8c3e-11e9-8196-81bdb1f4f197.png)

Collapsed view:
![image](https://user-images.githubusercontent.com/51409893/59286941-a5db8980-8c3e-11e9-840c-0bdc25fe525d.png)

Collapsed Hover:
![image](https://user-images.githubusercontent.com/51409893/59286983-bf7cd100-8c3e-11e9-9ec2-81650517bc7b.png)

## After:
Expanded:
![Screen Shot 2019-06-11 at 11 45 32 AM](https://user-images.githubusercontent.com/51409893/59287020-cd325680-8c3e-11e9-959c-4254413df112.png)

Collapsed:
![Screen Shot 2019-06-11 at 11 45 45 AM](https://user-images.githubusercontent.com/51409893/59287021-cd325680-8c3e-11e9-834d-447e5fc7aeb1.png)

Collaped Hover:
![Screen Shot 2019-06-11 at 11 45 58 AM](https://user-images.githubusercontent.com/51409893/59287019-cd325680-8c3e-11e9-8ffb-38ba8c2f9882.png)

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
-->

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
https://openscience.atlassian.net/browse/ENG-509

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
