### PR TITLE
[ENG-670] improved collections submit acceptance test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Engines
     - `collections`
         - fixed template lint and use angle brackets in submission templates
+        - `submit`
+            - reload bibliographicContributors when adding a contributor
 - Mirage
     - `osfNestedResource`
         - added custom `post` handler to fix `create` action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Components
     - `project-contributors`
         - added `onAddContributor` hook
+- Engines
+    - `collections`
+        - Tests
+            - improved submit acceptance tests to perform assertions in addition to taking snapshots
 - Tests
     - added `ember-basic-dropdown-wormhole` div to test index.html 
 - Mirage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Components
     - `project-contributors`
         - added `onAddContributor` hook
+- Tests
+    - added `ember-basic-dropdown-wormhole` div to test index.html 
 - Mirage
     - `osfNestedResource`
         - added `onCreate` hook to perform additional operations after creating a child resource

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Engines
     - `collections`
         - Tests
+            - added/improved test selectors to templates related to submit
             - improved submit acceptance tests to perform assertions in addition to taking snapshots
 - Tests
     - added `ember-basic-dropdown-wormhole` div to test index.html 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
+- Components
+    - `project-contributors`
+        - added `onAddContributor` hook
 - Mirage
     - `osfNestedResource`
         - added `onCreate` hook to perform additional operations after creating a child resource

--- a/lib/app-components/addon/components/project-contributors/component.ts
+++ b/lib/app-components/addon/components/project-contributors/component.ts
@@ -16,11 +16,15 @@ export default class ProjectContributors extends Component {
 
     @requiredAction discard!: () => void;
     @requiredAction continue!: () => void;
+    onAddContributor?: () => void;
 
     @action
     reloadContributors() {
         if (this.reloadContributorsList) {
             this.reloadContributorsList();
+        }
+        if (this.onAddContributor) {
+            this.onAddContributor();
         }
     }
 }

--- a/lib/app-components/addon/components/project-contributors/list/item/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/list/item/template.hbs
@@ -1,4 +1,5 @@
 <SortableItem
+    data-test-project-contributors-list-item-id={{@contributor.users.id}}
     local-class={{concat 'row ' (get @contributor 'highlightClass')}}
     @class='row'
     @model={{@contributor}}
@@ -12,7 +13,10 @@
     </div>
 
     {{! Profile image}}
-    <div class='col-xs-2 col-sm-1'>
+    <div
+        data-test-project-contributors-list-item-name
+        class='col-xs-2 col-sm-1'
+    >
         <img
             local-class='profile-image'
             class='m-l-xs'
@@ -22,7 +26,10 @@
     </div>
 
     {{! Name }}
