### PR TITLE
[ENG-657] Fix links for Privacy Policy and Term and Conditions

### DIFF
--- a/lib/osf-components/addon/components/sign-up-policy/template.hbs
+++ b/lib/osf-components/addon/components/sign-up-policy/template.hbs
@@ -1,4 +1,4 @@
 {{t 'osf-components.sign-up-policy.paragraph'
-    link1=@termsLink
-    link2=@privacyPolicyLink
+    link1=this.termsLink
+    link2=this.privacyPolicyLink
 }}


### PR DESCRIPTION
## Purpose

The links on `/register` currently do not go outside of the page (both links go to the current link).  They should go to our github pages for both the privacy policy and terms and conditions, respectively.

## Summary of Changes

- Changing `@termsLink` and `@privacyPolicyLink` to use `this` instead works in referring to the correct link.

## Side Effects

`N/A`

## Feature Flags

`N/A`

## QA Notes

This shouldn't affect anything outside of the links on the `/register` page, so just making sure that the links now go to the correct page instead of whatever the current URL is.

## Ticket

https://openscience.atlassian.net/browse/ENG-657

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
