### PR TITLE
[ENG-513] osf-dialog fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - update to [ember-angle-bracket-invocation-polyfill@^2.0.2](https://github.com/rwjblue/ember-angle-bracket-invocation-polyfill/releases/tag/v2.0.2)
 
 ### Fixed
+- Components
+    - `osf-dialog`
+        - fixed buggy behavior with `@isOpen` -- make it actually DDAU
+        - fixed styles so it displays the same both in and out of the handbook
+        - clean up global state on destroy
 - Engines
     - `collections`
         - fixed template lint and use angle brackets in submission templates

--- a/lib/handbook/addon/docs/components/osf-dialog/-components/demo-is-open/template.hbs
+++ b/lib/handbook/addon/docs/components/osf-dialog/-components/demo-is-open/template.hbs
@@ -3,7 +3,11 @@
         <OsfButton @onClick={{action (mut this.isOpen) true}}>
             Open it!
         </OsfButton>
-        <OsfDialog @isOpen={{this.isOpen}} as |dialog|>
+        <OsfDialog
+            @isOpen={{this.isOpen}}
+            @onClose={{action (mut this.isOpen) false}}
+            as |dialog|
+        >
             <dialog.heading>
                 No need to depend on user action!
             </dialog.heading>

--- a/lib/osf-components/addon/components/osf-dialog/component.ts
+++ b/lib/osf-components/addon/components/osf-dialog/component.ts
@@ -47,9 +47,9 @@ export default class OsfDialog extends Component {
     }
 
     @action
-    updateModalState() {
+    updateModalState(newModalState: boolean) {
         if (this.isModal) {
-            if (this.shouldBeOpen) {
+            if (newModalState) {
                 this.osfModalState.enterModalState();
             } else {
                 this.osfModalState.exitModalState();
@@ -70,6 +70,12 @@ export default class OsfDialog extends Component {
         // Close when `esc` is pressed
         if (event.keyCode === 27) {
             this.closeDialog();
+        }
+    }
+
+    willDestroy() {
+        if (this.shouldBeOpen && this.osfModalState.inModalState) {
+            this.osfModalState.exitModalState();
         }
     }
 }

--- a/lib/osf-components/addon/components/osf-dialog/component.ts
+++ b/lib/osf-components/addon/components/osf-dialog/component.ts
@@ -1,5 +1,6 @@
 import { tagName } from '@ember-decorators/component';
 import { action } from '@ember-decorators/object';
+import { or } from '@ember-decorators/object/computed';
 import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
 
@@ -24,9 +25,14 @@ export default class OsfDialog extends Component {
     renderInPlace: boolean = defaultTo(this.renderInPlace, false);
     fixedWidth: boolean = defaultTo(this.fixedWidth, false);
 
+    // private
+    hasTriggeredOpen: boolean = false;
+
+    @or('isOpen', 'hasTriggeredOpen') shouldBeOpen!: boolean;
+
     @action
     openDialog() {
-        this.set('isOpen', true);
+        this.set('hasTriggeredOpen', true);
         if (this.onOpen) {
             this.onOpen();
         }
@@ -34,7 +40,7 @@ export default class OsfDialog extends Component {
 
     @action
     closeDialog() {
-        this.set('isOpen', false);
+        this.set('hasTriggeredOpen', false);
         if (this.onClose) {
             this.onClose();
         }
@@ -43,7 +49,7 @@ export default class OsfDialog extends Component {
     @action
     updateModalState() {
         if (this.isModal) {
-            if (this.isOpen) {
+            if (this.shouldBeOpen) {
                 this.osfModalState.enterModalState();
             } else {
                 this.osfModalState.exitModalState();

--- a/lib/osf-components/addon/components/osf-dialog/footer/styles.scss
+++ b/lib/osf-components/addon/components/osf-dialog/footer/styles.scss
@@ -6,4 +6,8 @@
 
     border-top: 1px solid $color-border-gray;
     padding: 0.5rem 1.25rem;
+
+    & > button {
+        margin-left: 0.5rem;
+    }
 }

--- a/lib/osf-components/addon/components/osf-dialog/heading/styles.scss
+++ b/lib/osf-components/addon/components/osf-dialog/heading/styles.scss
@@ -9,6 +9,7 @@
 
 .Heading {
     padding: 1rem 0.75rem 1rem 1.25rem;
+    margin: 0;
 
     color: $color-text-gray-blue;
     font-size: 24px;

--- a/lib/osf-components/addon/components/osf-dialog/template.hbs
+++ b/lib/osf-components/addon/components/osf-dialog/template.hbs
@@ -2,7 +2,7 @@
     trigger=(component 'osf-dialog/trigger')
     open=(action this.openDialog)
 )}}
-{{#if this.isOpen}}
+{{#if this.shouldBeOpen}}
     <script
         {{! These should be on <EmberWormhole> below, but we need Ember 3.11 for that }}
         {{did-insert (action this.updateModalState)}}

--- a/lib/osf-components/addon/components/osf-dialog/template.hbs
+++ b/lib/osf-components/addon/components/osf-dialog/template.hbs
@@ -5,8 +5,8 @@
 {{#if this.shouldBeOpen}}
     <script
         {{! These should be on <EmberWormhole> below, but we need Ember 3.11 for that }}
-        {{did-insert (action this.updateModalState)}}
-        {{will-destroy (action this.updateModalState)}}
+        {{did-insert (action this.updateModalState true)}}
+        {{will-destroy (action this.updateModalState false)}}
     ></script>
     <EmberWormhole
         @tagName='span'

--- a/lib/osf-components/addon/services/osf-modal-state.ts
+++ b/lib/osf-components/addon/services/osf-modal-state.ts
@@ -19,6 +19,10 @@ export default class OsfModalState extends Service {
 
         // Update global state in another runloop to avoid "modified twice in one render" errors
         run.next(this, function() {
+            if (this.isDestroyed) {
+                // In tests, the service might be destroyed by now
+                return;
+            }
             const bodyElement = document.querySelector('body')!;
             bodyElement.classList.add('modal-open');
 
@@ -29,6 +33,10 @@ export default class OsfModalState extends Service {
     exitModalState() {
         // Update global state in another runloop to avoid "modified twice in one render" errors
         run.next(this, function() {
+            if (this.isDestroyed) {
+                // In tests, the service might be destroyed by now
+                return;
+            }
             const bodyElement = document.querySelector('body')!;
             bodyElement.classList.remove('modal-open');
 

--- a/tests/integration/components/osf-dialog/component-test.ts
+++ b/tests/integration/components/osf-dialog/component-test.ts
@@ -120,7 +120,7 @@ module('Integration | Component | osf-dialog', hooks => {
     });
 
     test('does not close on outside click', async assert => {
-        await render(hbs`<OsfDialog @renderInPlace={{true}} as |dialog|>
+        await render(hbs`<OsfDialog @renderInPlace={{true}} @closeOnOutsideClick={{false}} as |dialog|>
             <dialog.trigger>
                 <button test-open-dialog {{on 'click' dialog.open}}>Click me!</button>
             </dialog.trigger>
@@ -133,6 +133,6 @@ module('Integration | Component | osf-dialog', hooks => {
         assert.dom('[data-test-dialog]').exists('Dialog open');
 
         await untrackedClick('[data-test-dialog-background]');
-        assert.dom('[data-test-dialog]').doesNotExist('Dialog closed');
+        assert.dom('[data-test-dialog]').exists('Dialog still open');
     });
 });


### PR DESCRIPTION
- Ticket: [ENG-513]
- Feature flag: n/a

## Purpose

These are the parts of #742 that don't require QA

## Summary of Changes

### Fixed
- Components
    - `osf-dialog`
        - fixed buggy behavior with `@isOpen` -- make it actually DDAU
        - fixed styles so it displays the same both in and out of the handbook
        - clean up global state on destroy

## Side Effects

None expected.

## QA Notes

No QA needed for this PR. Will QA on #742


[ENG-513]: https://openscience.atlassian.net/browse/ENG-513