-    <div class='col-xs-7 col-sm-3 text-nowrap'>
+    <div
+        data-test-project-contributors-list-item-name
+        class='col-xs-7 col-sm-3 text-nowrap'
+    >
         {{#if @contributor.unregisteredContributor}}
             {{@contributor.unregisteredContributor}}
         {{else}}
@@ -34,6 +41,7 @@
 
     <div class='visible-xs-inline-block col-xs-1'>
         <button
+            data-test-project-contributors-list-item-x-button
             {{action @removeContributor @contributor}}
             class='text-danger'
             aria-label={{t 'app_components.project_contributors.list.item.remove_author'}}
@@ -52,6 +60,7 @@
         </span>
         {{#if this.canChangePermissions}}
             <PowerSelect
+                data-test-project-contributors-list-item-permissions-select
                 @searchEnabled={{false}}
                 @options={{this.permissions}}
                 @onchange={{action @updatePermissions @contributor}}
@@ -61,7 +70,10 @@
                 {{t (concat 'app_components.project_contributors.list.item.permissions.' option)}}
             </PowerSelect>
         {{else}}
-            <span class='text-smaller'>
+            <span
+                data-test-project-contributors-list-item-permissions-display
+                class='text-smaller'
+            >
                 {{t (concat 'app_components.project_contributors.list.item.permissions.' @contributor.permission)}}
             </span>
         {{/if}}
@@ -69,6 +81,7 @@
 
     {{! Bibliographic (Citation) }}
     <div
+        data-test-project-contributors-list-item-citation-checkbox
         local-class='text-sm-center'
         class='col-xs-10 col-xs-offset-2 col-sm-2 col-sm-offset-0 bib-padding'
     >
@@ -93,6 +106,7 @@
     {{! Remove }}
     <div class='hidden-xs col-sm-2 text-center'>
         <button
+            data-test-project-contributors-list-item-remove-button
             {{action @removeContributor @contributor}}
             class='btn btn-danger btn-sm'
             disabled={{not this.canRemove}}

--- a/lib/app-components/addon/components/project-contributors/list/item/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/list/item/template.hbs
@@ -14,7 +14,7 @@
 
     {{! Profile image}}
     <div
-        data-test-project-contributors-list-item-name
+        data-test-project-contributors-list-item-profile-image
         class='col-xs-2 col-sm-1'
     >
         <img

--- a/lib/app-components/addon/components/project-contributors/search/result/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/search/result/template.hbs
@@ -6,7 +6,9 @@
         height='30'
         width='30'
     >
-    <a href={{@user.links.html}} target='_blank' rel='noopener'>
+    <a
+        data-test-project-contributors-search-user-name
+        href={{@user.links.html}} target='_blank' rel='noopener'>
         {{~@user.fullName~}}
     </a>
     {{#if this.isSelf}}
@@ -21,12 +23,16 @@
             class='hint hint--left pull-right'
             aria-label={{t 'components.preprint-form-authors.already_added'}}
         >
-            <button class='btn btn-default btn-small disabled disabled-checkmark'>
+            <button
+                data-test-project-contributors-is-contributor-button
+                class='btn btn-default btn-small disabled disabled-checkmark'
+            >
                 <FaIcon @icon='check' @aria-hidden='true' />
             </button>
         </span>
     {{else}}
         <button
+            data-test-project-contributors-add-contributor-button
             class='btn btn-success btn-small pull-right'
             {{action this.addContributor @user}}
         >

--- a/lib/app-components/addon/components/project-contributors/search/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/search/template.hbs
@@ -1,5 +1,6 @@
 <form {{action (perform this.search) on='submit'}}>
     <div
+        data-test-project-contributors-search-box
         local-class='author-search-box'
         class='input-group'
     >
@@ -10,6 +11,7 @@
         />
         <span class='input-group-btn'>
             <button
+                data-test-project-contributors-search-button
                 local-class='authors-search-button'
                 class='btn btn-default'
                 type='submit'
@@ -32,6 +34,7 @@
     >
         <p>{{t 'app_components.project_contributors.search.unregistered_description'}}</p>
         <button
+            data-test-add-author-by-email-address-button
             class='btn btn-primary btn-small'
             {{action (mut this.showUnregisteredForm) true}}
         >
@@ -49,6 +52,7 @@
         <table class='table author-table'>
             {{#each this.results as |result|}}
                 <ProjectContributors::Search::Result
+                    data-test-project-contributors-search-user={{result.id}}
                     @user={{result}}
                     @contributors={{@contributors}}
                     @addContributor={{action (perform this.addContributor)}}

--- a/lib/app-components/addon/components/project-metadata/template.hbs
+++ b/lib/app-components/addon/components/project-metadata/template.hbs
@@ -1,24 +1,26 @@
-<ValidatedModelForm 
+<ValidatedModelForm
     @onSave={{action this.onSave}}
     @onError={{action this.onError}}
     @model={{this.node}}
     as |form|
 >
     <div class='col-md-6'>
-        <form.text 
+        <form.text
+            data-test-project-metadata-title
             @label={{t 'app_components.project_metadata.field_title_label'}}
             @valuePath='title'
         />
         <br>
-        <form.textarea 
+        <form.textarea
+            data-test-project-metadata-description
             @label={{t 'app_components.project_metadata.field_description_label'}}
             @valuePath='description'
         />
     </div>
-    
+
     <div class='col-md-6'>
         <LicensePicker
-            data-test-collections-license-picker
+            data-test-project-metadata-license-picker
             @node={{this.node}}
             @form={{form}}
         >
@@ -28,32 +30,35 @@
         <label>
             {{t 'app_components.project_metadata.field_tags_label'}}
             <form.custom
+                data-test-project-metadata-tags
                 @model={{this.node}}
                 @valuePath='tags'
             >
-                {{#tag-input
-                    tags=this.node.tags
-                    addTag=(action 'addTag')
-                    removeTagAtIndex=(action 'removeTagAtIndex')
-                    allowSpacesInTags=true
-                    placeholder=(t 'osf-components.tags-widget.add_tag')
-                    aria_label=(t 'file_detial.tags')
+                <TagInput
+                    data-test-project-metadata-tag-input
+                    @tags={{this.node.tags}}
+                    @addTag={{action this.addTag}}
+                    @removeTagAtIndex={{action this.removeTagAtIndex}}
+                    @allowSpacesInTags={{true}}
+                    @placeholder={{t 'osf-components.tags-widget.add_tag'}}
+                    @aria_label={{t 'file_detial.tags'}}
+                    @readOnly={{false}}
                     local-class='tagInput'
-                    readOnly=false
                     as |tag|
-                }}
+                >
                     <a
                         href='{{@searchUrl}}?q=(tags:"{{tag}}")'
                         onclick={{action 'click' 'link' 'Collections - Submit - Search by tag' target=this.analytics}}
                     >
                         {{tag}}
                     </a>
-                {{/tag-input}}
+                </TagInput>
             </form.custom>
         </label>
     </div>
     <div class='col-xs-12 text-right'>
         <OsfButton
+            data-test-project-metadata-discard-button
             @type='default'
             @disabled={{form.submitting}}
             @onClick={{perform this.reset}}
@@ -61,7 +66,7 @@
             {{t 'app_components.submit_section.discard'}}
         </OsfButton>
         <OsfButton
-            data-test-project-metadata-continue
+            data-test-project-metadata-save-button
             @type='primary'
             @buttonType='submit'
             @disabled={{form.submitting}}

--- a/lib/app-components/addon/components/project-metadata/template.hbs
+++ b/lib/app-components/addon/components/project-metadata/template.hbs
@@ -47,6 +47,7 @@
                     as |tag|
                 >
                     <a
+                        data-test-project-metadata-tag={{tag}}
                         href='{{@searchUrl}}?q=(tags:"{{tag}}")'
                         onclick={{action 'click' 'link' 'Collections - Submit - Search by tag' target=this.analytics}}
                     >

--- a/lib/app-components/addon/components/project-metadata/template.hbs
+++ b/lib/app-components/addon/components/project-metadata/template.hbs
@@ -41,7 +41,7 @@
                     @removeTagAtIndex={{action this.removeTagAtIndex}}
                     @allowSpacesInTags={{true}}
                     @placeholder={{t 'osf-components.tags-widget.add_tag'}}
-                    @aria_label={{t 'file_detial.tags'}}
+                    @aria_label={{t 'file_detail.tags'}}
                     @readOnly={{false}}
                     local-class='tagInput'
                     as |tag|

--- a/lib/app-components/addon/components/submit-section/complete/template.hbs
+++ b/lib/app-components/addon/components/submit-section/complete/template.hbs
@@ -1,6 +1,7 @@
 {{#if @showReopen}}
     {{! template-lint-disable invalid-interactive }}
     <div
+        data-test-submit-section-click-to-edit
         role='{{if this.editable 'button'}}'
         {{action 'edit'}}
     >

--- a/lib/collections/addon/components/collection-submission-confirmation-modal/template.hbs
+++ b/lib/collections/addon/components/collection-submission-confirmation-modal/template.hbs
@@ -1,27 +1,29 @@
-<BsModal 
+<BsModal
     @open={{@openModal}}
     @onSubmit={{action @addToCollection}}
     @onHidden={{action @cancel}}
     as |modal|
 >
     <modal.header>
-        <h3 data-test-modal-header>{{t 'collections.collection_submission_confirmation_modal.header'}}</h3>
+        <h3 data-test-collection-submission-confirmation-modal-header>
+            {{t 'collections.collection_submission_confirmation_modal.header'}}
+        </h3>
     </modal.header>
     <modal.body>
-        <p data-test-modal-body>
+        <p data-test-collection-submission-confirmation-modal-body>
             {{t 'collections.collection_submission_confirmation_modal.body'}}
         </p>
     </modal.body>
     <modal.footer data-analytics-scope='Collection - Submit'>
-        <OsfButton 
-            data-test-button-cancel
+        <OsfButton
+            data-test-collection-submission-confirmation-modal-cancel-button
             data-analytics-name='Cancel submission'
             @onClick={{action modal.close}}
         >
             {{t 'general.cancel'}}
         </OsfButton>
-        <OsfButton 
-            data-test-button-success
+        <OsfButton
+            data-test-collection-submission-confirmation-modal-add-button
             data-analytics-name='Confirm submission'
             @onClick={{action modal.submit}}
             @type='success'

--- a/lib/collections/addon/components/collections-submission/component.ts
+++ b/lib/collections/addon/components/collections-submission/component.ts
@@ -105,6 +105,7 @@ export default class Submit extends Component {
     get choiceFields(): Array<{ label: string; value: string | undefined; }> {
         return this.collectedMetadatum.displayChoiceFields
             .map(field => ({
+                name: field,
                 label: `collections.collection_metadata.${underscore(field)}_label`,
                 value: this.collectedMetadatum[field],
             }));

--- a/lib/collections/addon/components/collections-submission/component.ts
+++ b/lib/collections/addon/components/collections-submission/component.ts
@@ -169,6 +169,13 @@ export default class Submit extends Component {
         // Nothing to see here
     }
 
+    @action
+    onAddContributor() {
+        if (this.collectionItem) {
+            this.collectionItem.hasMany('bibliographicContributors').reload();
+        }
+    }
+
     /**
      * Advances to the next section of the form
      */

--- a/lib/collections/addon/components/collections-submission/template.hbs
+++ b/lib/collections/addon/components/collections-submission/template.hbs
@@ -121,6 +121,7 @@
                     @node={{this.collectionItem}}
                     @contributors={{this.collectionItem.contributors}}
                     @discard={{action this.noop}}
+                    @onAddContributor={{action this.onAddContributor}}
                     @continue={{action this.nextSection}}
                 />
             </section.active>

--- a/lib/collections/addon/components/collections-submission/template.hbs
+++ b/lib/collections/addon/components/collections-submission/template.hbs
@@ -8,11 +8,13 @@
 </div>
 <div local-class='body'>
     <SubmitSections
+        data-test-collections-submit-sections
         @activeSection={{this.activeSection}}
         @savedSections={{this.savedSections}}
         as |sections|
     >
         <sections.section
+            data-test-collections-submit-section='project'
             @section={{this.sections.project}}
             @title={{t (concat this.i18nKeyPrefix 'project_select_title')}}
             @continue={{action this.nextSection this.sections.project}}
@@ -36,6 +38,7 @@
         </sections.section>
 
         <sections.section
+            data-test-collections-submit-section='projectMetadata'
             @section={{this.sections.projectMetadata}}
             @tooltip={{t (concat this.i18nKeyPrefix 'closed_tooltip')}}
             @title={{t (concat this.i18nKeyPrefix 'project_metadata_title')}}
@@ -82,6 +85,7 @@
         </sections.section>
 
         <sections.section
+            data-test-collections-submit-section='projectContributors'
             @section={{this.sections.projectContributors}}
             @tooltip={{t (concat this.i18nKeyPrefix 'closed_tooltip')}}
             @title={{t (concat this.i18nKeyPrefix 'project_contributors_title')}}
@@ -108,6 +112,7 @@
         </sections.section>
 
         <sections.section
+            data-test-collections-submit-section='collectionMetadata'
             @section={{this.sections.collectionMetadata}}
             @tooltip={{t (concat this.i18nKeyPrefix 'closed_tooltip')}}
             @title={{t (concat this.i18nKeyPrefix 'collection_metadata_title')}}
@@ -131,14 +136,22 @@
             </section.complete>
         </sections.section>
 
-        <section class='row' local-class='last-buttons'>
+        <section
+            data-test-collections-submit-section='buttons'
+            class='row'
+            local-class='last-buttons'
+        >
             <div class='col-xs-12 text-right'>
-                <button class='btn btn-default' {{action this.cancel}}>
+                <button
+                    data-test-collections-submit-cancel-button
+                    class='btn btn-default'
+                    {{action this.cancel}}
+                >
                     {{t (concat this.i18nKeyPrefix 'cancel')}}
                 </button>
                 {{#if this.edit}}
                     <button
-                        data-test-collection-update
+                        data-test-collections-submit-update-button
                         data-analytics-name='Update'
                         class='btn btn-success'
                         {{action (perform this.save)}}
@@ -147,7 +160,7 @@
                     </button>
                 {{else}}
                     <button
-                        data-test-collection-submit
+                        data-test-collections-submit-submit-button
                         data-analytics-name='Submit'
                         class='btn btn-success'
                         {{action this.setShowSubmitModal}}

--- a/lib/collections/addon/components/collections-submission/template.hbs
+++ b/lib/collections/addon/components/collections-submission/template.hbs
@@ -31,8 +31,12 @@
             </section.active>
             <section.complete>
                 <p>
-                    <em>{{t (concat this.i18nKeyPrefix 'project_select_project_label')}}</em>
-                    <span>{{this.collectionItem.title}}</span>
+                    <em data-test-project-complete-title-label>
+                        {{t (concat this.i18nKeyPrefix 'project_select_project_label')}}
+                    </em>
+                    <span data-test-project-complete-title-value>
+                        {{this.collectionItem.title}}
+                    </span>
                 </p>
             </section.complete>
         </sections.section>
@@ -64,21 +68,40 @@
             </section.active>
             <section.complete>
                 <p>
-                    <em>{{t (concat this.i18nKeyPrefix 'project_metadata_title_label')}}</em>
-                    <span>{{this.collectionItem.title}}</span>
+                    <em data-test-project-metadata-complete-title-label>
+                        {{t (concat this.i18nKeyPrefix 'project_metadata_title_label')}}
+                    </em>
+                    <span data-test-project-metadata-complete-title-value>
+                        {{this.collectionItem.title}}
+                    </span>
                 </p>
                 <p>
-                    <em>{{t (concat this.i18nKeyPrefix 'project_metadata_description_label')}}</em>
-                    <span>{{this.collectionItem.description}}</span>
+                    <em data-test-project-metadata-complete-description-label>
+                        {{t (concat this.i18nKeyPrefix 'project_metadata_description_label')}}
+                    </em>
+                    <span data-test-project-metadata-complete-description-value>
+                        {{this.collectionItem.description}}
+                    </span>
                 </p>
                 <p>
-                    <em>{{t (concat this.i18nKeyPrefix 'project_metadata_license_label')}}</em>
-                    <span>{{this.collectionItem.license.name}}</span>
+                    <em data-test-project-metadata-complete-license-name-label>
+                        {{t (concat this.i18nKeyPrefix 'project_metadata_license_label')}}
+                    </em>
+                    <span data-test-project-metadata-complete-license-name-value>
+                        {{this.collectionItem.license.name}}
+                    </span>
                 </p>
                 <p>
-                    <em>{{t (concat this.i18nKeyPrefix 'project_metadata_tags_label')}}</em>
+                    <em data-test-project-metadata-complete-tags-label>
+                        {{t (concat this.i18nKeyPrefix 'project_metadata_tags_label')}}
+                    </em>
                     {{#each this.collectionItem.tags as |tag|}}
-                        <div local-class='subject'>{{tag}}</div>
+                        <div
+                            data-test-project-metadata-complete-tag={{tag}}
+                            local-class='subject'
+                        >
+                            {{tag}}
+                        </div>
                     {{/each}}
                 </p>
             </section.complete>
@@ -128,9 +151,13 @@
             </section.active>
             <section.complete>
                 {{#each this.choiceFields as |field|}}
-                    <p>
-                        <em>{{t field.label}}</em>
-                        <span>{{field.value}}</span>
+                    <p data-test-collection-metadata-complete-field={{field.name}}>
+                        <em data-test-collection-metadata-complete-field-label>
+                            {{t field.label}}
+                        </em>
+                        <span data-test-collection-metadata-complete-field-value>
+                            {{field.value}}
+                        </span>
                     </p>
                 {{/each}}
             </section.complete>

--- a/lib/osf-components/addon/components/contributor-list/contributor/template.hbs
+++ b/lib/osf-components/addon/components/contributor-list/contributor/template.hbs
@@ -4,14 +4,14 @@
         TODO: switch to `{{#osf-link}}` invocation when <Link> is renamed
     --}}
     <a
-        data-test-contributor-name
+        data-test-contributor-name={{@contributor.users.id}}
         data-analytics-name='Contributor name'
         href={{this.contributorLink}}
     >
         {{~this.contributorName~}}
     </a>
 {{~else~}}
-    <span data-test-contributor-name>
+    <span data-test-contributor-name={{@contributor.users.id}}>
         {{~this.contributorName~}}
     </span>
 {{~/if~}}

--- a/tests/engines/collections/acceptance/submit/submit-test.ts
+++ b/tests/engines/collections/acceptance/submit/submit-test.ts
@@ -1,8 +1,10 @@
-import { click as untrackedClick } from '@ember/test-helpers';
+import { click as untrackedClick, fillIn } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { percySnapshot } from 'ember-percy';
+import faker from 'faker';
 import { module, test } from 'qunit';
 
+import CollectionProvider from 'ember-osf-web/models/collection-provider';
 import { Permission } from 'ember-osf-web/models/osf-model';
 import { click, visit } from 'ember-osf-web/tests/helpers';
 import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
@@ -11,13 +13,14 @@ module('Collections | Acceptance | submit', hooks => {
     setupEngineApplicationTest(hooks, 'collections');
     setupMirage(hooks);
 
-    test('it renders', async () => {
+    test('it works', async function(assert) {
         server.loadFixtures('licenses');
         const currentUser = server.create('user', 'loggedIn');
         const primaryCollection = server.create('collection');
         const nodeToBeAdded = server.create('node', {
             title: 'Node to be added to collection',
             currentUserPermissions: Object.values(Permission),
+            tags: faker.lorem.words(5).split(' '),
         });
         server.create('contributor', {
             node: nodeToBeAdded,
@@ -30,33 +33,164 @@ module('Collections | Acceptance | submit', hooks => {
             primaryCollection,
             licensesAcceptable,
         });
+
+        const store = this.owner.lookup('service:store');
+
+        const newTitle = 'New Title';
+        const newDescription = 'New description.';
+
         await visit(`/collections/${provider.id}/submit`);
+
+        /* Select a project */
+
         await percySnapshot('Collections | Acceptance | submit | select project');
+
+        // open item picker
         await untrackedClick('[data-test-collections-item-picker] .ember-power-select-trigger');
-        await untrackedClick(`[data-test-collections-node-title="${nodeToBeAdded.title}"]`);
+        // select node
+        const nodeToBeAddedOption = document.querySelector(
+            `[data-test-collections-node-title="${nodeToBeAdded.title}"]`,
+        );
+        if (nodeToBeAddedOption) {
+            await untrackedClick(nodeToBeAddedOption);
+        }
+
+        /* Project metadata */
 
         await percySnapshot('Collections | Acceptance | submit | project metadata');
+
+        await fillIn('[data-test-project-metadata-title] input', newTitle);
+        await fillIn('[data-test-project-metadata-description] textarea', newDescription);
+        // open license picker
         await untrackedClick('[data-test-project-metadata-license-picker] .ember-power-select-trigger');
-        await untrackedClick('.ember-power-select-option');
+        // select first license
+        const firstLicenseOption = document.querySelector('.ember-power-select-option');
+        if (firstLicenseOption) {
+            await untrackedClick(firstLicenseOption);
+        }
+        // remove third tag
+        await untrackedClick(`[data-test-project-metadata-tag="${nodeToBeAdded.tags[2]}"] + .emberTagInput-remove`);
         await untrackedClick('[data-test-project-metadata-save-button]');
 
+        assert.dom('[data-test-project-metadata-complete-title-value]')
+            .hasText(newTitle, 'title is updated');
+        assert.dom('[data-test-project-metadata-complete-description-value]')
+            .hasText(newDescription, 'description is updated');
+        const collectionProvider: CollectionProvider = store.peekRecord('collection-provider', provider.id);
+        const licenses = await collectionProvider.get('licensesAcceptable');
+        const firstLicense = licenses.get('firstObject');
+        assert.dom('[data-test-project-metadata-complete-license-name-value]')
+            .hasText(firstLicense ? firstLicense.name : '', 'license is updated');
+        assert.dom('[data-test-project-metadata-complete-tag]')
+            .exists({ count: 4 }, 'only four tags remain');
+        nodeToBeAdded.tags.forEach(tag =>
+            assert.dom(`[data-test-project-metadata-complete-tag="${tag}"]`)
+                .exists({ count: 1 }, `found tag: "${tag}"`));
+
+        /* Project contributors */
+
         await percySnapshot('Collections | Acceptance | submit | project contributors');
+
+        // add contributor
+        const userToAdd = server.create('user');
+        await fillIn('[data-test-project-contributors-search-box] input', userToAdd.fullName);
+        await untrackedClick('[data-test-project-contributors-search-button]');
+        const userToAddSelector = `[data-test-project-contributors-search-user="${userToAdd.id}"]`;
+        assert.dom(userToAddSelector)
+            .exists({ count: 1 }, 'found contributor');
+        await untrackedClick(`${userToAddSelector} [data-test-project-contributors-add-contributor-button]`);
+        const contribListSelector = `[data-test-project-contributors-list-item-id=${userToAdd.id}]`;
+        assert.dom(contribListSelector)
+            .exists({ count: 1 }, 'contributor added to list');
         await untrackedClick('[data-test-collection-project-contributors] [data-test-submit-section-continue]');
+        assert.dom(`[data-test-contributor-name="${userToAdd.id}"]`)
+            .exists({ count: 1 }, 'contributor added to summary');
+
+        // remove contributor
+        await untrackedClick(
+            '[data-test-collections-submit-section="projectContributors"] [data-test-submit-section-click-to-edit]',
+        );
+        await untrackedClick(`${contribListSelector} [data-test-project-contributors-list-item-remove-button]`);
+        assert.dom(contribListSelector)
+            .doesNotExist('contributor removed from list');
+        await untrackedClick('[data-test-collection-project-contributors] [data-test-submit-section-continue]');
+        assert.dom(`[data-test-contributor-name="${userToAdd.id}"]`)
+            .doesNotExist('contributor removed from summary');
+
+        /* Collection metadata */
 
         await percySnapshot('Collections | Acceptance | submit | collection metadata');
+
+        assert.dom('[data-test-collection-metadata] [data-test-submit-section-continue]')
+            .isDisabled('metadata continue is disabled');
+
         await untrackedClick('[data-test-metadata-field="collected_type_label"] .ember-power-select-trigger');
-        await untrackedClick('.ember-power-select-option');
+        const firstCollectedTypeOption = document.querySelector('.ember-power-select-option');
+        if (firstCollectedTypeOption) {
+            await untrackedClick(firstCollectedTypeOption);
+        } else {
+            throw new Error('could not find collected type option');
+        }
+
         await untrackedClick('[data-test-metadata-field="issue_label"] .ember-power-select-trigger');
-        await untrackedClick('.ember-power-select-option');
+        const firstIssueOption = document.querySelector('.ember-power-select-option');
+        if (firstIssueOption) {
+            await untrackedClick(firstIssueOption);
+        } else {
+            throw new Error('could not find issue option');
+        }
+
         await untrackedClick('[data-test-metadata-field="program_area_label"] .ember-power-select-trigger');
-        await untrackedClick('.ember-power-select-option');
+        const firstProgramAreaOption = document.querySelector('.ember-power-select-option');
+        if (firstProgramAreaOption) {
+            await untrackedClick(firstProgramAreaOption);
+        } else {
+            throw new Error('could not find program area option');
+        }
+
         await untrackedClick('[data-test-metadata-field="status_label"] .ember-power-select-trigger');
-        await untrackedClick('.ember-power-select-option');
+        const firstStatusOption = document.querySelector('.ember-power-select-option');
+        if (firstStatusOption) {
+            await untrackedClick(firstStatusOption);
+        } else {
+            throw new Error('could not find status option');
+        }
+
         await untrackedClick('[data-test-metadata-field="volume_label"] .ember-power-select-trigger');
-        await untrackedClick('.ember-power-select-option');
+        const firstVolumeOption = document.querySelector('.ember-power-select-option');
+        if (firstVolumeOption) {
+            await untrackedClick(firstVolumeOption);
+        } else {
+            throw new Error('could not find volume option');
+        }
+
+        assert.dom('[data-test-collection-metadata] [data-test-submit-section-continue]')
+            .isNotDisabled('metadata continue is not disabled');
         await untrackedClick('[data-test-collection-metadata] [data-test-submit-section-continue]');
+
+        const metadataValueSelector = '[data-test-collection-metadata-complete-field-value]';
+        const collection = await collectionProvider.get('primaryCollection');
+        assert.dom(`[data-test-collection-metadata-complete-field="collectedType"] ${metadataValueSelector}`)
+            .hasText(collection.collectedTypeChoices[0], 'collected type in summary');
+        assert.dom(`[data-test-collection-metadata-complete-field="issue"] ${metadataValueSelector}`)
+            .hasText(collection.issueChoices[0], 'issue in summary');
+        assert.dom(`[data-test-collection-metadata-complete-field="programArea"] ${metadataValueSelector}`)
+            .hasText(collection.programAreaChoices[0], 'program area in summary');
+        assert.dom(`[data-test-collection-metadata-complete-field="status"] ${metadataValueSelector}`)
+            .hasText(collection.statusChoices[0], 'status in summary');
+        assert.dom(`[data-test-collection-metadata-complete-field="volume"] ${metadataValueSelector}`)
+            .hasText(collection.volumeChoices[0], 'volume in summary');
+
+        /* Add to collection */
+
         await click('[data-test-collections-submit-submit-button]');
+        assert.dom('[data-test-collection-submission-confirmation-modal-header]')
+            .exists({ count: 1 }, 'confirmation modal is displayed');
 
         await percySnapshot('Collections | Acceptance | submit | confirm public modal');
+
+        await click('[data-test-collection-submission-confirmation-modal-cancel-button]');
+        assert.dom('[data-test-collection-submission-confirmation-modal-header]')
+            .doesNotExist('confirmation modal is dismissed');
     });
 });

--- a/tests/engines/collections/acceptance/submit/submit-test.ts
+++ b/tests/engines/collections/acceptance/submit/submit-test.ts
@@ -55,7 +55,7 @@ module('Collections | Acceptance | submit', hooks => {
         await untrackedClick('[data-test-metadata-field="volume_label"] .ember-power-select-trigger');
         await untrackedClick('.ember-power-select-option');
         await untrackedClick('[data-test-collection-metadata] [data-test-submit-section-continue]');
-        await click('[data-test-collection-submit]');
+        await click('[data-test-collections-submit-submit-button]');
 
         await percySnapshot('Collections | Acceptance | submit | confirm public modal');
     });

--- a/tests/engines/collections/acceptance/submit/submit-test.ts
+++ b/tests/engines/collections/acceptance/submit/submit-test.ts
@@ -36,9 +36,9 @@ module('Collections | Acceptance | submit', hooks => {
         await untrackedClick(`[data-test-collections-node-title="${nodeToBeAdded.title}"]`);
 
         await percySnapshot('Collections | Acceptance | submit | project metadata');
-        await untrackedClick('[data-test-collections-license-picker] .ember-power-select-trigger');
+        await untrackedClick('[data-test-project-metadata-license-picker] .ember-power-select-trigger');
         await untrackedClick('.ember-power-select-option');
-        await untrackedClick('[data-test-project-metadata-continue]');
+        await untrackedClick('[data-test-project-metadata-save-button]');
 
         await percySnapshot('Collections | Acceptance | submit | project contributors');
         await untrackedClick('[data-test-collection-project-contributors] [data-test-submit-section-continue]');

--- a/tests/engines/collections/acceptance/update/update-test.ts
+++ b/tests/engines/collections/acceptance/update/update-test.ts
@@ -39,7 +39,7 @@ module('Collections | Acceptance | update', hooks => {
         });
         await visit(`/collections/${provider.id}/${nodeAdded.id}/edit`);
         await percySnapshot('Collections | Acceptance | update | project metadata');
-        await untrackedClick('[data-test-project-metadata-continue]');
+        await untrackedClick('[data-test-project-metadata-save-button]');
         await percySnapshot('Collections | Acceptance | update | project contributors');
         await untrackedClick('[data-test-collection-project-contributors] [data-test-submit-section-continue]');
         await percySnapshot('Collections | Acceptance | update | collection metadata');

--- a/tests/engines/collections/integration/components/collection-submission-confirmation-modal/component-test.ts
+++ b/tests/engines/collections/integration/components/collection-submission-confirmation-modal/component-test.ts
@@ -14,16 +14,16 @@ module('Integration | Component | collection-submission-confirmation-modal', hoo
             openModal=true addToCollection=(action this.noop)
             cancel=(action this.noop)
         }}`);
-        assert.dom('[data-test-modal-header]').hasText(
+        assert.dom('[data-test-collection-submission-confirmation-modal-header]').hasText(
             t('collections.collection_submission_confirmation_modal.header').toString(),
         );
-        assert.dom('[data-test-modal-body]').hasText(
+        assert.dom('[data-test-collection-submission-confirmation-modal-body]').hasText(
             t('collections.collection_submission_confirmation_modal.body').toString(),
         );
-        assert.dom('[data-test-button-cancel]').hasText(
+        assert.dom('[data-test-collection-submission-confirmation-modal-cancel-button]').hasText(
             t('general.cancel').toString(),
         );
-        assert.dom('[data-test-button-success]').hasText(
+        assert.dom('[data-test-collection-submission-confirmation-modal-add-button]').hasText(
             t('collections.collection_submission_confirmation_modal.add_button').toString(),
         );
     });
@@ -40,7 +40,7 @@ module('Integration | Component | collection-submission-confirmation-modal', hoo
             addToCollection=(action this.externalSaveAction)
             cancel=(action this.noop)
         }}`);
-        await click('[data-test-button-success]');
+        await click('[data-test-collection-submission-confirmation-modal-add-button]');
     });
 
     test('Cancel button calls cancel action', async function(assert) {
@@ -55,6 +55,6 @@ module('Integration | Component | collection-submission-confirmation-modal', hoo
             addToCollection=(action this.noop)
             cancel=(action this.externalCancelAction)
         }}`);
-        await click('[data-test-button-cancel]');
+        await click('[data-test-collection-submission-confirmation-modal-cancel-button]');
     });
 });

--- a/tests/index.html
+++ b/tests/index.html
@@ -26,6 +26,7 @@
     {{content-for "test-head-footer"}}
   </head>
   <body>
+    <div id="ember-basic-dropdown-wormhole"></div>
     {{content-for "body"}}
     {{content-for "test-body"}}
 


### PR DESCRIPTION
- Ticket: [ENG-670]
- Feature flag: n/a

## Purpose

This PR adds test selectors and improves the collections submit acceptance test to perform actual assertions (previously just Percy snapshots).

## Summary of Changes

### Changed
- Components
    - `project-contributors`
        - added `onAddContributor` hook
- Engines
    - `collections`
        - Tests
            - added/improved test selectors to templates related to submit
            - improved submit acceptance tests to perform assertions in addition to taking snapshots
- Tests
    - added `ember-basic-dropdown-wormhole` div to test index.html

### Fixed
- Engines
    - `collections`
        - `submit`
            - reload bibliographicContributors when adding a contributor

## Side Effects

None expected.

## QA Notes

This should be tested as part of the full regression. The only functional change in this PR is to reload bibliographic contributors after adding a new contributor so that the contributor list displayed when the project contributors panel is collapsed is updated.


[ENG-670]: https://openscience.atlassian.net/browse/ENG-670