### PR TITLE
[ENG-670] fix lint and refactor templates for collections submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - update to [ember-angle-bracket-invocation-polyfill@^2.0.2](https://github.com/rwjblue/ember-angle-bracket-invocation-polyfill/releases/tag/v2.0.2)
 
 ### Fixed
+- Engines
+    - `collections`
+        - fixed template lint and use angle brackets in submission templates
 - Mirage
     - `osfNestedResource`
         - added custom `post` handler to fix `create` action

--- a/lib/app-components/addon/components/project-contributors/list/item/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/list/item/template.hbs
@@ -54,7 +54,7 @@
             <PowerSelect
                 @searchEnabled={{false}}
                 @options={{this.permissions}}
-                @onchange={{action (action @updatePermissions @contributor)}}
+                @onchange={{action @updatePermissions @contributor}}
                 @selected={{@contributor.permission}}
                 as |option|
             >

--- a/lib/app-components/addon/components/project-contributors/list/item/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/list/item/template.hbs
@@ -1,7 +1,7 @@
 <SortableItem
-    @model={{@contributor}}
-    @class='row'
     local-class={{concat 'row ' (get @contributor 'highlightClass')}}
+    @class='row'
+    @model={{@contributor}}
     @group={{@group}}
     @spacing={{1}}
     @handle='.handle'
@@ -14,10 +14,10 @@
     {{! Profile image}}
     <div class='col-xs-2 col-sm-1'>
         <img
-            alt={{t 'app_components.project_contributors.list.item.img_alt'}}
-            class='m-l-xs'
             local-class='profile-image'
+            class='m-l-xs'
             src={{@contributor.users.profileImage}}
+            alt={{t 'app_components.project_contributors.list.item.img_alt'}}
         >
     </div>
 
@@ -69,13 +69,13 @@
 
     {{! Bibliographic (Citation) }}
     <div
-        class='col-xs-10 col-xs-offset-2 col-sm-2 col-sm-offset-0 bib-padding'
         local-class='text-sm-center'
+        class='col-xs-10 col-xs-offset-2 col-sm-2 col-sm-offset-0 bib-padding'
     >
         <label
-            for='{{@contributor.id}}-citation'
-            class='visible-xs-inline'
             local-class='checkbox-label'
+            class='visible-xs-inline'
+            for='{{@contributor.id}}-citation'
         >
             <em>
                 {{t 'app_components.project_contributors.list.item.in_citation_label'}}

--- a/lib/app-components/addon/components/project-contributors/list/item/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/list/item/template.hbs
@@ -1,96 +1,103 @@
-{{#sortable-item
-    model=contributor
-    class="row"
-    local-class=(concat 'row ' (get contributor 'highlightClass'))
-    group=group
-    spacing=1
-    handle=".handle"
-}}
+<SortableItem
+    @model={{@contributor}}
+    @class='row'
+    local-class={{concat 'row ' (get @contributor 'highlightClass')}}
+    @group={{@group}}
+    @spacing={{1}}
+    @handle='.handle'
+>
     {{! Handle }}
-    <div class="col-xs-2 col-sm-1 text-nowrap">
-        <span class="fa fa-bars sortable-bars handle small"></span>
+    <div class='col-xs-2 col-sm-1 text-nowrap'>
+        <span class='fa fa-bars sortable-bars handle small'></span>
     </div>
 
     {{! Profile image}}
-    <div class="col-xs-2 col-sm-1">
+    <div class='col-xs-2 col-sm-1'>
         <img
             alt={{t 'app_components.project_contributors.list.item.img_alt'}}
-            class="m-l-xs"
-            local-class="profile-image"
-            src={{contributor.users.profileImage}}
+            class='m-l-xs'
+            local-class='profile-image'
+            src={{@contributor.users.profileImage}}
         >
     </div>
 
     {{! Name }}
-    <div class="col-xs-7 col-sm-3 text-nowrap">
-        {{#if contributor.unregisteredContributor}}
-            {{contributor.unregisteredContributor}}
+    <div class='col-xs-7 col-sm-3 text-nowrap'>
+        {{#if @contributor.unregisteredContributor}}
+            {{@contributor.unregisteredContributor}}
         {{else}}
-            <a href={{contributor.users.links.html}} target="_blank" rel="noopener">
-                {{contributor.users.fullName}}
+            <a href={{@contributor.users.links.html}} target='_blank' rel='noopener'>
+                {{@contributor.users.fullName}}
             </a>
         {{/if}}
     </div>
 
-    <div class="visible-xs-inline-block col-xs-1">
+    <div class='visible-xs-inline-block col-xs-1'>
         <button
-            {{action removeContributor contributor}}
-            class="text-danger"
+            {{action @removeContributor @contributor}}
+            class='text-danger'
             aria-label={{t 'app_components.project_contributors.list.item.remove_author'}}
-            hidden={{not canRemove}}
+            hidden={{not this.canRemove}}
         >
-            {{fa-icon 'times'}}
+            <FaIcon @icon='times' />
         </button>
     </div>
 
     {{! Permissions }}
-    <div class="col-xs-10 col-xs-offset-2 col-sm-3 col-sm-offset-0 text-nowrap">
-        <span class="visible-xs-inline permission-label">
+    <div class='col-xs-10 col-xs-offset-2 col-sm-3 col-sm-offset-0 text-nowrap'>
+        <span class='visible-xs-inline permission-label'>
             <em>
                 {{t 'app_components.project_contributors.list.item.permissions_label'}}
             </em>
         </span>
-        {{#if canChangePermissions}}
-            {{#power-select
-                searchEnabled=false
-                options=permissions
-                onchange=(action (action updatePermissions contributor))
-                selected=contributor.permission
+        {{#if this.canChangePermissions}}
+            <PowerSelect
+                @searchEnabled={{false}}
+                @options={{this.permissions}}
+                @onchange={{action (action @updatePermissions @contributor)}}
+                @selected={{@contributor.permission}}
                 as |option|
-            }}
+            >
                 {{t (concat 'app_components.project_contributors.list.item.permissions.' option)}}
-            {{/power-select}}
+            </PowerSelect>
         {{else}}
-            <span class="text-smaller">
-                {{t (concat 'app_components.project_contributors.list.item.permissions.' contributor.permission)}}
+            <span class='text-smaller'>
+                {{t (concat 'app_components.project_contributors.list.item.permissions.' @contributor.permission)}}
             </span>
         {{/if}}
     </div>
 
     {{! Bibliographic (Citation) }}
-    <div class="col-xs-10 col-xs-offset-2 col-sm-2 col-sm-offset-0 bib-padding" local-class="text-sm-center">
-        <label for="{{contributor.id}}-citation" class="visible-xs-inline" local-class="checkbox-label">
+    <div
+        class='col-xs-10 col-xs-offset-2 col-sm-2 col-sm-offset-0 bib-padding'
+        local-class='text-sm-center'
+    >
+        <label
+            for='{{@contributor.id}}-citation'
+            class='visible-xs-inline'
+            local-class='checkbox-label'
+        >
             <em>
                 {{t 'app_components.project_contributors.list.item.in_citation_label'}}
             </em>
         </label>
-        {{input
-            id=(concat contributor.id '-citation')
-            type='checkbox'
-            disabled=(not canChangeBibliographic)
-            checked=contributor.bibliographic
-            change=(action toggleBibliographic contributor)
-        }}
+        <Input
+            @id={{concat @contributor.id '-citation'}}
+            @type='checkbox'
+            @disabled={{not this.canChangeBibliographic}}
+            @checked={{@contributor.bibliographic}}
+            @change={{action @toggleBibliographic @contributor}}
+        />
     </div>
 
     {{! Remove }}
-    <div class="hidden-xs col-sm-2 text-center">
+    <div class='hidden-xs col-sm-2 text-center'>
         <button
-            {{action removeContributor contributor}}
-            class="btn btn-danger btn-sm"
-            disabled={{not canRemove}}
+            {{action @removeContributor @contributor}}
+            class='btn btn-danger btn-sm'
+            disabled={{not this.canRemove}}
         >
             {{t 'app_components.project_contributors.list.item.remove'}}
         </button>
     </div>
-{{/sortable-item}}
+</SortableItem>

--- a/lib/app-components/addon/components/project-contributors/search/result/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/search/result/template.hbs
@@ -1,32 +1,35 @@
-<td class="p-v-xs">
+<td class='p-v-xs'>
     <img
-        class="m-l-xs"
-        src={{user.links.profile_image}}
-        alt="{{user.fullname}}"
-        height="30"
-        width="30"
+        class='m-l-xs'
+        src={{@user.links.profile_image}}
+        alt={{@user.fullname}}
+        height='30'
+        width='30'
     >
-    <a href={{user.links.html}} target="_blank" rel="noopener">
-        {{~user.fullName~}}
+    <a href={{@user.links.html}} target='_blank' rel='noopener'>
+        {{~@user.fullName~}}
     </a>
-    {{#if isSelf}}
-        <span class="small">
+    {{#if this.isSelf}}
+        <span class='small'>
             {{t 'app_components.project_contributors.search.result.yourself'}}
         </span>
     {{/if}}
 </td>
-<td class="p-v-xs">
-    {{#if isContributor}}
+<td class='p-v-xs'>
+    {{#if this.isContributor}}
         <span
-            class="hint hint--left pull-right"
-            aria-label="{{t "components.preprint-form-authors.already_added"}}"
+            class='hint hint--left pull-right'
+            aria-label={{t 'components.preprint-form-authors.already_added'}}
         >
-            <button class="btn btn-default btn-small disabled disabled-checkmark">
-                {{fa-icon 'check' aria-hidden='true'}}
+            <button class='btn btn-default btn-small disabled disabled-checkmark'>
+                <FaIcon @icon='check' @aria-hidden='true' />
             </button>
         </span>
     {{else}}
-        <button class="btn btn-success btn-small pull-right" {{action addContributor user}}>
+        <button
+            class='btn btn-success btn-small pull-right'
+            {{action this.addContributor @user}}
+        >
             {{t 'app_components.project_contributors.search.result.add'}}
         </button>
     {{/if}}

--- a/lib/app-components/addon/components/project-contributors/search/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/search/template.hbs
@@ -1,14 +1,17 @@
 <form {{action (perform this.search) on='submit'}}>
-    <div class='input-group' local-class='author-search-box'>
+    <div
+        local-class='author-search-box'
+        class='input-group'
+    >
         <Input
-            @value={{this.query}}
             @class='form-control'
+            @value={{this.query}}
             @placeholder={{t 'app_components.project_contributors.search.placeholder'}}
         />
         <span class='input-group-btn'>
             <button
-                class='btn btn-default'
                 local-class='authors-search-button'
+                class='btn btn-default'
                 type='submit'
             >
                 <i class='glyphicon glyphicon-search'></i>
@@ -23,7 +26,10 @@
         @closeForm={{action (mut this.showUnregisteredForm) false}}
     />
 {{else if this.results.isLoaded}}
-    <div class='text-center' local-class='unregisteredUsers'>
+    <div
+        local-class='unregisteredUsers'
+        class='text-center'
+    >
         <p>{{t 'app_components.project_contributors.search.unregistered_description'}}</p>
         <button
             class='btn btn-primary btn-small'

--- a/lib/app-components/addon/components/project-contributors/search/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/search/template.hbs
@@ -1,33 +1,33 @@
-<form {{action (perform search) on='submit'}}>
-    <div class="input-group" local-class="author-search-box">
-        {{input
-            value=query
-            class='form-control'
-            placeholder=(t 'app_components.project_contributors.search.placeholder')
-        }}
-        <span class="input-group-btn">
+<form {{action (perform this.search) on='submit'}}>
+    <div class='input-group' local-class='author-search-box'>
+        <Input
+            @value={{this.query}}
+            @class='form-control'
+            @placeholder={{t 'app_components.project_contributors.search.placeholder'}}
+        />
+        <span class='input-group-btn'>
             <button
-                class="btn btn-default"
-                local-class="authors-search-button"
-                type="submit"
+                class='btn btn-default'
+                local-class='authors-search-button'
+                type='submit'
             >
-                <i class="glyphicon glyphicon-search"></i>
+                <i class='glyphicon glyphicon-search'></i>
             </button>
         </span>
     </div>
 </form>
 
-{{#if showUnregisteredForm}}
-    {{project-contributors/search/unregistered-contributor
-        node=node
-        closeForm=(action (mut showUnregisteredForm) false)
-    }}
-{{else if results.isLoaded}}
-    <div class="text-center" local-class="unregisteredUsers">
+{{#if this.showUnregisteredForm}}
+    <ProjectContributors::Search::UnregisteredContributor
+        @node={{@node}}
+        @closeForm={{action (mut this.showUnregisteredForm) false}}
+    />
+{{else if this.results.isLoaded}}
+    <div class='text-center' local-class='unregisteredUsers'>
         <p>{{t 'app_components.project_contributors.search.unregistered_description'}}</p>
         <button
-            class="btn btn-primary btn-small"
-            {{action (mut showUnregisteredForm) true}}
+            class='btn btn-primary btn-small'
+            {{action (mut this.showUnregisteredForm) true}}
         >
             {{t 'app_components.project_contributors.search.unregistered_button'}}
         </button>
@@ -35,26 +35,26 @@
     <h3>
         {{t 'app_components.project_contributors.search.results'}}
     </h3>
-    {{#if search.isRunning}}
-        <div class="text-center">
-            {{fa-icon 'spinner' pulse=true size=2}}
+    {{#if this.search.isRunning}}
+        <div class='text-center'>
+            <FaIcon @icon='spinner' @pulse={{true}} @size={{2}} />
         </div>
-    {{else if results.length}}
-        <table class="table author-table">
-            {{#each results as |result|}}
-                {{project-contributors/search/result
-                    user=result
-                    contributors=contributors
-                    addContributor=(action (perform addContributor))
-                }}
+    {{else if this.results.length}}
+        <table class='table author-table'>
+            {{#each this.results as |result|}}
+                <ProjectContributors::Search::Result
+                    @user={{result}}
+                    @contributors={{@contributors}}
+                    @addContributor={{action (perform this.addContributor)}}
+                />
             {{/each}}
         </table>
-        <div class="pull-right text-right">
-            {{search-paginator
-                pageChanged=(action (perform search))
-                current=page
-                maximum=totalPages
-            }}
+        <div class='pull-right text-right'>
+            <SearchPaginator
+                @pageChanged={{action (perform this.search)}}
+                @current={{this.page}}
+                @maximum={{this.totalPages}}
+            />
         </div>
     {{else}}
         {{t 'app_components.project_contributors.search.no_results'}}

--- a/lib/app-components/addon/components/project-contributors/search/unregistered-contributor/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/search/unregistered-contributor/template.hbs
@@ -1,37 +1,39 @@
-<h3>{{t 'app_components.project_contributors.search.unregistered_contributor.title'}}</h3>
-<label local-class="fullwidth">
+<h3>
+    {{t 'app_components.project_contributors.search.unregistered_contributor.title'}}
+</h3>
+<label local-class='fullwidth'>
     {{t 'app_components.project_contributors.search.unregistered_contributor.full_name'}}
-    {{validated-input/text
-        model=model
-        shouldShowMessages=didValidate
-        valuePath='fullName'
-        placeholder=(t 'app_components.project_contributors.search.unregistered_contributor.full_name')
-    }}
+    <ValidatedInput::Text
+        @model={{this.model}}
+        @shouldShowMessages={{this.didValidate}}
+        @valuePath='fullName'
+        @placeholder={{t 'app_components.project_contributors.search.unregistered_contributor.full_name'}}
+    />
 </label>
 <br>
-<label local-class="fullwidth">
+<label local-class='fullwidth'>
     {{t 'app_components.project_contributors.search.unregistered_contributor.email'}}
-    {{validated-input/text
-        model=model
-        shouldShowMessages=didValidate
-        valuePath='email'
-        placeholder=(t 'app_components.project_contributors.search.unregistered_contributor.email')
-    }}
+    <ValidatedInput::Text
+        @model={{this.model}}
+        @shouldShowMessages={{this.didValidate}}
+        @valuePath='email'
+        @placeholder={{t 'app_components.project_contributors.search.unregistered_contributor.email'}}
+    />
 </label>
-<p class="text-muted">
+<p class='text-muted'>
     {{t 'app_components.project_contributors.search.unregistered_contributor.paragraph'}}
 </p>
-<div class="pull-right text-right">
+<div class='pull-right text-right'>
     <button
-        class="btn btn-default"
-        {{action 'cancel'}}
+        class='btn btn-default'
+        {{action this.cancel}}
     >
         {{t 'app_components.project_contributors.search.unregistered_contributor.cancel'}}
     </button>
     <button
-        class="btn btn-success"
-        disabled={{and didValidate (v-get model 'isInvalid')}}
-        {{action (perform add)}}
+        class='btn btn-success'
+        disabled={{and this.didValidate (v-get this.model 'isInvalid')}}
+        {{action (perform this.add)}}
     >
         {{t 'app_components.project_contributors.search.unregistered_contributor.add'}}
     </button>

--- a/lib/app-components/addon/components/project-contributors/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/template.hbs
@@ -1,30 +1,37 @@
-<div class='col-xs-12 col-md-5' local-class='col-division-right'>
-    {{project-contributors/search
-        node=this.node
-        contributors=this.contributors
-        onAddContributor=(action this.reloadContributors)
-    }}
+<div
+    class='col-xs-12 col-md-5'
+    local-class='col-division-right'
+>
+    <ProjectContributors::Search
+        @node={{@node}}
+        @contributors={{@contributors}}
+        @onAddContributor={{action this.reloadContributors}}
+    />
 </div>
 <div class='col-xs-12 col-md-7'>
-    <h2 local-class='inline'>{{t 'app_components.project_contributors.title'}}</h2>
-    {{#fa-icon 'question-circle'}}
-        {{#bs-popover
-            placement='bottom'
-            triggerEvents='hover'
-            title=(t 'app_components.project_contributors.contributors_popover_title')
-        }}
+    <h2 local-class='inline'>
+        {{t 'app_components.project_contributors.title'}}
+    </h2>
+    <FaIcon @icon='question-circle'>
+        <BsPopover
+            @placement='bottom'
+            @triggerEvents='hover'
+            @title={{t 'app_components.project_contributors.contributors_popover_title'}}
+        >
             {{t 'app_components.project_contributors.contributors_popover'}}
-        {{/bs-popover}}
-    {{/fa-icon}}
-    <p>{{t 'app_components.project_contributors.instructions'}}</p>
-    {{project-contributors/list
-        node=this.node
-        bindReload=(action (mut this.reloadContributorsList))
-    }}
+        </BsPopover>
+    </FaIcon>
+    <p>
+        {{t 'app_components.project_contributors.instructions'}}
+    </p>
+    <ProjectContributors::List
+        @node={{this.node}}
+        @bindReload={{action (mut this.reloadContributorsList)}}
+    />
 </div>
-{{submit-section-buttons
-    showDiscard=false
-    discard=this.discard
-    continue=this.continue
-    continueButtonLabel=(t 'app_components.submit_section.continue')
-}}
+<SubmitSectionButtons
+    @showDiscard={{false}}
+    @discard={{this.discard}}
+    @continue={{this.continue}}
+    @continueButtonLabel={{t 'app_components.submit_section.continue'}}
+/>

--- a/lib/app-components/addon/components/project-contributors/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/template.hbs
@@ -1,6 +1,6 @@
 <div
-    class='col-xs-12 col-md-5'
     local-class='col-division-right'
+    class='col-xs-12 col-md-5'
 >
     <ProjectContributors::Search
         @node={{@node}}

--- a/lib/app-components/addon/components/submit-section/complete/template.hbs
+++ b/lib/app-components/addon/components/submit-section/complete/template.hbs
@@ -6,7 +6,11 @@
     >
         {{! template-lint-enable invalid-interactive }}
         {{yield}}
-        <p class='text-smaller' local-class='edit-message' hidden={{not this.editable}}>
+        <p
+            local-class='edit-message'
+            class='text-smaller'
+            hidden={{not this.editable}}
+        >
             {{t 'app_components.submit_section.click_to_edit'}}
         </p>
     </div>

--- a/lib/app-components/addon/components/submit-section/complete/template.hbs
+++ b/lib/app-components/addon/components/submit-section/complete/template.hbs
@@ -1,12 +1,12 @@
-{{#if showReopen}}
+{{#if @showReopen}}
     {{! template-lint-disable invalid-interactive }}
     <div
-        role="{{if this.editable 'button'}}"
+        role='{{if this.editable 'button'}}'
         {{action 'edit'}}
     >
         {{! template-lint-enable invalid-interactive }}
         {{yield}}
-        <p class="text-smaller" local-class="edit-message" hidden={{not this.editable}}>
+        <p class='text-smaller' local-class='edit-message' hidden={{not this.editable}}>
             {{t 'app_components.submit_section.click_to_edit'}}
         </p>
     </div>

--- a/lib/app-components/addon/components/submit-section/template.hbs
+++ b/lib/app-components/addon/components/submit-section/template.hbs
@@ -1,12 +1,12 @@
 {{#if this.showTooltip}}
-    {{bs-tooltip
-        title=this.tooltip
-        triggerElement='parentView'
-        autoPlacement=true
-        viewportSelector=this.elementId
-    }}
+    <BsTooltip
+        @title={{this.tooltip}}
+        @triggerElement='parentView'
+        @autoPlacement={{true}}
+        @viewportSelector={{this.elementId}}
+    />
 {{/if}}
-{{#panels.panel
+{{#@panels.panel
     open=this.isOpen
     as |panel|
 }}
@@ -23,4 +23,4 @@
             editSection=(action 'editSection')
         )
     )}}
-{{/panels.panel}}
+{{/@panels.panel}}

--- a/lib/app-components/addon/components/submit-sections/template.hbs
+++ b/lib/app-components/addon/components/submit-sections/template.hbs
@@ -1,5 +1,8 @@
-<div class="row m-t-lg">
-    {{#cp-panels accordion=true as |panels|}}
+<div class='row m-t-lg'>
+    <CpPanels
+        @accordion={{true}}
+        as |panels|
+    >
         {{yield (hash
             section=(component 'submit-section'
                 panels=panels
@@ -7,5 +10,5 @@
                 savedSections=@savedSections
             )
         )}}
-    {{/cp-panels}}
+    </CpPanels>
 </div>

--- a/lib/collections/addon/components/collection-item-picker/after-options/template.hbs
+++ b/lib/collections/addon/components/collection-item-picker/after-options/template.hbs
@@ -1,11 +1,11 @@
-{{#if isLoading}}
+{{#if @isLoading}}
     {{t 'collections.collection_item_picker.after_options.loading'}}
-{{else if hasMore}}
+{{else if this.hasMore}}
     <li
-        role="button"
-        class="ember-power-select-option text-center"
-        local-class="nobullet"
-        {{action loadMore}}
+        role='button'
+        class='ember-power-select-option text-center'
+        local-class='nobullet'
+        {{action @loadMore}}
     >
         {{t 'collections.collection_item_picker.after_options.load_more'}}
     </li>

--- a/lib/collections/addon/components/collection-item-picker/after-options/template.hbs
+++ b/lib/collections/addon/components/collection-item-picker/after-options/template.hbs
@@ -2,9 +2,9 @@
     {{t 'collections.collection_item_picker.after_options.loading'}}
 {{else if this.hasMore}}
     <li
-        role='button'
-        class='ember-power-select-option text-center'
         local-class='nobullet'
+        class='ember-power-select-option text-center'
+        role='button'
         {{action @loadMore}}
     >
         {{t 'collections.collection_item_picker.after_options.load_more'}}

--- a/lib/collections/addon/components/collections-submission/template.hbs
+++ b/lib/collections/addon/components/collections-submission/template.hbs
@@ -7,55 +7,59 @@
     <h1>{{t (concat this.i18nKeyPrefix (if this.edit 'update' 'add') '_header')}}</h1>
 </div>
 <div local-class='body'>
-    {{#submit-sections
-        activeSection=this.activeSection
-        savedSections=this.savedSections
+    <SubmitSections
+        @activeSection={{this.activeSection}}
+        @savedSections={{this.savedSections}}
         as |sections|
-    }}
-        {{#sections.section
-            section=this.sections.project
-            title=(t (concat this.i18nKeyPrefix 'project_select_title'))
-            continue=(action 'nextSection' this.sections.project)
-            editable=(not this.edit)
+    >
+        <sections.section
+            @section={{this.sections.project}}
+            @title={{t (concat this.i18nKeyPrefix 'project_select_title')}}
+            @continue={{action this.nextSection this.sections.project}}
+            @editable={{not this.edit}}
             as |section|
-        }}
-            {{#section.active}}
-                {{collection-item-picker
-                    class='col-xs-12'
-                    collection=this.collection
-                    projectSelected=(action 'projectSelected')
-                    validationChanged=(action (mut this.isProjectSelectorValid))
-                }}
-            {{/section.active}}
-            {{#section.complete}}
+        >
+            <section.active>
+                <CollectionItemPicker
+                    @class='col-xs-12'
+                    @collection={{this.collection}}
+                    @projectSelected={{action this.projectSelected}}
+                    @validationChanged={{action (mut this.isProjectSelectorValid)}}
+                />
+            </section.active>
+            <section.complete>
                 <p>
                     <em>{{t (concat this.i18nKeyPrefix 'project_select_project_label')}}</em>
                     <span>{{this.collectionItem.title}}</span>
                 </p>
-            {{/section.complete}}
-        {{/sections.section}}
+            </section.complete>
+        </sections.section>
 
-        {{#sections.section
-            section=this.sections.projectMetadata
-            tooltip=(t (concat this.i18nKeyPrefix 'closed_tooltip'))
-            title=(t (concat this.i18nKeyPrefix 'project_metadata_title'))
-            description=(t (concat this.i18nKeyPrefix 'project_metadata_description'))
+        <sections.section
+            @section={{this.sections.projectMetadata}}
+            @tooltip={{t (concat this.i18nKeyPrefix 'closed_tooltip')}}
+            @title={{t (concat this.i18nKeyPrefix 'project_metadata_title')}}
+            @description={{t (concat this.i18nKeyPrefix 'project_metadata_description')}}
             as |section|
-        }}
-            {{#section.active}}
+        >
+            <section.active>
                 {{#if this.collectionItem}}
-                    {{project-metadata
-                        node=this.collectionItem
-                        makePublicOnSave=true
-                        continue=(action 'nextSection')
-                    }}
+                    <ProjectMetadata
+                        @node={{this.collectionItem}}
+                        @makePublicOnSave={{true}}
+                        @continue={{action this.nextSection}}
+                    />
                 {{else}}
                     <div class='text-center'>
-                        {{fa-icon 'spinner' pulse=true size=2}}
+                        <FaIcon
+                            @icon='spinner'
+                            @pulse={{true}}
+                            @size={{2}}
+                        />
                     </div>
                 {{/if}}
-            {{/section.active}}
-            {{#section.complete}}
+            </section.active>
+            <section.complete>
                 <p>
                     <em>{{t (concat this.i18nKeyPrefix 'project_metadata_title_label')}}</em>
                     <span>{{this.collectionItem.title}}</span>
@@ -74,69 +78,85 @@
                         <div local-class='subject'>{{tag}}</div>
                     {{/each}}
                 </p>
-            {{/section.complete}}
-        {{/sections.section}}
+            </section.complete>
+        </sections.section>
 
-        {{#sections.section
-            section=this.sections.projectContributors
-            tooltip=(t (concat this.i18nKeyPrefix 'closed_tooltip'))
-            title=(t (concat this.i18nKeyPrefix 'project_contributors_title'))
-            description=(t (concat this.i18nKeyPrefix 'project_contributors_description'))
+        <sections.section
+            @section={{this.sections.projectContributors}}
+            @tooltip={{t (concat this.i18nKeyPrefix 'closed_tooltip')}}
+            @title={{t (concat this.i18nKeyPrefix 'project_contributors_title')}}
+            @description={{t (concat this.i18nKeyPrefix 'project_contributors_description')}}
             as |section|
-        }}
-            {{#section.active}}
+        >
+            <section.active>
                 <ProjectContributors
                     data-test-collection-project-contributors
                     @node={{this.collectionItem}}
                     @contributors={{this.collectionItem.contributors}}
-                    @discard={{action 'noop'}}
-                    @continue={{action 'nextSection'}}
+                    @discard={{action this.noop}}
+                    @continue={{action this.nextSection}}
                 />
-            {{/section.active}}
-            {{#section.complete}}
-                <p>{{contributor-list node=this.collectionItem shouldTruncate=false}}</p>
-            {{/section.complete}}
-        {{/sections.section}}
+            </section.active>
+            <section.complete>
+                <p>
+                    <ContributorList
+                        @node={{this.collectionItem}}
+                        @shouldTruncate={{false}}
+                    />
+                </p>
+            </section.complete>
+        </sections.section>
 
-        {{#sections.section
-            section=this.sections.collectionMetadata
-            tooltip=(t (concat this.i18nKeyPrefix 'closed_tooltip'))
-            title=(t (concat this.i18nKeyPrefix 'collection_metadata_title'))
+        <sections.section
+            @section={{this.sections.collectionMetadata}}
+            @tooltip={{t (concat this.i18nKeyPrefix 'closed_tooltip')}}
+            @title={{t (concat this.i18nKeyPrefix 'collection_metadata_title')}}
             as |section|
-        }}
-            {{#section.active}}
+        >
+            <section.active>
                 <CollectionMetadata
                     data-test-collection-metadata
                     @collection={{this.collection}}
                     @collectedMetadatum={{this.collectedMetadatum}}
-                    @continue={{action 'nextSection'}}
+                    @continue={{action this.nextSection}}
                 />
-            {{/section.active}}
-            {{#section.complete}}
+            </section.active>
+            <section.complete>
                 {{#each this.choiceFields as |field|}}
                     <p>
                         <em>{{t field.label}}</em>
                         <span>{{field.value}}</span>
                     </p>
                 {{/each}}
-            {{/section.complete}}
-        {{/sections.section}}
+            </section.complete>
+        </sections.section>
 
         <section class='row' local-class='last-buttons'>
             <div class='col-xs-12 text-right'>
-                <button class='btn btn-default' {{action 'cancel'}}>
+                <button class='btn btn-default' {{action this.cancel}}>
                     {{t (concat this.i18nKeyPrefix 'cancel')}}
                 </button>
                 {{#if this.edit}}
-                    <button data-test-collection-update data-analytics-name='Update' class='btn btn-success' {{action (perform this.save)}}>
+                    <button
+                        data-test-collection-update
+                        data-analytics-name='Update'
+                        class='btn btn-success'
+                        {{action (perform this.save)}}
+                    >
                         {{t (concat this.i18nKeyPrefix 'update' '_button')}}
                     </button>
                 {{else}}
-                    <button data-test-collection-submit data-analytics-name='Submit' class='btn btn-success' {{action this.setShowSubmitModal}} disabled={{not (eq this.activeSection this.sections.submit)}}>
+                    <button
+                        data-test-collection-submit
+                        data-analytics-name='Submit'
+                        class='btn btn-success'
+                        {{action this.setShowSubmitModal}}
+                        disabled={{not (eq this.activeSection this.sections.submit)}}
+                    >
                         {{t (concat this.i18nKeyPrefix 'add' '_button')}}
                     </button>
                 {{/if}}
             </div>
         </section>
-    {{/submit-sections}}
+    </SubmitSections>
 </div>


### PR DESCRIPTION
## Purpose

This is a series of refactors to templates for components used in Collections submission. For each template, template lint issues were fixed and angle bracket invocation was used wherever possible. I also reformatted for readability in a number of places.

Note: this PR depends on #745

## Summary of Changes

### Fixed
- Engines
    - `collections`
        - fixed template lint and use angle brackets in submission templates

## Side Effects

None expected.

## Feature Flags

n/a

## QA Notes

The Collections submission workflow should be thoroughly tested.

## Ticket

https://openscience.atlassian.net/browse/ENG-670

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
