### PR TITLE
[ENG-284] make project contributors loading indicator work better for load more

### DIFF
--- a/lib/app-components/addon/components/project-contributors/list/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/list/template.hbs
@@ -28,35 +28,33 @@
             </FaIcon>
         </div>
     </div>
+    <SortableGroup
+        @onChange={{action (perform this.reorderContributors)}}
+        as |group|
+    >
+        {{#each this.contributors as |contributor|}}
+            <ProjectContributors::List::Item
+                @group={{group}}
+                @contributor={{contributor}}
+                @isAdmin={{this.isAdmin}}
+                @adminCount={{this.adminCount}}
+                @bibliographicCount={{this.bibliographicCount}}
+                @removeContributor={{action (perform this.removeContributor)}}
+                @toggleBibliographic={{action (perform this.toggleBibliographic)}}
+                @updatePermissions={{action (perform this.updatePermissions)}}
+            />
+        {{/each}}
+    </SortableGroup>
     {{#if this.loadContributors.isRunning}}
         <LoadingIndicator @dark={{true}} />
-    {{else}}
-        <SortableGroup
-            @onChange={{action (perform this.reorderContributors)}}
-            as |group|
-        >
-            {{#each this.contributors as |contributor|}}
-                <ProjectContributors::List::Item
-                    @group={{group}}
-                    @contributor={{contributor}}
-                    @isAdmin={{this.isAdmin}}
-                    @adminCount={{this.adminCount}}
-                    @bibliographicCount={{this.bibliographicCount}}
-                    @removeContributor={{action (perform this.removeContributor)}}
-                    @toggleBibliographic={{action (perform this.toggleBibliographic)}}
-                    @updatePermissions={{action (perform this.updatePermissions)}}
-                />
-            {{/each}}
-        </SortableGroup>
-        {{#if this.hasMore}}
-            <div local-class='has-more-container'>
-                <OsfButton
-                    @type='link'
-                    @onClick={{action this.loadMoreContributors}}
-                >
-                    {{t 'app_components.project_contributors.list.load_more_contributors'}}
-                </OsfButton>
-            </div>
-        {{/if}}
+    {{else if this.hasMore}}
+        <div local-class='has-more-container'>
+            <OsfButton
+                @type='link'
+                @onClick={{action this.loadMoreContributors}}
+            >
+                {{t 'app_components.project_contributors.list.load_more_contributors'}}
+            </OsfButton>
+        </div>
     {{/if}}
 </div>


### PR DESCRIPTION
## Purpose

The way I implemented the loading indicator, it hides the existing list of contributors when loading more pages. This is less than ideal.

## Summary of Changes

Move the loading indicator to after the contributor list display instead of conditionally rendering the loading indicator or the list. The works well because the list is initially empty and is simply appended to for "Load more". And reloads clear the list and start over from page 1.

(recommend [hide whitespace changes](https://github.com/CenterForOpenScience/ember-osf-web/pull/728/files?w=1) when viewing the diff)

## Side Effects

None expected.

## Feature Flags

n/a

## QA Notes

Should check that the loading indicator works well for initial load, load more, add contributor, and remove contributor.

## Ticket

https://openscience.atlassian.net/browse/ENG-284

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(already included)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
