### PR TITLE
[ENG-627] sort meetings by submission count by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Components:
     - `meetings`
+        - `index`
+            - `meetings-list` - sort by submission count (descending) by default
         - `detail`
             - `meeting-submissions-list` - removed download count sorting
 - Tests:

--- a/app/meetings/index/-components/meetings-list/component.ts
+++ b/app/meetings/index/-components/meetings-list/component.ts
@@ -10,7 +10,7 @@ export default class MeetingsList extends Component.extend({
 }) {
     // Private properties
     search?: string;
-    sort?: string;
+    sort = '-submissions_count';
 
     @computed('search', 'sort')
     get query() {


### PR DESCRIPTION
## Purpose

Sort meetings by submission count (descending) by default.

## Summary of Changes

Set default sort on `meetings-list` component to be: `-submissions_count`

## Side Effects

None expected.

## Feature Flags

`ember_meetings_page`

## QA Notes

Make sure meetings are sorted by submission count (descending) by default.

## Ticket

https://openscience.atlassian.net/browse/ENG-627

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
