### PR TITLE
[ENG-831] improved collections update acceptance test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         - added custom `post` handler to fix `create` action
     - `node/contributors` nested resource
         - conditionally create bibliographic contributors when creating contributors
+    - Factories
+        - `collected-metadatum`
+            - allow manual setting of collection metadata
     - Serializers
         - `contributors` - serialize correct nested self link
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         - Tests
             - added/improved test selectors to templates related to submit
             - improved submit acceptance tests to perform assertions in addition to taking snapshots
+            - improved update acceptance tests to perform assertions in addition to taking snapshots
 - Tests
     - added `ember-basic-dropdown-wormhole` div to test index.html 
 - Mirage

--- a/mirage/factories/collected-metadatum.ts
+++ b/mirage/factories/collected-metadatum.ts
@@ -8,24 +8,27 @@ export default Factory.extend<CollectedMetadatum>({
     id: guid('collected-metadatum'),
     afterCreate(collectedMetadatum, server) {
         guidAfterCreate(collectedMetadatum, server);
-        const collectedType = faker.random.arrayElement(collectedMetadatum.collection.collectedTypeChoices);
-        const issue = faker.random.arrayElement(collectedMetadatum.collection.issueChoices);
-        const programArea = faker.random.arrayElement(collectedMetadatum.collection.programAreaChoices);
-        const status = faker.random.arrayElement(collectedMetadatum.collection.statusChoices);
-        const volume = faker.random.arrayElement(collectedMetadatum.collection.volumeChoices);
-        collectedMetadatum.update({
-            collectedType,
-            issue,
-            programArea,
-            status,
-            volume,
-        });
+        if (!collectedMetadatum.collectedType) {
+            const collectedType = faker.random.arrayElement(collectedMetadatum.collection.collectedTypeChoices);
+            collectedMetadatum.update({ collectedType });
+        }
+        if (!collectedMetadatum.issue) {
+            const issue = faker.random.arrayElement(collectedMetadatum.collection.issueChoices);
+            collectedMetadatum.update({ issue });
+        }
+        if (!collectedMetadatum.programArea) {
+            const programArea = faker.random.arrayElement(collectedMetadatum.collection.programAreaChoices);
+            collectedMetadatum.update({ programArea });
+        }
+        if (!collectedMetadatum.status) {
+            const status = faker.random.arrayElement(collectedMetadatum.collection.statusChoices);
+            collectedMetadatum.update({ status });
+        }
+        if (!collectedMetadatum.volume) {
+            const volume = faker.random.arrayElement(collectedMetadatum.collection.volumeChoices);
+            collectedMetadatum.update({ volume });
+        }
     },
-    collectedType: faker.lorem.word,
-    issue: faker.lorem.word,
-    programArea: faker.lorem.word,
-    status: faker.lorem.word,
-    volume: faker.lorem.word,
 });
 
 declare module 'ember-cli-mirage/types/registries/schema' {

--- a/tests/engines/collections/acceptance/update/update-test.ts
+++ b/tests/engines/collections/acceptance/update/update-test.ts
@@ -1,8 +1,10 @@
-import { click as untrackedClick } from '@ember/test-helpers';
+import { click as untrackedClick, fillIn } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { percySnapshot } from 'ember-percy';
 import { module, test } from 'qunit';
 
+import Collection from 'ember-osf-web/models/collection';
+import CollectionProvider from 'ember-osf-web/models/collection-provider';
 import { Permission } from 'ember-osf-web/models/osf-model';
 import { visit } from 'ember-osf-web/tests/helpers';
 import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
@@ -11,7 +13,7 @@ module('Collections | Acceptance | update', hooks => {
     setupEngineApplicationTest(hooks, 'collections');
     setupMirage(hooks);
 
-    test('it renders', async () => {
+    test('it works', async function(assert) {
         server.loadFixtures('licenses');
         const licensesAcceptable = server.schema.licenses.all().models;
         const currentUser = server.create('user', 'loggedIn');
@@ -26,24 +28,183 @@ module('Collections | Acceptance | update', hooks => {
             users: currentUser,
             index: 0,
         });
+        const store = this.owner.lookup('service:store');
+        const collection: Collection = await store.findRecord('collection', primaryCollection.id);
+        collection.collectedTypeChoices.sort();
+        collection.issueChoices.sort();
+        collection.programAreaChoices.sort();
+        collection.statusChoices.sort();
+        collection.volumeChoices.sort();
         server.create('collected-metadatum', {
             creator: currentUser,
             guid: nodeAdded,
             id: nodeAdded.id,
             collection: primaryCollection,
+            collectedType: collection.collectedTypeChoices[0],
+            issue: collection.issueChoices[0],
+            programArea: collection.programAreaChoices[0],
+            status: collection.statusChoices[0],
+            volume: collection.volumeChoices[0],
         });
         const provider = server.create('collection-provider', {
             id: 'studyswap',
             primaryCollection,
             licensesAcceptable,
         });
+
+        const newTitle = 'New Title';
+        const newDescription = 'New description.';
+
         await visit(`/collections/${provider.id}/${nodeAdded.id}/edit`);
+
+        /* Project metadata */
+
+        await fillIn('[data-test-project-metadata-title] input', newTitle);
+        await fillIn('[data-test-project-metadata-description] textarea', newDescription);
+        // open license picker
+        await untrackedClick('[data-test-project-metadata-license-picker] .ember-power-select-trigger');
+        // select first license
+        const firstLicenseOption = document.querySelector('.ember-power-select-option');
+        if (firstLicenseOption) {
+            await untrackedClick(firstLicenseOption);
+        }
+        // remove third tag
+        await untrackedClick(`[data-test-project-metadata-tag="${nodeAdded.tags[2]}"] + .emberTagInput-remove`);
+
         await percySnapshot('Collections | Acceptance | update | project metadata');
         await untrackedClick('[data-test-project-metadata-save-button]');
-        await percySnapshot('Collections | Acceptance | update | project contributors');
+
+        assert.dom('[data-test-project-metadata-complete-title-value]')
+            .hasText(newTitle, 'title is updated');
+        assert.dom('[data-test-project-metadata-complete-description-value]')
+            .hasText(newDescription, 'description is updated');
+        const collectionProvider: CollectionProvider = store.peekRecord('collection-provider', provider.id);
+        const licenses = await collectionProvider.get('licensesAcceptable');
+        const firstLicense = licenses.get('firstObject');
+        assert.dom('[data-test-project-metadata-complete-license-name-value]')
+            .hasText(firstLicense ? firstLicense.name : '', 'license is updated');
+        assert.dom('[data-test-project-metadata-complete-tag]')
+            .exists({ count: 4 }, 'only four tags remain');
+        nodeAdded.tags.forEach(tag =>
+            assert.dom(`[data-test-project-metadata-complete-tag="${tag}"]`)
+                .exists({ count: 1 }, `found tag: "${tag}"`));
+
+        /* Project contributors */
+
+        // add contributor
+        const userToAdd = server.create('user');
+        await fillIn('[data-test-project-contributors-search-box] input', userToAdd.fullName);
+        await untrackedClick('[data-test-project-contributors-search-button]');
+        const userToAddSelector = `[data-test-project-contributors-search-user="${userToAdd.id}"]`;
+        assert.dom(userToAddSelector)
+            .exists({ count: 1 }, 'found contributor');
+        await untrackedClick(`${userToAddSelector} [data-test-project-contributors-add-contributor-button]`);
+        const contribListSelector = `[data-test-project-contributors-list-item-id=${userToAdd.id}]`;
+        assert.dom(contribListSelector)
+            .exists({ count: 1 }, 'contributor added to list');
+
+        await percySnapshot('Collections | Acceptance | update | added project contributor');
         await untrackedClick('[data-test-collection-project-contributors] [data-test-submit-section-continue]');
+
+        assert.dom(`[data-test-contributor-name="${userToAdd.id}"]`)
+            .exists({ count: 1 }, 'contributor added to summary');
+
+        // remove contributor
+        await untrackedClick(
+            '[data-test-collections-submit-section="projectContributors"] [data-test-submit-section-click-to-edit]',
+        );
+        await untrackedClick(`${contribListSelector} [data-test-project-contributors-list-item-remove-button]`);
+        assert.dom(contribListSelector)
+            .doesNotExist('contributor removed from list');
+
+        await percySnapshot('Collections | Acceptance | update | removed project contributor');
+        await untrackedClick('[data-test-collection-project-contributors] [data-test-submit-section-continue]');
+        assert.dom(`[data-test-contributor-name="${userToAdd.id}"]`)
+            .doesNotExist('contributor removed from summary');
+
+        /* Collection metadata */
+
+        await untrackedClick('[data-test-collection-metadata] [data-test-submit-section-continue]');
+        const metadataValueSelector = '[data-test-collection-metadata-complete-field-value]';
+
+        // confirm original values are first option
+        assert.dom(`[data-test-collection-metadata-complete-field="collectedType"] ${metadataValueSelector}`)
+            .hasText(collection.collectedTypeChoices[0], 'collected type in summary is first option');
+        assert.dom(`[data-test-collection-metadata-complete-field="issue"] ${metadataValueSelector}`)
+            .hasText(collection.issueChoices[0], 'issue in summary is first option');
+        assert.dom(`[data-test-collection-metadata-complete-field="programArea"] ${metadataValueSelector}`)
+            .hasText(collection.programAreaChoices[0], 'program area in summary is first option');
+        assert.dom(`[data-test-collection-metadata-complete-field="status"] ${metadataValueSelector}`)
+            .hasText(collection.statusChoices[0], 'status in summary is first option');
+        assert.dom(`[data-test-collection-metadata-complete-field="volume"] ${metadataValueSelector}`)
+            .hasText(collection.volumeChoices[0], 'volume in summary is first option');
+
+        await untrackedClick(
+            '[data-test-collections-submit-section="collectionMetadata"] [data-test-submit-section-click-to-edit]',
+        );
+
+        // set collected type to second option
+        await untrackedClick('[data-test-metadata-field="collected_type_label"] .ember-power-select-trigger');
+        const firstCollectedTypeOption = document.querySelector('[data-option-index="1"].ember-power-select-option');
+        if (firstCollectedTypeOption) {
+            await untrackedClick(firstCollectedTypeOption);
+        } else {
+            throw new Error('could not find collected type option');
+        }
+
+        // set issue to second option
+        await untrackedClick('[data-test-metadata-field="issue_label"] .ember-power-select-trigger');
+        const firstIssueOption = document.querySelector('[data-option-index="1"].ember-power-select-option');
+        if (firstIssueOption) {
+            await untrackedClick(firstIssueOption);
+        } else {
+            throw new Error('could not find issue option');
+        }
+
+        // set program area to second option
+        await untrackedClick('[data-test-metadata-field="program_area_label"] .ember-power-select-trigger');
+        const firstProgramAreaOption = document.querySelector('[data-option-index="1"].ember-power-select-option');
+        if (firstProgramAreaOption) {
+            await untrackedClick(firstProgramAreaOption);
+        } else {
+            throw new Error('could not find program area option');
+        }
+
+        // set status to second option
+        await untrackedClick('[data-test-metadata-field="status_label"] .ember-power-select-trigger');
+        const firstStatusOption = document.querySelector('[data-option-index="1"].ember-power-select-option');
+        if (firstStatusOption) {
+            await untrackedClick(firstStatusOption);
+        } else {
+            throw new Error('could not find status option');
+        }
+
+        // set volume to second option
+        await untrackedClick('[data-test-metadata-field="volume_label"] .ember-power-select-trigger');
+        const firstVolumeOption = document.querySelector('[data-option-index="1"].ember-power-select-option');
+        if (firstVolumeOption) {
+            await untrackedClick(firstVolumeOption);
+        } else {
+            throw new Error('could not find volume option');
+        }
+
         await percySnapshot('Collections | Acceptance | update | collection metadata');
         await untrackedClick('[data-test-collection-metadata] [data-test-submit-section-continue]');
+
+        // Confirm modified values are second option
+        assert.dom(`[data-test-collection-metadata-complete-field="collectedType"] ${metadataValueSelector}`)
+            .hasText(collection.collectedTypeChoices[1], 'collected type in summary is second option');
+        assert.dom(`[data-test-collection-metadata-complete-field="issue"] ${metadataValueSelector}`)
+            .hasText(collection.issueChoices[1], 'issue in summary is second option');
+        assert.dom(`[data-test-collection-metadata-complete-field="programArea"] ${metadataValueSelector}`)
+            .hasText(collection.programAreaChoices[1], 'program area in summary is second option');
+        assert.dom(`[data-test-collection-metadata-complete-field="status"] ${metadataValueSelector}`)
+            .hasText(collection.statusChoices[1], 'status in summary is second option');
+        assert.dom(`[data-test-collection-metadata-complete-field="volume"] ${metadataValueSelector}`)
+            .hasText(collection.volumeChoices[1], 'volume in summary is second option');
+
+        /* Finished */
+
         await percySnapshot('Collections | Acceptance | update | finished');
     });
 });


### PR DESCRIPTION
- Ticket: [ENG-831]
- Feature flag: n/a

## Purpose

This PR improves the collections update acceptance test to perform actual assertions (previously just Percy snapshots).

## Summary of Changes

### Changed
- Engines
    - `collections`
        - Tests
            - improved update acceptance tests to perform assertions in addition to taking snapshots

### Fixed
- Mirage
    - Factories
        - `collected-metadatum`
            - allow manual setting of collection metadata

## Side Effects

None expected.

## QA Notes

No QA needed specific to this PR.


[ENG-831]: https://openscience.atlassian.net/browse/ENG-831