### PR TITLE
[ENG-807] Refine & use osf-dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `project-contributors/list`
         - add ability to load more pages of contributors
         - add loading indicator
+    - `osf-dialog`
+        - add `@isOpen` param for programmatic control
+        - add `@isModal` param (default `true`)
 - Engines
     - `collections`
         - Components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `form-controls` - a form-input wrapper that takes a changeset
 - Models
     - `schema-block` - for registration-schemas
+- Modifiers
+    - `capture-element` - easily store an element from the template
 
 ### Changed
 - Models

--- a/app/application/template.hbs
+++ b/app/application/template.hbs
@@ -32,9 +32,5 @@
     <OsfFooter />
     <CookieBanner />
 </div>
-<div
-    {{! This is where dialog boxes are wormhole'd }}
-    {{did-insert (action (mut this.osfModalState.dialogWormholeTarget))}}
-    {{will-destroy (action (mut this.osfModalState.dialogWormholeTarget) null)}}
-></div>
+<div {{capture-element (action (mut this.osfModalState.dialogWormholeTarget))}}></div>
 <OsfModeFooter />

--- a/app/modifiers/capture-element.ts
+++ b/app/modifiers/capture-element.ts
@@ -1,0 +1,28 @@
+import Modifier from 'ember-oo-modifiers';
+
+type CaptureFn = (e: Element | null) => void;
+
+/**
+ * `capture-element` modifier
+ *
+ * Usage:
+ * ```
+ * {{capture-element (action (mut this.myElement))}}
+ * ```
+ * The above is equivalent to:
+ * ```
+ * {{did-insert (action (mut this.myElement))}}
+ * {{will-destroy (action (mut this.myElement) null)}}
+ * ```
+ */
+class CaptureElementModifier extends Modifier {
+    didInsertElement([captureFn]: [CaptureFn]) {
+        captureFn(this.element);
+    }
+
+    willDestroyElement([captureFn]: [CaptureFn]) {
+        captureFn(null);
+    }
+}
+
+export default Modifier.modifier(CaptureElementModifier);

--- a/lib/handbook/addon/docs/components/osf-dialog/-components/demo-is-open/template.hbs
+++ b/lib/handbook/addon/docs/components/osf-dialog/-components/demo-is-open/template.hbs
@@ -1,0 +1,17 @@
+<DocsDemo as |demo|>
+    <demo.example @name='osf-dialog.demo-is-open.hbs'>
+        <OsfButton @onClick={{action (mut this.isOpen) true}}>
+            Open it!
+        </OsfButton>
+        <OsfDialog @isOpen={{this.isOpen}} as |dialog|>
+            <dialog.heading>
+                No need to depend on user action!
+            </dialog.heading>
+            <dialog.main>
+                This is a small dialog again.
+            </dialog.main>
+        </OsfDialog>
+    </demo.example>
+
+    <demo.snippet @name='osf-dialog.demo-is-open.hbs' />
+</DocsDemo>

--- a/lib/handbook/addon/docs/components/osf-dialog/-components/demo-non-modal/template.hbs
+++ b/lib/handbook/addon/docs/components/osf-dialog/-components/demo-non-modal/template.hbs
@@ -1,0 +1,19 @@
+<DocsDemo as |demo|>
+    <demo.example @name='osf-dialog.demo-non-modal.hbs'>
+        <OsfDialog @isModal={{false}} as |dialog|>
+            <dialog.trigger>
+                <OsfButton @onClick={{dialog.open}}>
+                    Open!
+                </OsfButton>
+            </dialog.trigger>
+            <dialog.heading>
+                This one doesn't block the rest of the app.
+            </dialog.heading>
+            <dialog.main>
+                Click around in the background!
+            </dialog.main>
+        </OsfDialog>
+    </demo.example>
+
+    <demo.snippet @name='osf-dialog.demo-non-modal.hbs' />
+</DocsDemo>

--- a/lib/handbook/addon/docs/components/osf-dialog/template.md
+++ b/lib/handbook/addon/docs/components/osf-dialog/template.md
@@ -3,8 +3,17 @@
 This is a dialog box! Use it for dialog boxes and modal popup things.
 
 ## Params
+* `@onOpen` (optional)
+    * callback called when the dialog is opened
+* `@onClose` (optional)
+    * callback called when the dialog is closed
+* `@isOpen` (optional; default `false`)
+    * allows opening/closing the dialog programatically, instead of putting a button in `<dialog.trigger>`
+* `@isModal` (optional; default `true`)
+    * whether to block interaction with the rest of the app while the dialog is open
 * `@closeOnOutsideClick` (optional; default `true`)
     * whether the dialog should close when the user clicks outside it
+    * no effect when `@isModal` is `false`
 * `@renderInPlace` (optional; default `false`)
     * whether the dialog should be rendered in place (instead of wormhole'd to the app root)
     * forwarded to [ember-wormhole](https://github.com/yapplabs/ember-wormhole#can-i-render-in-place-ie-unwormhole)
@@ -43,7 +52,15 @@ Invoked as `<OsfDialog as |dialog|>`, the yielded hash `dialog` provides the fol
 `<OsfDialog>` will grow to fit its contents, but will never grow larger than the browser viewport:
 {{docs/components/osf-dialog/-components/demo-big}}
 
+### Using `@isOpen`
+Instead of using `<dialog.trigger>`, you can also open/close the dialog by passing `@isOpen`:
+{{docs/components/osf-dialog/-components/demo-is-open}}
+
 ### No outside click
 By default, `<OsfDialog>` will close when the user clicks outside. You can disable this behavior
 with `@closeOnOutsideClick={{false}}`.
 {{docs/components/osf-dialog/-components/demo-no-outside-click}}
+
+### Non-modal dialogs
+Use `@isModal={{false}}` to show a dialog that does not block interaction with the rest of the app.
+{{docs/components/osf-dialog/-components/demo-non-modal}}

--- a/lib/osf-components/addon/components/osf-dialog/component.ts
+++ b/lib/osf-components/addon/components/osf-dialog/component.ts
@@ -16,32 +16,44 @@ export default class OsfDialog extends Component {
     @service osfModalState!: OsfModalState;
 
     // optional
+    onClose?: () => void;
+    onOpen?: () => void;
+    isOpen: boolean = defaultTo(this.isOpen, false);
+    isModal: boolean = defaultTo(this.isModal, true);
     closeOnOutsideClick: boolean = defaultTo(this.closeOnOutsideClick, true);
     renderInPlace: boolean = defaultTo(this.renderInPlace, false);
-    isModal: boolean = defaultTo(this.isModal, true);
-
-    isDialogVisible: boolean = defaultTo(this.isDialogVisible, false);
 
     @action
     openDialog() {
-        this.set('isDialogVisible', true);
-        if (this.isModal) {
-            this.osfModalState.enterModalState();
+        this.set('isOpen', true);
+        if (this.onOpen) {
+            this.onOpen();
         }
     }
 
     @action
     closeDialog() {
-        this.set('isDialogVisible', false);
+        this.set('isOpen', false);
+        if (this.onClose) {
+            this.onClose();
+        }
+    }
+
+    @action
+    updateModalState() {
         if (this.isModal) {
-            this.osfModalState.exitModalState();
+            if (this.isOpen) {
+                this.osfModalState.enterModalState();
+            } else {
+                this.osfModalState.exitModalState();
+            }
         }
     }
 
     @action
     onClickBackground(event: MouseEvent) {
         const isOutsideDialog = event.target === event.currentTarget;
-        if (isOutsideDialog && this.closeOnOutsideClick) {
+        if (isOutsideDialog && this.closeOnOutsideClick && this.isModal) {
             this.closeDialog();
         }
     }

--- a/lib/osf-components/addon/components/osf-dialog/styles.scss
+++ b/lib/osf-components/addon/components/osf-dialog/styles.scss
@@ -14,7 +14,12 @@
     z-index: 900;
 }
 
+.Unclickable {
+    pointer-events: none;
+}
+
 .Dialog {
+    pointer-events: auto;
     max-height: 90vh;
 
     .DialogDocument {

--- a/lib/osf-components/addon/components/osf-dialog/template.hbs
+++ b/lib/osf-components/addon/components/osf-dialog/template.hbs
@@ -2,7 +2,12 @@
     trigger=(component 'osf-dialog/trigger')
     open=(action this.openDialog)
 )}}
-{{#if this.isDialogVisible}}
+{{#if this.isOpen}}
+    <script
+        {{! These should be on <EmberWormhole> below, but we need Ember 3.11 for that }}
+        {{did-insert (action this.updateModalState)}}
+        {{will-destroy (action this.updateModalState)}}
+    ></script>
     <EmberWormhole
         @tagName='span'
         @destinationElement={{this.osfModalState.dialogWormholeTarget}}
@@ -10,7 +15,7 @@
     >
         <div
             data-test-dialog-background
-            local-class='DialogBackground'
+            local-class='DialogBackground {{unless this.isModal 'Unclickable'}}'
             {{on 'click' (action this.onClickBackground)}}
         >
             <div

--- a/lib/osf-components/addon/components/osf-mode-footer/component.ts
+++ b/lib/osf-components/addon/components/osf-mode-footer/component.ts
@@ -30,7 +30,6 @@ export default class OsfModeFooter extends Component {
     @service router!: RouterService;
 
     showDevBanner = config.showDevBanner;
-    showModal = false;
     showUrlInput = false;
     url: string = '/';
 

--- a/lib/osf-components/addon/components/osf-mode-footer/styles.scss
+++ b/lib/osf-components/addon/components/osf-mode-footer/styles.scss
@@ -18,9 +18,16 @@
 }
 
 .Tabs {
+    min-width: 60vw;
+
     :global(.tab-content) {
         padding: 10px;
     }
+}
+
+.OptionsList {
+    list-style-type: none;
+    padding-left: 0;
 }
 
 .features {

--- a/lib/osf-components/addon/components/osf-mode-footer/template.hbs
+++ b/lib/osf-components/addon/components/osf-mode-footer/template.hbs
@@ -1,37 +1,45 @@
 {{#if this.showDevBanner}}
-    <div local-class='DevBanner'>
-        <OsfButton
-            title={{t 'dev_tools.title'}}
-            @type='link'
-            @onClick={{action (mut this.showModal) true}}
-        >
-            {{#if this.showUrlInput}}
-                {{fa-icon 'rocket'}}
-            {{else}}
-                <strong>{{t 'general.warning'}}</strong>: {{t 'osf_mode_footer.dev_mode'}}
-            {{/if}}
-        </OsfButton>
-        {{#if this.showUrlInput}}
-            {{input type='text' value=this.url enter=(action this.transitionToUrl)}}
-        {{/if}}
-    </div>
-    <BsModal
-        @open={{this.showModal}}
-        @onHide={{action (mut this.showModal) false}}
-        as |modal|
-    >
-        <modal.header @title={{t 'dev_tools.title'}} />
-        <modal.body>
+    <OsfDialog @isModal={{false}} as |dialog|>
+        <dialog.trigger>
+            <div local-class='DevBanner'>
+                <OsfButton
+                    title={{t 'dev_tools.title'}}
+                    @type='link'
+                    @onClick={{dialog.open}}
+                >
+                    {{#if this.showUrlInput}}
+                        {{fa-icon 'rocket'}}
+                    {{else}}
+                        <strong>{{t 'general.warning'}}</strong>: {{t 'osf_mode_footer.dev_mode'}}
+                    {{/if}}
+                </OsfButton>
+                {{#if this.showUrlInput}}
+                    {{input type='text' value=this.url enter=(action this.transitionToUrl)}}
+                {{/if}}
+            </div>
+        </dialog.trigger>
+
+        <dialog.heading>
+            {{t 'dev_tools.title'}}
+        </dialog.heading>
+
+        <dialog.main>
             <BsTab local-class='Tabs' as |tab|>
                 <tab.pane @title='Options'>
-                    <label>
-                        {{input type='checkbox' checked=this.analytics.shouldToastOnEvent}}
-                        {{t 'dev_tools.options.toast_events'}}
-                    </label>
-                    <label>
-                        {{input type='checkbox' checked=this.showUrlInput}}
-                        {{t 'dev_tools.options.show_url_bar'}}
-                    </label>
+                    <ul local-class='OptionsList'>
+                        <li>
+                            <label>
+                                {{input type='checkbox' checked=this.analytics.shouldToastOnEvent}}
+                                {{t 'dev_tools.options.toast_events'}}
+                            </label>
+                        </li>
+                        <li>
+                            <label>
+                                {{input type='checkbox' checked=this.showUrlInput}}
+                                {{t 'dev_tools.options.show_url_bar'}}
+                            </label>
+                        </li>
+                    </ul>
                 </tab.pane>
                 <tab.pane @title='Zoom to route'>
                     <ZoomToRoute />
@@ -53,6 +61,6 @@
                     </ul>
                 </tab.pane>
             </BsTab>
-        </modal.body>
-    </BsModal>
+        </dialog.main>
+    </OsfDialog>
 {{/if}}

--- a/tests/unit/services/osf-modal-state-test.ts
+++ b/tests/unit/services/osf-modal-state-test.ts
@@ -1,3 +1,4 @@
+import { settled } from '@ember/test-helpers';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -6,16 +7,19 @@ import OsfModalState from 'osf-components/services/osf-modal-state';
 module('Unit | Service | osf-modal-state', hooks => {
     setupTest(hooks);
 
-    test('it handles dialog state', function(assert) {
+    test('it handles dialog state', async function(assert) {
         const service: OsfModalState = this.owner.lookup('service:osf-modal-state');
 
-        assert.ok(!service.inModalState);
+        assert.ok(!service.inModalState, 'Started in non-modal state');
         service.enterModalState();
-        assert.ok(service.inModalState);
+        await settled(); // enterModalState schedules the change asynchronously
+        assert.ok(service.inModalState, 'Entered modal state');
         service.exitModalState();
-        assert.ok(!service.inModalState);
+        await settled(); // exitModalState schedules the change asynchronously
+        assert.ok(!service.inModalState, 'Exited modal state');
 
         service.enterModalState();
+        await settled(); // enterModalState schedules the change asynchronously
         assert.throws(
             () => service.enterModalState(),
             'Throws error on double modal',


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[EMB-123] some really great stuff`
-->

## Purpose
Use the previously-added `osf-dialog` component. Add refinements that came to light while using it.
<!-- Describe the purpose of your changes. -->

## Summary of Changes
- Update dev-mode pop-up to use `osf-dialog`
- Add `@isOpen` and `@isModal` params to `osf-dialog`
- Add `capture-element` modifier to clean things up
<!-- Briefly describe or list your changes. -->

## Side Effects
Navigating the dev-mode tabs makes the dialog change size in a weird way.

The lesson here: Avoid putting complex/re-flowy widgets inside a dialog. If you must, use CSS to control the size.
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## Feature Flags
n/a
<!--
  Please list any feature flags that need to be enabled for these changes to go into effect.
  For each flag, what is the expected behavior with the flag enabled vs disabled?
-->

## QA Notes
n/a
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
-->

## Ticket

<!-- Link to JIRA ticket. Please indicate unticketed PRs with: `N/A` -->
https://openscience.atlassian.net/browse/ENG-807

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->


[EMB-123]: https://openscience.atlassian.net/browse/EMB-123