### PR TITLE
[ENG-601] move tasks to ember object extend

### DIFF
--- a/app/guid-file/controller.ts
+++ b/app/guid-file/controller.ts
@@ -39,7 +39,13 @@ const lookupTable: { [k: string]: { [s: string]: string} } = {
     },
 };
 
-export default class GuidFile extends Controller {
+export default class GuidFile extends Controller.extend({
+    updateFilter: task(function *(this: GuidFile, filter: string) {
+        yield timeout(250);
+        this.setProperties({ filter });
+        this.analytics.track('list', 'filter', 'Quick Files - Filter file browser');
+    }).restartable(),
+}) {
     @service analytics!: Analytics;
     @service currentUser!: CurrentUser;
     @service i18n!: I18N;
@@ -93,12 +99,6 @@ export default class GuidFile extends Controller {
     get fileText(this: GuidFile) {
         return Boolean(this.file) && this.file.getContents();
     }
-
-    updateFilter = task(function *(this: GuidFile, filter: string) {
-        yield timeout(250);
-        this.setProperties({ filter });
-        this.analytics.track('list', 'filter', 'Quick Files - Filter file browser');
-    }).restartable();
 
     @computed('allFiles.[]', 'filter', 'sort')
     get files(this: GuidFile) {

--- a/app/guid-file/route.ts
+++ b/app/guid-file/route.ts
@@ -14,16 +14,8 @@ import CurrentUser from 'ember-osf-web/services/current-user';
 import MetaTags, { HeadTagDef } from 'ember-osf-web/services/meta-tags';
 import Ready from 'ember-osf-web/services/ready';
 
-export default class GuidFile extends Route {
-    @service analytics!: Analytics;
-    @service currentUser!: CurrentUser;
-    @service('head-tags') headTagsService!: HeadTagsService;
-    @service metaTags!: MetaTags;
-    @service ready!: Ready;
-
-    headTags?: HeadTagDef[];
-
-    setHeadTags = task(function *(this: GuidFile, model: any) {
+export default class GuidFile extends Route.extend({
+    setHeadTags: task(function *(this: GuidFile, model: any) {
         const blocker = this.get('ready').getBlocker();
         const dateCreated = model.file.get('dateCreated');
         const dateModified = model.file.get('dateModified');
@@ -38,7 +30,15 @@ export default class GuidFile extends Route {
         this.set('headTags', this.get('metaTags').getHeadTags(metaTagsData));
         this.get('headTagsService').collectHeadTags();
         blocker.done();
-    });
+    }),
+}) {
+    @service analytics!: Analytics;
+    @service currentUser!: CurrentUser;
+    @service('head-tags') headTagsService!: HeadTagsService;
+    @service metaTags!: MetaTags;
+    @service ready!: Ready;
+
+    headTags?: HeadTagDef[];
 
     async model(this: GuidFile, params: { guid: string }) {
         try {

--- a/app/guid-node/registrations/controller.ts
+++ b/app/guid-node/registrations/controller.ts
@@ -13,7 +13,23 @@ import pathJoin from 'ember-osf-web/utils/path-join';
 
 const { OSF: { url: baseURL } } = config;
 
-export default class GuidNodeRegistrations extends Controller {
+export default class GuidNodeRegistrations extends Controller.extend({
+    getRegistrationSchemas: task(function *(this: GuidNodeRegistrations) {
+        let schemas = yield this.store.findAll('registration-schema',
+            {
+                adapterOptions: {
+                    query: {
+                        'filter[active]': true,
+                    },
+                },
+            });
+        schemas = schemas.toArray();
+        schemas.sort((a: RegistrationSchema, b: RegistrationSchema) => a.name.length - b.name.length);
+        this.set('defaultSchema', schemas.firstObject);
+        this.set('selectedSchema', this.defaultSchema);
+        this.set('schemas', schemas);
+    }),
+}) {
     @service analytics!: Analytics;
     @service store!: DS.Store;
 
@@ -37,22 +53,6 @@ export default class GuidNodeRegistrations extends Controller {
         embargoedCountries: 'https://www.pmddtc.state.gov/?id=ddtc_public_portal_country_landing',
         terms: 'https://osf.io/4uxbj/',
     };
-
-    getRegistrationSchemas = task(function *(this: GuidNodeRegistrations) {
-        let schemas = yield this.store.findAll('registration-schema',
-            {
-                adapterOptions: {
-                    query: {
-                        'filter[active]': true,
-                    },
-                },
-            });
-        schemas = schemas.toArray();
-        schemas.sort((a: RegistrationSchema, b: RegistrationSchema) => a.name.length - b.name.length);
-        this.set('defaultSchema', schemas.firstObject);
-        this.set('selectedSchema', this.defaultSchema);
-        this.set('schemas', schemas);
-    });
 
     @alias('model.taskInstance.value') node!: Node | null;
 

--- a/app/guid-user/quickfiles/route.ts
+++ b/app/guid-user/quickfiles/route.ts
@@ -30,13 +30,8 @@ export default class UserQuickfiles extends Route.extend({
             }),
         });
     },
-}) {
-    @service analytics!: Analytics;
-    @service currentUser!: CurrentUser;
-    @service ready!: Ready;
-    @service router!: any;
 
-    loadModel = task(function *(this: UserQuickfiles, userModel: any) {
+    loadModel: task(function *(this: UserQuickfiles, userModel: any) {
         const blocker = this.get('ready').getBlocker();
         try {
             const user = yield userModel.taskInstance;
@@ -52,7 +47,12 @@ export default class UserQuickfiles extends Route.extend({
             this.replaceWith('not-found', notFoundURL(this.router.currentURL));
             return undefined;
         }
-    });
+    }),
+}) {
+    @service analytics!: Analytics;
+    @service currentUser!: CurrentUser;
+    @service ready!: Ready;
+    @service router!: any;
 
     model(this: UserQuickfiles) {
         return {

--- a/app/institutions/controller.ts
+++ b/app/institutions/controller.ts
@@ -7,18 +7,18 @@ import DS from 'ember-data';
 import Institution from 'ember-osf-web/models/institution';
 import Analytics from 'ember-osf-web/services/analytics';
 
-export default class Institutions extends Controller {
+export default class Institutions extends Controller.extend({
+    trackFilter: task(function *(this: Institutions) {
+        yield timeout(1000);
+        this.analytics.track('list', 'filter', 'Institutions - Search');
+    }).restartable(),
+}) {
     @service store!: DS.Store;
     @service analytics!: Analytics;
 
     sortOrder: 'title' | '-title' = 'title';
     page = 1;
     textValue: string = '';
-
-    trackFilter = task(function *(this: Institutions) {
-        yield timeout(1000);
-        this.analytics.track('list', 'filter', 'Institutions - Search');
-    }).restartable();
 
     @computed('model', 'textValue')
     get filtered(): Institution[] {

--- a/app/meetings/detail/route.ts
+++ b/app/meetings/detail/route.ts
@@ -5,11 +5,8 @@ import Route from '@ember/routing/route';
 import { task } from 'ember-concurrency';
 import Analytics from 'ember-osf-web/services/analytics';
 
-export default class MeetingsDetail extends Route {
-    @service analytics!: Analytics;
-    @service router!: any;
-
-    loadMeetingDetail = task(function *(this: MeetingsDetail, meetingId: string) {
+export default class MeetingsDetail extends Route.extend({
+    loadMeetingDetail: task(function *(this: MeetingsDetail, meetingId: string) {
         try {
             const meeting = yield this.store.findRecord('meeting', meetingId);
             return meeting;
@@ -17,7 +14,10 @@ export default class MeetingsDetail extends Route {
             this.transitionTo('not-found', this.get('router').get('currentURL').slice(1));
             return undefined;
         }
-    });
+    }),
+}) {
+    @service analytics!: Analytics;
+    @service router!: any;
 
     model(this: MeetingsDetail, params: Record<string, string>) {
         return {

--- a/app/services/analytics.ts
+++ b/app/services/analytics.ts
@@ -141,18 +141,8 @@ class EventInfo {
     }
 }
 
-export default class Analytics extends Service {
-    @service metrics!: Metrics;
-    @service session!: Session;
-    @service ready!: Ready;
-    @service router!: RouterService;
-    @service toast!: Toast;
-
-    shouldToastOnEvent: boolean = false;
-
-    rootElement?: Element;
-
-    trackPageTask = task(function *(
+export default class Analytics extends Service.extend({
+    trackPageTask: task(function *(
         this: Analytics,
         pagePublic: boolean | undefined,
         resourceType: string,
@@ -204,7 +194,17 @@ export default class Analytics extends Service {
             pagePublic,
             ...eventParams,
         });
-    }).restartable();
+    }).restartable(),
+}) {
+    @service metrics!: Metrics;
+    @service session!: Session;
+    @service ready!: Ready;
+    @service router!: RouterService;
+    @service toast!: Toast;
+
+    shouldToastOnEvent: boolean = false;
+
+    rootElement?: Element;
 
     @action
     click(this: Analytics, category: string, label: string, extraInfo?: string | object) {

--- a/app/services/ready.ts
+++ b/app/services/ready.ts
@@ -18,13 +18,8 @@ export enum Events {
     Error = 'error',
 }
 
-export default class Ready extends Service.extend(Evented) {
-    isReady = false;
-
-    lastId = 0;
-    blockers = A();
-
-    tryReady = task(function *(this: Ready) {
+export default class Ready extends Service.extend(Evented, {
+    tryReady: task(function *(this: Ready) {
         // Waiting until `destroy` makes sure that everyone in `render` and `afterRender`
         // (e.g. components, jQuery plugins, etc.) has a chance to call `getBlocker`, and that
         // all DOM manipulation has settled.
@@ -33,7 +28,12 @@ export default class Ready extends Service.extend(Evented) {
             set(this, 'isReady', true);
             this.trigger(Events.IsReady);
         }
-    }).restartable();
+    }).restartable(),
+}) {
+    isReady = false;
+
+    lastId = 0;
+    blockers = A();
 
     getBlocker(this: Ready): Blocker {
         if (get(this, 'isReady')) {

--- a/lib/analytics-page/addon/application/route.ts
+++ b/lib/analytics-page/addon/application/route.ts
@@ -12,12 +12,8 @@ import { GuidRouteModel } from 'ember-osf-web/resolve-guid/guid-route';
 import AnalyticsService from 'ember-osf-web/services/analytics';
 import Ready, { Blocker } from 'ember-osf-web/services/ready';
 
-export default class AnalyticsPageRoute extends Route {
-    @service analytics!: AnalyticsService;
-    @service ready!: Ready;
-    @service store!: DS.Store;
-
-    reloadNode = task(function *(this: AnalyticsPageRoute, model: Node, blocker: Blocker) {
+export default class AnalyticsPageRoute extends Route.extend({
+    reloadNode: task(function *(this: AnalyticsPageRoute, model: Node, blocker: Blocker) {
         const node = yield model.reload({
             adapterOptions: {
                 query: {
@@ -29,9 +25,9 @@ export default class AnalyticsPageRoute extends Route {
         blocker.done();
 
         return node;
-    });
+    }),
 
-    getNodeWithCounts = task(function *(this: AnalyticsPageRoute, taskInstance: TaskInstance<Node>) {
+    getNodeWithCounts: task(function *(this: AnalyticsPageRoute, taskInstance: TaskInstance<Node>) {
         const blocker = this.ready.getBlocker();
 
         const node = yield taskInstance;
@@ -43,7 +39,11 @@ export default class AnalyticsPageRoute extends Route {
             modelName: node.modelName,
             taskInstance: this.get('reloadNode').perform(node, blocker),
         };
-    });
+    }),
+}) {
+    @service analytics!: AnalyticsService;
+    @service ready!: Ready;
+    @service store!: DS.Store;
 
     model(this: AnalyticsPageRoute, _: {}, transition: Transition) {
         const guidHandlerInfo = transition.handlerInfos.find(

--- a/lib/analytics-page/addon/components/analytics-charts/x-chart-wrapper/component.ts
+++ b/lib/analytics-page/addon/components/analytics-charts/x-chart-wrapper/component.ts
@@ -21,25 +21,8 @@ enum OverlayReason {
 }
 
 @layout(template, styles)
-export default class ChartWrapper extends Component {
-    @service keen!: KeenService;
-    @service i18n!: I18n;
-    @service analytics!: AnalyticsService;
-
-    // Required arguments
-    chartSpec!: ChartSpec;
-    chartEnabled!: boolean;
-    nodeTaskInstance!: TaskInstance<Node>;
-    startDate!: Moment;
-    endDate!: Moment;
-
-    // Private properties
-    chart!: KeenDataviz; // set in didInsertElement
-    overlayShown: boolean = true;
-    keenError: boolean = false;
-    loading: boolean = false;
-
-    loadKeen = task(function *(this: ChartWrapper) {
+export default class ChartWrapper extends Component.extend({
+    loadKeen: task(function *(this: ChartWrapper) {
         this.showOverlay(OverlayReason.Loading);
         const node = yield this.nodeTaskInstance;
         try {
@@ -61,7 +44,24 @@ export default class ChartWrapper extends Component {
             this.showOverlay(OverlayReason.Error);
             throw e;
         }
-    }).restartable();
+    }).restartable(),
+}) {
+    @service keen!: KeenService;
+    @service i18n!: I18n;
+    @service analytics!: AnalyticsService;
+
+    // Required arguments
+    chartSpec!: ChartSpec;
+    chartEnabled!: boolean;
+    nodeTaskInstance!: TaskInstance<Node>;
+    startDate!: Moment;
+    endDate!: Moment;
+
+    // Private properties
+    chart!: KeenDataviz; // set in didInsertElement
+    overlayShown: boolean = true;
+    keenError: boolean = false;
+    loading: boolean = false;
 
     didInsertElement(this: ChartWrapper) {
         this.chart = new KeenDataviz()

--- a/lib/app-components/addon/components/project-contributors/list/component.ts
+++ b/lib/app-components/addon/components/project-contributors/list/component.ts
@@ -18,39 +18,31 @@ import styles from './styles';
 import template from './template';
 
 @layout(template, styles)
-export default class List extends Component {
-    @service analytics!: Analytics;
-    @service i18n!: I18N;
-    @service store!: DS.Store;
-    @service toast!: Toast;
-
-    contributors: ArrayProxy<Contributor> = this.contributors;
-    node: Node = this.node;
-
+export default class List extends Component.extend({
     /**
      * Changes the contributor's permissions
      */
-    updatePermissions = task(function *(this: List, contributor: HighlightableContributor, permission: Permission) {
+    updatePermissions: task(function *(this: List, contributor: HighlightableContributor, permission: Permission) {
         this.analytics.track('option', 'select', 'Collections - Submit - Change Permission');
         contributor.setProperties({ permission });
 
         yield this.get('saveAndHighlight').perform(contributor);
-    }).enqueue();
+    }).enqueue(),
 
     /**
      * Changes the contributor's bibliographic
      */
-    toggleBibliographic = task(function *(this: List, contributor: HighlightableContributor) {
+    toggleBibliographic: task(function *(this: List, contributor: HighlightableContributor) {
         const actionName = `${contributor.toggleProperty('bibliographic') ? '' : 'de'}select`;
         this.analytics.track('checkbox', actionName, 'Collections - Submit - Update Bibliographic');
 
         yield this.get('saveAndHighlight').perform(contributor);
-    }).enqueue();
+    }).enqueue(),
 
     /**
      * Changes the order of contributors for ember-sortable
      */
-    reorderContributors = task(function *(
+    reorderContributors: task(function *(
         this: List,
         contributors: HighlightableContributor[],
         contributor: HighlightableContributor,
@@ -62,12 +54,12 @@ export default class List extends Component {
         contributor.set('index', newIndex);
 
         yield this.get('saveAndHighlight').perform(contributor);
-    }).drop();
+    }).drop(),
 
     /**
      * Saves the contributor and highlights the row with success/failure
      */
-    saveAndHighlight = task(function *(this: List, contributor: HighlightableContributor): IterableIterator<any> {
+    saveAndHighlight: task(function *(this: List, contributor: HighlightableContributor): IterableIterator<any> {
         let highlightClass: typeof contributor.highlightClass;
 
         try {
@@ -80,12 +72,12 @@ export default class List extends Component {
         contributor.setProperties({ highlightClass });
         yield timeout(2000);
         contributor.setProperties({ highlightClass: '' });
-    });
+    }),
 
     /**
      * Removes a contributor
      */
-    removeContributor = task(function *(this: List, contributor: Contributor) {
+    removeContributor: task(function *(this: List, contributor: Contributor) {
         this.analytics.track('button', 'click', 'Collections - Submit - Remove Contributor');
 
         try {
@@ -98,7 +90,15 @@ export default class List extends Component {
         // It's necessary to unload the record from the store after destroying it, in case the user is added back as a
         // contributor again
         this.store.unloadRecord(contributor);
-    });
+    }),
+}) {
+    @service analytics!: Analytics;
+    @service i18n!: I18N;
+    @service store!: DS.Store;
+    @service toast!: Toast;
+
+    contributors: ArrayProxy<Contributor> = this.contributors;
+    node: Node = this.node;
 
     /**
      * If the current user is an admin

--- a/lib/app-components/addon/components/project-contributors/search/component.ts
+++ b/lib/app-components/addon/components/project-contributors/search/component.ts
@@ -21,21 +21,8 @@ const nameFields = [
 ].join();
 
 @layout(template, styles)
-export default class Search extends Component {
-    @service analytics!: Analytics;
-    @service i18n!: I18N;
-    @service store!: DS.Store;
-    @service toast!: Toast;
-
-    query: string = '';
-    page: number = 1;
-    showUnregisteredForm: boolean = false;
-    node: Node = this.node;
-
-    @alias('search.lastSuccessful.value') results?: DS.AdapterPopulatedRecordArray<User>;
-    @alias('results.meta.total_pages') totalPages?: number;
-
-    search = task(function *(this: Search, page?: number) {
+export default class Search extends Component.extend({
+    search: task(function *(this: Search, page?: number) {
         if (!this.query) {
             return undefined;
         }
@@ -55,9 +42,9 @@ export default class Search extends Component {
         });
 
         return results;
-    }).restartable();
+    }).restartable(),
 
-    addContributor = task(function *(this: Search, user: User) {
+    addContributor: task(function *(this: Search, user: User) {
         this.analytics.track('list', 'filter', 'Collections - Contributors - Add Contributor');
 
         const contributor = this.store.createRecord('contributor', {
@@ -75,5 +62,18 @@ export default class Search extends Component {
             this.toast.error(this.i18n.t('app_components.project_contributors.search.add_contributor_error'));
             throw e;
         }
-    });
+    }),
+}) {
+    @service analytics!: Analytics;
+    @service i18n!: I18N;
+    @service store!: DS.Store;
+    @service toast!: Toast;
+
+    query: string = '';
+    page: number = 1;
+    showUnregisteredForm: boolean = false;
+    node: Node = this.node;
+
+    @alias('search.lastSuccessful.value') results?: DS.AdapterPopulatedRecordArray<User>;
+    @alias('results.meta.total_pages') totalPages?: number;
 }

--- a/lib/app-components/addon/components/project-contributors/search/unregistered-contributor/component.ts
+++ b/lib/app-components/addon/components/project-contributors/search/unregistered-contributor/component.ts
@@ -15,19 +15,8 @@ import styles from './styles';
 import template from './template';
 
 @layout(template, styles)
-export default class UnregisteredContributor extends Component {
-    @service analytics!: Analytics;
-    @service i18n!: I18N;
-    @service store!: DS.Store;
-    @service toast!: Toast;
-
-    model?: Contributor;
-    node: Node = this.node;
-    didValidate: boolean = false;
-
-    @requiredAction closeForm!: () => void;
-
-    add = task(function *(this: UnregisteredContributor) {
+export default class UnregisteredContributor extends Component.extend({
+    add: task(function *(this: UnregisteredContributor) {
         const { validations } = yield this.model!.validate();
         this.set('didValidate', true);
 
@@ -50,7 +39,18 @@ export default class UnregisteredContributor extends Component {
 
         this.reset(false);
         this.closeForm();
-    }).drop();
+    }).drop(),
+}) {
+    @service analytics!: Analytics;
+    @service i18n!: I18N;
+    @service store!: DS.Store;
+    @service toast!: Toast;
+
+    model?: Contributor;
+    node: Node = this.node;
+    didValidate: boolean = false;
+
+    @requiredAction closeForm!: () => void;
 
     didReceiveAttrs(this: UnregisteredContributor) {
         this.reset();

--- a/lib/app-components/addon/components/project-metadata/component.ts
+++ b/lib/app-components/addon/components/project-metadata/component.ts
@@ -15,7 +15,12 @@ import template from './template';
 
 @layout(template, styles)
 @tagName('')
-export default class ProjectMetadata extends Component {
+export default class ProjectMetadata extends Component.extend({
+    reset: task(function *(this: ProjectMetadata) {
+        this.node.rollbackAttributes();
+        yield this.node.reload();
+    }),
+}) {
     @service analytics!: Analytics;
     @service i18n!: I18N;
     @service store!: DS.Store;
@@ -24,11 +29,6 @@ export default class ProjectMetadata extends Component {
     node: Node = this.node;
 
     @requiredAction continue!: () => void;
-
-    reset = task(function *(this: ProjectMetadata) {
-        this.node.rollbackAttributes();
-        yield this.node.reload();
-    });
 
     @action
     addTag(this: ProjectMetadata, tag: string) {

--- a/lib/collections/addon/components/collections-submission/component.ts
+++ b/lib/collections/addon/components/collections-submission/component.ts
@@ -31,35 +31,8 @@ enum Section {
 }
 
 @layout(template, styles)
-export default class Submit extends Component {
-    @service analytics!: Analytics;
-    @service currentUser!: CurrentUser;
-    @service i18n!: I18N;
-    @service store!: DS.Store;
-    @service theme!: Theme;
-    @service toast!: Toast;
-
-    readonly edit: boolean = defaultTo(this.edit, false);
-    readonly provider: CollectionProvider = this.provider;
-    readonly collection: Collection = this.collection;
-    readonly collectedMetadatum: CollectedMetadatum = this.collectedMetadatum;
-
-    collectionItem: Node | null = defaultTo(this.collectionItem, null);
-    isProjectSelectorValid: boolean = false;
-    sections = Section;
-    activeSection: Section = this.edit ? Section.projectMetadata : Section.project;
-    savedSections: Section[] = this.edit ? [
-        Section.project,
-        Section.projectMetadata,
-        Section.projectContributors,
-        Section.collectionSubjects,
-        Section.collectionMetadata,
-    ] : [];
-    showCancelDialog: boolean = false;
-    i18nKeyPrefix = 'collections.collections_submission.';
-    showSubmitModal: boolean = false;
-
-    save = task(function *(this: Submit) {
+export default class Submit extends Component.extend({
+    save: task(function *(this: Submit) {
         if (!this.collectionItem) {
             return;
         }
@@ -109,7 +82,34 @@ export default class Submit extends Component {
                 error: e.errors[0].detail,
             }));
         }
-    }).drop();
+    }).drop(),
+}) {
+    @service analytics!: Analytics;
+    @service currentUser!: CurrentUser;
+    @service i18n!: I18N;
+    @service store!: DS.Store;
+    @service theme!: Theme;
+    @service toast!: Toast;
+
+    readonly edit: boolean = defaultTo(this.edit, false);
+    readonly provider: CollectionProvider = this.provider;
+    readonly collection: Collection = this.collection;
+    readonly collectedMetadatum: CollectedMetadatum = this.collectedMetadatum;
+
+    collectionItem: Node | null = defaultTo(this.collectionItem, null);
+    isProjectSelectorValid: boolean = false;
+    sections = Section;
+    activeSection: Section = this.edit ? Section.projectMetadata : Section.project;
+    savedSections: Section[] = this.edit ? [
+        Section.project,
+        Section.projectMetadata,
+        Section.projectContributors,
+        Section.collectionSubjects,
+        Section.collectionMetadata,
+    ] : [];
+    showCancelDialog: boolean = false;
+    i18nKeyPrefix = 'collections.collections_submission.';
+    showSubmitModal: boolean = false;
 
     @computed('collectedMetadatum.{displayChoiceFields,collectedType,issue,volume,programArea,status}')
     get choiceFields(): Array<{ label: string; value: string | undefined; }> {

--- a/lib/collections/addon/guid/route.ts
+++ b/lib/collections/addon/guid/route.ts
@@ -21,12 +21,8 @@ interface Params {
     guid: string;
 }
 
-export default class Guid extends Route {
-    @service currentUser!: CurrentUser;
-    @service store!: DS.Store;
-    @service theme!: Theme;
-
-    loadModel = task(function *(this: Guid, guid: string): IterableIterator<any> {
+export default class Guid extends Route.extend({
+    loadModel: task(function *(this: Guid, guid: string): IterableIterator<any> {
         const provider = this.theme.provider as CollectionProvider;
 
         let collection: Collection;
@@ -67,7 +63,11 @@ export default class Guid extends Route {
             this.intermediateTransitionTo(this.theme.prefixRoute('page-not-found'));
             return undefined;
         }
-    });
+    }),
+}) {
+    @service currentUser!: CurrentUser;
+    @service store!: DS.Store;
+    @service theme!: Theme;
 
     model(this: Guid) {
         const { guid } = this.paramsFor(this.routeName) as Params;

--- a/lib/collections/addon/submit/route.ts
+++ b/lib/collections/addon/submit/route.ts
@@ -20,16 +20,8 @@ interface TaskInstanceResult {
 }
 
 @requireAuth()
-export default class Submit extends Route.extend(ConfirmationMixin, {}) {
-    @service currentUser!: CurrentUser;
-    @service store!: DS.Store;
-    @service theme!: Theme;
-    @service i18n!: I18N;
-
-    // This tells ember-onbeforeunload what to use as the body for the warning before leaving the page.
-    confirmationMessage = this.i18n.t('collections.collections_submission.warning_body');
-
-    loadModel = task(function *(this: Submit): IterableIterator<any> {
+export default class Submit extends Route.extend(ConfirmationMixin, {
+    loadModel: task(function *(this: Submit): IterableIterator<any> {
         const provider = this.theme.provider as CollectionProvider;
         const collection = yield provider.primaryCollection;
 
@@ -43,7 +35,15 @@ export default class Submit extends Route.extend(ConfirmationMixin, {}) {
             collection,
             collectedMetadatum,
         } as TaskInstanceResult;
-    });
+    }),
+}) {
+    @service currentUser!: CurrentUser;
+    @service store!: DS.Store;
+    @service theme!: Theme;
+    @service i18n!: I18N;
+
+    // This tells ember-onbeforeunload what to use as the body for the warning before leaving the page.
+    confirmationMessage = this.i18n.t('collections.collections_submission.warning_body');
 
     model(this: Submit) {
         return {

--- a/lib/osf-components/addon/components/paginated-list/all/component.ts
+++ b/lib/osf-components/addon/components/paginated-list/all/component.ts
@@ -1,5 +1,6 @@
 import { service } from '@ember-decorators/service';
-import { task } from 'ember-concurrency';
+import ComputedProperty from '@ember/object/computed';
+import { Task, task } from 'ember-concurrency';
 import DS from 'ember-data';
 import ModelRegistry from 'ember-data/types/registries/model';
 
@@ -15,18 +16,23 @@ export default class PaginatedAll extends BaseDataComponent {
 
     // Private properties
     @service store!: DS.Store;
-
-    loadItemsTask = task(function *(this: PaginatedAll) {
-        const items: any = yield this.store.query(this.modelName, {
-            page: this.page,
-            'page[size]': this.pageSize,
-            ...this.query,
-        });
-
-        this.setProperties({
-            items: items.toArray(),
-            totalCount: items.meta.total,
-            errorShown: false,
-        });
-    });
+    loadItemsTask!: ComputedProperty<Task<void>>;
 }
+
+Object.defineProperties(PaginatedAll.prototype, {
+    loadItemsTask: {
+        value: task(function *(this: PaginatedAll) {
+            const items: any = yield this.store.query(this.modelName, {
+                page: this.page,
+                'page[size]': this.pageSize,
+                ...this.query,
+            });
+
+            this.setProperties({
+                items: items.toArray(),
+                totalCount: items.meta.total,
+                errorShown: false,
+            });
+        }),
+    },
+});

--- a/lib/osf-components/addon/components/paginated-list/has-many/component.ts
+++ b/lib/osf-components/addon/components/paginated-list/has-many/component.ts
@@ -1,8 +1,8 @@
 import { or } from '@ember-decorators/object/computed';
 import { assert } from '@ember/debug';
 import { defineProperty } from '@ember/object';
-import { reads as readsMacro } from '@ember/object/computed';
-import { task, TaskInstance } from 'ember-concurrency';
+import ComputedProperty, { reads as readsMacro } from '@ember/object/computed';
+import { task, Task, TaskInstance } from 'ember-concurrency';
 
 import { layout } from 'ember-osf-web/decorators/component';
 import OsfModel from 'ember-osf-web/models/osf-model';
@@ -23,48 +23,9 @@ export default class PaginatedHasMany extends BaseDataComponent {
     usePlaceholders: boolean = defaultTo(this.usePlaceholders, true);
 
     // Private properties
-    loadItemsTask = task(function *(this: PaginatedHasMany, { reloading }: LoadItemsOptions) {
-        const model = yield this.get('getModelTask').perform();
-        if (this.usePlaceholders) {
-            yield this.get('loadRelatedCountTask').perform(reloading);
-            // Don't bother querying if we already know there's nothing there.
-            if (this.totalCount === 0) {
-                return;
-            }
-        }
-        const items = yield model.queryHasMany(
-            this.relationshipName,
-            {
-                page: this.page,
-                'page[size]': this.pageSize,
-                ...this.query,
-            },
-        );
-
-        this.setProperties({
-            items,
-            totalCount: items.meta.total,
-            errorShown: false,
-        });
-    });
-
-    getModelTask = task(function *(this: PaginatedHasMany) {
-        let model = this.modelInstance;
-        if (!model && this.modelTaskInstance) {
-            model = yield this.modelTaskInstance;
-        }
-        if (!model) {
-            throw new Error('Error loading model');
-        }
-        return model;
-    });
-
-    loadRelatedCountTask = task(function *(this: PaginatedHasMany, reloading: boolean) {
-        const model = yield this.get('getModelTask').perform();
-        if (reloading || typeof this.totalCount === 'undefined') {
-            yield model.loadRelatedCount(this.relationshipName);
-        }
-    }).restartable();
+    loadItemsTask!: ComputedProperty<Task<void>>;
+    getModelTask!: ComputedProperty<Task<OsfModel>>;
+    loadRelatedCountTask!: ComputedProperty<Task<void>>;
 
     @or('model', 'modelTaskInstance.value')
     modelInstance?: OsfModel;
@@ -84,3 +45,52 @@ export default class PaginatedHasMany extends BaseDataComponent {
         );
     }
 }
+
+Object.defineProperties(PaginatedHasMany.prototype, {
+    loadItemsTask: {
+        value: task(function *(this: PaginatedHasMany, { reloading }: LoadItemsOptions) {
+            const model = yield this.get('getModelTask').perform();
+            if (this.usePlaceholders) {
+                yield this.get('loadRelatedCountTask').perform(reloading);
+                // Don't bother querying if we already know there's nothing there.
+                if (this.totalCount === 0) {
+                    return;
+                }
+            }
+            const items = yield model.queryHasMany(
+                this.relationshipName,
+                {
+                    page: this.page,
+                    'page[size]': this.pageSize,
+                    ...this.query,
+                },
+            );
+
+            this.setProperties({
+                items,
+                totalCount: items.meta.total,
+                errorShown: false,
+            });
+        }),
+    },
+    getModelTask: {
+        value: task(function *(this: PaginatedHasMany) {
+            let model = this.modelInstance;
+            if (!model && this.modelTaskInstance) {
+                model = yield this.modelTaskInstance;
+            }
+            if (!model) {
+                throw new Error('Error loading model');
+            }
+            return model;
+        }),
+    },
+    loadRelatedCountTask: {
+        value: task(function *(this: PaginatedHasMany, reloading: boolean) {
+            const model = yield this.get('getModelTask').perform();
+            if (reloading || typeof this.totalCount === 'undefined') {
+                yield model.loadRelatedCount(this.relationshipName);
+            }
+        }).restartable(),
+    },
+});

--- a/lib/osf-components/addon/components/sign-up-form/component.ts
+++ b/lib/osf-components/addon/components/sign-up-form/component.ts
@@ -42,6 +42,16 @@ export default class SignUpForm extends Component.extend({
 
         this.set('hasSubmitted', true);
     }).drop(),
+
+    strength: task(function *(this: SignUpForm, value: string) {
+        if (!value) {
+            return 0;
+        }
+
+        yield timeout(250);
+
+        return yield this.passwordStrength.strength(value);
+    }).restartable(),
 }) {
     // Optional parameters
     campaign?: string;
@@ -56,16 +66,6 @@ export default class SignUpForm extends Component.extend({
     @service passwordStrength!: PasswordStrength;
     @service analytics!: Analytics;
     @service store!: DS.Store;
-
-    strength = task(function *(this: SignUpForm, value: string) {
-        if (!value) {
-            return 0;
-        }
-
-        yield timeout(250);
-
-        return yield this.passwordStrength.strength(value);
-    }).restartable();
 
     @computed('userRegistration.password', 'strength.lastSuccessful.value.score')
     get progress(this: SignUpForm): number {

--- a/lib/osf-components/addon/components/tos-consent-banner/component.ts
+++ b/lib/osf-components/addon/components/tos-consent-banner/component.ts
@@ -14,16 +14,8 @@ import template from './template';
 
 @layout(template, styles)
 @localClassNames('TosConsentBanner')
-export default class TosConsentBanner extends Component {
-    @service analytics!: Analytics;
-    @service currentUser!: CurrentUser;
-
-    // Private properties
-    show = false;
-    didValidate = false;
-    hasSubmitted = false;
-
-    saveUser = task(function *(this: TosConsentBanner) {
+export default class TosConsentBanner extends Component.extend({
+    saveUser: task(function *(this: TosConsentBanner) {
         const user = yield this.currentUser.user;
         const { validations } = yield user.validate();
         this.set('didValidate', true);
@@ -34,7 +26,15 @@ export default class TosConsentBanner extends Component {
 
         yield user.save();
         this.currentUser.set('showTosConsentBanner', false);
-    }).drop();
+    }).drop(),
+}) {
+    @service analytics!: Analytics;
+    @service currentUser!: CurrentUser;
+
+    // Private properties
+    show = false;
+    didValidate = false;
+    hasSubmitted = false;
 
     constructor(properties: object) {
         super(properties);

--- a/lib/registries/addon/discover/controller.ts
+++ b/lib/registries/addon/discover/controller.ts
@@ -176,40 +176,8 @@ export default class Discover extends Controller.extend(discoverQueryParams.Mixi
         this.set('searchable', results.total);
         this.set('filterableSources', filterableSources);
     }).on('init'),
-}) {
-    @service i18n!: I18N;
-    @service analytics!: Analytics;
-    @service shareSearch!: ShareSearch;
 
-    sortOptions = sortOptions;
-
-    results: EmberArray<ShareRegistration> = A([]);
-    searchable!: number;
-    totalResults: number = 0;
-    searchOptions!: SearchOptions;
-
-    filterableSources: Array<{
-        count: number;
-        filter: SearchFilter;
-    }> = defaultTo(this.filterableSources, []);
-
-    get filterStyles() {
-        return {
-            sources: styles['ActiveFilters--Sources'],
-            registration_type: styles['ActiveFilters--RegistrationType'],
-        };
-    }
-
-    @computed('searchOptions', 'totalResults')
-    get maxPage() {
-        const max = Math.ceil(this.totalResults / this.searchOptions.size);
-        if (max > (10000 / this.searchOptions.size)) {
-            return Math.ceil(10000 / this.searchOptions.size);
-        }
-        return max;
-    }
-
-    doSearch = task(function *(this: Discover) {
+    doSearch: task(function *(this: Discover) {
         // Unless OSF is the only source, registration_type filters must be cleared
         if (!(this.sources.length === 1 && this.sources[0]!.value === 'OSF')) {
             this.set('registrationTypes', A([]));
@@ -250,7 +218,39 @@ export default class Discover extends Controller.extend(discoverQueryParams.Mixi
 
         this.set('results', A(results.results));
         this.set('totalResults', results.total);
-    }).restartable();
+    }).restartable(),
+}) {
+    @service i18n!: I18N;
+    @service analytics!: Analytics;
+    @service shareSearch!: ShareSearch;
+
+    sortOptions = sortOptions;
+
+    results: EmberArray<ShareRegistration> = A([]);
+    searchable!: number;
+    totalResults: number = 0;
+    searchOptions!: SearchOptions;
+
+    filterableSources: Array<{
+        count: number;
+        filter: SearchFilter;
+    }> = defaultTo(this.filterableSources, []);
+
+    get filterStyles() {
+        return {
+            sources: styles['ActiveFilters--Sources'],
+            registration_type: styles['ActiveFilters--RegistrationType'],
+        };
+    }
+
+    @computed('searchOptions', 'totalResults')
+    get maxPage() {
+        const max = Math.ceil(this.totalResults / this.searchOptions.size);
+        if (max > (10000 / this.searchOptions.size)) {
+            return Math.ceil(10000 / this.searchOptions.size);
+        }
+        return max;
+    }
 
     setup(this: Discover) {
         this.get('doSearch').perform();


### PR DESCRIPTION
## Purpose

Assigning computed properties (which ember-concurrency tasks are) directly to class fields does not work in Ember 3.6+. This moves any of these assignments to `extend()` or, in a few cases where `.extend()` could not be used because we are extending a native class, directly to the prototype using `Object.defineProperties`.

## Summary of Changes

* move tasks in `paginated-list/all`, `paginated-list/has-many`, and registries overview route to `Object.defineProperties()` because they extend from ES6 classes.
* move all other tasks to `.extend()`

## Side Effects

None expected.

## Feature Flags

n/a

## QA Notes

No specific QA needed.

## Ticket

https://openscience.atlassian.net/browse/ENG-601

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
