### PR TITLE
[ENG-721] Read-only contributors list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Components
     - `form-controls` - a form-input wrapper that takes a changeset
+    - `read-only-contributors-list` - a read only list of a node's contributors with a link to contributors page for editing
 - Models
     - `schema-block` - for registration-schemas
 

--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -1544,6 +1544,11 @@ export default {
             next_slide: 'Next slide',
             go_to_slide: 'Go to slide {{slideIndex}}',
         },
+        registries: {
+            'read-only-contributors-list': {
+                editContributorsOnYourProject: 'Edit contributors on your project',
+            },
+        },
     },
     settings: {
         toggleNav: 'Toggle navigation',

--- a/lib/osf-components/addon/components/registries/read-only-contributors-list/component.ts
+++ b/lib/osf-components/addon/components/registries/read-only-contributors-list/component.ts
@@ -1,0 +1,9 @@
+import { layout, tagName } from '@ember-decorators/component';
+import Component from '@ember/component';
+
+import template from './template';
+
+@layout(template)
+@tagName('')
+export default class FormControls extends Component {
+}

--- a/lib/osf-components/addon/components/registries/read-only-contributors-list/component.ts
+++ b/lib/osf-components/addon/components/registries/read-only-contributors-list/component.ts
@@ -1,9 +1,11 @@
-import { layout, tagName } from '@ember-decorators/component';
+import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 
+import { layout } from 'ember-osf-web/decorators/component';
+import styles from './styles';
 import template from './template';
 
-@layout(template)
+@layout(template, styles)
 @tagName('')
 export default class FormControls extends Component {
 }

--- a/lib/osf-components/addon/components/registries/read-only-contributors-list/styles.scss
+++ b/lib/osf-components/addon/components/registries/read-only-contributors-list/styles.scss
@@ -1,0 +1,3 @@
+.contributorContainer {
+    display: flex;
+}

--- a/lib/osf-components/addon/components/registries/read-only-contributors-list/template.hbs
+++ b/lib/osf-components/addon/components/registries/read-only-contributors-list/template.hbs
@@ -1,0 +1,16 @@
+<div>
+    <ContributorList
+        @node={{this.node}}
+        @shouldTruncate={{false}}
+        @shouldLinkUsers={{true}}
+    />
+    <br>
+    <OsfLink
+        data-test-edit-contributors-link
+        data-analytics-name='edit_contributors'
+        class='btn btn-link'
+        @href='/{{@node.id}}/contributors'
+    >
+        {{t 'osf-components.registries.read-only-contributors-list.editContributorsOnYourProject'}}
+    </OsfLink>
+</div>

--- a/lib/osf-components/addon/components/registries/read-only-contributors-list/template.hbs
+++ b/lib/osf-components/addon/components/registries/read-only-contributors-list/template.hbs
@@ -1,14 +1,12 @@
-<div>
+<div local-class='contributorContainer' ...attributes>
     <ContributorList
         @node={{this.node}}
         @shouldTruncate={{false}}
         @shouldLinkUsers={{true}}
     />
-    <br>
     <OsfLink
         data-test-edit-contributors-link
         data-analytics-name='edit_contributors'
-        class='btn btn-link'
         @href='/{{@node.id}}/contributors'
     >
         {{t 'osf-components.registries.read-only-contributors-list.editContributorsOnYourProject'}}

--- a/lib/osf-components/addon/components/registries/read-only-contributors-list/template.hbs
+++ b/lib/osf-components/addon/components/registries/read-only-contributors-list/template.hbs
@@ -6,7 +6,7 @@
     />
     <OsfLink
         data-test-edit-contributors-link
-        data-analytics-name='edit_contributors'
+        data-analytics-name='Edit contributors'
         @href='/{{@node.id}}/contributors'
     >
         {{t 'osf-components.registries.read-only-contributors-list.editContributorsOnYourProject'}}

--- a/lib/osf-components/app/components/registries/read-only-contributors-list/component.js
+++ b/lib/osf-components/app/components/registries/read-only-contributors-list/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/registries/read-only-contributors-list/component';

--- a/tests/integration/components/read-only-contributors-list/component-test.ts
+++ b/tests/integration/components/read-only-contributors-list/component-test.ts
@@ -21,7 +21,7 @@ module('Integration | Component | read-only-contributors-list', hooks => {
 
         await render(hbs`<Registries::ReadOnlyContributorsList @node={{this.node}} />`);
 
-        assert.dom('a[data-test-contributor-name]').exists({ count: 3 });
+        assert.dom('[data-test-contributor-name]').exists({ count: 4 });
 
         assert.ok('[data-test-edit-contributors-link]');
     });

--- a/tests/integration/components/read-only-contributors-list/component-test.ts
+++ b/tests/integration/components/read-only-contributors-list/component-test.ts
@@ -1,28 +1,16 @@
 import { render } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import I18N from 'ember-i18n/services/i18n';
 
 import { setupRenderingTest } from 'ember-qunit';
-import { TestContext } from 'ember-test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
 
-import CurrentUser from 'ember-osf-web/services/current-user';
-
-interface ThisTestContext extends TestContext {
-    i18n: I18N;
-    currentUser: CurrentUser;
-}
-
-module('Integration | Component | read-only-contributor-list', hooks => {
+module('Integration | Component | read-only-contributors-list', hooks => {
     setupRenderingTest(hooks);
     setupMirage(hooks);
 
-    hooks.beforeEach(function(this: ThisTestContext) {
+    test('it renders', async function(assert) {
         this.store = this.owner.lookup('service:store');
-    });
-
-    test('it renders 991', async function(assert) {
         const node = server.create('node');
         const users = server.createList('user', 4);
         for (const user of users) {

--- a/tests/integration/components/read-only-contributors-list/component-test.ts
+++ b/tests/integration/components/read-only-contributors-list/component-test.ts
@@ -1,0 +1,40 @@
+import { render } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import I18N from 'ember-i18n/services/i18n';
+
+import { setupRenderingTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+
+import CurrentUser from 'ember-osf-web/services/current-user';
+
+interface ThisTestContext extends TestContext {
+    i18n: I18N;
+    currentUser: CurrentUser;
+}
+
+module('Integration | Component | read-only-contributor-list', hooks => {
+    setupRenderingTest(hooks);
+    setupMirage(hooks);
+
+    hooks.beforeEach(function(this: ThisTestContext) {
+        this.store = this.owner.lookup('service:store');
+    });
+
+    test('it renders 991', async function(assert) {
+        const node = server.create('node');
+        const users = server.createList('user', 4);
+        for (const user of users) {
+            server.create('contributor', { node, users: user });
+        }
+        const nodeWithContribs = await this.store.findRecord('node', node.id);
+        this.set('node', nodeWithContribs);
+
+        await render(hbs`<Registries::ReadOnlyContributorsList @node={{this.node}} />`);
+
+        assert.dom('a[data-test-contributor-name]').exists({ count: 3 });
+
+        assert.ok('[data-test-edit-contributors-link]');
+    });
+});


### PR DESCRIPTION
## Purpose

To make a component containing a read-only list of contributors for a node and a link to the node's contributors page for editing.  To be used primarily for registries submission workflow.

## Summary of Changes

- Add `read-only-contributors-list` component
- Create new folder workspace in `osf-components` for registries components to be used outside of the registries engine
- Add test

## Side Effects

`N/A`

## Feature Flags

`N/A`

## QA Notes

This will just be a list that contains all of the contributors that the node has.  Beneath the list of names there will also be a link that will take the user to the node's contributors page so that they can have the option to edit contributors there.  The component itself will not have any functionality for editing/adding/removing contributors.

## Ticket

https://openscience.atlassian.net/browse/ENG-721

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
