### PR TITLE
[ENG-673] use img tag with alt text for OSF logo in nav bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Components
+    - `osf-navbar` - use img tag with alt text for navbar OSF logo instead of background CSS image
 
 ## [19.6.1] - 2019-07-12
 ### Fixed

--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -316,6 +316,7 @@ export default {
         other_views: 'Other OSF views',
         login: 'Login',
         join: 'Join',
+        osf_logo: 'OSF logo',
     },
     auth_dropdown: {
         log_out: 'Log Out',

--- a/app/styles/_components.scss
+++ b/app/styles/_components.scss
@@ -492,15 +492,6 @@
     background-color: #214762;
 }
 
-.osf-navbar-logo {
-    float: left;
-    margin-right: 8px;
-    background: url('/assets/images/global/cos-white2.png');
-    background-size: 100%;
-    width: 27px;
-    height: 27px;
-}
-
 .dropdown-menu {
     position: absolute;
     top: 100%;
@@ -781,10 +772,13 @@
         /* Enlarges OSF Font */
         /* Enlarges OSF logo and modifies placement */
         .osf-navbar-logo {
-            width: 35px;
-            height: 35px;
-            margin-top: -4px;
-            margin-left: -4px;
+            float: left;
+            margin: -4px 8px 0 -4px;
+
+            img {
+                width: 35px;
+                height: 35px;
+            }
         }
 
         /* Defines position of dropdown toggle (caret) for primary navigation*/

--- a/lib/osf-components/addon/components/osf-navbar/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/template.hbs
@@ -2,14 +2,16 @@
     <nav class='navbar navbar-inverse navbar-fixed-top' id='navbarScope' role='navigation'>
         <div class='container'>
             <div class='navbar-header'>
-                <OsfLink 
+                <OsfLink
                     data-test-nav-home-link
                     data-analytics-name='Home'
                     aria-label={{t 'navbar.go_home'}}
                     class='navbar-brand'
                     @route='home'
                 >
-                    <span class='osf-navbar-logo'></span>
+                    <span class='osf-navbar-logo'>
+                        <img src='/assets/images/global/cos-white2.png' alt={{t 'navbar.osf_logo'}}>
+                    </span>
                 </OsfLink>
                 {{! Current app }}
                 <div class='service-name'>


### PR DESCRIPTION
## Purpose

To improve the experience of users using screen readers.

## Summary of Changes

- use `img` tag with alt text for navbar OSF logo instead of background CSS image

## Side Effects

None expected.

## Feature Flags

n/a

## QA Notes

This is minor change that should result in no visual difference. Percy should catch any visual regressions in Chrome, but cross-browser testing would be good. I've tested locally on Chrome, Firefox, and Safari. This is low risk.

## Ticket

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
