### PR TITLE
[ENG-670] mirage: create bibliographic contributor on create contributor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Mirage
-    - `osfNestedResource` - added custom `post` handler to fix `create` action
+    - `osfNestedResource`
+        - added custom `post` handler to fix `create` action
+    - `node/contributors` nested resource
+        - conditionally create bibliographic contributors when creating contributors
 
 ## [19.8.0] - 2019-08-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Mirage
+    - `osfNestedResource`
+        - added `onCreate` hook to perform additional operations after creating a child resource
+
 ### Fixed
 - Mirage
     - `osfNestedResource` - added custom `post` handler to fix `create` action

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -4,6 +4,7 @@ import config from 'ember-get-config';
 import { getCitation } from './views/citation';
 import { searchCollections } from './views/collection-search';
 import { reportDelete } from './views/comment';
+import { createBibliographicContributor } from './views/contributor';
 import { createDeveloperApp, resetClientSecret } from './views/developer-app';
 import { createFork, createRegistrationFork } from './views/fork';
 import { guidDetail } from './views/guid';
@@ -47,7 +48,10 @@ export default function(this: Server) {
     osfResource(this, 'node', { except: ['create'] });
     this.post('/nodes/', createNode);
     osfNestedResource(this, 'node', 'children');
-    osfNestedResource(this, 'node', 'contributors', { defaultSortKey: 'index' });
+    osfNestedResource(this, 'node', 'contributors', {
+        defaultSortKey: 'index',
+        onCreate: createBibliographicContributor,
+    });
     osfNestedResource(this, 'node', 'bibliographicContributors', {
         only: ['index'],
         relatedModelName: 'contributor',

--- a/mirage/views/contributor.ts
+++ b/mirage/views/contributor.ts
@@ -1,0 +1,14 @@
+import { ModelInstance } from 'ember-cli-mirage';
+
+import Contributor from 'ember-osf-web/models/contributor';
+import Node from 'ember-osf-web/models/node';
+
+export function createBibliographicContributor(
+    node: ModelInstance<Node>,
+    contributor: ModelInstance<Contributor>,
+) {
+    if (contributor.bibliographic) {
+        node.bibliographicContributors.models.pushObject(contributor);
+        node.save();
+    }
+}

--- a/mirage/views/osf-resource.ts
+++ b/mirage/views/osf-resource.ts
@@ -14,6 +14,7 @@ interface ResourceOptions extends ActionOptions<resourceAction> {
 
 interface NestedResourceOptions extends ResourceOptions {
     relatedModelName: keyof ModelRegistry;
+    onCreate?: (parent: ModelInstance, child: ModelInstance) => void;
 }
 
 type relationshipAction = 'related' | 'update' | 'add' | 'remove';
@@ -139,6 +140,9 @@ export function osfNestedResource<K extends keyof ModelRegistry>(
             parent[relationshipName].models.pushObject(child);
             parent.save();
             child.reload();
+            if (opts.onCreate) {
+                opts.onCreate(parent, child);
+            }
             return child;
         });
     }


### PR DESCRIPTION
## Purpose

In Mirage, when a contributor is created, if the contributor is bibliographic, we need to also add that contributor to the node's list of bibliographic contributors.

## Summary of Changes

### Changed
- Mirage
    - `osfNestedResource`
        - added `onCreate` hook to perform additional operations after creating a child resource
### Fixed
- Mirage
    - `node/contributors` nested resource
        - conditionally create bibliographic contributors when creating contributors

## Side Effects

None expected.

## Feature Flags

n/a

## QA Notes

No QA needed.

## Ticket

https://openscience.atlassian.net/browse/ENG-670

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
