### PR TITLE
[ENG-629] rename meeting-submission field: created to dateCreated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
             - `detail`
                 - `meeting-submissions-list` - removed checking of download count sorting
 
+### Fixed
+- Models:
+    - `meeting-submission` - renamed `created` to `dateCreated` to match API
+- Components:
+    - `meetings`
+        - `detail`
+            - `meeting-submissions-list` - renamed `created` to `dateCreated` to match API
+- Tests:
+    - Integration:
+        - `meetings`
+            - `detail`
+                - `meeting-submissions-list` - renamed `created` to `dateCreated` to match API
+- Mirage:
+    - `meeting-submission` factory - renamed `created` to `dateCreated` to match API
+
 ## [19.5.0] - 2019-06-07
 ### Added
 - Models:

--- a/app/meetings/detail/-components/meeting-submissions-list/template.hbs
+++ b/app/meetings/detail/-components/meeting-submissions-list/template.hbs
@@ -58,7 +58,7 @@
                     {{submission.meetingCategory}}
                 </div>
                 <div data-test-submissions-list-item-date>
-                    {{moment-format submission.created 'YYYY-MM-DD hh:mm A'}}
+                    {{moment-format submission.dateCreated 'YYYY-MM-DD hh:mm A'}}
                 </div>
                 <div data-test-submissions-list-item-download>
                     {{#if submission.links.download}}

--- a/app/models/meeting-submission.ts
+++ b/app/models/meeting-submission.ts
@@ -15,7 +15,7 @@ export default class MeetingSubmissionModel extends OsfModel {
     @attr('string') meetingCategory!: string;
     @attr('string') authorName!: string;
     @attr('number') downloadCount!: number;
-    @attr('date') created!: Date;
+    @attr('date') dateCreated!: Date;
     @attr() links!: MeetingSubmissionLinks;
 
     @belongsTo('user', { inverse: null })

--- a/mirage/factories/meeting-submission.ts
+++ b/mirage/factories/meeting-submission.ts
@@ -2,7 +2,11 @@ import { Factory, faker } from 'ember-cli-mirage';
 
 import MeetingSubmission from 'ember-osf-web/models/meeting-submission';
 
-export default Factory.extend<MeetingSubmission>({
+export interface MirageMeetingSubmission extends MeetingSubmission {
+    created: Date | string;
+}
+
+export default Factory.extend<MirageMeetingSubmission>({
     title() {
         return faker.lorem.sentence();
     },
@@ -18,13 +22,19 @@ export default Factory.extend<MeetingSubmission>({
     downloadCount() {
         return faker.random.number({ min: 5, max: 500 });
     },
-    created() {
+    dateCreated() {
         return faker.date.past(5, new Date(2020, 0, 0));
     },
 });
 
+declare module 'ember-cli-mirage/types/registries/model' {
+    export default interface MirageModelRegistry {
+        'meeting-submission': MirageMeetingSubmission;
+    } // eslint-disable-line semi
+}
+
 declare module 'ember-cli-mirage/types/registries/schema' {
     export default interface MirageSchemaRegistry {
-        meetingSubmissions: MeetingSubmission;
+        meetingSubmissions: MirageMeetingSubmission;
     } // eslint-disable-line semi
 }

--- a/tests/integration/routes/meetings/detail/-components/meeting-submissions-list/component-test.ts
+++ b/tests/integration/routes/meetings/detail/-components/meeting-submissions-list/component-test.ts
@@ -104,6 +104,8 @@ module('Integration | routes | meetings | detail | -components | meeting-submiss
                     authorName: 'Jisoo',
                     meetingCategory: 'poster',
                     downloadCount: 100,
+                    dateCreated: new Date(2017, 1, 1),
+                    // Also set created because the sort key is the underlying model field in the BE
                     created: new Date(2017, 1, 1),
                 }),
                 server.create('meeting-submission', {
@@ -111,6 +113,8 @@ module('Integration | routes | meetings | detail | -components | meeting-submiss
                     authorName: 'Lisa',
                     meetingCategory: 'poster',
                     downloadCount: 300,
+                    dateCreated: new Date(2018, 1, 1),
+                    // Also set created because the sort key is the underlying model field in the BE
                     created: new Date(2018, 1, 1),
                 }),
                 server.create('meeting-submission', {
@@ -118,6 +122,8 @@ module('Integration | routes | meetings | detail | -components | meeting-submiss
                     authorName: 'Rosé',
                     meetingCategory: 'talk',
                     downloadCount: 250,
+                    dateCreated: new Date(2019, 1, 1),
+                    // Also set created because the sort key is the underlying model field in the BE
                     created: new Date(2019, 1, 1),
                 }),
             ],


### PR DESCRIPTION
## Purpose

Rename meeting-submission `created` field to `dateCreated` to match the API

## Summary of Changes

### Fixed
- Models:
    - `meeting-submission` - renamed `created` to `dateCreated` to match API
- Components:
    - `meetings`
        - `detail`
            - `meeting-submissions-list` - renamed `created` to `dateCreated` and `date_created` to match API
- Tests:
    - Integration:
        - `meetings`
            - `detail`
                - `meeting-submissions-list` - renamed `created` to `dateCreated` and `date_created` to match API
- Mirage:
    - `meeting-submission` factory - renamed `created` to `dateCreated` to match API

## Side Effects

None expectd

## Feature Flags

`ember_meetings_detail_page`

## QA Notes

Make sure `Date created` column matches the `date_created` in the API response.

## Ticket

https://openscience.atlassian.net/browse/ENG-629

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
