### PR TITLE
[ENG-761] analytics adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Hotfix]
+### Changed
+- Services
+    - `analytics` - allow passing through of `nonIteraction` flag to Google Analytics
+- Modifiers
+    - `trackScroll` - set `nonInteraction` flag when calling `analytics.trackFromElement()`
+
 ## [19.7.0] - 2019-07-31
 ### Added
 - Components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `analytics` - allow passing through of `nonIteraction` flag to Google Analytics
 - Modifiers
     - `trackScroll` - set `nonInteraction` flag when calling `analytics.trackFromElement()`
+- Routes
+    - `home` - remove version and shorten analytics scope
 
 ## [19.7.0] - 2019-07-31
 ### Added

--- a/app/home/template.hbs
+++ b/app/home/template.hbs
@@ -1,4 +1,4 @@
-<main data-analytics-scope='Logged-out homepage - {{this.version}}'>
+<main data-analytics-scope='Home'>
     <Home::-Components::HeroBanner />
     <Home::-Components::SupportSection />
     <Home::-Components::Testimonials />

--- a/app/modifiers/track-scroll.ts
+++ b/app/modifiers/track-scroll.ts
@@ -25,6 +25,7 @@ class TrackScrollModifier extends Modifier {
                     name,
                     category: 'page',
                     action: 'scroll',
+                    nonInteraction: true,
                 },
             );
             this.didShow = true;

--- a/app/services/analytics.ts
+++ b/app/services/analytics.ts
@@ -23,6 +23,7 @@ export interface TrackedData {
     action?: string;
     extra?: string;
     label: string;
+    nonInteraction?: boolean;
 }
 
 export interface InitialEventInfo {
@@ -30,6 +31,7 @@ export interface InitialEventInfo {
     category?: string;
     action?: string;
     extra?: string;
+    nonInteraction?: boolean;
 }
 
 function logEvent(analytics: Analytics, title: string, data: object) {
@@ -58,6 +60,7 @@ class EventInfo {
     category?: string;
     action?: string;
     extra?: string;
+    nonInteraction?: boolean;
 
     constructor(targetElement: Element, rootElement: Element, initialInfo?: InitialEventInfo) {
         if (initialInfo) {
@@ -84,6 +87,7 @@ class EventInfo {
             action: this.action,
             label: [...this.scopes.reverse(), this.name].join(' - '),
             extra: this.extra,
+            nonInteraction: this.nonInteraction,
         };
     }
 

--- a/tests/integration/analytics-test.ts
+++ b/tests/integration/analytics-test.ts
@@ -32,6 +32,7 @@ module('Integration | Analytics handling', hooks => {
                 action: 'click',
                 label: 'Scope! - Button!',
                 extra: undefined,
+                nonInteraction: undefined,
             }],
         ], 'One click event');
     });
@@ -54,6 +55,7 @@ module('Integration | Analytics handling', hooks => {
                 action: 'click',
                 label: 'Scope! - Button!',
                 extra: 'Foo',
+                nonInteraction: undefined,
             }],
         ], 'One click event');
     });
@@ -74,11 +76,13 @@ module('Integration | Analytics handling', hooks => {
                 action: 'click',
                 label: 'Scope! - Button!',
                 extra: undefined,
+                nonInteraction: undefined,
             }], [{
                 category: 'button',
                 action: 'click',
                 label: 'Scope! - Button!',
                 extra: undefined,
+                nonInteraction: undefined,
             }],
         ], 'Two click events');
     });
@@ -110,6 +114,7 @@ module('Integration | Analytics handling', hooks => {
                 action: 'click',
                 label: 'Scope 1 - Scope 2 - Scope 3 - Button!',
                 extra: undefined,
+                nonInteraction: undefined,
             }],
         ], 'One click event with nested scopes');
     });
@@ -135,11 +140,13 @@ module('Integration | Analytics handling', hooks => {
                 action: 'click',
                 label: 'Scope 1 - Scope 3 - Link!',
                 extra: undefined,
+                nonInteraction: undefined,
             }], [{
                 category: 'button',
                 action: 'click',
                 label: 'Scope 1 - Scope 2 - Button!',
                 extra: undefined,
+                nonInteraction: undefined,
             }],
         ], 'One button, one link');
     });
@@ -172,30 +179,35 @@ module('Integration | Analytics handling', hooks => {
                 action: 'click',
                 label: 'Scope! - Button!',
                 extra: undefined,
+                nonInteraction: undefined,
             }],
             [{
                 category: 'link',
                 action: 'click',
                 label: 'Scope! - Link!',
                 extra: undefined,
+                nonInteraction: undefined,
             }],
             [{
                 category: 'button',
                 action: 'click',
                 label: 'Scope! - Button link!',
                 extra: undefined,
+                nonInteraction: undefined,
             }],
             [{
                 category: 'checkbox',
                 action: 'click',
                 label: 'Scope! - Checkbox!',
                 extra: undefined,
+                nonInteraction: undefined,
             }],
             [{
                 category: 'other',
                 action: 'click',
                 label: 'Scope! - Other button!',
                 extra: undefined,
+                nonInteraction: undefined,
             }],
         ], 'Correct categories');
     });


### PR DESCRIPTION
## Purpose

Scroll events are counting as interaction and affecting the bounce rate for Google Analytics. This can be fixed by setting nonInteraction: true when sending the event. Additionally, the inclusion of the version in the label is messing up reporting. It is not necessary to have version in the label because we already have a custom dimension for version. Also, the "Logged-out Homepage" label scope prefix is too long and messes up graphs in Google analytics.

## Summary of Changes

### Changed
- Services
    - `analytics` - allow passing through of `nonIteraction` flag to Google Analytics
- Modifiers
    - `trackScroll` - set `nonInteraction` flag when calling `analytics.trackFromElement()`
- Routes
    - `home` - remove version and shorten analytics scope

## Side Effects

None expected.

## Feature Flags

n/a

## QA Notes

n/a

## Ticket

https://openscience.atlassian.net/browse/ENG-761

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
