### PR TITLE
[ENG-284] trigger contributors reload on add/remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Components
+    - `project-contributors/list`
+        - add ability to load more pages of contributors
+        - add loading indicator
 
 ## [19.7.0] - 2019-07-31
 ### Added
@@ -30,10 +35,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Components
     - `sign-up-policy` - fixed links to terms of service and privacy policy
-
-### Fixed
-- Components
-    - `project-contributors/list` - add ability to load more pages of contributors
 
 ## [19.6.1] - 2019-07-12
 ### Fixed

--- a/lib/app-components/addon/components/project-contributors/component.ts
+++ b/lib/app-components/addon/components/project-contributors/component.ts
@@ -1,3 +1,4 @@
+import { action } from '@ember-decorators/object';
 import ArrayProxy from '@ember/array/proxy';
 import Component from '@ember/component';
 
@@ -11,7 +12,15 @@ import template from './template';
 export default class ProjectContributors extends Component {
     node: Node = this.node;
     contributors: ArrayProxy<Contributor> = this.contributors;
+    reloadContributorsList?: () => void; // bound by project-contributors/list
 
     @requiredAction discard!: () => void;
     @requiredAction continue!: () => void;
+
+    @action
+    reloadContributors() {
+        if (this.reloadContributorsList) {
+            this.reloadContributorsList();
+        }
+    }
 }

--- a/lib/app-components/addon/components/project-contributors/list/component.ts
+++ b/lib/app-components/addon/components/project-contributors/list/component.ts
@@ -27,8 +27,11 @@ export default class List extends Component.extend({
         this.set('hasMore', this.contributors && this.contributors.length < contributors.meta.total);
     }),
 }) {
-    // Required paramaters
+    // Required parameters
     node: Node = this.node;
+
+    // Optional parameters
+    bindReload?: (action: () => void) => void;
 
     // Private properties
     @service analytics!: Analytics;
@@ -103,6 +106,7 @@ export default class List extends Component.extend({
 
         try {
             yield contributor.destroyRecord();
+            this._doReload();
             this.toast.success(this.i18n.t('app_components.project_contributors.list.remove_contributor_success'));
         } catch (e) {
             this.toast.error(this.i18n.t('app_components.project_contributors.list.remove_contributor_error'));
@@ -145,9 +149,22 @@ export default class List extends Component.extend({
         this.loadContributors.perform();
     }
 
+    didReceiveAttrs() {
+        if (this.bindReload) {
+            this.bindReload(this._doReload.bind(this));
+        }
+    }
+
     @action
     loadMoreContributors() {
         this.page++;
+        this.loadContributors.perform();
+    }
+
+    @action
+    _doReload() {
+        this.page = 1;
+        this.set('contributors', []);
         this.loadContributors.perform();
     }
 }

--- a/lib/app-components/addon/components/project-contributors/list/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/list/template.hbs
@@ -28,31 +28,35 @@
             </FaIcon>
         </div>
     </div>
-    <SortableGroup
-        @onChange={{action (perform this.reorderContributors)}}
-        as |group|
-    >
-        {{#each this.contributors as |contributor|}}
-            <ProjectContributors::List::Item
-                @group={{group}}
-                @contributor={{contributor}}
-                @isAdmin={{this.isAdmin}}
-                @adminCount={{this.adminCount}}
-                @bibliographicCount={{this.bibliographicCount}}
-                @removeContributor={{action (perform this.removeContributor)}}
-                @toggleBibliographic={{action (perform this.toggleBibliographic)}}
-                @updatePermissions={{action (perform this.updatePermissions)}}
-            />
-        {{/each}}
-    </SortableGroup>
-    {{#if this.hasMore}}
-        <div local-class='has-more-container'>
-            <OsfButton
-                @type='link'
-                @onClick={{action this.loadMoreContributors}}
-            >
-                {{t 'app_components.project_contributors.list.load_more_contributors'}}
-            </OsfButton>
-        </div>
+    {{#if this.loadContributors.isRunning}}
+        <LoadingIndicator @dark={{true}} />
+    {{else}}
+        <SortableGroup
+            @onChange={{action (perform this.reorderContributors)}}
+            as |group|
+        >
+            {{#each this.contributors as |contributor|}}
+                <ProjectContributors::List::Item
+                    @group={{group}}
+                    @contributor={{contributor}}
+                    @isAdmin={{this.isAdmin}}
+                    @adminCount={{this.adminCount}}
+                    @bibliographicCount={{this.bibliographicCount}}
+                    @removeContributor={{action (perform this.removeContributor)}}
+                    @toggleBibliographic={{action (perform this.toggleBibliographic)}}
+                    @updatePermissions={{action (perform this.updatePermissions)}}
+                />
+            {{/each}}
+        </SortableGroup>
+        {{#if this.hasMore}}
+            <div local-class='has-more-container'>
+                <OsfButton
+                    @type='link'
+                    @onClick={{action this.loadMoreContributors}}
+                >
+                    {{t 'app_components.project_contributors.list.load_more_contributors'}}
+                </OsfButton>
+            </div>
+        {{/if}}
     {{/if}}
 </div>

--- a/lib/app-components/addon/components/project-contributors/search/component.ts
+++ b/lib/app-components/addon/components/project-contributors/search/component.ts
@@ -31,6 +31,7 @@ export default class Search extends Component {
     page: number = 1;
     showUnregisteredForm: boolean = false;
     node: Node = this.node;
+    onAddContributor?: () => void;
 
     @alias('search.lastSuccessful.value') results?: DS.AdapterPopulatedRecordArray<User>;
     @alias('results.meta.total_pages') totalPages?: number;
@@ -70,6 +71,9 @@ export default class Search extends Component {
 
         try {
             yield contributor.save();
+            if (this.onAddContributor) {
+                this.onAddContributor();
+            }
             this.toast.success(this.i18n.t('app_components.project_contributors.search.add_contributor_success'));
         } catch (e) {
             this.toast.error(this.i18n.t('app_components.project_contributors.search.add_contributor_error'));

--- a/lib/app-components/addon/components/project-contributors/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/template.hbs
@@ -2,6 +2,7 @@
     {{project-contributors/search
         node=this.node
         contributors=this.contributors
+        onAddContributor=(action this.reloadContributors)
     }}
 </div>
 <div class='col-xs-12 col-md-7'>
@@ -18,6 +19,7 @@
     <p>{{t 'app_components.project_contributors.instructions'}}</p>
     {{project-contributors/list
         node=this.node
+        bindReload=(action (mut this.reloadContributorsList))
     }}
 </div>
 {{submit-section-buttons


### PR DESCRIPTION
## Purpose

The refactoring in #722 introduced an issue where the contributors list does not reload when adding or removing contributors. There should also be loading indicator displayed while contributors are loading.

## Summary of Changes

### Changed
- Components
    - `project-contributors/list`
        - add ability to load more pages of contributors
        - add loading indicator

## Side Effects

None expected.

## Feature Flags

n/a

## QA Notes

Need to make sure contributors management on Collections works as expected.

## Ticket

https://openscience.atlassian.net/browse/ENG-284

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
