### PR TITLE
[ENG-514]Change bullet points to checkmarks for registry options

### DIFF
--- a/lib/registries/addon/components/registration-form-view/x-options/styles.scss
+++ b/lib/registries/addon/components/registration-form-view/x-options/styles.scss
@@ -11,7 +11,7 @@
 }
 
 .OptionsList li { 
-    padding: 2px;
+    padding: 5px 0;
 }
 
 .OptionsList li:first-of-type {

--- a/lib/registries/addon/components/registration-form-view/x-options/styles.scss
+++ b/lib/registries/addon/components/registration-form-view/x-options/styles.scss
@@ -1,23 +1,23 @@
 .OptionsList {
     list-style: none;
     margin-left: 0;
-    padding-left: 40px;
+    padding-left: 20px;
     text-indent: -20px;
-}
-  
-.OptionsList li::before {
-    content: '✓';
-    padding-right: 8px;
-}
 
-.OptionsList li { 
-    padding: 5px 0;
-}
+    li { 
+        padding: 5px 0;
+    }
 
-.OptionsList li:first-of-type {
-    padding-top: 0;
-}
+    li::before {
+        content: '✓';
+        padding-right: 8px;
+    }
 
-.OptionsList li:last-of-type {
-    padding-bottom: 0;
+    li:last-of-type {
+        padding-bottom: 0;
+    }
+
+    li:first-of-type {
+        padding-top: 0;
+    }
 }

--- a/lib/registries/addon/components/registration-form-view/x-options/styles.scss
+++ b/lib/registries/addon/components/registration-form-view/x-options/styles.scss
@@ -1,8 +1,8 @@
 .OptionsList {
     list-style: none;
     margin-left: 0;
-    padding-left: 3em;
-    text-indent: -2em;
+    padding-left: 40px;
+    text-indent: -20px;
 }
   
 .OptionsList li::before {

--- a/lib/registries/addon/components/registration-form-view/x-options/styles.scss
+++ b/lib/registries/addon/components/registration-form-view/x-options/styles.scss
@@ -1,0 +1,11 @@
+.OptionsList {
+    list-style: none;
+    margin-left: 0;
+    padding-left: 3em;
+    text-indent: -2em;
+}
+  
+.OptionsList li::before {
+    content: '✓';
+    padding-right: 8px;
+}

--- a/lib/registries/addon/components/registration-form-view/x-options/styles.scss
+++ b/lib/registries/addon/components/registration-form-view/x-options/styles.scss
@@ -9,3 +9,15 @@
     content: '✓';
     padding-right: 8px;
 }
+
+.OptionsList li { 
+    padding: 2px;
+}
+
+.OptionsList li:first-of-type {
+    padding-top: 0;
+}
+
+.OptionsList li:last-of-type {
+    padding-bottom: 0;
+}

--- a/lib/registries/addon/components/registration-form-view/x-options/template.hbs
+++ b/lib/registries/addon/components/registration-form-view/x-options/template.hbs
@@ -1,9 +1,9 @@
-<ul>
-    {{#if this.selectedOptions.length}}
+{{#if  this.selectedOptions.length}}
+    <ul local-class='OptionsList'>
         {{#each this.selectedOptions as |option|}}
             <li>{{option}}</li>
         {{/each}}
-    {{else}}
-        <li>{{t 'registries.form_view.none_selected'}}</li>
-    {{/if}}
-</ul>
+    </ul>
+{{else}}
+    <span>{{t 'registries.form_view.none_selected'}}</span>
+{{/if}}

--- a/lib/registries/addon/components/registration-form-view/x-options/template.hbs
+++ b/lib/registries/addon/components/registration-form-view/x-options/template.hbs
@@ -1,9 +1,7 @@
-{{#if  this.selectedOptions.length}}
-    <ul local-class='OptionsList'>
-        {{#each this.selectedOptions as |option|}}
-            <li>{{option}}</li>
-        {{/each}}
-    </ul>
-{{else}}
-    <span>{{t 'registries.form_view.none_selected'}}</span>
-{{/if}}
+<ul local-class='OptionsList'>
+    {{#each this.selectedOptions as |option|}}
+        <li>{{option}}</li>
+    {{else}}
+        <span>{{t 'registries.form_view.none_selected'}}</span>
+    {{/each}}
+</ul>


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[EMB-123] some really great stuff`
-->

## Purpose
Change the default bullet points of user-selectable options in the registry to checkmarks.
<!-- Describe the purpose of your changes. -->

## Summary of Changes
Change to the x-options template
Add CSS file to x-options
<!-- Briefly describe or list your changes. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## Feature Flags

<!--
  Please list any feature flags that need to be enabled for these changes to go into effect.
  For each flag, what is the expected behavior with the flag enabled vs disabled?
-->

## QA Notes
The bullet points for user-selectable options (ie: Design Plan > Study Type or Blinding) in the registry overview has been changed to be a checkmark. 
Please double-check that it looks ok across browsers and devices. 
Lists of uploaded files should not have the checkmark.
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
-->

## Ticket
https://openscience.atlassian.net/browse/ENG-514
<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
