### PR TITLE
[ENG-695] Remove ember-test-selectors

### DIFF
--- a/lib/osf-components/addon/components/new-project-modal/template.hbs
+++ b/lib/osf-components/addon/components/new-project-modal/template.hbs
@@ -13,7 +13,7 @@
                     {{t 'general.title'}}
                     {{! template-lint-disable no-implicit-this }}
                     {{input
-                        data-test-new-project-title
+                        (html-attributes data-test-new-project-title=true)
                         placeholder=(t 'new_project.title_placeholder')
                         autofocus='autofocus'
                         class='form-control project-name'
@@ -104,7 +104,7 @@
                         {{t 'general.description'}}
                         {{! template-lint-disable no-implicit-this }}
                         {{input
-                            data-test-project-description-input
+                            (html-attributes data-test-project-description-input=true)
                             placeholder=(t 'new_project.description_placeholder')
                             class='form-control noresize project-desc'
                             value=this.description

--- a/lib/osf-components/addon/components/sign-up-form/template.hbs
+++ b/lib/osf-components/addon/components/sign-up-form/template.hbs
@@ -3,9 +3,8 @@
     local-class='SignUpForm'
     {{action 'submit' on='submit'}}
 >
-    {{! template-lint-disable no-implicit-this }}
     {{validated-input/text
-        data-test-sign-up-full-name
+        (html-attributes data-test-sign-up-full-name=true)
         model=this.userRegistration
         valuePath='fullName'
         shouldShowMessages=this.didValidate
@@ -14,7 +13,7 @@
         ariaLabel=(t 'osf-components.sign-up-form.full_name')
     }}
     {{validated-input/text
-        data-test-sign-up-email-1
+        (html-attributes data-test-sign-up-email-1=true)
         model=this.userRegistration
         valuePath='email1'
         shouldShowMessages=this.didValidate
@@ -23,7 +22,7 @@
         ariaLabel=(t 'osf-components.sign-up-form.contact_email')
     }}
     {{validated-input/text
-        data-test-sign-up-email-2
+        (html-attributes data-test-sign-up-email-2=true)
         model=this.userRegistration
         valuePath='email2'
         shouldShowMessages=this.didValidate
@@ -32,7 +31,7 @@
         ariaLabel=(t 'osf-components.sign-up-form.confirm_email')
     }}
     {{validated-input/text
-        data-test-sign-up-password
+        (html-attributes data-test-sign-up-password=true)
         password=true
         model=this.userRegistration
         valuePath='password'

--- a/lib/osf-components/package.json
+++ b/lib/osf-components/package.json
@@ -19,7 +19,6 @@
     "ember-css-modules": "*",
     "ember-css-modules-sass": "*",
     "ember-i18n": "*",
-    "ember-i18n-inject": "*",
-    "ember-test-selectors": "*"
+    "ember-i18n-inject": "*"
   }
 }

--- a/lib/registries/addon/components/registries-header/template.hbs
+++ b/lib/registries/addon/components/registries-header/template.hbs
@@ -1,26 +1,32 @@
-<div class="container">
+{{! template-lint-disable no-implicit-this }}
+<div class='container'>
 
-    <div class="row m-v-md">
-        <div class="text-center m-t-lg col-xs-12">
-            <div local-class="RegistriesHeader__Brand"></div>
-            <p class="lead">
+    <div class='row m-v-md'>
+        <div class='text-center m-t-lg col-xs-12'>
+            <div local-class='RegistriesHeader__Brand'></div>
+            <p class='lead'>
                 {{yield 'lead'}}
             </p>
         </div>
     </div>
 
-    <div class="row m-t-md m-b-lg text-center">
-        <div class="col-xs-12 col-sm-8 col-sm-offset-2">
-            <div class="input-group input-group-lg">
-                {{input data-test-search-box value=value class="form-control" placeholder=(t 'registries.header.search_placeholder')}}
-                <span class="input-group-btn">
+    <div class='row m-t-md m-b-lg text-center'>
+        <div class='col-xs-12 col-sm-8 col-sm-offset-2'>
+            <div class='input-group input-group-lg'>
+                {{input
+                    (html-attributes data-test-search-box=true)
+                    value=value
+                    class='form-control'
+                    placeholder=(t 'registries.header.search_placeholder')
+                }}
+                <span class='input-group-btn'>
                     {{#if showHelp}}
-                        <button class="btn btn-default" type="button" {{action "toggleHelp"}}>{{fa-icon "question" class="text-muted"}}</button>
+                        <button class='btn btn-default' type='button' {{action 'toggleHelp'}}>{{fa-icon 'question' class='text-muted'}}</button>
                     {{/if}}
-                    <button data-test-search-button class="btn btn-default" type="button" {{action "onClick"}}>{{t 'registries.header.search'}}</button>
+                    <button data-test-search-button class='btn btn-default' type='button' {{action 'onClick'}}>{{t 'registries.header.search'}}</button>
                 </span>
             </div>
-            <p class="p-l-md text-left">
+            <p class='p-l-md text-left'>
                 {{t 'registries.header.searchable_as_of'
                     registrations=(number-format searchable)
                     today=(moment-format today 'MMMM D, YYYY')
@@ -29,10 +35,11 @@
         </div>
     </div>
 
-    <div class="row p-v-sm">
+    <div class='row p-v-sm'>
         {{yield}}
     </div>
 
     {{search-help-modal isOpen=(mut showingHelp)}}
 
 </div>
+{{! template-lint-enable no-implicit-this }}

--- a/lib/registries/addon/components/registries-provider-facet/template.hbs
+++ b/lib/registries/addon/components/registries-provider-facet/template.hbs
@@ -1,12 +1,20 @@
-{{#registries-search-facet-container title="Provider"}}
+{{! template-lint-disable no-implicit-this }}
+{{#registries-search-facet-container title='Provider'}}
     <ul>
         {{#each providers as |provider index|}}
             <li>
                 <label>
-                    {{input data-test-source-filter-id=index type="checkbox" change=(action 'providerChecked' provider.filter provider.checked) checked=provider.checked}} {{provider.filter.display}}
+                    {{input
+                        (html-attributes data-test-source-filter-id=index)
+                        type='checkbox'
+                        change=(action 'providerChecked' provider.filter provider.checked)
+                        checked=provider.checked
+                    }}
+                    {{provider.filter.display}}
                     <small>({{number-format provider.count}})</small>
                 </label>
             </li>
         {{/each}}
     </ul>
 {{/registries-search-facet-container}}
+{{! template-lint-enable no-implicit-this }}

--- a/lib/registries/addon/components/registries-registration-type-facet/template.hbs
+++ b/lib/registries/addon/components/registries-registration-type-facet/template.hbs
@@ -1,16 +1,23 @@
+{{! template-lint-disable no-implicit-this }}
 {{#registries-search-facet-container title=title}}
-    <div local-class="{{if onlyOSF 'RegistrationType' 'RegistrationType--Disabled'}}">
+    <div local-class={{if onlyOSF 'RegistrationType' 'RegistrationType--Disabled'}}>
         {{#unless onlyOSF}}
-            <i local-class="RegistrationType__Warning">
+            <i local-class='RegistrationType__Warning'>
                 {{t 'registries.facets.registration_type.only_available_with_osf'}}
             </i>
         {{/unless}}
 
-        <ul class="m-t-sm" local-class="RegistrationType__List">
+        <ul class='m-t-sm' local-class='RegistrationType__List'>
             {{#each types as |type index|}}
-                <li local-class="RegistrationType__Item">
+                <li local-class='RegistrationType__Item'>
                     <label>
-                        {{input data-test-registration-type-filter-id=index type='checkbox' disabled=(not onlyOSF) checked=type.checked change=(action 'typeChecked' type.filter type.checked)}}
+                        {{input
+                            (html-attributes data-test-registration-type-filter-id=index)
+                            type='checkbox'
+                            disabled=(not onlyOSF)
+                            checked=type.checked
+                            change=(action 'typeChecked' type.filter type.checked)
+                        }}
                         {{type.name}}
                     </label>
                 </li>
@@ -18,3 +25,4 @@
         </ul>
     </div>
 {{/registries-search-facet-container}}
+{{! template-lint-enable no-implicit-this }}

--- a/lib/registries/addon/discover/template.hbs
+++ b/lib/registries/addon/discover/template.hbs
@@ -1,21 +1,22 @@
+{{! template-lint-disable no-implicit-this }}
 {{title (t 'registries.discover.page_title')}}
 
 {{#registries-header showHelp=true value=(mut query) onSearch=(action 'onSearch') searchable=searchable as |header|}}
     {{#if (eq header 'lead')}}
         {{t 'registries.discover.powered_by' }}
-        <a href="https://share.osf.io/" local-class="ShareLogo" data-test-share-logo title={{t 'registries.discover.SHARE'}} onclick={{action "click" "link" "Discover - SHARE Logo" target=analytics}}></a>
+        <a href='https://share.osf.io/' local-class='ShareLogo' data-test-share-logo title={{t 'registries.discover.SHARE'}} onclick={{action 'click' 'link' 'Discover - SHARE Logo' target=analytics}}></a>
     {{else}}
-        <div class="col-sm-6 pull-right">
-            {{#bs-dropdown class="pull-right" as |dd|}}
-                {{#dd.button data-test-sort-dropdown=''}}
+        <div class='col-sm-6 pull-right'>
+            {{#bs-dropdown class='pull-right' as |dd|}}
+                {{#dd.button (html-attributes data-test-sort-dropdown=true)}}
                     {{t 'registries.discover.sort_by'}}: {{t searchOptions.order.display}}
-                    <span aria-label="{{t 'registries.discover.sort_by'}}" class="caret"></span>
+                    <span aria-label='{{t 'registries.discover.sort_by'}}' class='caret'></span>
                 {{/dd.button}}
 
                 {{#dd.menu class=(local-class 'SortDropDown__List') as |ddm|}}
                     {{#each sortOptions as |option index|}}
                         {{#ddm.item}}
-                            <button data-test-sort-option-id="{{index}}" class="btn" local-class="SortDropDown__Option" {{action 'setOrder' option}}>{{t option.display}}</button>
+                            <button data-test-sort-option-id='{{index}}' class='btn' local-class='SortDropDown__Option' {{action 'setOrder' option}}>{{t option.display}}</button>
                         {{/ddm.item}}
                     {{/each}}
                 {{/dd.menu}}
@@ -45,18 +46,21 @@
     {{/discover.sidebar}}
 
     {{#if (not doSearch.isIdle) }}
-        <div class="text-center p-v-md" aria-label={{t 'eosf.components.discoverPage.searchLoading'}}>
+        <div class='text-center p-v-md' aria-label={{t 'eosf.components.discoverPage.searchLoading'}}>
             {{loading-indicator dark=true}}
         </div>
     {{else}}
-        {{#discover.results data-test-results as |result|}}
+        {{#discover.results
+            (html-attributes data-test-results=true)
+            as |result|
+        }}
             {{registries-search-result result=result}}
         {{/discover.results}}
 
         {{#unless totalResults}}
-            <div class="col-sm-8 col-xs-12">
-                <div class="text-center text-muted">
-                    <p class="lead">
+            <div class='col-sm-8 col-xs-12'>
+                <div class='text-center text-muted'>
+                    <p class='lead'>
                         {{t 'registries.discover.no_results'}}
                     </p>
                     {{t 'registries.discover.try_broadening'}}
@@ -65,7 +69,7 @@
         {{/unless}}
 
         {{#if (gt maxPage 1) }}
-            <div local-class="Pagination" class="col-xs-12">
+            <div local-class='Pagination' class='col-xs-12'>
                 {{search-paginator
                     current=searchOptions.page
                     maximum=maxPage
@@ -77,3 +81,4 @@
     {{/if}}
 
 {{/registries-discover-search}}
+{{! template-lint-enable no-implicit-this }}

--- a/lib/registries/package.json
+++ b/lib/registries/package.json
@@ -31,7 +31,6 @@
     "ember-page-title": "*",
     "ember-parachute": "*",
     "ember-responsive": "*",
-    "ember-test-selectors": "*",
     "ember-toastr": "*",
     "ember-truth-helpers": "*",
     "immutable": "*"

--- a/package.json
+++ b/package.json
@@ -161,7 +161,6 @@
     "ember-source": "~3.4.0",
     "ember-tag-input": "^1.2.2",
     "ember-template-compiler": "^1.9.0-alpha",
-    "ember-test-selectors": "^2.1.0",
     "ember-toastr": "^1.7.2",
     "ember-wormhole": "^0.5.4",
     "ember-youtube": "^0.9.0",

--- a/tests/engines/registries/integration/components/x-dummy/component-test.ts
+++ b/tests/engines/registries/integration/components/x-dummy/component-test.ts
@@ -28,7 +28,7 @@ module('Registries | Integration | Component | x-dummy', hooks => {
 
     test('it yields yieldValue', async assert => {
         await render(hbs`
-            {{#x-dummy data-test-dummy='1' yieldValue='It works!' as |val|}}
+            {{#x-dummy (html-attributes data-test-dummy='1') yieldValue='It works!' as |val|}}
                 <p>{{val}}</p>
             {{/x-dummy}}
         `);


### PR DESCRIPTION
## Purpose 

`ember-test-selectors` is currently tripping up components that are tag-less, and is breaking the handbook.

## Summary of Changes

- Remove `ember-test-selectors`
- Fix components to use `(html-attributes ...)` to fix tests

## Side Effects

`N/A`

## Feature Flags

`N/A`

## QA Notes

This shouldn't have any visible affects, please make sure that the affected areas still look/act as intended.

## Ticket

https://openscience.atlassian.net/browse/ENG-695

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
