### PR TITLE
Remove get-started-button from bottom of integrations section

### DIFF
--- a/app/home/-components/integrations-section/template.hbs
+++ b/app/home/-components/integrations-section/template.hbs
@@ -93,9 +93,4 @@
             </div>
         </div>
     </div>
-    {{#if (not this.shouldShowVersionB)}}
-        <div local-class='buttonContainer'>
-            <GetStartedButton />
-        </div>
-    {{/if}}
 </section>

--- a/tests/acceptance/logged-out-homepage-test.ts
+++ b/tests/acceptance/logged-out-homepage-test.ts
@@ -68,7 +68,7 @@ module('Acceptance | logged-out home page test', hooks => {
         assert.dom('[data-test-storage-heading]')
             .containsText(t('new-home.integrations-section.storage').toString());
         assert.dom('[data-test-logo]').exists({ count: 8 });
-        assert.dom('[data-test-get-started-button]').exists({ count: 2 });
+        assert.dom('[data-test-get-started-button]').exists({ count: 1 });
 
         // Check footer
         assert.dom('footer').exists();


### PR DESCRIPTION
## Purpose

We shouldn't have a `get-started-button` on the bottom of the integrations-section for this round of testing.

## Summary of Changes

- Remove the `get-started-button` from the integrations-section

## Side Effects

`N/A`

## Feature Flags

`N/A`

## QA Notes

This will only remove the button from one part of the logged-out homepage

## Ticket

`N/A`

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
