### PR TITLE
[ENG-645] Truncate registration description

### DIFF
--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -1093,6 +1093,8 @@ export default {
         registration_metadata: {
             contributors: 'Contributors',
             description: 'Description',
+            show_more: 'Show more',
+            show_less: 'Show less',
             no_description: 'No description given.',
             registration_type: 'Registration type',
             date_registered: 'Date registered',

--- a/lib/osf-components/addon/components/node-description/component.ts
+++ b/lib/osf-components/addon/components/node-description/component.ts
@@ -17,8 +17,8 @@ export default class NodeDescription extends Component {
     truncateDescription: boolean = true;
 
     setTruncate(element: Element) {
-        const { height, width } = element.getBoundingClientRect();
-        if (height && width && height > (heightLimit - 1)) {
+        const height = element.clientHeight;
+        if (height && height > (heightLimit - 1)) {
             this.set('shouldTruncate', true);
             this.set('truncateDescription', true);
         } else {

--- a/lib/osf-components/addon/components/node-description/component.ts
+++ b/lib/osf-components/addon/components/node-description/component.ts
@@ -7,6 +7,8 @@ import { DescriptionManager } from 'osf-components/components/editable-field/des
 import styles from './styles';
 import template from './template';
 
+const heightLimit: number = 200; // height limit should be (.hide {max-height} - 1)
+
 @tagName('')
 @layout(template, styles)
 export default class NodeDescription extends Component {
@@ -16,7 +18,7 @@ export default class NodeDescription extends Component {
 
     setTruncate(element: Element) {
         const { height, width } = element.getBoundingClientRect();
-        if (height && width && height > 49) { // height limit should be (.hide {max-height} - 1)
+        if (height && width && height > (heightLimit - 1)) {
             this.set('shouldTruncate', true);
             this.set('truncateDescription', true);
         } else {

--- a/lib/osf-components/addon/components/node-description/component.ts
+++ b/lib/osf-components/addon/components/node-description/component.ts
@@ -14,14 +14,13 @@ export default class NodeDescription extends Component {
     shouldTruncate: boolean = false;
     truncateDescription: boolean = true;
 
-    setTruncate(element: Element, args: any[]) { // args: [description, this]
-        const node = args[1];
+    setTruncate(element: Element) {
         const { height, width } = element.getBoundingClientRect();
         if (height && width && height > 49) { // height limit should be (.hide {max-height} - 1)
-            node.set('shouldTruncate', true);
-            node.set('truncateDescription', true);
+            this.set('shouldTruncate', true);
+            this.set('truncateDescription', true);
         } else {
-            node.set('shouldTruncate', false);
+            this.set('shouldTruncate', false);
         }
     }
 

--- a/lib/osf-components/addon/components/node-description/component.ts
+++ b/lib/osf-components/addon/components/node-description/component.ts
@@ -1,6 +1,7 @@
 import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 
+import { action } from '@ember-decorators/object';
 import { layout } from 'ember-osf-web/decorators/component';
 import { DescriptionManager } from 'osf-components/components/editable-field/description-manager/component';
 import styles from './styles';
@@ -10,4 +11,22 @@ import template from './template';
 @layout(template, styles)
 export default class NodeDescription extends Component {
     manager!: DescriptionManager;
+    shouldTruncate: boolean = false;
+    truncateDescription: boolean = true;
+
+    setTruncate(element: Element, args: any[]) { // args: [description, this]
+        const node = args[1];
+        const { height, width } = element.getBoundingClientRect();
+        if (height && width && height > 49) { // height limit should be (.hide {max-height} - 1)
+            node.set('shouldTruncate', true);
+            node.set('truncateDescription', true);
+        } else {
+            node.set('shouldTruncate', false);
+        }
+    }
+
+    @action
+    toggleFullDescription() {
+        this.set('truncateDescription', !this.truncateDescription);
+    }
 }

--- a/lib/osf-components/addon/components/node-description/styles.scss
+++ b/lib/osf-components/addon/components/node-description/styles.scss
@@ -18,7 +18,6 @@
     right: 0;
     width: 100%;
     height: 100%;
-    cursor: pointer;
 
     &.collapsed {
         background-image: linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));

--- a/lib/osf-components/addon/components/node-description/styles.scss
+++ b/lib/osf-components/addon/components/node-description/styles.scss
@@ -1,6 +1,5 @@
 .Description__field {
     word-break: break-word;
-    margin-bottom: 15px;
 }
 
 .DescriptionWrapper {

--- a/lib/osf-components/addon/components/node-description/styles.scss
+++ b/lib/osf-components/addon/components/node-description/styles.scss
@@ -2,3 +2,25 @@
     word-break: break-word;
     margin-bottom: 15px;
 }
+
+.DescriptionWrapper {
+    position: relative;
+    overflow: hidden;
+}
+
+.hide {
+    max-height: 50px;
+}
+
+.DescriptionOverlay {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    cursor: pointer;
+
+    &.collapsed {
+        background-image: linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
+    }
+}

--- a/lib/osf-components/addon/components/node-description/styles.scss
+++ b/lib/osf-components/addon/components/node-description/styles.scss
@@ -8,8 +8,9 @@
     overflow: hidden;
 }
 
+// This max-height property should match the heightLimit param in the component file
 .hide {
-    max-height: 50px;
+    max-height: 200px; 
 }
 
 .DescriptionOverlay {

--- a/lib/osf-components/addon/components/node-description/template.hbs
+++ b/lib/osf-components/addon/components/node-description/template.hbs
@@ -1,8 +1,8 @@
 <div 
-    {{!-- did-update will not trigger without listening to manager.description. 'this' is not accessible within setTruncate function --}}
-    {{did-insert this.setTruncate @manager.description this}} 
-    {{did-update this.setTruncate @manager.description this}} 
-    local-class='DescriptionWrapper {{if this.truncateDescription 'hide'}}'>
+    {{did-insert (action this.setTruncate) @manager.description}} 
+    {{did-update (action this.setTruncate) @manager.description}} 
+    local-class='DescriptionWrapper Description__field {{if this.truncateDescription 'hide'}}'
+    ...attributes>
 
     {{#if this.shouldTruncate}}
         <div 
@@ -11,9 +11,7 @@
         </div>
     {{/if}}
 
-    <span local-class='Description__field' ...attributes>
-        {{@manager.description}}
-    </span>
+    {{@manager.description}}
 </div>
 
 {{#if this.shouldTruncate}}

--- a/lib/osf-components/addon/components/node-description/template.hbs
+++ b/lib/osf-components/addon/components/node-description/template.hbs
@@ -7,8 +7,7 @@
 
     {{#if this.shouldTruncate}}
         <div 
-            local-class='DescriptionOverlay {{if this.truncateDescription 'collapsed' 'expanded'}}'
-            {{!-- {{action this.toggleFullDescription}} --}}
+            local-class='DescriptionOverlay {{if this.truncateDescription 'collapsed'}}'
         >
         </div>
     {{/if}}

--- a/lib/osf-components/addon/components/node-description/template.hbs
+++ b/lib/osf-components/addon/components/node-description/template.hbs
@@ -21,11 +21,12 @@
     <OsfButton
         data-test-load-more-contribs   
         data-analytics-name='Show full description'
-        aria-label={{t 'contributor_list.more'}}
+        aria-label={{t (if this.truncateDescription 'registries.registration_metadata.show_more' 'registries.registration_metadata.show_less')}}
         local-class='ToggleButton'
         @type='link'
         @onClick={{action this.toggleFullDescription}}
     >
+        {{t (if this.truncateDescription 'registries.registration_metadata.show_more' 'registries.registration_metadata.show_less')}}
         <FaIcon @icon='{{if this.truncateDescription 'caret-down' 'caret-up'}}'/>
     </OsfButton>
 {{/if}}

--- a/lib/osf-components/addon/components/node-description/template.hbs
+++ b/lib/osf-components/addon/components/node-description/template.hbs
@@ -2,7 +2,6 @@
     {{!-- did-update will not trigger without listening to manager.description. 'this' is not accessible within setTruncate function --}}
     {{did-insert this.setTruncate @manager.description this}} 
     {{did-update this.setTruncate @manager.description this}} 
-    id='description' 
     local-class='DescriptionWrapper {{if this.truncateDescription 'hide'}}'>
 
     {{#if this.shouldTruncate}}
@@ -19,10 +18,8 @@
 
 {{#if this.shouldTruncate}}
     <OsfButton
-        data-test-load-more-contribs   
         data-analytics-name='Show full description'
         aria-label={{t (if this.truncateDescription 'registries.registration_metadata.show_more' 'registries.registration_metadata.show_less')}}
-        local-class='ToggleButton'
         @type='link'
         @onClick={{action this.toggleFullDescription}}
     >

--- a/lib/osf-components/addon/components/node-description/template.hbs
+++ b/lib/osf-components/addon/components/node-description/template.hbs
@@ -1,4 +1,5 @@
 <div 
+    data-test-node-description-wrapper
     {{did-insert (action this.setTruncate) @manager.description}} 
     {{did-update (action this.setTruncate) @manager.description}} 
     local-class='DescriptionWrapper Description__field {{if this.truncateDescription 'hide'}}'
@@ -6,6 +7,7 @@
 
     {{#if this.shouldTruncate}}
         <div 
+            data-test-node-description-overlay
             local-class='DescriptionOverlay {{if this.truncateDescription 'collapsed'}}'
         >
         </div>
@@ -16,6 +18,7 @@
 
 {{#if this.shouldTruncate}}
     <OsfButton
+        data-test-node-description-button
         data-analytics-name='Show full description'
         aria-label={{t (if this.truncateDescription 'registries.registration_metadata.show_more' 'registries.registration_metadata.show_less')}}
         @type='link'

--- a/lib/osf-components/addon/components/node-description/template.hbs
+++ b/lib/osf-components/addon/components/node-description/template.hbs
@@ -1,3 +1,32 @@
-<span local-class='Description__field' ...attributes>
-    {{@manager.description}}
-</span>
+<div 
+    {{!-- did-update will not trigger without listening to manager.description. 'this' is not accessible within setTruncate function --}}
+    {{did-insert this.setTruncate @manager.description this}} 
+    {{did-update this.setTruncate @manager.description this}} 
+    id='description' 
+    local-class='DescriptionWrapper {{if this.truncateDescription 'hide'}}'>
+
+    {{#if this.shouldTruncate}}
+        <div 
+            local-class='DescriptionOverlay {{if this.truncateDescription 'collapsed' 'expanded'}}'
+            {{!-- {{action this.toggleFullDescription}} --}}
+        >
+        </div>
+    {{/if}}
+
+    <span local-class='Description__field' ...attributes>
+        {{@manager.description}}
+    </span>
+</div>
+
+{{#if this.shouldTruncate}}
+    <OsfButton
+        data-test-load-more-contribs   
+        data-analytics-name='Show full description'
+        aria-label={{t 'contributor_list.more'}}
+        local-class='ToggleButton'
+        @type='link'
+        @onClick={{action this.toggleFullDescription}}
+    >
+        <FaIcon @icon='{{if this.truncateDescription 'caret-down' 'caret-up'}}'/>
+    </OsfButton>
+{{/if}}

--- a/lib/registries/package.json
+++ b/lib/registries/package.json
@@ -5,6 +5,7 @@
     "ember-engine"
   ],
   "dependencies": {
+    "@ember/render-modifiers": "*",
     "ember-angle-bracket-invocation-polyfill": "*",
     "ember-basic-dropdown": "*",
     "ember-bootstrap": "*",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@centerforopenscience/eslint-config": "^2.0.0",
     "@ember/jquery": "^0.6.0",
     "@ember/optional-features": "^0.7.0",
+    "@ember/render-modifiers": "^1.0.0",
     "@ember/test-helpers": "^1.5.0",
     "@types/ace": "^0.0.42",
     "@types/dropzone": "^5.0.4",

--- a/tests/engines/registries/acceptance/overview/overview-test.ts
+++ b/tests/engines/registries/acceptance/overview/overview-test.ts
@@ -267,13 +267,22 @@ module('Registries | Acceptance | overview.overview', hooks => {
         await click('[data-test-edit-button="description"]');
         assert.dom('[data-test-description-input]').isVisible();
 
-        const newDescription = faker.lorem.sentences(2);
+        const newDescription = faker.lorem.sentences(500);
 
         await fillIn('[data-test-description-input] textarea', newDescription);
         assert.dom('[data-test-save-edits]').isVisible();
         await click('[data-test-save-edits]');
 
         assert.equal(reg.description, newDescription, 'description successfully updated');
+        assert.dom('[data-test-node-description-overlay]').exists('description is truncated');
+        assert.dom('[data-test-node-description-button]').exists();
+        assert.dom('[data-test-node-description-wrapper]').hasStyle({
+            maxHeight: '200px',
+        });
+        await click('[data-test-node-description-button]');
+        assert.dom('[data-test-node-description-wrapper]').hasStyle({
+            maxHeight: 'none',
+        });
         reg.update({ currentUserPermissions: [] });
         await visit(`/${reg.id}/`);
         assert.dom('[data-test-edit-button="description"]').isNotVisible();

--- a/tests/integration/components/node-description/component-test.ts
+++ b/tests/integration/components/node-description/component-test.ts
@@ -1,0 +1,49 @@
+import { click, render } from '@ember/test-helpers';
+import { faker } from 'ember-cli-mirage';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { setupRenderingTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
+import { module, test } from 'qunit';
+
+import hbs from 'htmlbars-inline-precompile';
+import { OsfLinkRouterStub } from '../../helpers/osf-link-router-stub';
+
+module('Integration | Component | node-description', hooks => {
+    setupRenderingTest(hooks);
+    setupMirage(hooks);
+
+    hooks.beforeEach(function(this: TestContext) {
+        this.store = this.owner.lookup('service:store');
+    });
+    test('it renders', async function(assert) {
+        this.owner.register('service:router', OsfLinkRouterStub);
+        const node = server.create('node', {}, 'withContributors');
+        const project = await this.store.findRecord('node', node.id, { include: 'bibliographic_contributors' });
+        this.set('node', project);
+
+        // do the short description first
+        const shortDescription = faker.lorem.sentences(2);
+        this.set('manager', { description: shortDescription });
+        await render(hbs`<NodeDescription @manager={{this.manager}} />`);
+        assert.dom('[data-test-node-description-wrapper]').containsText(shortDescription);
+        assert.dom('[data-test-node-description-overlay]').doesNotExist('no overlay needed');
+        assert.dom('[data-test-node-description-button]').doesNotExist('button does not show up');
+
+        // change it to a longer description
+        const longDescription = faker.lorem.sentences(500);
+        this.set('manager', { description: longDescription });
+        await render(hbs`<NodeDescription @manager={{this.manager}}  />`);
+        assert.dom('[data-test-node-description-wrapper]').containsText(longDescription);
+        assert.dom('[data-test-node-description-overlay]').exists('overlay needed');
+        assert.dom('[data-test-node-description-button]').exists('button shows up');
+        assert.dom('[data-test-node-description-wrapper]').hasStyle({
+            maxHeight: '200px',
+        });
+
+        // click the "See more" button
+        await click('[data-test-node-description-button]');
+        assert.dom('[data-test-node-description-wrapper]').hasStyle({
+            maxHeight: 'none',
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -849,6 +849,14 @@
     ember-cli-babel "^6.16.0"
     ember-compatibility-helpers "^1.1.1"
 
+"@ember/render-modifiers@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@ember/render-modifiers/-/render-modifiers-1.0.0.tgz#dc1e4c615e38507da4b6a80f6e4b27fe4d37ec8f"
+  integrity sha512-TqUW7exzLUwnzqHqKbo5ui0rvrS/YkbRlFD+h07kDYVFJkS2uPwkQE/K4YDeTywqN6er7VamFwl7Og98sPjmiQ==
+  dependencies:
+    ember-cli-babel "^7.1.2"
+    ember-modifier-manager-polyfill "^1.0.1"
+
 "@ember/test-helpers@^0.7.26":
   version "0.7.27"
   resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-0.7.27.tgz#c622cabd0cbb95b34efc1e1b6274ab5a14edc138"
@@ -2484,7 +2492,7 @@ babel-plugin-ember-modules-api-polyfill@^1.4.2:
   dependencies:
     ember-rfc176-data "^0.2.0"
 
-babel-plugin-ember-modules-api-polyfill@^2.3.0, babel-plugin-ember-modules-api-polyfill@^2.6.0, babel-plugin-ember-modules-api-polyfill@^2.7.0, babel-plugin-ember-modules-api-polyfill@^2.8.0:
+babel-plugin-ember-modules-api-polyfill@^2.3.0, babel-plugin-ember-modules-api-polyfill@^2.6.0, babel-plugin-ember-modules-api-polyfill@^2.7.0, babel-plugin-ember-modules-api-polyfill@^2.8.0, babel-plugin-ember-modules-api-polyfill@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.9.0.tgz#8503e7b4192aeb336b00265e6235258ff6b754aa"
   integrity sha512-c03h50291phJ2gQxo/aIOvFQE2c6glql1A7uagE3XbPXpKVAJOUxtVDjvWG6UAB6BC5ynsJfMWvY0w4TPRKIHQ==
@@ -6574,6 +6582,33 @@ ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cl
     ensure-posix-path "^1.0.2"
     semver "^5.5.0"
 
+ember-cli-babel@^7.4.2:
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.8.0.tgz#e596500eca0f5a7c9aaee755f803d1542f578acf"
+  integrity sha512-xUBgJQ81fqd7k/KIiGU+pjpoXhrmmRf9pUrqLenNSU5N+yeNFT5a1+w0b+p1F7oBphfXVwuxApdZxrmAHOdA3Q==
+  dependencies:
+    "@babel/core" "^7.0.0"
+    "@babel/plugin-proposal-class-properties" "^7.3.4"
+    "@babel/plugin-proposal-decorators" "^7.3.0"
+    "@babel/plugin-transform-modules-amd" "^7.0.0"
+    "@babel/plugin-transform-runtime" "^7.2.0"
+    "@babel/polyfill" "^7.0.0"
+    "@babel/preset-env" "^7.0.0"
+    "@babel/runtime" "^7.2.0"
+    amd-name-resolver "^1.2.1"
+    babel-plugin-debug-macros "^0.3.0"
+    babel-plugin-ember-modules-api-polyfill "^2.9.0"
+    babel-plugin-module-resolver "^3.1.1"
+    broccoli-babel-transpiler "^7.1.2"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.1"
+    broccoli-source "^1.1.0"
+    clone "^2.1.2"
+    ember-cli-babel-plugin-helpers "^1.1.0"
+    ember-cli-version-checker "^2.1.2"
+    ensure-posix-path "^1.0.2"
+    semver "^5.5.0"
+
 ember-cli-blueprint-test-helpers@^0.19.2:
   version "0.19.2"
   resolved "https://registry.yarnpkg.com/ember-cli-blueprint-test-helpers/-/ember-cli-blueprint-test-helpers-0.19.2.tgz#9e563cd81ab39931253ced0982c5d02475895401"
@@ -7794,6 +7829,15 @@ ember-modal-dialog@2.4.3:
     ember-cli-version-checker "^2.1.0"
     ember-ignore-children-helper "^1.0.0"
     ember-wormhole "^0.5.1"
+
+ember-modifier-manager-polyfill@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.0.3.tgz#6554b70d09a7d3b80d366b72ed482fb9a3e813c0"
+  integrity sha512-d8Uz0BhAZaqzttF4NXTwJ/A8uPrgd7fMho5jh89BfzJAHu5WZfGewX9cbjh3m6f512ZyxkIeeolw3Z5/Jyaujg==
+  dependencies:
+    ember-cli-babel "^7.4.2"
+    ember-cli-version-checker "^2.1.2"
+    ember-compatibility-helpers "^1.2.0"
 
 ember-moment@^7.7.0:
   version "7.8.1"


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[EMB-123] some really great stuff`
-->

## Purpose

<!-- Describe the purpose of your changes. -->
Have  long descriptions get truncated after a certain threshold. A button 
 
## Summary of Changes

<!-- Briefly describe or list your changes. -->

- Set a height limit (currently 50px) to the description text area. 
- If the description is short enough to not exceed this height limit, nothing should appear different. 
- If the description exceeds the height threshold, it will fade vertically to white and a button will appear below it, giving the option to "Show more"
- Clicking "Show more" will show the entire description. Button changes to "Show less" and will hide the description again.
- If the user changes the description, it should dynamically update the appearance if the description is made longer or shorter beyond the set height threshold.
- When the description is updated, the default behavior is to have the description box collapse down again.

![image](https://user-images.githubusercontent.com/51409893/60742892-1f645000-9f3d-11e9-91ce-61213e4bd077.png)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## Feature Flags

<!--
  Please list any feature flags that need to be enabled for these changes to go into effect.
  For each flag, what is the expected behavior with the flag enabled vs disabled?
-->

## QA Notes

1. Are there any accessiblity issues with this? i.e: Is the current height threshold of 50px too low? Does the fade-overlay make it too hard to see?

2. Please verify the behavior listed above 
a.no change for short descriptions
b. fading overlay and a "show more/less" button below
c. automatically detect descriptions that are too long after updating the description using the "Edit description" feature
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
-->

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
https://openscience.atlassian.net/browse/ENG-645

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->


[EMB-123]: https://openscience.atlassian.net/browse/EMB-123