### PR TITLE
[ENG-835] add subjects widget to handbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Packages
     - `ember-animated`
     - `ember-element-helper` (`fix-engines` branch)
+- Handbook
+    - `Subjects::Widget` component to gallery
 
 ### Changed
 - Models

--- a/lib/handbook/addon/docs/components/subject-widget/demo/template.hbs
+++ b/lib/handbook/addon/docs/components/subject-widget/demo/template.hbs
@@ -1,0 +1,16 @@
+<DocsDemo as |demo|>
+    <demo.example @name='subject-widget.demo.hbs'>
+        <Subjects::Manager
+            @model={{this.model}}
+            @provider={{this.model.provider}}
+            as |subjectsManager|
+        >
+            <Subjects::Widget
+                data-analytics-scope='Handbook'
+                @subjectsManager={{subjectsManager}}
+            />
+        </Subjects::Manager>
+    </demo.example>
+
+    <demo.snippet @name='subject-widget.demo.hbs' />
+</DocsDemo>

--- a/lib/handbook/addon/docs/components/subject-widget/route.ts
+++ b/lib/handbook/addon/docs/components/subject-widget/route.ts
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class SubjectWidgetDemo extends Route {
+    model() {
+        return this.store.findRecord('registration', 'subj');
+    }
+}

--- a/lib/handbook/addon/docs/components/subject-widget/template.md
+++ b/lib/handbook/addon/docs/components/subject-widget/template.md
@@ -1,0 +1,6 @@
+# subject widget
+
+## Parameters
+
+## demo
+{{docs/components/subject-widget/demo model=this.model}}

--- a/lib/handbook/addon/docs/template.hbs
+++ b/lib/handbook/addon/docs/template.hbs
@@ -27,6 +27,7 @@
         <nav.item @label='form-controls' @route='docs.components.form-controls' />
         <nav.item @label='institutions-widget' @route='docs.components.institutions-widget' />
         <nav.item @label='loading-indicator' @route='docs.components.loading-indicator' />
+        <nav.item @label='subject-widget' @route='docs.components.subject-widget' />
         <nav.item @label='new-project-modal' @route='docs.components.new-project-modal' />
         <nav.item @label='new-project-navigation-modal' @route='docs.components.new-project-navigation-modal' />
         <nav.item @label='osf-button' @route='docs.components.osf-button' />

--- a/lib/handbook/addon/routes.js
+++ b/lib/handbook/addon/routes.js
@@ -40,6 +40,7 @@ export default buildRoutes(function() {
             this.route('panel');
             this.route('placeholder');
             this.route('schema-chunk');
+            this.route('subject-widget');
             this.route('tags-widget');
             this.route('validated-model-form');
         });

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -193,6 +193,14 @@ function handbookScenario(server: Server, currentUser: ModelInstance<User>) {
     const child = server.create('node', { parent, id: 'ezcuj1', title: faker.lorem.sentences(5) });
     const grandChild = server.create('node', { parent: child, root: parent, id: 'ezcuj2' });
     server.create('node', { parent: grandChild, root: parent, id: 'ezcuj3' });
+
+    // SubjectWidgets
+    server.createList('subject', 10, 'withChildren');
+    const provider = server.schema.registrationProviders.find('osf');
+    provider.update({
+        subjects: server.schema.subjects.all().models,
+    });
+    server.create('registration', { id: 'subj' }, 'withSubjects');
 }
 
 function settingsScenario(server: Server, currentUser: ModelInstance<User>) {


### PR DESCRIPTION
- Ticket: [ENG-835]
- Feature flag: n/a

## Purpose

Add `Subjects::Widget` to the handbook component gallery.

## Summary of Changes

### Added
- Handbook
    - `Subjects::Widget` component to gallery

## Side Effects

None.

## QA Notes

n/a


[ENG-835]: https://openscience.atlassian.net/browse/ENG-835