### PR TITLE
[ENG-590] remove meetings submission list download count sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Components:
+    - `meetings`
+        - `detail`
+            - `meeting-submissions-list` - removed download count sorting
+- Tests:
+    - Integration:
+        - `meetings`
+            - `detail`
+                - `meeting-submissions-list` - removed checking of download count sorting
 
 ## [19.5.0] - 2019-06-07
 ### Added

--- a/app/meetings/detail/-components/meeting-submissions-list/template.hbs
+++ b/app/meetings/detail/-components/meeting-submissions-list/template.hbs
@@ -41,7 +41,6 @@
                 </div>
                 <div data-test-submissions-list-header-download style='width: 15%'>
                     {{t 'meetings.detail.meeting-submissions-list.downloads'}}
-                    <SortButton @sortBy='download_count' />
                 </div>
             {{/let}}
         </list.header>

--- a/tests/integration/routes/meetings/detail/-components/meeting-submissions-list/component-test.ts
+++ b/tests/integration/routes/meetings/detail/-components/meeting-submissions-list/component-test.ts
@@ -162,13 +162,5 @@ module('Integration | routes | meetings | detail | -components | meeting-submiss
         await click('[data-test-descending-sort="created"]');
         assert.dom('[data-test-submissions-list-item-date]')
             .containsText('2019', 'Sorts by date descending');
-
-        await click('[data-test-ascending-sort="download_count"]');
-        assert.dom('[data-test-submissions-list-item-download]')
-            .hasText('100', 'Sorts by download_count ascending');
-
-        await click('[data-test-descending-sort="download_count"]');
-        assert.dom('[data-test-submissions-list-item-download]')
-            .hasText('300', 'Sorts by download_count descending');
     });
 });


### PR DESCRIPTION
## Purpose

Download count sorting will be removed from the back end, so need to remove it from the front end.

## Summary of Changes

* remove meetings submission list download count sorting
* modify integration test to not check submission list download count sorting

## Side Effects

None expected.

## Feature Flags

`ember_meetings_detail_page`

## QA Notes

Make sure sorting by download count is not available.

## Ticket

https://openscience.atlassian.net/browse/ENG-578

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
