### PR TITLE
[ENG-730]Add schema chunking utility

### DIFF
--- a/app/models/registration-schema.ts
+++ b/app/models/registration-schema.ts
@@ -60,8 +60,8 @@ export default class RegistrationSchemaModel extends OsfModel {
     @attr('number') schemaVersion!: number;
     @attr('object') schema!: Schema;
 
-    @hasMany('schema-block', { inverse: null })
-    schemaBlocks!: DS.PromiseManyArray<SchemaBlock>;
+    @hasMany('schema-block', { inverse: null, async: false })
+    schemaBlocks!: DS.PromiseManyArray<SchemaBlock> | SchemaBlock[];
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/models/schema-block.ts
+++ b/app/models/schema-block.ts
@@ -2,14 +2,24 @@ import { attr } from '@ember-decorators/data';
 
 import OsfModel from './osf-model';
 
-export default class SchemaBlockModel extends OsfModel {
+export interface SchemaBlock {
+    blockType?: string;
+    chunkId?: string;
+    answerId?: string;
+    displayText?: string;
+    helpText?: string;
+    required?: boolean;
+    index?: number;
+}
+
+export default class SchemaBlockModel extends OsfModel implements SchemaBlock {
     @attr('string') blockType?: string;
     @attr('string') chunkId?: string;
     @attr('string') answerId?: string;
     @attr('string') displayText?: string;
     @attr('string') helpText?: string;
     @attr('boolean') required?: boolean;
-    @attr('number') index!: number;
+    @attr('number') index?: number;
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/utils/schema-blocks.ts
+++ b/app/utils/schema-blocks.ts
@@ -1,0 +1,92 @@
+import { assert } from '@ember/debug';
+import { SchemaBlock } from 'ember-osf-web/models/schema-block';
+
+export class QuestionChunk {
+  labelBlock?: SchemaBlock;
+  inputBlock?: SchemaBlock;
+  optionBlocks?: SchemaBlock[];
+  chunkId?: string;
+  answerId?: string;
+}
+
+function isEmpty(input: string | undefined) {
+    if (input === undefined || input === null || input === '') {
+        return true;
+    }
+    return false;
+}
+
+export function getPages(blocks: SchemaBlock[]) {
+    const pageArray = blocks.reduce(
+        (pages, block) => {
+            // instantiate first page if the schema doesn't start with a page-heading
+            if (pages.length === 0 && block.blockType !== 'page-heading') {
+                const blankPage: SchemaBlock[] = [];
+                pages.push(blankPage);
+            }
+
+            const lastPage: Array<SchemaBlock | QuestionChunk> = pages.slice(-1)[0];
+            if (block.blockType === 'page-heading') {
+                pages.push([block]);
+            } else {
+                lastPage.push(block);
+            }
+            return pages;
+        },
+        [] as Array<Array<SchemaBlock | QuestionChunk>>,
+    );
+    return pageArray;
+}
+
+export function getQuestionChunk(blocks: SchemaBlock[], id: string) {
+    const questionChunk: QuestionChunk = {};
+    blocks.forEach(block => {
+        if (block.chunkId === id) {
+            switch (block.blockType) {
+            case 'question-title':
+                questionChunk.labelBlock = block;
+                break;
+            case 'long-text-input':
+            case 'short-text-input':
+            case 'file-input':
+            case 'contributors-input':
+            case 'single-select-input':
+            case 'multi-select-input':
+                assert('input block with no answerID!', !isEmpty(block.answerId));
+                assert('input block with no chunkID!', !isEmpty(block.chunkId));
+                assert('question with multiple input blocks!', !questionChunk.inputBlock);
+                if (questionChunk.chunkId) {
+                    assert('question with mismatched chunkID!', questionChunk.chunkId === block.chunkId);
+                } else {
+                    questionChunk.chunkId = block.chunkId;
+                }
+                questionChunk.inputBlock = block;
+                questionChunk.answerId = block.answerId;
+                break;
+            case 'select-input-option':
+                if (questionChunk.inputBlock) {
+                    assert('question with mismatched chunkID!',
+                        !isEmpty(block.chunkId) && questionChunk.chunkId === block.chunkId);
+                    questionChunk.optionBlocks = [
+                        ...(questionChunk.optionBlocks || []),
+                        block,
+                    ];
+                } else {
+                    assert('select-option without a question!');
+                }
+                break;
+            default:
+                break;
+            }
+        }
+    });
+    assert('question chunk with no input element',
+        questionChunk.inputBlock !== null && questionChunk.inputBlock !== undefined);
+    if ((questionChunk.inputBlock) &&
+        (questionChunk.inputBlock.blockType === 'single-select-input' ||
+        questionChunk.inputBlock.blockType === 'multi-select-input')) {
+        assert('single/multi select with no option',
+            questionChunk.optionBlocks && questionChunk.optionBlocks.length > 0);
+    }
+    return questionChunk;
+}

--- a/tests/unit/utils/schema-blocks-test.ts
+++ b/tests/unit/utils/schema-blocks-test.ts
@@ -1,0 +1,231 @@
+import { SchemaBlock } from 'ember-osf-web/models/schema-block';
+import { getPages, getQuestionChunk } from 'ember-osf-web/utils/schema-blocks';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | schema-blocks', () => {
+    test('Chunk multipage schema', assert => {
+        const multipageSchema: SchemaBlock[] = [
+            {
+                blockType: 'page-heading',
+                displayText: 'First Page',
+                index: 0,
+            },
+            {
+                blockType: 'section-heading',
+                displayText: 'Section in the First Page',
+                index: 1,
+            },
+            {
+                blockType: 'question-title',
+                displayText: 'Question Title in the First Page',
+                chunkId: 'q1',
+                index: 2,
+            },
+            {
+                blockType: 'short-text-input',
+                displayText: 'Text Input in the First Page',
+                chunkId: 'q1',
+                answerId: 'a1',
+                index: 3,
+            },
+            {
+                blockType: 'page-heading',
+                displayText: 'Second Page',
+                index: 4,
+            },
+            {
+                blockType: 'section-heading',
+                displayText: 'Section in the Second Page',
+                index: 5,
+            },
+            {
+                blockType: 'question-title',
+                displayText: 'Single Select on Page Two',
+                chunkId: 'q2',
+                index: 6,
+            },
+            {
+                blockType: 'single-select-input',
+                chunkId: 'q2',
+                answerId: 'a2',
+                index: 7,
+            },
+            {
+                blockType: 'select-input-option',
+                displayText: 'Opt1 for Single Select',
+                chunkId: 'q2',
+                index: 8,
+            },
+            {
+                blockType: 'select-input-option',
+                displayText: 'Opt2 for Single Select',
+                chunkId: 'q2',
+                index: 9,
+            },
+            {
+                blockType: 'page-heading',
+                displayText: 'Third Page',
+                index: 10,
+            },
+            {
+                blockType: 'section-heading',
+                displayText: 'Section in the Third Page',
+                index: 11,
+            },
+        ];
+        const result = getPages(multipageSchema);
+        assert.equal(result.length, 3, 'has proper page length');
+    });
+
+    test('Chunk single page schema', assert => {
+        const singlepageSchema: SchemaBlock[] = [
+            {
+                blockType: 'page-heading',
+                displayText: 'First Page',
+                index: 0,
+            },
+            {
+                blockType: 'section-heading',
+                displayText: 'Section in the First Page',
+                index: 1,
+            },
+            {
+                blockType: 'question-title',
+                displayText: 'Question Title in the First Page',
+                chunkId: 'q1',
+                index: 2,
+            },
+            {
+                blockType: 'short-text-input',
+                displayText: 'Text Input in the First Page',
+                chunkId: 'q1',
+                answerId: 'a1',
+                index: 3,
+            },
+        ];
+        const result = getPages(singlepageSchema);
+        assert.equal(result.length, 1, 'has proper page length');
+    });
+
+    test('Chunk schema with no page-heading', assert => {
+        const noPageHeadingSchema: SchemaBlock[] = [
+            {
+                blockType: 'section-heading',
+                displayText: 'Section in the First Page',
+                index: 0,
+            },
+            {
+                blockType: 'question-title',
+                displayText: 'Question Title in the First Page',
+                chunkId: 'q1',
+                index: 1,
+            },
+            {
+                blockType: 'short-text-input',
+                displayText: 'Text Input in the First Page',
+                chunkId: 'q1',
+                answerId: 'a1',
+                index: 2,
+            },
+        ];
+        const result = getPages(noPageHeadingSchema);
+        assert.equal(result.length, 1, 'has proper page length');
+    });
+
+    test('Chunk stand alone input as question chunk', assert => {
+        const standAloneSchema: SchemaBlock[] = [
+            {
+                blockType: 'section-heading',
+                displayText: 'Section in the First Page',
+                index: 0,
+            },
+            {
+                blockType: 'short-text-input',
+                chunkId: 'q1',
+                answerId: 'a1',
+                index: 1,
+            },
+        ];
+        const result = getQuestionChunk(standAloneSchema, 'q1');
+        assert.equal(result.answerId, 'a1', 'has proper answerId');
+        assert.equal(result.chunkId, 'q1', 'has proper chunkId');
+        assert.ok(!result.optionBlocks, 'has proper optionBlocks');
+    });
+
+    test('Chunk multiple choice question as schema chunk', assert => {
+        const mulitSelectSchema: SchemaBlock[] = [
+            {
+                blockType: 'section-heading',
+                displayText: 'Extraneous heading',
+                index: 0,
+            },
+            {
+                blockType: 'question-title',
+                displayText: 'Multi Select',
+                chunkId: 'testMulti',
+                index: 1,
+            },
+            {
+                blockType: 'multi-select-input',
+                chunkId: 'testMulti',
+                answerId: 'testMultiAnswer',
+                index: 2,
+            },
+            {
+                blockType: 'select-input-option',
+                chunkId: 'testMulti',
+                displayText: 'Multi-option 1',
+                index: 3,
+            },
+            {
+                blockType: 'select-input-option',
+                chunkId: 'testMulti',
+                displayText: 'Multi-option 2',
+                index: 4,
+            },
+            {
+                blockType: 'select-input-option',
+                chunkId: 'testMulti',
+                displayText: 'Multi-option 3',
+                index: 5,
+            },
+        ];
+        const result = getQuestionChunk(mulitSelectSchema, 'testMulti');
+        assert.equal(result.answerId, 'testMultiAnswer', 'has proper answerId');
+        assert.equal(result.chunkId, 'testMulti', 'has proper chunkId');
+        assert.equal(result.optionBlocks!.length, 3, 'has proper optionBlocks');
+    });
+
+    test('Chunk single choice question as schema chunk', assert => {
+        const mulitSelectSchema: SchemaBlock[] = [
+            {
+                blockType: 'question-title',
+                displayText: 'Single Select',
+                chunkId: 'testSingle',
+                index: 0,
+            },
+            {
+                blockType: 'single-select-input',
+                chunkId: 'testSingle',
+                answerId: 'testSingleAnswer',
+                index: 1,
+            },
+            {
+                blockType: 'select-input-option',
+                chunkId: 'testSingle',
+                displayText: 'single-option 1',
+                index: 2,
+            },
+            {
+                blockType: 'select-input-option',
+                chunkId: 'testSingle',
+                displayText: 'single-option 2',
+                index: 3,
+            },
+        ];
+        const result = getQuestionChunk(mulitSelectSchema, 'testSingle');
+        assert.equal(result.answerId, 'testSingleAnswer', 'has proper answerId');
+        assert.equal(result.chunkId, 'testSingle', 'has proper chunkId');
+        assert.equal(result.optionBlocks!.length, 2, 'has proper optionsBlocks');
+    });
+});


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-730]
- Feature flag: n/a

## Purpose

This utility has functions that will group schema blocks by pages and also by chunkId. ChunkId is used to group together blocks pertaining to the same question.

## Summary of Changes

Added a utility to group SchemaBlocks into pages and QuestionChunks.

- SchemaBlocks are chunked into pages by `page-heading` blocks. If the schema has no `page-heading` block, it is chunked into one page.

- SchemaBlocks are chunked into `QuestionChunk` based on chunkId. `QuestionChunk`s must have an `inputBlock` and an `answerId`

Added tests for both functions.

## Side Effects
`NA`

## QA Notes
`NA`