### PR TITLE
[ENG-631] handle missing dates on meeting detail header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Tests:
+    - Integration:
+        - `meetings`
+            - `detail`
+                - `meeting-detail-header` - add tests for location and dates
+
 ### Changed
 - Components:
     - `meetings`
@@ -25,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `meetings`
         - `detail`
             - `meeting-submissions-list` - renamed `created` to `dateCreated` to match API
+            - `meeting-detail-header` - only attempt to display dates when defined
 - Tests:
     - Integration:
         - `meetings`

--- a/app/meetings/detail/-components/meeting-detail-header/template.hbs
+++ b/app/meetings/detail/-components/meeting-detail-header/template.hbs
@@ -1,9 +1,11 @@
 <h1 data-test-meeting-name>{{this.meeting.name}}</h1>
 
 <div data-test-meeting-location-and-date local-class='location-and-date-text'>
-    {{if this.meeting.location (concat this.meeting.location ' | ')}}
-    {{moment-format this.meeting.startDate 'MMM DD, YYYY'}}
-    {{if this.meeting.endDate (concat ' - ' (moment-format this.meeting.endDate 'MMM DD, YYYY'))}}
+    {{if this.meeting.location this.meeting.location}}
+    {{if (and this.meeting.location (or this.meeting.startDate this.meeting.endDate)) ' | '}}
+    {{if this.meeting.startDate (moment-format this.meeting.startDate 'MMM DD, YYYY')}}
+    {{if (or this.meeting.startDate this.meeting.endDate) ' - '}}
+    {{if this.meeting.endDate (moment-format this.meeting.endDate 'MMM DD, YYYY')}}
 </div>
 
 {{#if this.meeting.logoUrl}}

--- a/tests/integration/routes/meetings/detail/-components/meeting-detail-header/component-test.ts
+++ b/tests/integration/routes/meetings/detail/-components/meeting-detail-header/component-test.ts
@@ -1,9 +1,10 @@
-import { render } from '@ember/test-helpers';
+import { render, settled } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { click } from 'ember-osf-web/tests/helpers';
 import { setupRenderingTest } from 'ember-qunit';
 import { TestContext } from 'ember-test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import moment from 'moment';
 import { module, test } from 'qunit';
 
 module('Integration | routes | meetings | detail | -components | meeting-detail-header', hooks => {
@@ -103,5 +104,79 @@ module('Integration | routes | meetings | detail | -components | meeting-detail-
         assert.dom('[data-test-meeting-format-body]').hasTextContaining(meeting.fieldNames.mail_message_body);
         assert.dom('[data-test-meeting-format-body]').hasTextContaining(meeting.fieldNames.mail_attachment);
         assert.dom('[data-test-meeting-panel-footer-note]').exists();
+    });
+
+    test('it handles location and dates properly', async function(assert) {
+        server.create('meeting', {
+            id: 'testmeeting',
+            name: 'Test Meeting',
+            location: undefined,
+            startDate: undefined,
+            endDate: undefined,
+        });
+        const meeting = await this.store.findRecord('meeting', 'testmeeting');
+        this.set('meeting', meeting);
+        await render(hbs`<Meetings::Detail::-Components::MeetingDetailHeader @meeting={{this.meeting}} />`);
+        assert.dom('[data-test-meeting-location-and-date]')
+            .hasText(
+                '',
+                'Nothing displayed when no location or dates defined',
+            );
+        const location = 'Timbuktu';
+        meeting.set('location', location);
+        await settled();
+        assert.dom('[data-test-meeting-location-and-date]')
+            .hasText(
+                location,
+                'Only location displayed when only location is defined',
+            );
+        const startDate = new Date('2000-01-02');
+        const formattedStartDate = moment(startDate).format('MMM DD, YYYY');
+        meeting.set('startDate', startDate);
+        await settled();
+        assert.dom('[data-test-meeting-location-and-date]')
+            .hasText(
+                `${location} | ${formattedStartDate} -`,
+                'Only location and start date displayed when only location and start date are defined',
+            );
+        const endDate = new Date('2000-01-03');
+        const formattedEndDate = moment(endDate).format('MMM DD, YYYY');
+        meeting.set('endDate', endDate);
+        meeting.set('startDate', undefined);
+        await settled();
+        assert.dom('[data-test-meeting-location-and-date]')
+            .hasText(
+                `${location} | - ${formattedEndDate}`,
+                'Only location and end date displayed when only location and end date are defined',
+            );
+        meeting.set('location', undefined);
+        await settled();
+        assert.dom('[data-test-meeting-location-and-date]')
+            .hasText(
+                `- ${formattedEndDate}`,
+                'Only end date displayed when only end date is defined',
+            );
+        meeting.set('startDate', startDate);
+        meeting.set('endDate', undefined);
+        await settled();
+        assert.dom('[data-test-meeting-location-and-date]')
+            .hasText(
+                `${formattedStartDate} -`,
+                'Only start date displayed when only start date is defined',
+            );
+        meeting.set('endDate', endDate);
+        await settled();
+        assert.dom('[data-test-meeting-location-and-date]')
+            .hasText(
+                `${formattedStartDate} - ${formattedEndDate}`,
+                'Only start date and end date displayed when only start date and end date are defined',
+            );
+        meeting.set('location', location);
+        await settled();
+        assert.dom('[data-test-meeting-location-and-date]')
+            .hasText(
+                `${location} | ${formattedStartDate} - ${formattedEndDate}`,
+                'Location and dates displayed when all are defined',
+            );
     });
 });


### PR DESCRIPTION
## Purpose

An undefined start date would result in "Invalid date" in the detail header.

## Summary of Changes

### Added
- Tests:
    - Integration:
        - `meetings`
            - `detail`
                - `meeting-detail-header` - add tests for location and dates

### Fixed
- Components:
    - `meetings`
        - `detail`
            - `meeting-detail-header` - only attempt to display dates when defined

## Side Effects

None expected.

## Feature Flags

`ember_meetings_detail_page`

## QA Notes

An empty start date should not result in "Invalid date" being displayed.

## Ticket

https://openscience.atlassian.net/browse/ENG-631

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
