### PR TITLE
[ENG-670] mirage: serialize correct self link for contributors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Mirage
     - `osfNestedResource` - added custom `post` handler to fix `create` action
+    - Serializers
+        - `contributors` - serialize correct nested self link
 
 ## [19.8.0] - 2019-08-15
 ### Added

--- a/mirage/serializers/contributor.ts
+++ b/mirage/serializers/contributor.ts
@@ -8,6 +8,12 @@ import ApplicationSerializer from './application';
 const { OSF: { apiUrl } } = config;
 
 export default class ContributorSerializer extends ApplicationSerializer<Contributor> {
+    buildNormalLinks(model: ModelInstance<Contributor>) {
+        return {
+            self: `${apiUrl}/v2/nodes/${model.node.id}/contributors/${model.id}`,
+        };
+    }
+
     buildRelationships(model: ModelInstance<Contributor>) {
         return {
             users: {


### PR DESCRIPTION
## Purpose

The contributors endpoint is nested under the node so we need to serialize the self link this way.

## Summary of Changes

- Mirage
    - Serializers
        - `contributors` - serialize correct nested self link

## Side Effects

None expected.

## Feature Flags

n/a

## QA Notes

NO QA needed.

## Ticket

https://openscience.atlassian.net/browse/ENG-670

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
