### PR TITLE
[No ticket]Move schema-block utility to app/package/registration-schema

### DIFF
--- a/app/models/schema-block.ts
+++ b/app/models/schema-block.ts
@@ -1,31 +1,6 @@
 import { attr } from '@ember-decorators/data';
-
+import { SchemaBlock, SchemaBlockType } from 'ember-osf-web/packages/registration-schema/schema-block';
 import OsfModel from './osf-model';
-
-type SchemaBlockType =
-    'page-heading' |
-    'section-heading' |
-    'subsection-heading' |
-    'paragraph' |
-    'question-label' |
-    'short-text-input' |
-    'long-text-input' |
-    'file-input' |
-    'contributors-input' |
-    'multi-select-input' |
-    'single-select-input' |
-    'select-input-option' |
-    'select-other-option';
-
-export interface SchemaBlock {
-    blockType?: SchemaBlockType;
-    schemaBlockGroupKey?: string;
-    registrationResponseKey?: string;
-    displayText?: string;
-    helpText?: string;
-    required?: boolean;
-    index?: number;
-}
 
 export default class SchemaBlockModel extends OsfModel implements SchemaBlock {
     @attr('string') blockType?: SchemaBlockType;

--- a/app/models/schema-block.ts
+++ b/app/models/schema-block.ts
@@ -1,5 +1,5 @@
 import { attr } from '@ember-decorators/data';
-import { SchemaBlock, SchemaBlockType } from 'ember-osf-web/packages/registration-schema/schema-block';
+import { SchemaBlock, SchemaBlockType } from 'ember-osf-web/packages/registration-schema';
 import OsfModel from './osf-model';
 
 export default class SchemaBlockModel extends OsfModel implements SchemaBlock {

--- a/app/packages/registration-schema/get-pages.ts
+++ b/app/packages/registration-schema/get-pages.ts
@@ -1,0 +1,23 @@
+import { SchemaBlock } from 'ember-osf-web/packages/registration-schema/schema-block';
+
+export function getPages(blocks: SchemaBlock[]) {
+    const pageArray = blocks.reduce(
+        (pages, block) => {
+            // instantiate first page if the schema doesn't start with a page-heading
+            if (pages.length === 0 && block.blockType !== 'page-heading') {
+                const blankPage: SchemaBlock[] = [];
+                pages.push(blankPage);
+            }
+
+            const lastPage: SchemaBlock[] = pages.slice(-1)[0];
+            if (block.blockType === 'page-heading') {
+                pages.push([block]);
+            } else {
+                lastPage.push(block);
+            }
+            return pages;
+        },
+        [] as SchemaBlock[][],
+    );
+    return pageArray;
+}

--- a/app/packages/registration-schema/get-pages.ts
+++ b/app/packages/registration-schema/get-pages.ts
@@ -1,4 +1,4 @@
-import { SchemaBlock } from 'ember-osf-web/packages/registration-schema/schema-block';
+import { SchemaBlock } from 'ember-osf-web/packages/registration-schema';
 
 export function getPages(blocks: SchemaBlock[]) {
     const pageArray = blocks.reduce(

--- a/app/packages/registration-schema/get-schema-block-group.ts
+++ b/app/packages/registration-schema/get-schema-block-group.ts
@@ -1,6 +1,5 @@
 import { assert } from '@ember/debug';
-import { SchemaBlock } from 'ember-osf-web/packages/registration-schema/schema-block';
-import { SchemaBlockGroup } from 'ember-osf-web/packages/registration-schema/schema-block-group';
+import { SchemaBlock, SchemaBlockGroup } from 'ember-osf-web/packages/registration-schema';
 
 function isEmpty(input: string | undefined) {
     if (input === undefined || input === null || input === '') {

--- a/app/packages/registration-schema/get-schema-block-group.ts
+++ b/app/packages/registration-schema/get-schema-block-group.ts
@@ -1,41 +1,12 @@
 import { assert } from '@ember/debug';
-import { SchemaBlock } from 'ember-osf-web/models/schema-block';
-
-export interface SchemaBlockGroup {
-  labelBlock?: SchemaBlock;
-  inputBlock?: SchemaBlock;
-  optionBlocks?: SchemaBlock[];
-  schemaBlockGroupKey?: string;
-  registrationResponseKey?: string;
-}
+import { SchemaBlock } from 'ember-osf-web/packages/registration-schema/schema-block';
+import { SchemaBlockGroup } from 'ember-osf-web/packages/registration-schema/schema-block-group';
 
 function isEmpty(input: string | undefined) {
     if (input === undefined || input === null || input === '') {
         return true;
     }
     return false;
-}
-
-export function getPages(blocks: SchemaBlock[]) {
-    const pageArray = blocks.reduce(
-        (pages, block) => {
-            // instantiate first page if the schema doesn't start with a page-heading
-            if (pages.length === 0 && block.blockType !== 'page-heading') {
-                const blankPage: SchemaBlock[] = [];
-                pages.push(blankPage);
-            }
-
-            const lastPage: SchemaBlock[] = pages.slice(-1)[0];
-            if (block.blockType === 'page-heading') {
-                pages.push([block]);
-            } else {
-                lastPage.push(block);
-            }
-            return pages;
-        },
-        [] as SchemaBlock[][],
-    );
-    return pageArray;
 }
 
 export function getSchemaBlockGroup(blocks: SchemaBlock[], key: string) {

--- a/app/packages/registration-schema/index.ts
+++ b/app/packages/registration-schema/index.ts
@@ -1,2 +1,4 @@
 export { getPages } from './get-pages';
 export { getSchemaBlockGroup } from './get-schema-block-group';
+export { SchemaBlock, SchemaBlockType } from './schema-block';
+export { SchemaBlockGroup } from './schema-block-group';

--- a/app/packages/registration-schema/index.ts
+++ b/app/packages/registration-schema/index.ts
@@ -1,0 +1,2 @@
+export { getPages } from './get-pages';
+export { getSchemaBlockGroup } from './get-schema-block-group';

--- a/app/packages/registration-schema/schema-block-group.ts
+++ b/app/packages/registration-schema/schema-block-group.ts
@@ -1,0 +1,9 @@
+import { SchemaBlock } from 'ember-osf-web/packages/registration-schema/schema-block';
+
+export interface SchemaBlockGroup {
+    labelBlock?: SchemaBlock;
+    inputBlock?: SchemaBlock;
+    optionBlocks?: SchemaBlock[];
+    schemaBlockGroupKey?: string;
+    registrationResponseKey?: string;
+  }

--- a/app/packages/registration-schema/schema-block-group.ts
+++ b/app/packages/registration-schema/schema-block-group.ts
@@ -1,4 +1,4 @@
-import { SchemaBlock } from 'ember-osf-web/packages/registration-schema/schema-block';
+import { SchemaBlock } from 'ember-osf-web/packages/registration-schema';
 
 export interface SchemaBlockGroup {
     labelBlock?: SchemaBlock;

--- a/app/packages/registration-schema/schema-block.ts
+++ b/app/packages/registration-schema/schema-block.ts
@@ -1,0 +1,24 @@
+export type SchemaBlockType =
+    'page-heading' |
+    'section-heading' |
+    'subsection-heading' |
+    'paragraph' |
+    'question-label' |
+    'short-text-input' |
+    'long-text-input' |
+    'file-input' |
+    'contributors-input' |
+    'multi-select-input' |
+    'single-select-input' |
+    'select-input-option' |
+    'select-other-option';
+
+export interface SchemaBlock {
+    blockType?: SchemaBlockType;
+    schemaBlockGroupKey?: string;
+    registrationResponseKey?: string;
+    displayText?: string;
+    helpText?: string;
+    required?: boolean;
+    index?: number;
+}

--- a/tests/unit/packages/registration-schema/get-pages-test.ts
+++ b/tests/unit/packages/registration-schema/get-pages-test.ts
@@ -1,5 +1,4 @@
-import { getPages } from 'ember-osf-web/packages/registration-schema/get-pages';
-import { SchemaBlock } from 'ember-osf-web/packages/registration-schema/schema-block';
+import { getPages, SchemaBlock } from 'ember-osf-web/packages/registration-schema';
 import { module, test } from 'qunit';
 
 module('Unit | Packages | registration-schema | get-pages', () => {

--- a/tests/unit/packages/registration-schema/get-pages-test.ts
+++ b/tests/unit/packages/registration-schema/get-pages-test.ts
@@ -1,8 +1,8 @@
-import { SchemaBlock } from 'ember-osf-web/models/schema-block';
-import { getPages, getSchemaBlockGroup } from 'ember-osf-web/utils/schema-blocks';
+import { getPages } from 'ember-osf-web/packages/registration-schema/get-pages';
+import { SchemaBlock } from 'ember-osf-web/packages/registration-schema/schema-block';
 import { module, test } from 'qunit';
 
-module('Unit | Utility | schema-blocks', () => {
+module('Unit | Packages | registration-schema | get-pages', () => {
     test('Group multipage schema', assert => {
         const multipageSchema: SchemaBlock[] = [
             {
@@ -130,102 +130,5 @@ module('Unit | Utility | schema-blocks', () => {
         ];
         const result = getPages(noPageHeadingSchema);
         assert.equal(result.length, 1, 'has proper page length');
-    });
-
-    test('Group stand alone input as question group', assert => {
-        const standAloneSchema: SchemaBlock[] = [
-            {
-                blockType: 'section-heading',
-                displayText: 'Section in the First Page',
-                index: 0,
-            },
-            {
-                blockType: 'short-text-input',
-                schemaBlockGroupKey: 'q1',
-                registrationResponseKey: 'a1',
-                index: 1,
-            },
-        ];
-        const result = getSchemaBlockGroup(standAloneSchema, 'q1');
-        assert.equal(result.registrationResponseKey, 'a1', 'has proper registrationResponseKey');
-        assert.equal(result.schemaBlockGroupKey, 'q1', 'has proper schemaBlockGroupKey');
-        assert.ok(!result.optionBlocks, 'has proper optionBlocks');
-    });
-
-    test('Group multiple choice question as schema block group', assert => {
-        const mulitSelectSchema: SchemaBlock[] = [
-            {
-                blockType: 'section-heading',
-                displayText: 'Extraneous heading',
-                index: 0,
-            },
-            {
-                blockType: 'question-label',
-                displayText: 'Multi Select',
-                schemaBlockGroupKey: 'testMulti',
-                index: 1,
-            },
-            {
-                blockType: 'multi-select-input',
-                schemaBlockGroupKey: 'testMulti',
-                registrationResponseKey: 'testMultiAnswer',
-                index: 2,
-            },
-            {
-                blockType: 'select-input-option',
-                schemaBlockGroupKey: 'testMulti',
-                displayText: 'Multi-option 1',
-                index: 3,
-            },
-            {
-                blockType: 'select-input-option',
-                schemaBlockGroupKey: 'testMulti',
-                displayText: 'Multi-option 2',
-                index: 4,
-            },
-            {
-                blockType: 'select-input-option',
-                schemaBlockGroupKey: 'testMulti',
-                displayText: 'Multi-option 3',
-                index: 5,
-            },
-        ];
-        const result = getSchemaBlockGroup(mulitSelectSchema, 'testMulti');
-        assert.equal(result.registrationResponseKey, 'testMultiAnswer', 'has proper registrationResponseKey');
-        assert.equal(result.schemaBlockGroupKey, 'testMulti', 'has proper schemaBlockGroupKey');
-        assert.equal(result.optionBlocks!.length, 3, 'has proper optionBlocks');
-    });
-
-    test('Group single choice question as schema block group', assert => {
-        const mulitSelectSchema: SchemaBlock[] = [
-            {
-                blockType: 'question-label',
-                displayText: 'Single Select',
-                schemaBlockGroupKey: 'testSingle',
-                index: 0,
-            },
-            {
-                blockType: 'single-select-input',
-                schemaBlockGroupKey: 'testSingle',
-                registrationResponseKey: 'testSingleAnswer',
-                index: 1,
-            },
-            {
-                blockType: 'select-input-option',
-                schemaBlockGroupKey: 'testSingle',
-                displayText: 'single-option 1',
-                index: 2,
-            },
-            {
-                blockType: 'select-input-option',
-                schemaBlockGroupKey: 'testSingle',
-                displayText: 'single-option 2',
-                index: 3,
-            },
-        ];
-        const result = getSchemaBlockGroup(mulitSelectSchema, 'testSingle');
-        assert.equal(result.registrationResponseKey, 'testSingleAnswer', 'has proper registrationResponseKey');
-        assert.equal(result.schemaBlockGroupKey, 'testSingle', 'has proper schemaBlockGroupKey');
-        assert.equal(result.optionBlocks!.length, 2, 'has proper optionsBlocks');
     });
 });

--- a/tests/unit/packages/registration-schema/get-schema-block-group-test.ts
+++ b/tests/unit/packages/registration-schema/get-schema-block-group-test.ts
@@ -1,0 +1,102 @@
+import { getSchemaBlockGroup } from 'ember-osf-web/packages/registration-schema/get-schema-block-group';
+import { SchemaBlock } from 'ember-osf-web/packages/registration-schema/schema-block';
+import { module, test } from 'qunit';
+
+module('Unit | Packages | registration-schema | get-schema-block-group', () => {
+    test('Group stand alone input as question group', assert => {
+        const standAloneSchema: SchemaBlock[] = [
+            {
+                blockType: 'section-heading',
+                displayText: 'Section in the First Page',
+                index: 0,
+            },
+            {
+                blockType: 'short-text-input',
+                schemaBlockGroupKey: 'q1',
+                registrationResponseKey: 'a1',
+                index: 1,
+            },
+        ];
+        const result = getSchemaBlockGroup(standAloneSchema, 'q1');
+        assert.equal(result.registrationResponseKey, 'a1', 'has proper registrationResponseKey');
+        assert.equal(result.schemaBlockGroupKey, 'q1', 'has proper schemaBlockGroupKey');
+        assert.ok(!result.optionBlocks, 'has proper optionBlocks');
+    });
+
+    test('Group multiple choice question as schema block group', assert => {
+        const mulitSelectSchema: SchemaBlock[] = [
+            {
+                blockType: 'section-heading',
+                displayText: 'Extraneous heading',
+                index: 0,
+            },
+            {
+                blockType: 'question-label',
+                displayText: 'Multi Select',
+                schemaBlockGroupKey: 'testMulti',
+                index: 1,
+            },
+            {
+                blockType: 'multi-select-input',
+                schemaBlockGroupKey: 'testMulti',
+                registrationResponseKey: 'testMultiAnswer',
+                index: 2,
+            },
+            {
+                blockType: 'select-input-option',
+                schemaBlockGroupKey: 'testMulti',
+                displayText: 'Multi-option 1',
+                index: 3,
+            },
+            {
+                blockType: 'select-input-option',
+                schemaBlockGroupKey: 'testMulti',
+                displayText: 'Multi-option 2',
+                index: 4,
+            },
+            {
+                blockType: 'select-input-option',
+                schemaBlockGroupKey: 'testMulti',
+                displayText: 'Multi-option 3',
+                index: 5,
+            },
+        ];
+        const result = getSchemaBlockGroup(mulitSelectSchema, 'testMulti');
+        assert.equal(result.registrationResponseKey, 'testMultiAnswer', 'has proper registrationResponseKey');
+        assert.equal(result.schemaBlockGroupKey, 'testMulti', 'has proper schemaBlockGroupKey');
+        assert.equal(result.optionBlocks!.length, 3, 'has proper optionBlocks');
+    });
+
+    test('Group single choice question as schema block group', assert => {
+        const mulitSelectSchema: SchemaBlock[] = [
+            {
+                blockType: 'question-label',
+                displayText: 'Single Select',
+                schemaBlockGroupKey: 'testSingle',
+                index: 0,
+            },
+            {
+                blockType: 'single-select-input',
+                schemaBlockGroupKey: 'testSingle',
+                registrationResponseKey: 'testSingleAnswer',
+                index: 1,
+            },
+            {
+                blockType: 'select-input-option',
+                schemaBlockGroupKey: 'testSingle',
+                displayText: 'single-option 1',
+                index: 2,
+            },
+            {
+                blockType: 'select-input-option',
+                schemaBlockGroupKey: 'testSingle',
+                displayText: 'single-option 2',
+                index: 3,
+            },
+        ];
+        const result = getSchemaBlockGroup(mulitSelectSchema, 'testSingle');
+        assert.equal(result.registrationResponseKey, 'testSingleAnswer', 'has proper registrationResponseKey');
+        assert.equal(result.schemaBlockGroupKey, 'testSingle', 'has proper schemaBlockGroupKey');
+        assert.equal(result.optionBlocks!.length, 2, 'has proper optionsBlocks');
+    });
+});

--- a/tests/unit/packages/registration-schema/get-schema-block-group-test.ts
+++ b/tests/unit/packages/registration-schema/get-schema-block-group-test.ts
@@ -1,5 +1,4 @@
-import { getSchemaBlockGroup } from 'ember-osf-web/packages/registration-schema/get-schema-block-group';
-import { SchemaBlock } from 'ember-osf-web/packages/registration-schema/schema-block';
+import { getSchemaBlockGroup, SchemaBlock } from 'ember-osf-web/packages/registration-schema';
 import { module, test } from 'qunit';
 
 module('Unit | Packages | registration-schema | get-schema-block-group', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -88,7 +88,6 @@
     "config",
     "tests",
     "mirage",
-    "app/packages",
     "types",
     "lib/analytics-page",
     "lib/collections",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -88,6 +88,7 @@
     "config",
     "tests",
     "mirage",
+    "app/packages",
     "types",
     "lib/analytics-page",
     "lib/collections",


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: `NA`
- Feature flag: n/a

## Purpose

<!-- Describe the purpose of your changes. -->
Move the Schema-blocks utility to a new home at `app/packages/registration-schema`
## Summary of Changes

<!-- Briefly describe or list your changes. -->
Each function that used to be in `util/schema-blocks.ts` is now its own file in `packages/registration-schema` and placeholder files added for `page-manager` and `validations`. We (@futa-ikeda  and @adlius ) could not move the packages directory directly under project root because it would not be built into the bundle resulting in test failure. 
## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
`NA`
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
