### PR TITLE
[ENG-670] chore: update to ember-angle-bracket-invocation-polyfill@^2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Packages
+    - update to [ember-angle-bracket-invocation-polyfill@^2.0.2](https://github.com/rwjblue/ember-angle-bracket-invocation-polyfill/releases/tag/v2.0.2)
+
 ### Fixed
 - Mirage
     - `osfNestedResource` - added custom `post` handler to fix `create` action

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "ember-a11y-testing": "^1.0.0",
     "ember-ace": "^2.0.1",
     "ember-ajax": "^5.0.0",
-    "ember-angle-bracket-invocation-polyfill": "^1.3.0",
+    "ember-angle-bracket-invocation-polyfill": "^2.0.2",
     "ember-basic-dropdown": "^1.0.3",
     "ember-bootstrap": "^1.2.2",
     "ember-bootstrap-datepicker": "^2.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6221,14 +6221,15 @@ ember-ajax@^5.0.0:
     ember-cli-babel "^7.5.0"
     najax "^1.0.3"
 
-ember-angle-bracket-invocation-polyfill@^1.3.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/ember-angle-bracket-invocation-polyfill/-/ember-angle-bracket-invocation-polyfill-1.3.1.tgz#3dd0b91b3776a8048a943889c031fa7f9ea44ec4"
-  integrity sha512-eeE4LBFIxJ5EclTIydPMPs04vvSDv64m+1fxwN2UKdSdRDWwus36k4B/LquDfWuG1WI0Dk3R4WoTFcRYlbNTWg==
+ember-angle-bracket-invocation-polyfill@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ember-angle-bracket-invocation-polyfill/-/ember-angle-bracket-invocation-polyfill-2.0.2.tgz#117ab5238305f11046a2eb3a5bc026c98d2cf5c1"
+  integrity sha512-HkG0xyTHtAhWVjU0Q5V/i4xe4FRvNIOaiUEgIvN815F3TIUboV/J0xhYgivm0uDZp9lAYUVF+U5PI1sCnlC3Og==
   dependencies:
     ember-cli-babel "^6.17.0"
     ember-cli-version-checker "^2.1.2"
     ember-compatibility-helpers "^1.0.2"
+    silent-error "^1.1.1"
 
 ember-app-scheduler@^1.0.1:
   version "1.0.3"
@@ -16931,7 +16932,7 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
-silent-error@^1.0.0, silent-error@^1.0.1, silent-error@^1.1.0:
+silent-error@^1.0.0, silent-error@^1.0.1, silent-error@^1.1.0, silent-error@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/silent-error/-/silent-error-1.1.1.tgz#f72af5b0d73682a2ba1778b7e32cd8aa7c2d8662"
   integrity sha512-n4iEKyNcg4v6/jpb3c0/iyH2G1nzUNl7Gpqtn/mHIJK9S/q/7MCfoO4rwVOoO59qPFIc0hVHvMbiOJ0NdtxKKw==


### PR DESCRIPTION
## Purpose

Update to latest [ember-angle-bracket-invocation-polyfill](https://github.com/rwjblue/ember-angle-bracket-invocation-polyfill), which gives us angle bracket invocation of built-in components `<LinkTo>`, `<Input>`, and `<Textarea>`. 

## Summary of Changes

### Changed
- Packages
    - update to [ember-angle-bracket-invocation-polyfill@^2.0.2](https://github.com/rwjblue/ember-angle-bracket-invocation-polyfill/releases/tag/v2.0.2)

## Side Effects

None expected.

## Feature Flags

n/a

## QA Notes

No QA needed.

## Ticket

https://openscience.atlassian.net/browse/ENG-670

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
