### PR TITLE
[no ticket] fix: populate `relatedCounts` for all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
             - allow manual setting of collection metadata
     - Serializers
         - `contributors` - serialize correct nested self link
+- Serializers
+    - `relatedCounts` were not populated for resources loaded via `store.pushPayload`,
+      which includes all embeds and results from `OsfModel.queryHasMany`
 
 ## [19.8.0] - 2019-08-15
 ### Added


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: n/a
- Feature flag: n/a

## Purpose
I was trying to use `queryHasMany` to get a list of things with a `related_count`, and discovered that didn't work! The resulting model instances had `relatedCounts: undefined`. This fixes that.
<!-- Describe the purpose of your changes. -->

## Summary of Changes
Previously, related counts were gathered in the serializer's `normalizeSingleResponse` method, which is not used by `store.pushPayload`. This means `queryHasMany` results and embeds didn't have their `relatedCount` filled out.

This PR moves the `relatedCount` logic to the serializer's `normalize` method, which is always used for normalizing resources, regardless of where the resource came from.
<!-- Briefly describe or list your changes. -->

## Side Effects
none?
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
n/a
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
