### PR TITLE
[ENG-284] load more collections contributors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Components
     - `osf-navbar` - use img tag with alt text for navbar OSF logo instead of background CSS image
 
+### Fixed
+- Components
+    - `project-contributors/list` - add ability to load more pages of contributors
+
 ## [19.6.1] - 2019-07-12
 ### Fixed
 - Config:

--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -808,6 +808,7 @@ export default {
                     remove: 'Remove',
                     remove_author: 'Remove author',
                 },
+                load_more_contributors: 'Load more contributors',
             },
             search: {
                 placeholder: 'Search by name',

--- a/lib/app-components/addon/components/project-contributors/list/styles.scss
+++ b/lib/app-components/addon/components/project-contributors/list/styles.scss
@@ -1,0 +1,3 @@
+.has-more-container {
+    text-align: center;
+}

--- a/lib/app-components/addon/components/project-contributors/list/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/list/template.hbs
@@ -45,4 +45,14 @@
             />
         {{/each}}
     </SortableGroup>
+    {{#if this.hasMore}}
+        <div local-class='has-more-container'>
+            <OsfButton
+                @type='link'
+                @onClick={{action this.loadMoreContributors}}
+            >
+                {{t 'app_components.project_contributors.list.load_more_contributors'}}
+            </OsfButton>
+        </div>
+    {{/if}}
 </div>

--- a/lib/app-components/addon/components/project-contributors/list/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/list/template.hbs
@@ -1,45 +1,48 @@
-<div class="container-fluid">
-    <div class="row hidden-xs">
-        <div class="col-sm-3 col-sm-offset-2">
+<div class='container-fluid'>
+    <div class='row hidden-xs'>
+        <div class='col-sm-3 col-sm-offset-2'>
             <strong>{{t 'app_components.project_contributors.list.name'}}</strong>
         </div>
-        <div class="col-sm-3">
+        <div class='col-sm-3'>
             <strong>{{t 'app_components.project_contributors.list.permissions'}}</strong>
-            {{#fa-icon 'question-circle'}}
-                {{#bs-popover
-                    placement='bottom'
-                    triggerEvents='hover'
-                    title=(t 'app_components.project_contributors.list.permissions_popover_title')
-                }}
+            <FaIcon @icon='question-circle'>
+                <BsPopover
+                    @placement='bottom'
+                    @triggerEvents='hover'
+                    @title={{t 'app_components.project_contributors.list.permissions_popover_title'}}
+                >
                     {{t 'app_components.project_contributors.list.permissions_popover'}}
-                {{/bs-popover}}
-            {{/fa-icon}}
+                </BsPopover>
+            </FaIcon>
         </div>
-        <div class="col-sm-2 bib-padding">
+        <div class='col-sm-2 bib-padding'>
             <strong>{{t 'app_components.project_contributors.list.citation'}}</strong>
-            {{#fa-icon 'question-circle'}}
-                {{#bs-popover
-                    placement='bottom'
-                    triggerEvents='hover'
-                    title=(t 'app_components.project_contributors.list.citation_popover_title')
-                }}
+            <FaIcon @icon='question-circle'>
+                <BsPopover
+                    @placement='bottom'
+                    @triggerEvents='hover'
+                    @title={{t 'app_components.project_contributors.list.citation_popover_title'}}
+                >
                     {{t 'app_components.project_contributors.list.citation_popover'}}
-                {{/bs-popover}}
-            {{/fa-icon}}
+                </BsPopover>
+            </FaIcon>
         </div>
     </div>
-    {{#sortable-group onChange=(action (perform reorderContributors)) as |group|}}
-        {{#each contributors as |contributor|}}
-            {{project-contributors/list/item
-                group=group
-                contributor=contributor
-                isAdmin=isAdmin
-                adminCount=adminCount
-                bibliographicCount=bibliographicCount
-                removeContributor=(action (perform removeContributor))
-                toggleBibliographic=(action (perform toggleBibliographic))
-                updatePermissions=(action (perform updatePermissions))
-            }}
+    <SortableGroup
+        @onChange={{action (perform this.reorderContributors)}}
+        as |group|
+    >
+        {{#each this.contributors as |contributor|}}
+            <ProjectContributors::List::Item
+                @group={{group}}
+                @contributor={{contributor}}
+                @isAdmin={{this.isAdmin}}
+                @adminCount={{this.adminCount}}
+                @bibliographicCount={{this.bibliographicCount}}
+                @removeContributor={{action (perform this.removeContributor)}}
+                @toggleBibliographic={{action (perform this.toggleBibliographic)}}
+                @updatePermissions={{action (perform this.updatePermissions)}}
+            />
         {{/each}}
-    {{/sortable-group}}
+    </SortableGroup>
 </div>

--- a/lib/app-components/addon/components/project-contributors/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/template.hbs
@@ -18,7 +18,6 @@
     <p>{{t 'app_components.project_contributors.instructions'}}</p>
     {{project-contributors/list
         node=this.node
-        contributors=this.contributors
     }}
 </div>
 {{submit-section-buttons


### PR DESCRIPTION
## Purpose

As implemented, Collections only allows users to manage the first ten contributors on a node. Users need to be able to manage all contributors.

## Summary of Changes

### Fixed
- Components
    - `project-contributors/list` - add ability to load more pages of contributors

![Screen Shot 2019-07-29 at 3 54 06 PM](https://user-images.githubusercontent.com/348630/62077906-469afe00-b219-11e9-9eee-23277ac953ef.png)

![Screen Shot 2019-07-29 at 3 54 21 PM](https://user-images.githubusercontent.com/348630/62077914-4ac71b80-b219-11e9-9c76-78cefcbffe9d.png)

## Side Effects

None expected.

## Feature Flags

n/a

## QA Notes

Need to make sure, for projects with more than ten contributors, a "Load more contributors" link appears and loads additional pages of contributors.

## Ticket

https://openscience.atlassian.net/browse/ENG-284

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
