### PR TITLE
[no ticket] enable template-only-glimmer-components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Components
     - `home/support-section/support-item`
         - s/this./@/ because this is template-only
+    - `registries/registries-advisory-board`
+        - fixed template lint
 
 ## [19.9.0] - 2019-09-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Ember Optional Features
+    - `template-only-glimmer-components`
 
 ## [19.9.0] - 2019-09-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Components
     - `home/support-section/support-item`
         - s/this./@/ because this is template-only
+        - added splattributes because this is template-only
     - `registries/registries-advisory-board`
         - fixed template lint
+        - added splattributes because this is template-only
+    - `meetings/index/meetings-footer`
+        - added splattributes because this is template-only
+    - `registries/registries-advisory-board`
+        - added splattributes because this is template-only
+    - `registries/sharing-icons/popover`
+        - added splattributes because this is template-only
 
 ## [19.9.0] - 2019-09-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Ember Optional Features
     - `template-only-glimmer-components`
 
+### Fixed
+- Components
+    - `home/support-section/support-item`
+        - s/this./@/ because this is template-only
+
 ## [19.9.0] - 2019-09-06
 ### Added
 - Components

--- a/app/home/-components/support-section/support-item/template.hbs
+++ b/app/home/-components/support-section/support-item/template.hbs
@@ -1,4 +1,4 @@
-<div local-class='container'>
+<div local-class='container' ...attributes>
     {{#if (eq @icon 'search')}}
         <img data-test-icon-image src='/assets/images/new-home/search.svg' alt={{@icon}}>
     {{else if (eq @icon 'pencil-alt')}}

--- a/app/home/-components/support-section/support-item/template.hbs
+++ b/app/home/-components/support-section/support-item/template.hbs
@@ -1,17 +1,17 @@
 <div local-class='container'>
-    {{#if (eq this.icon 'search')}}
-        <img data-test-icon-image src='/assets/images/new-home/search.svg' alt={{this.icon}}>
-    {{else if (eq this.icon 'pencil-alt')}}
-        <img data-test-icon-image src='/assets/images/new-home/pencil-alt.svg' alt={{this.icon}}>
-    {{else if (eq this.icon 'chart-area')}}
-        <img data-test-icon-image src='/assets/images/new-home/chart-area.svg' alt={{this.icon}}>
-    {{else if (eq this.icon 'file-alt')}}
-        <img data-test-icon-image src='/assets/images/new-home/file-alt.svg' alt={{this.icon}}>
+    {{#if (eq @icon 'search')}}
+        <img data-test-icon-image src='/assets/images/new-home/search.svg' alt={{@icon}}>
+    {{else if (eq @icon 'pencil-alt')}}
+        <img data-test-icon-image src='/assets/images/new-home/pencil-alt.svg' alt={{@icon}}>
+    {{else if (eq @icon 'chart-area')}}
+        <img data-test-icon-image src='/assets/images/new-home/chart-area.svg' alt={{@icon}}>
+    {{else if (eq @icon 'file-alt')}}
+        <img data-test-icon-image src='/assets/images/new-home/file-alt.svg' alt={{@icon}}>
     {{/if}}
     <h2 data-test-support-header>
-        {{this.header}}
+        {{@header}}
     </h2>
     <p data-test-support-description>
-        {{this.description}}
+        {{@description}}
     </p>
 </div>

--- a/app/meetings/index/-components/meetings-footer/template.hbs
+++ b/app/meetings/index/-components/meetings-footer/template.hbs
@@ -1,4 +1,4 @@
-<div class='row icon-bar m-v-lg'>
+<div class='row icon-bar m-v-lg' ...attributes>
     <div class='col-md-4 col-sm-4 text-center '>
         <div class='p-v-md m-t-xl m-h-md'>
             <FaIcon

--- a/config/optional-features.json
+++ b/config/optional-features.json
@@ -1,0 +1,3 @@
+{
+  "template-only-glimmer-components": true
+}

--- a/lib/registries/addon/components/registries-advisory-board/template.hbs
+++ b/lib/registries/addon/components/registries-advisory-board/template.hbs
@@ -1,5 +1,9 @@
 {{! template-lint-disable no-bare-strings }}
-<div local-class='AdvisoryGroup' class='p-v-md'>
+<div
+    local-class='AdvisoryGroup'
+    class='p-v-md'
+    ...attributes
+>
     <div class='container'>
         <div class='row'>
             <div class='col-xs-12'>

--- a/lib/registries/addon/components/registries-advisory-board/template.hbs
+++ b/lib/registries/addon/components/registries-advisory-board/template.hbs
@@ -1,12 +1,12 @@
 {{! template-lint-disable no-bare-strings }}
-<div local-class="AdvisoryGroup" class="p-v-md">
-    <div class="container">
-        <div class="row">
-            <div class="col-xs-12">
-                <h2>{{t "registries.index.advisory.heading"}}</h2>
-                <p class="m-b-lg">{{t "registries.index.advisory.paragraph"}}</p>
+<div local-class='AdvisoryGroup' class='p-v-md'>
+    <div class='container'>
+        <div class='row'>
+            <div class='col-xs-12'>
+                <h2>{{t 'registries.index.advisory.heading'}}</h2>
+                <p class='m-b-lg'>{{t 'registries.index.advisory.paragraph'}}</p>
             </div>
-            <div class="col-xs-6">
+            <div class='col-xs-6'>
                 <ul>
                     <li><b>Stuart Buck :</b> Laura and John Arnold Foundation</li>
                     <li><b>Chris Chambers :</b> Registered Reports, Cardiff University</li>
@@ -15,7 +15,7 @@
                     <li><b>Brendan Nyhan :</b> University of Michigan</li>
                 </ul>
             </div>
-            <div class="col-xs-6">
+            <div class='col-xs-6'>
                 <ul>
                     <li><b>Neeta Goel :</b> RIDIE, 3ie</li>
                     <li><b>Jessaca Spybrook :</b> IES, Western Michigan University</li>

--- a/lib/registries/addon/components/sharing-icons/popover/template.hbs
+++ b/lib/registries/addon/components/sharing-icons/popover/template.hbs
@@ -1,4 +1,9 @@
-<a tabindex='0' local-class='SharingIconsPopover__anchor' class='btn-link pull-right'>
+<a
+    local-class='SharingIconsPopover__anchor'
+    class='btn-link pull-right'
+    tabindex='0'
+    ...attributes
+>
     <FaIcon @icon='share-alt' />
     {{#bs-popover placement='left' triggerEvents='focus' local-class='Popover' viewportSelector=(concat '#' @parentId) autoPlacement=true }}
         <SharingIcons


### PR DESCRIPTION
- Ticket: n/a
- Feature flag: n/a

## Purpose

Enable [template-only-glimmer-components](https://github.com/emberjs/rfcs/blob/master/text/0278-template-only-components.md) so that we don't have to create component.ts files just for the purpose of making components tagless.

## Summary of Changes

### Added
- Ember Optional Features
    - `template-only-glimmer-components`

## Side Effects

Any existing template-only components will become tagless, but this *shouldn't* affect anything. 🤞

## QA Notes

No QA needed. Percy will catch any issues that could arise.
