### PR TITLE
[ENG-266] Add percy snapshots to test collections.

### DIFF
--- a/lib/collections/addon/components/collection-metadata/template.hbs
+++ b/lib/collections/addon/components/collection-metadata/template.hbs
@@ -1,7 +1,7 @@
 {{#each this.chunkedDisplayFields as |fields|}}
     <div class='row'>
         {{#each fields as |field|}}
-            <div class='col-md-6'>
+            <div data-test-metadata-field={{field.labelKey}} class='col-md-6'>
                 <label>
                     {{t (concat 'collections.collection_metadata.' field.labelKey)}}
                 </label>

--- a/lib/collections/addon/components/collection-search-result/node/component.ts
+++ b/lib/collections/addon/components/collection-search-result/node/component.ts
@@ -19,7 +19,7 @@ import template from './template';
 export default class SearchResultNode extends Component.extend({
     didRender(...args: any[]) {
         this._super(...args);
-        // MathJax.Hub.Queue(['Typeset', MathJax.Hub, this.$()[0]]);
+        MathJax.Hub.Queue(['Typeset', MathJax.Hub, this.$()[0]]);
     },
 }) {
     @service analytics!: Analytics;

--- a/lib/collections/addon/components/collection-search-result/node/component.ts
+++ b/lib/collections/addon/components/collection-search-result/node/component.ts
@@ -19,7 +19,7 @@ import template from './template';
 export default class SearchResultNode extends Component.extend({
     didRender(...args: any[]) {
         this._super(...args);
-        MathJax.Hub.Queue(['Typeset', MathJax.Hub, this.$()[0]]);
+        // MathJax.Hub.Queue(['Typeset', MathJax.Hub, this.$()[0]]);
     },
 }) {
     @service analytics!: Analytics;

--- a/lib/collections/addon/discover/template.hbs
+++ b/lib/collections/addon/discover/template.hbs
@@ -1,33 +1,31 @@
-{{title (t 'collections.discover.title')}}
-
 {{discover-page
     query=(action 'query')
     searchResultComponent='collection-search-result'
-    activeFilters=activeFilters
-    consumingService=consumingService
-    discoverHeader=discoverHeader
-    facets=facets
-    lockedParams=lockedParams
+    activeFilters=this.activeFilters
+    consumingService=this.consumingService
+    discoverHeader=this.discoverHeader
+    facets=this.facets
+    lockedParams=this.lockedParams
     
-    queryParams=queryParams
-    searchPlaceholder=searchPlaceholder
+    queryParams=this.queryParams
+    searchPlaceholder=this.searchPlaceholder
     showActiveFilters=true
-    sortOptions=sortOptions
+    sortOptions=this.sortOptions
 
-    sources=sources
-    start=start
-    end=end
-    tags=tags
+    sources=this.sources
+    start=this.start
+    end=this.end
+    tags=this.tags
 
-    page=page
-    provider=provider
-    q=q
-    type=type
-    taxonomy=subject
+    page=this.page
+    provider=this.provider
+    q=this.q
+    type=this.type
+    taxonomy=this.subject
 
-    collectedType=collectedType
-    issue=issue
-    programArea=programArea
-    status=status
-    volume=volume
+    collectedType=this.collectedType
+    issue=this.issue
+    programArea=this.programArea
+    status=this.status
+    volume=this.volume
 }}

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -64,6 +64,8 @@ function quickfilesScenario(server: Server, currentUser: ModelInstance<User>) {
 }
 
 function collectionScenario(server: Server, currentUser: ModelInstance<User>) {
+    const taxonomies = server.schema.taxonomies.all().models;
+    const licensesAcceptable = server.schema.licenses.all().models;
     const primaryCollection = server.create('collection');
     const nodeToBeAdded = server.create('node', {
         title: 'Node to be added to collection',
@@ -75,7 +77,9 @@ function collectionScenario(server: Server, currentUser: ModelInstance<User>) {
         index: 0,
     });
     const nodeAdded = server.create('node', {
+        description: 'A random description',
         title: 'Added to collection',
+        license: licensesAcceptable[0],
         currentUserPermissions: Object.values(Permission),
     });
     server.create('contributor', {
@@ -112,8 +116,6 @@ function collectionScenario(server: Server, currentUser: ModelInstance<User>) {
             ],
         ],
     });
-    const taxonomies = server.schema.taxonomies.all().models;
-    const licensesAcceptable = server.schema.licenses.all().models;
     server.create('collection-provider', {
         id: 'studyswap',
         primaryCollection,

--- a/tests/engines/collections/acceptance/discover/discover-test.ts
+++ b/tests/engines/collections/acceptance/discover/discover-test.ts
@@ -1,0 +1,47 @@
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { percySnapshot } from 'ember-percy';
+import { module, test } from 'qunit';
+
+import { Permission } from 'ember-osf-web/models/osf-model';
+import { visit } from 'ember-osf-web/tests/helpers';
+import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
+
+module('Collections | Acceptance | discover', hooks => {
+    setupEngineApplicationTest(hooks, 'collections');
+    setupMirage(hooks);
+
+    test('it renders', async assert => {
+        server.loadFixtures('taxonomies');
+        const currentUser = server.create('user', 'loggedIn');
+        const primaryCollection = server.create('collection');
+        const nodeAdded = server.create('node', {
+            title: 'Added to collection',
+            currentUserPermissions: Object.values(Permission),
+        });
+        server.create('contributor', {
+            node: nodeAdded,
+            users: currentUser,
+            index: 0,
+        });
+        server.create('collected-metadatum', {
+            creator: currentUser,
+            guid: nodeAdded,
+            id: nodeAdded.id,
+            collection: primaryCollection,
+            subjects: [[{ text: 'Arts and Humanities', id: '123' }]],
+        });
+        const taxonomies = server.schema.taxonomies.all().models;
+        const licensesAcceptable = server.schema.licenses.all().models;
+        const provider = server.create('collection-provider', {
+            id: 'studyswap',
+            primaryCollection,
+            taxonomies,
+            licensesAcceptable,
+        });
+        await visit(`/collections/${provider.id}/discover`);
+        assert.dom('.results-top').exists();
+        assert.dom('.results-top').hasTextContaining(nodeAdded.title);
+        assert.dom('.results-top').hasTextContaining(currentUser.familyName);
+        await percySnapshot(assert);
+    });
+});

--- a/tests/engines/collections/acceptance/submit/submit-test.ts
+++ b/tests/engines/collections/acceptance/submit/submit-test.ts
@@ -1,0 +1,64 @@
+import { click } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { percySnapshot } from 'ember-percy';
+import { module, test } from 'qunit';
+
+import { Permission } from 'ember-osf-web/models/osf-model';
+import { visit } from 'ember-osf-web/tests/helpers';
+import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
+
+module('Collections | Acceptance | submit', hooks => {
+    setupEngineApplicationTest(hooks, 'collections');
+    setupMirage(hooks);
+
+    test('it renders', async assert => {
+        server.loadFixtures('taxonomies');
+        server.loadFixtures('licenses');
+        const currentUser = server.create('user', 'loggedIn');
+        const primaryCollection = server.create('collection');
+        const nodeToBeAdded = server.create('node', {
+            title: 'Node to be added to collection',
+            currentUserPermissions: Object.values(Permission),
+        });
+        server.create('contributor', {
+            node: nodeToBeAdded,
+            users: currentUser,
+            index: 0,
+        });
+        const taxonomies = server.schema.taxonomies.all().models;
+        const licensesAcceptable = server.schema.licenses.all().models;
+        const provider = server.create('collection-provider', {
+            id: 'studyswap',
+            primaryCollection,
+            taxonomies,
+            licensesAcceptable,
+        });
+        await visit(`/collections/${provider.id}/submit`);
+        await percySnapshot(assert);
+        await click('.ember-power-select-placeholder');
+        await click('.ember-power-select-option');
+        await percySnapshot(assert);
+        await click('.ember-power-select-placeholder');
+        await click('.ember-power-select-option');
+        await click('.btn-primary');
+        await percySnapshot(assert);
+        await click('.btn-primary');
+        await percySnapshot(assert);
+        await click('ol > li');
+        await click('.btn-primary');
+        await percySnapshot(assert);
+        await click('[data-test-metadata-field="collected_type_label"] > div > div > .ember-power-select-trigger');
+        await click('.ember-power-select-option');
+        await click('[data-test-metadata-field="issue_label"] > div > div > .ember-power-select-trigger');
+        await click('.ember-power-select-option');
+        await click('[data-test-metadata-field="program_area_label"] > div > div > .ember-power-select-trigger');
+        await click('.ember-power-select-option');
+        await click('[data-test-metadata-field="status_label"] > div > div > .ember-power-select-trigger');
+        await click('.ember-power-select-option');
+        await click('[data-test-metadata-field="volume_label"] > div > div > .ember-power-select-trigger');
+        await click('.ember-power-select-option');
+        await click('.btn-primary');
+        await click('.btn-success');
+        await percySnapshot(assert);
+    });
+});

--- a/tests/engines/collections/acceptance/update/update-test.ts
+++ b/tests/engines/collections/acceptance/update/update-test.ts
@@ -1,0 +1,55 @@
+import { click } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { percySnapshot } from 'ember-percy';
+import { module, test } from 'qunit';
+
+import { Permission } from 'ember-osf-web/models/osf-model';
+import { visit } from 'ember-osf-web/tests/helpers';
+import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
+
+module('Collections | Acceptance | update', hooks => {
+    setupEngineApplicationTest(hooks, 'collections');
+    setupMirage(hooks);
+
+    test('it renders', async assert => {
+        server.loadFixtures('taxonomies');
+        server.loadFixtures('licenses');
+        const taxonomies = server.schema.taxonomies.all().models;
+        const licensesAcceptable = server.schema.licenses.all().models;
+        const currentUser = server.create('user', 'loggedIn');
+        const primaryCollection = server.create('collection');
+        const nodeAdded = server.create('node', {
+            title: 'Added to collection',
+            license: licensesAcceptable[0],
+            currentUserPermissions: Object.values(Permission),
+        });
+        server.create('contributor', {
+            node: nodeAdded,
+            users: currentUser,
+            index: 0,
+        });
+        server.create('collected-metadatum', {
+            creator: currentUser,
+            guid: nodeAdded,
+            id: nodeAdded.id,
+            collection: primaryCollection,
+            subjects: [[{ text: 'Arts and Humanities', id: '123' }]],
+        });
+        const provider = server.create('collection-provider', {
+            id: 'studyswap',
+            primaryCollection,
+            taxonomies,
+            licensesAcceptable,
+        });
+        await visit(`/collections/${provider.id}/${nodeAdded.id}/edit`);
+        await percySnapshot(assert);
+        await click('.btn-primary');
+        await percySnapshot(assert);
+        await click('.btn-primary');
+        await percySnapshot(assert);
+        await click('.btn-primary');
+        await percySnapshot(assert);
+        await click('.btn-primary');
+        await percySnapshot(assert);
+    });
+});

--- a/tests/index.html
+++ b/tests/index.html
@@ -6,7 +6,15 @@
     <title>Ember OSF Web Tests</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-
+    <script type="text/x-mathjax-config">
+      MathJax.Hub.Config({
+          tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']], processEscapes: true},
+          skipStartupTypeset: true
+      });
+    </script>
+    <script type="text/javascript" async
+      src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+    </script>
     {{content-for "head"}}
     {{content-for "test-head"}}
 


### PR DESCRIPTION
## Purpose

Add percy snapshots to test collection discover, submission and update views.

## Summary of Changes

Added acceptance tests.

## QA Notes

No QA is expected for this ticket.
## Ticket

https://openscience.atlassian.net/browse/ENG-266

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
