### PR TITLE
[ENG-670] fix: create for osfNestedResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Mirage
+    - `osfNestedResource` - added custom `post` handler to fix `create` action
 
 ## [19.8.0] - 2019-08-15
 ### Added


### PR DESCRIPTION
## Purpose

The `create` action for `osfNestedResource` is not working properly. Namely, it does not connect the nested child resource it creates to the parent resource. This is because the default handler for `post` in mirage doesn't know to connect the resource it creates to the parent. This PR fixes this by implementing a custom handler function for `post` in `osfNestedResource` that creates the child and then connects it to the parent.

## Summary of Changes

### Fixed
- Mirage
    - `osfNestedResource` - added custom `post` handler to fix `create` action

## Side Effects

None expected.

## Feature Flags

n/a

## QA Notes

No QA needed.

## Ticket

https://openscience.atlassian.net/browse/ENG-670

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
