### PR TITLE
[no ticket] add fixedWidth option to osf-dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Components
     - `project-contributors`
         - added `onAddContributor` hook
+    - `osf-dialog`
+        - add `@fixedWidth` param to prevent shrinking to fit contents
 - Engines
     - `collections`
         - Tests

--- a/lib/handbook/addon/docs/components/osf-dialog/template.md
+++ b/lib/handbook/addon/docs/components/osf-dialog/template.md
@@ -14,6 +14,8 @@ This is a dialog box! Use it for dialog boxes and modal popup things.
 * `@closeOnOutsideClick` (optional; default `true`)
     * whether the dialog should close when the user clicks outside it
     * no effect when `@isModal` is `false`
+* `@fixedWidth` (optional; default `false`)
+    * whether to shrink width-wise to fit contents
 * `@renderInPlace` (optional; default `false`)
     * whether the dialog should be rendered in place (instead of wormhole'd to the app root)
     * forwarded to [ember-wormhole](https://github.com/yapplabs/ember-wormhole#can-i-render-in-place-ie-unwormhole)

--- a/lib/osf-components/addon/components/osf-dialog/component.ts
+++ b/lib/osf-components/addon/components/osf-dialog/component.ts
@@ -22,6 +22,7 @@ export default class OsfDialog extends Component {
     isModal: boolean = defaultTo(this.isModal, true);
     closeOnOutsideClick: boolean = defaultTo(this.closeOnOutsideClick, true);
     renderInPlace: boolean = defaultTo(this.renderInPlace, false);
+    fixedWidth: boolean = defaultTo(this.fixedWidth, false);
 
     @action
     openDialog() {

--- a/lib/osf-components/addon/components/osf-dialog/styles.scss
+++ b/lib/osf-components/addon/components/osf-dialog/styles.scss
@@ -32,21 +32,39 @@
 }
 
 @media (max-width: 500px) {
+    $width: 95vw;
+
     .Dialog {
-        max-width: 95vw;
+        max-width: $width;
+    }
+
+    .Dialog.FixedWidth {
+        width: $width;
     }
 }
 
 @media (min-width: 501px) and (max-width: 991px) {
+    // at 501px, same as 95vw above
+    $width: calc(60vw + 175px);
+
     .Dialog {
-        // at 501px, same as 95vw above
-        max-width: calc(60vw + 175px);
+        max-width: $width;
+    }
+
+    .Dialog.FixedWidth {
+        width: $width;
     }
 }
 
 @media (min-width: 992px) {
+    // at 992px, same as (60vw + 175px) above
+    $width: calc(40vw + 373px);
+
     .Dialog {
-        // at 992px, same as (60vw + 175px) above
-        max-width: calc(40vw + 373px);
+        max-width: $width;
+    }
+
+    .Dialog.FixedWidth {
+        width: $width;
     }
 }

--- a/lib/osf-components/addon/components/osf-dialog/template.hbs
+++ b/lib/osf-components/addon/components/osf-dialog/template.hbs
@@ -20,7 +20,7 @@
         >
             <div
                 data-test-dialog
-                local-class='Dialog'
+                local-class='Dialog {{if this.fixedWidth 'FixedWidth'}}'
                 tabindex='0'
                 role='dialog'
                 aria-labelledby='osf-dialog-heading'


### PR DESCRIPTION
- Ticket: n/a
- Feature flag: n/a

## Purpose

Add a `fixedWidth` option to `osf-dialog` to prevent shrinking to fit contents.

## Summary of Changes

### Changed
- Components
    - `osf-dialog`
        - add `@fixedWidth` param to prevent shrinking to fit contents

## Side Effects

none expected

## QA Notes

n/a
