### PR TITLE
[ENG-630] fix long meeting names and submission titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - Acceptance:
         - `meetings`
             - `detail` - add submission with long title
+            - `index` - add meeting with long name
 
 ### Fixed
 - Models:
@@ -38,6 +39,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
                 - renamed `created` to `dateCreated` to match API
                 - applied `table-layout: fixed` to force truncating of long submission titles
             - `meeting-detail-header` - only attempt to display dates when defined
+        - `index`
+            - `meetings-list` - applied `table-layout: fixed` to force truncating of long meeting names
 - Tests:
     - Integration:
         - `meetings`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         - `meetings`
             - `detail`
                 - `meeting-submissions-list` - removed checking of download count sorting
+    - Acceptance:
+        - `meetings`
+            - `detail` - add submission with long title
 
 ### Fixed
 - Models:
@@ -31,7 +34,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Components:
     - `meetings`
         - `detail`
-            - `meeting-submissions-list` - renamed `created` to `dateCreated` to match API
+            - `meeting-submissions-list`
+                - renamed `created` to `dateCreated` to match API
+                - applied `table-layout: fixed` to force truncating of long submission titles
             - `meeting-detail-header` - only attempt to display dates when defined
 - Tests:
     - Integration:

--- a/app/meetings/detail/-components/meeting-submissions-list/styles.scss
+++ b/app/meetings/detail/-components/meeting-submissions-list/styles.scss
@@ -1,6 +1,7 @@
 .table {
     ul {
         display: table;
+        table-layout: fixed;
         width: 100%;
         border: 1px solid #eee;
         margin: 0;

--- a/app/meetings/index/-components/meetings-list/styles.scss
+++ b/app/meetings/index/-components/meetings-list/styles.scss
@@ -5,6 +5,7 @@
 .table {
     ul {
         display: table;
+        table-layout: fixed;
         width: 100%;
         border: 1px solid #eee;
         margin: 0;

--- a/tests/acceptance/meetings/detail-test.ts
+++ b/tests/acceptance/meetings/detail-test.ts
@@ -1,4 +1,5 @@
 import { currentURL, visit } from '@ember/test-helpers';
+import { faker } from 'ember-cli-mirage';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { percySnapshot } from 'ember-percy';
 import { module, test } from 'qunit';
@@ -12,10 +13,13 @@ module(moduleName, hooks => {
     setupMirage(hooks);
 
     test('meetings detail', async assert => {
+        const longTitleSubmission = server.create('meeting-submission', {
+            title: faker.lorem.paragraph(),
+        });
         server.create('meeting', {
             id: 'testmeeting',
             name: 'Test Meeting',
-            submissions: server.createList('meeting-submission', 15),
+            submissions: server.createList('meeting-submission', 15).concat(longTitleSubmission),
         });
         await visit('/meetings/testmeeting');
         assert.equal(currentURL(), '/meetings/testmeeting', "Still at '/meetings/testmeeting'.");

--- a/tests/acceptance/meetings/index-test.ts
+++ b/tests/acceptance/meetings/index-test.ts
@@ -1,4 +1,5 @@
 import { click as untrackedClick, currentURL, visit } from '@ember/test-helpers';
+import { faker } from 'ember-cli-mirage';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { percySnapshot } from 'ember-percy';
 import { module, test } from 'qunit';
@@ -13,6 +14,7 @@ module(moduleName, hooks => {
 
     test('meetings index', async assert => {
         server.createList('meeting', 15);
+        server.create('meeting', { name: faker.lorem.paragraph() });
         await visit('/meetings');
         assert.equal(currentURL(), '/meetings', "Still at '/meetings'.");
         await percySnapshot(`${moduleName} - default`);


### PR DESCRIPTION
## Purpose

Long submission titles and meeting names do not wrap or truncate, which causes the column to accommodate the entire string and force the other columns off the screen. The legacy page truncates long titles and names and adds an ellipsis. This PR applies `table-layout: fixed` to each table to force truncation based on the width of the header rows, which are set to percentages. The result is:

Submissions:

![Screen Shot 2019-06-20 at 11 07 09 AM](https://user-images.githubusercontent.com/348630/59859880-9c8fa280-934b-11e9-83ca-b9be998ab18a.png)

Meetings:

![Screen Shot 2019-06-20 at 11 06 01 AM](https://user-images.githubusercontent.com/348630/59859906-a5807400-934b-11e9-9e4e-2e27a921f169.png)

## Summary of Changes

### Changed
- Tests:
    - Acceptance:
        - `meetings`
            - `detail` - add submission with long title
            - `index` - add meeting with long name
### Fixed
- Components:
    - `meetings`
        - `detail`
            - `meeting-submissions-list`
                - applied `table-layout: fixed` to force truncating of long submission titles
         - `index`
            - `meetings-list`
                - applied `table-layout: fixed` to force truncating of long meeting names

## Side Effects

None expected.

## Feature Flags

`ember_meetings_page`
`ember_meetings_detail_page`

## QA Notes

Make sure long meeting names and submission titles are truncated with an ellipsis.

## Ticket

https://openscience.atlassian.net/browse/ENG-630

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
