### PR TITLE
[ENG-835] add subject-field-manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         - `search`
         - `search/search-result`
         - `widget`
+    - `editable-field/subject-field-manager`
 - Tests
     - Integration
         - `unique-id`

--- a/lib/osf-components/addon/components/editable-field/subject-field-manager/component.ts
+++ b/lib/osf-components/addon/components/editable-field/subject-field-manager/component.ts
@@ -1,0 +1,59 @@
+import { tagName } from '@ember-decorators/component';
+import { action, computed } from '@ember-decorators/object';
+import { alias, and } from '@ember-decorators/object/computed';
+import Component from '@ember/component';
+import { task } from 'ember-concurrency';
+
+import { layout } from 'ember-osf-web/decorators/component';
+import Node from 'ember-osf-web/models/node';
+import { SubjectManager } from 'osf-components/components/subjects/manager/component';
+
+import template from './template';
+
+@tagName('')
+@layout(template)
+export default class SubjectFieldManagerComponent extends Component.extend({
+    save: task(function *(this: SubjectFieldManagerComponent) {
+        try {
+            yield this.subjectsManager.saveChanges();
+        } catch (e) {
+            // TODO
+            throw e;
+        }
+        this.set('requestedEditMode', false);
+    }).drop(),
+}) {
+    // required
+    node!: Node;
+    subjectsManager!: SubjectManager;
+
+    requestedEditMode: boolean = false;
+
+    @alias('node.userHasAdminPermission')
+    userCanEdit!: boolean;
+
+    @and('userCanEdit', 'requestedEditMode')
+    inEditMode!: boolean;
+
+    @computed('subjectsManager.savedSubjects.length')
+    get fieldIsEmpty() {
+        return !this.subjectsManager.savedSubjects.length;
+    }
+
+    @computed('fieldIsEmpty', 'userCanEdit')
+    get shouldShowField() {
+        return this.userCanEdit || !this.fieldIsEmpty;
+    }
+
+    @action
+    startEditing() {
+        this.subjectsManager.discardChanges();
+        this.set('requestedEditMode', true);
+    }
+
+    @action
+    cancel() {
+        this.subjectsManager.discardChanges();
+        this.set('requestedEditMode', false);
+    }
+}

--- a/lib/osf-components/addon/components/editable-field/subject-field-manager/template.hbs
+++ b/lib/osf-components/addon/components/editable-field/subject-field-manager/template.hbs
@@ -1,0 +1,13 @@
+{{yield (hash
+    save=(perform this.save)
+    cancel=(action this.cancel)
+    startEditing=(action this.startEditing)
+
+    shouldShowField=this.shouldShowField
+    userCanEdit=this.userCanEdit
+    fieldIsEmpty=this.fieldIsEmpty
+    inEditMode=this.inEditMode
+    isSaving=this.save.isRunning
+
+    emptyFieldText=(t 'registries.registration_metadata.no_subjects')
+)}}

--- a/lib/osf-components/app/components/editable-field/subject-field-manager/component.js
+++ b/lib/osf-components/app/components/editable-field/subject-field-manager/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/editable-field/subject-field-manager/component';


### PR DESCRIPTION
**Note:** this PR depends on #771 

- Ticket: [ENG-835]
- Feature flag: n/a

## Purpose

Add a manager component for subjects editable field.

## Summary of Changes

### Added
- Components
    - `editable-field/subject-field-manager`

## Side Effects

Should be none.

## QA Notes

n/a


[ENG-835]: https://openscience.atlassian.net/browse/ENG-835