### PR TITLE
[hotfix][ENG-747] add isWithdrawn dimension to google analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Components
     - `osf-navbar` - use img tag with alt text for navbar OSF logo instead of background CSS image
+    - `analytics` - added isWithdrawn analytic to trackpage
 
 ## [19.6.1] - 2019-07-12
 ### Fixed

--- a/app/home/route.ts
+++ b/app/home/route.ts
@@ -2,13 +2,19 @@ import { action } from '@ember-decorators/object';
 import { service } from '@ember-decorators/service';
 import Transition from '@ember/routing/-private/transition';
 import Route from '@ember/routing/route';
+import { camelize } from '@ember/string';
+import Features from 'ember-feature-flags/services/features';
+import config from 'ember-get-config';
 import Session from 'ember-simple-auth/services/session';
 
 import Analytics from 'ember-osf-web/services/analytics';
 
+const { featureFlagNames: { ABTesting } } = config;
+
 export default class Home extends Route {
   @service analytics!: Analytics;
   @service session!: Session;
+  @service features!: Features;
 
   async beforeModel(transition: Transition) {
       await super.beforeModel(transition);
@@ -20,6 +26,8 @@ export default class Home extends Route {
 
   @action
   didTransition() {
-      this.analytics.trackPage();
+      const shouldShowVersionB = this.features.isEnabled(camelize(ABTesting.homePageVersionB));
+      const version = shouldShowVersionB ? 'versionB' : 'versionA';
+      this.analytics.trackPage(undefined, undefined, undefined, version);
   }
 }

--- a/app/home/route.ts
+++ b/app/home/route.ts
@@ -2,7 +2,6 @@ import { action } from '@ember-decorators/object';
 import { service } from '@ember-decorators/service';
 import Transition from '@ember/routing/-private/transition';
 import Route from '@ember/routing/route';
-import { camelize } from '@ember/string';
 import Features from 'ember-feature-flags/services/features';
 import config from 'ember-get-config';
 import Session from 'ember-simple-auth/services/session';
@@ -26,7 +25,7 @@ export default class Home extends Route {
 
   @action
   didTransition() {
-      const shouldShowVersionB = this.features.isEnabled(camelize(ABTesting.homePageVersionB));
+      const shouldShowVersionB = this.features.isEnabled(ABTesting.homePageVersionB);
       const version = shouldShowVersionB ? 'versionB' : 'versionA';
       this.analytics.trackPage(undefined, undefined, undefined, version);
   }

--- a/app/services/analytics.ts
+++ b/app/services/analytics.ts
@@ -156,6 +156,7 @@ export default class Analytics extends Service {
         this: Analytics,
         pagePublic: boolean | undefined,
         resourceType: string,
+        withdrawn: string,
         versionType: string,
     ) {
         // Wait until everything has settled
@@ -169,6 +170,7 @@ export default class Analytics extends Service {
         logEvent(this, 'Tracked page', {
             pagePublic,
             resourceType,
+            withdrawn,
             versionType,
             ...eventParams,
         });
@@ -179,6 +181,7 @@ export default class Analytics extends Service {
                 authenticated,
                 isPublic,
                 resource,
+                isWithdrawn,
                 version,
             } = gaConfig.dimensions!;
 
@@ -199,6 +202,7 @@ export default class Analytics extends Service {
                 [authenticated]: this.session.isAuthenticated ? 'Logged in' : 'Logged out',
                 [isPublic]: isPublicValue,
                 [resource]: resourceType,
+                [isWithdrawn]: withdrawn,
                 [version]: versionType,
                 ...eventParams,
             });
@@ -247,9 +251,10 @@ export default class Analytics extends Service {
         this: Analytics,
         pagePublic?: boolean,
         resourceType: string = 'n/a',
+        withdrawn: string = 'n/a',
         version: string = 'n/a',
     ) {
-        this.get('trackPageTask').perform(pagePublic, resourceType, version);
+        this.get('trackPageTask').perform(pagePublic, resourceType, withdrawn, version);
     }
 
     trackFromElement(target: Element, initialInfo: InitialEventInfo) {

--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -55,6 +55,7 @@ declare const config: {
             authenticated: string;
             resource: string;
             isPublic: string;
+            isWithdrawn: string;
             version: string;
         };
     }>;

--- a/config/environment.js
+++ b/config/environment.js
@@ -119,7 +119,8 @@ module.exports = function(environment) {
                     authenticated: 'dimension1',
                     resource: 'dimension2',
                     isPublic: 'dimension3',
-                    version: 'dimension4',
+                    isWithdrawn: 'dimension4',
+                    version: 'dimension5',
                 },
             },
             {


### PR DESCRIPTION
## Purpose

We're currently using `isWithdrawn` in preprints analytics and it should be consistent everywhere.  It's dimension 4 on preprints, but dimension 4 on ember-osf-web is currently version.  We should update ember-osf-web to match.

## Summary of Changes

- Add `isWithdrawn` analytic as dimension 4 to the config and update types

## Side Effects

`N/A`

## Feature Flags

`N/A`

## QA Notes

`N/A`

## Ticket

https://openscience.atlassian.net/browse/ENG-747

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
