### PR TITLE
[no ticket] Expose editable field isSaving to disable submit/cancel buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Components
     - `editable-field`
         - use `osf-dialog` instead of `bs-modal`
+        - pass `@fixedWidth` through to `OsfDialog`
+        - use `@manager.isSaving` to disable submit & cancel buttons
+        - `category-manager`
+            - expose `isSaving` as alias for `save.isRunning`
+        - `description-manager`
+            - expose `isSaving` as alias for `save.isRunning`
+        - `institutions-manager`
+            - expose `isSaving` as alias for `save.isRunning`
+        - `license-manager`
+            - expose `isSaving` as alias for `save.isRunning`
+        - `publication-doi-manager`
+            - expose `isSaving` as alias for `save.isRunning`
+        - `tags-manager`
+            - expose `isSaving` as alias for `save.isRunning`
     - `node-category-picker`
         - remove `@renderInPlace={{true}}` from `PowerSelect` invocation
     - `zoom-to-route`

--- a/lib/osf-components/addon/components/editable-field/category-manager/template.hbs
+++ b/lib/osf-components/addon/components/editable-field/category-manager/template.hbs
@@ -9,4 +9,5 @@
     shouldShowField=this.shouldShowField
     selectedCategory=this.selectedCategory
     category=this.category
+    isSaving=this.save.isRunning
 )}}

--- a/lib/osf-components/addon/components/editable-field/description-manager/template.hbs
+++ b/lib/osf-components/addon/components/editable-field/description-manager/template.hbs
@@ -9,4 +9,5 @@
     shouldShowField=this.shouldShowField
     currentDescription=this.currentDescription
     description=this.node.description
+    isSaving=this.save.isRunning
 )}}

--- a/lib/osf-components/addon/components/editable-field/institutions-manager/template.hbs
+++ b/lib/osf-components/addon/components/editable-field/institutions-manager/template.hbs
@@ -14,4 +14,5 @@
     bindReload=(action (mut this.reloadList))
     node=this.node
     user=this.currentUser.user
+    isSaving=this.save.isRunning
 )}}

--- a/lib/osf-components/addon/components/editable-field/license-manager/template.hbs
+++ b/lib/osf-components/addon/components/editable-field/license-manager/template.hbs
@@ -16,4 +16,5 @@
     requiredFields=this.requiredFields
     selectedLicense=this.selectedLicense
     licensesAcceptable=this.licensesAcceptable
+    isSaving=this.save.isRunning
 )}}

--- a/lib/osf-components/addon/components/editable-field/publication-doi-manager/template.hbs
+++ b/lib/osf-components/addon/components/editable-field/publication-doi-manager/template.hbs
@@ -10,4 +10,5 @@
     validationNode=this.validationNode
     publicationDoi=this.node.articleDoi
     didValidate=this.didValidate
+    isSaving=this.save.isRunning
 )}}

--- a/lib/osf-components/addon/components/editable-field/tags-manager/template.hbs
+++ b/lib/osf-components/addon/components/editable-field/tags-manager/template.hbs
@@ -12,4 +12,5 @@
     inEditMode=this.inEditMode
     userCanEdit=this.userCanEdit
     shouldShowField=this.shouldShowField
+    isSaving=this.save.isRunning
 )}}

--- a/lib/osf-components/addon/components/editable-field/template.hbs
+++ b/lib/osf-components/addon/components/editable-field/template.hbs
@@ -32,6 +32,7 @@
     @isOpen={{@manager.inEditMode}}
     @onClose={{@manager.cancel}}
     @closeOnOutsideClick={{false}}
+    @fixedWidth={{@fixedWidth}}
     as |dialog|
 >
     <dialog.heading>
@@ -55,7 +56,7 @@
                 <OsfButton
                     data-test-discard-edits
                     data-analytics-name='Discard'
-                    @disabled={{@manager.save.isRunning}}
+                    @disabled={{@manager.isSaving}}
                     @onClick={{action @manager.cancel}}
                 >
                     {{t 'general.cancel'}}
@@ -66,7 +67,7 @@
                     data-test-save-edits
                     data-analytics-name='Save'
                     @type='primary'
-                    @disabled={{@manager.save.isRunning}}
+                    @disabled={{@manager.isSaving}}
                     @onClick={{action @manager.save}}
                 >
                     {{t 'general.save'}}


### PR DESCRIPTION
- Ticket: n/a
- Feature flag: n/a

## Purpose

Expose `isSaving` as an alias for `save.isRunning` in each of the editable field managers for better abstraction. Also pass through `@fixedWith` to add ability to configure the dialog.

## Summary of Changes

### Changed
- Components
    - `editable-field`
        - pass `@fixedWidth` through to `OsfDialog`
        - use `@manager.isSaving` to disable submit & cancel buttons
        - `category-manager`
            - expose `isSaving` as alias for `save.isRunning`
        - `description-manager`
            - expose `isSaving` as alias for `save.isRunning`
        - `institutions-manager`
            - expose `isSaving` as alias for `save.isRunning`
        - `license-manager`
            - expose `isSaving` as alias for `save.isRunning`
        - `publication-doi-manager`
            - expose `isSaving` as alias for `save.isRunning`
        - `tags-manager`
            - expose `isSaving` as alias for `save.isRunning`

## Side Effects

None expected.

## QA Notes

n/a