### PR TITLE
[ENG-393] Add admin editable publication doi

### DIFF
--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -532,6 +532,7 @@ export default {
         min_subjects: 'You must select at least {{minLength}} subject(s).',
         node_license_invalid: 'Invalid required fields for the license',
         node_license_missing_fields: 'The following required fields are missing: {{missingFields}}',
+        invalid_doi: 'Please use a valid DOI format (10.xxxx/xxxxx)',
     },
     validated_input_form: {
         discard_changes: 'Discard changes',
@@ -1104,6 +1105,7 @@ export default {
             affiliated_institutions: 'Affiliated institutions',
             license: 'License',
             no_license: 'No license',
+            no_publication_doi: 'No publication DOI given',
             disciplines: 'Disciplines',
             tags: 'Tags',
             citation: 'Citation',

--- a/app/models/registration.ts
+++ b/app/models/registration.ts
@@ -50,6 +50,7 @@ export default class RegistrationModel extends NodeModel.extend(Validations) {
     @attr('fixstring') withdrawalJustification?: string;
     @attr('boolean') pendingWithdrawal!: boolean;
     @attr('fixstring') registrationSupplement?: string;
+    @attr('fixstring') articleDoi!: string | null;
     @attr('object') registeredMeta!: RegistrationMetadata;
 
     // Write-only attributes

--- a/app/utils/doi.ts
+++ b/app/utils/doi.ts
@@ -1,0 +1,19 @@
+import { assert } from '@ember/debug';
+
+export const DOIRegex = /\b(10\.\d{4,}(?:\.\d+)*\/\S+(?:(?!["&'<>])\S))\b/;
+export const DOIUrlPrefix = 'https://doi.org/';
+export const DOIPlaceholder = '10.xxxx/xxxxx';
+
+export function extractDoi(doi: string) {
+    const doiOnly = DOIRegex.exec(doi);
+    return doiOnly && doiOnly[0];
+}
+
+export function validateDoi(doi: string): boolean {
+    return DOIRegex.test(doi);
+}
+
+export function formatDoiAsUrl(doi: string) {
+    assert(`Invalid DOI. ${doi} should be in the format: ${DOIPlaceholder}`, validateDoi(doi));
+    return `${DOIUrlPrefix}${doi}`;
+}

--- a/lib/osf-components/addon/components/editable-field/publication-doi-manager/component.ts
+++ b/lib/osf-components/addon/components/editable-field/publication-doi-manager/component.ts
@@ -1,0 +1,107 @@
+import { tagName } from '@ember-decorators/component';
+import { action, computed } from '@ember-decorators/object';
+import { alias, and, not } from '@ember-decorators/object/computed';
+import { service } from '@ember-decorators/service';
+import Component from '@ember/component';
+import EmberObject from '@ember/object';
+import { task } from 'ember-concurrency';
+import { buildValidations, Validations, validator } from 'ember-cp-validations';
+import I18N from 'ember-i18n/services/i18n';
+import Toast from 'ember-toastr/services/toast';
+
+import { layout } from 'ember-osf-web/decorators/component';
+import Registration from 'ember-osf-web/models/registration';
+import { DOIRegex, extractDoi } from 'ember-osf-web/utils/doi';
+import template from './template';
+
+export interface PublicationDoiManager {
+    save: () => void;
+    publicationDoi: string;
+    inEditMode: boolean;
+    validationNode: Registration & Validations;
+    didValidate: boolean;
+}
+
+const DoiValidations = buildValidations({
+    articleDoi: [
+        validator('format', {
+            allowBlank: true,
+            regex: DOIRegex,
+            messageKey: 'validationErrors.invalid_doi',
+        }),
+    ],
+});
+
+const ValidatedModel = EmberObject.extend(DoiValidations);
+
+@tagName('')
+@layout(template)
+export default class PublicationDoiManagerComponent extends Component.extend({
+    save: task(function *(this: PublicationDoiManagerComponent) {
+        const { validations } = yield this.validationNode.validate();
+        this.set('didValidate', true);
+
+        if (!validations.isValid) {
+            return;
+        }
+
+        const doi = extractDoi(this.validationNode.articleDoi as string) || '';
+
+        this.node.set('articleDoi', doi);
+        try {
+            yield this.node.save();
+            this.set('requestedEditMode', false);
+        } catch (e) {
+            this.toast.error(this.i18n.t('registries.node_metadata.save_pub_doi.error'));
+            throw e;
+        }
+    }).restartable(),
+}) {
+    // required
+    node!: Registration;
+
+    // private
+    @service i18n!: I18N;
+    @service toast!: Toast;
+
+    requestedEditMode: boolean = false;
+    validationNode!: Registration & Validations;
+    didValidate = false;
+
+    @not('didValidate') didNotValidate!: boolean;
+    @alias('node.userHasAdminPermission') userCanEdit!: boolean;
+    @and('userCanEdit', 'requestedEditMode') inEditMode!: boolean;
+    @alias('node.category') category!: boolean;
+
+    didReceiveAttrs() {
+        if (this.node) {
+            this.setProperties({
+                validationNode: ValidatedModel.create({ ...this.node }),
+            });
+        }
+    }
+
+    @computed('node.articleDoi')
+    get fieldIsEmpty() {
+        return !this.node.articleDoi;
+    }
+
+    @computed('fieldIsEmpty', 'userCanEdit')
+    get shouldShowField() {
+        return this.userCanEdit || !this.fieldIsEmpty;
+    }
+
+    @action
+    startEditing() {
+        this.set('requestedEditMode', true);
+    }
+
+    @action
+    cancel() {
+        this.setProperties({
+            requestedEditMode: false,
+            didValidate: false,
+        });
+        this.validationNode.set('articleDoi', this.node.articleDoi || '');
+    }
+}

--- a/lib/osf-components/addon/components/editable-field/publication-doi-manager/template.hbs
+++ b/lib/osf-components/addon/components/editable-field/publication-doi-manager/template.hbs
@@ -1,0 +1,13 @@
+{{yield (hash
+    save=(perform this.save)
+    cancel=(action this.cancel)
+    fieldIsEmpty=this.fieldIsEmpty
+    emptyFieldText=(t 'registries.registration_metadata.no_publication_doi')
+    startEditing=(action this.startEditing)
+    inEditMode=this.inEditMode
+    userCanEdit=this.userCanEdit
+    shouldShowField=this.shouldShowField
+    validationNode=this.validationNode
+    publicationDoi=this.node.articleDoi
+    didValidate=this.didValidate
+)}}

--- a/lib/osf-components/addon/components/node-publication-doi-editable/component.ts
+++ b/lib/osf-components/addon/components/node-publication-doi-editable/component.ts
@@ -1,0 +1,17 @@
+import Component from '@ember/component';
+
+import { layout } from 'ember-osf-web/decorators/component';
+import { DOIPlaceholder, DOIUrlPrefix } from 'ember-osf-web/utils/doi';
+import { PublicationDoiManager } from 'osf-components/components/editable-field/publication-doi-manager/component';
+
+import styles from './styles';
+import template from './template';
+
+@layout(template, styles)
+export default class NodePublicationDoiEditable extends Component {
+    // Private
+    manager!: PublicationDoiManager;
+
+    doiPlaceholder = DOIPlaceholder;
+    doiUrlPrefix = DOIUrlPrefix;
+}

--- a/lib/osf-components/addon/components/node-publication-doi-editable/styles.scss
+++ b/lib/osf-components/addon/components/node-publication-doi-editable/styles.scss
@@ -1,18 +1,9 @@
 .Controls {
     display: flex;
     justify-content: flex-end;
-    margin-top: 10px;
+    margin-top: 15px;
 
     button:first-child {
         margin-right: 10px;
     }
-}
-
-.LinkButton {
-    padding: 0;
-    border: 0;
-}
-
-.small {
-    font-size: 85%;
 }

--- a/lib/osf-components/addon/components/node-publication-doi-editable/template.hbs
+++ b/lib/osf-components/addon/components/node-publication-doi-editable/template.hbs
@@ -1,0 +1,39 @@
+<form>
+    <ValidatedInput::Custom
+        data-test-publication-doi-input
+        @model={{@manager.validationNode}}
+        @valuePath='articleDoi'
+        @shouldShowMessages={{@manager.didValidate}}
+        @placeholder={{this.doiPlaceholder}}
+    >
+        <div class='input-group'>
+            <span class='input-group-addon'>{{this.doiUrlPrefix}}</span>
+            {{input
+                value=@manager.validationNode.articleDoi
+                type='text'
+                class='form-control form-group'
+                placeholder=this.doiPlaceholder
+            }}
+        </div>
+    </ValidatedInput::Custom>
+
+    <div local-class='Controls'>
+        <OsfButton
+            data-analytics-name='Cancel'
+            @onClick={{action @manager.cancel}}
+            @disabled={{@manager.save.isRunning}}
+        >
+            {{t 'general.cancel'}}
+        </OsfButton>
+        <OsfButton
+            data-analytics-name='Save'
+            data-test-save-publication-doi
+            @type='primary'
+            @buttonType='submit'
+            @onClick={{action @manager.save}}
+            @disabled={{@manager.save.isRunning}}
+        >
+            {{t 'general.save'}}
+        </OsfButton>
+    </div>
+</form>

--- a/lib/osf-components/addon/components/node-publication-doi/component.ts
+++ b/lib/osf-components/addon/components/node-publication-doi/component.ts
@@ -1,0 +1,19 @@
+import { tagName } from '@ember-decorators/component';
+import { computed } from '@ember-decorators/object';
+import Component from '@ember/component';
+
+import { layout } from 'ember-osf-web/decorators/component';
+import { formatDoiAsUrl } from 'ember-osf-web/utils/doi';
+import { PublicationDoiManager } from 'osf-components/components/editable-field/publication-doi-manager/component';
+import template from './template';
+
+@tagName('')
+@layout(template)
+export default class NodePublicationDoi extends Component {
+    manager!: PublicationDoiManager;
+
+    @computed('manager.publicationDoi')
+    get publicationDoiUrl() {
+        return formatDoiAsUrl(this.manager.publicationDoi);
+    }
+}

--- a/lib/osf-components/addon/components/node-publication-doi/template.hbs
+++ b/lib/osf-components/addon/components/node-publication-doi/template.hbs
@@ -1,0 +1,7 @@
+<OsfLink
+    ...attributes
+    data-analytics-name='Publication DOI'
+    @href={{this.publicationDoiUrl}}
+>
+    {{this.publicationDoiUrl}}
+</OsfLink>

--- a/lib/osf-components/app/components/editable-field/publication-doi-manager/component.js
+++ b/lib/osf-components/app/components/editable-field/publication-doi-manager/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/editable-field/publication-doi-manager/component';

--- a/lib/osf-components/app/components/node-publication-doi-editable/component.js
+++ b/lib/osf-components/app/components/node-publication-doi-editable/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/node-publication-doi-editable/component';

--- a/lib/osf-components/app/components/node-publication-doi/component.js
+++ b/lib/osf-components/app/components/node-publication-doi/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/node-publication-doi/component';

--- a/lib/registries/addon/components/registries-license-picker/template.hbs
+++ b/lib/registries/addon/components/registries-license-picker/template.hbs
@@ -68,22 +68,20 @@
 
             <div local-class='Controls'>
                 <OsfButton
+                    @type='default'
+                    @disabled={{form.disabled}}
+                    @onClick={{action @manager.onCancel}}
+                >
+                    {{t 'general.cancel'}}
+                </OsfButton>
+                <OsfButton
                     data-analytics-name='Save license'
                     data-test-save-license
                     @type='primary'
                     @buttonType='submit'
                     @disabled={{form.disabled}}
-                    @size='sm'
                 >
                     {{t 'general.save'}}
-                </OsfButton>
-                <OsfButton
-                    @type='default'
-                    @disabled={{form.disabled}}
-                    @onClick={{action @manager.onCancel}}
-                    @size='sm'
-                >
-                    {{t 'general.cancel'}}
                 </OsfButton>
             </div>
         {{/if}}

--- a/lib/registries/addon/components/registries-metadata/template.hbs
+++ b/lib/registries/addon/components/registries-metadata/template.hbs
@@ -112,11 +112,26 @@
                 </EditableField>
             </EditableField::DoiManager>
         </div>
-        {{!--
+
         <div local-class='Field'>
-            <h4>{{t 'registries.registration_metadata.publication_doi'}}</h4>
+            <EditableField::PublicationDoiManager @node={{this.registration}} as |pubDoiManager|>
+                <EditableField
+                    data-analytics-scope='Publication DOI'
+                    @manager={{pubDoiManager}}
+                    @title={{t 'registries.registration_metadata.publication_doi'}}
+                    @name='publication DOI'
+                    @hasCustomButtons={{true}}
+                    as |field|
+                >
+                    <field.edit>
+                        <NodePublicationDoiEditable @manager={{pubDoiManager}} />
+                    </field.edit>
+                    <field.display>
+                        <NodePublicationDoi @manager={{pubDoiManager}} />
+                    </field.display>
+                </EditableField>
+            </EditableField::PublicationDoiManager>
         </div>
-        --}}
 
         <div local-class='Field'>
             <EditableField::InstitutionsManager @node={{this.registration}} as |institutionsManager|>

--- a/mirage/factories/registration.ts
+++ b/mirage/factories/registration.ts
@@ -125,6 +125,7 @@ export default NodeFactory.extend<MirageRegistration & RegistrationTraits>({
     pendingEmbargoApproval: false,
     withdrawn: false,
     dateWithdrawn: null,
+    articleDoi: null,
     pendingWithdrawal: false,
     pendingEmbargoTerminationApproval: false,
 

--- a/tests/unit/utils/doi-test.ts
+++ b/tests/unit/utils/doi-test.ts
@@ -1,0 +1,22 @@
+import { extractDoi, validateDoi } from 'ember-osf-web/utils/doi';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | doi', () => {
+    test('doi regex', assert => {
+        const strs = [
+            ['', null, false],
+            ['10.12/f2tg', null, false],
+            ['10.1121', null, false],
+            ['10.1121.12121', null, false],
+            ['10.1121/f2kl', '10.1121/f2kl', true],
+            ['10.1121/f2kl.qwes', '10.1121/f2kl.qwes', true],
+            ['http://dx.doi.org/10.1121/f2kl', '10.1121/f2kl', true],
+            ['https://doi.org/10.1121/f2kl', '10.1121/f2kl', true],
+        ];
+
+        for (const [actual, expected, valid] of strs) {
+            assert.equal(validateDoi(actual as string), valid);
+            assert.equal(extractDoi(actual as string), expected);
+        }
+    });
+});


### PR DESCRIPTION
## Purpose

Add admin editable publication doi

## Summary of Changes

- Add tests
- Add publication DOI editable field with validation
- Add publication DOI manager component
-  Add `extractDOI` helper

## Side Effects

## Feature Flags

## QA Notes

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
[ENG-393](https://openscience.atlassian.net/browse/ENG-393)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
