### PR TITLE
[ENG-734]Build validations from schemablock groups

### DIFF
--- a/app/packages/registration-schema/get-schema-block-group.ts
+++ b/app/packages/registration-schema/get-schema-block-group.ts
@@ -69,10 +69,15 @@ export function getSchemaBlockGroups(blocks: SchemaBlock[]) {
             if (newGroupStart) {
                 groups.push(schemaBlockGroup);
             }
+            schemaBlockGroup.blocks = [
+                ...(schemaBlockGroup.blocks || []),
+                block,
+            ];
         } else {
             currentGroupKey = null;
             schemaBlockGroup.labelBlock = block;
             schemaBlockGroup.groupType = block.blockType;
+            schemaBlockGroup.blocks = [block];
             groups.push(schemaBlockGroup);
         }
         return groups;

--- a/app/packages/registration-schema/get-schema-block-group.ts
+++ b/app/packages/registration-schema/get-schema-block-group.ts
@@ -34,7 +34,6 @@ export function getSchemaBlockGroups(blocks: SchemaBlock[]) {
             case 'contributors-input':
             case 'single-select-input':
             case 'multi-select-input':
-                assert('input block with no schemaBlockGroupKey!', !isEmpty(block.schemaBlockGroupKey));
                 assert('input block with no registrationResponseKey!', !isEmpty(block.registrationResponseKey));
                 assert('question with multiple input blocks!', !schemaBlockGroup.inputBlock);
                 assert('non-unique response key used',

--- a/app/packages/registration-schema/get-schema-block-group.ts
+++ b/app/packages/registration-schema/get-schema-block-group.ts
@@ -8,20 +8,25 @@ function isEmpty(input: string | undefined) {
     return false;
 }
 
-export function getSchemaBlockGroup(blocks: SchemaBlock[], key: string) {
-    const schemaBlockGroup: SchemaBlockGroup = {};
-    let lastGroupIndex: number | undefined;
-    let consecutiveGroup = true;
-    const groupBlocks = blocks.filter(block => block.schemaBlockGroupKey === key);
-    groupBlocks.forEach(groupBlock => {
-        if (lastGroupIndex && groupBlock.index && Math.abs(lastGroupIndex - groupBlock.index) !== 1) {
-            consecutiveGroup = false;
-        }
-        lastGroupIndex = groupBlock.index;
-        if (groupBlock.schemaBlockGroupKey === key) {
-            switch (groupBlock.blockType) {
+export function getSchemaBlockGroups(blocks: SchemaBlock[]) {
+    let currentGroupKey: string | null = null;
+    const groupKeysEncountered: string[] = [];
+    const responseKeysEncountered: string[] = [];
+    const allGroups = blocks.reduce((groups: SchemaBlockGroup[], block: SchemaBlock) => {
+        let schemaBlockGroup: SchemaBlockGroup = {};
+        if (block.schemaBlockGroupKey) {
+            const newGroupStart = (!currentGroupKey) || (currentGroupKey !== block.schemaBlockGroupKey);
+            if (newGroupStart) {
+                currentGroupKey = block.schemaBlockGroupKey;
+                assert('groupKey is used out of order', groupKeysEncountered.indexOf(block.schemaBlockGroupKey) < 0);
+                groupKeysEncountered.push(block.schemaBlockGroupKey);
+            } else if (currentGroupKey === block.schemaBlockGroupKey) {
+                schemaBlockGroup = groups[groups.length - 1];
+            }
+
+            switch (block.blockType) {
             case 'question-label':
-                schemaBlockGroup.labelBlock = groupBlock;
+                schemaBlockGroup.labelBlock = block;
                 break;
             case 'long-text-input':
             case 'short-text-input':
@@ -29,26 +34,30 @@ export function getSchemaBlockGroup(blocks: SchemaBlock[], key: string) {
             case 'contributors-input':
             case 'single-select-input':
             case 'multi-select-input':
-                assert('input block with no schemaBlockGroupKey!', !isEmpty(groupBlock.schemaBlockGroupKey));
-                assert('input block with no registrationResponseKey!', !isEmpty(groupBlock.registrationResponseKey));
+                assert('input block with no schemaBlockGroupKey!', !isEmpty(block.schemaBlockGroupKey));
+                assert('input block with no registrationResponseKey!', !isEmpty(block.registrationResponseKey));
                 assert('question with multiple input blocks!', !schemaBlockGroup.inputBlock);
+                assert('non-unique response key used',
+                    responseKeysEncountered.indexOf(block.registrationResponseKey!) < 0);
+                responseKeysEncountered.push(block.registrationResponseKey!);
                 if (schemaBlockGroup.schemaBlockGroupKey) {
                     assert('question with mismatched schemaBlockGroupKey!',
-                        schemaBlockGroup.schemaBlockGroupKey === groupBlock.schemaBlockGroupKey);
+                        schemaBlockGroup.schemaBlockGroupKey === block.schemaBlockGroupKey);
                 } else {
-                    schemaBlockGroup.schemaBlockGroupKey = groupBlock.schemaBlockGroupKey;
+                    schemaBlockGroup.schemaBlockGroupKey = block.schemaBlockGroupKey;
                 }
-                schemaBlockGroup.inputBlock = groupBlock;
-                schemaBlockGroup.registrationResponseKey = groupBlock.registrationResponseKey;
+                schemaBlockGroup.inputBlock = block;
+                schemaBlockGroup.registrationResponseKey = block.registrationResponseKey;
+                schemaBlockGroup.groupType = block.blockType;
                 break;
             case 'select-input-option':
                 if (schemaBlockGroup.inputBlock) {
                     assert('question with mismatched schemaBlockGroupKey!',
-                        !isEmpty(groupBlock.schemaBlockGroupKey) &&
-                        schemaBlockGroup.schemaBlockGroupKey === groupBlock.schemaBlockGroupKey);
+                        !isEmpty(block.schemaBlockGroupKey) &&
+                        schemaBlockGroup.schemaBlockGroupKey === block.schemaBlockGroupKey);
                     schemaBlockGroup.optionBlocks = [
                         ...(schemaBlockGroup.optionBlocks || []),
-                        groupBlock,
+                        block,
                     ];
                 } else {
                     assert('select-option without a question!');
@@ -57,16 +66,16 @@ export function getSchemaBlockGroup(blocks: SchemaBlock[], key: string) {
             default:
                 break;
             }
+            if (newGroupStart) {
+                groups.push(schemaBlockGroup);
+            }
+        } else {
+            currentGroupKey = null;
+            schemaBlockGroup.labelBlock = block;
+            schemaBlockGroup.groupType = block.blockType;
+            groups.push(schemaBlockGroup);
         }
-    });
-    assert('non-consecutive blocks used to create group', consecutiveGroup);
-    assert('schema block group with no input element',
-        schemaBlockGroup.inputBlock !== null && schemaBlockGroup.inputBlock !== undefined);
-    if ((schemaBlockGroup.inputBlock) &&
-        (schemaBlockGroup.inputBlock.blockType === 'single-select-input' ||
-        schemaBlockGroup.inputBlock.blockType === 'multi-select-input')) {
-        assert('single/multi select with no option',
-            schemaBlockGroup.optionBlocks && schemaBlockGroup.optionBlocks.length > 0);
-    }
-    return schemaBlockGroup;
+        return groups;
+    }, []);
+    return allGroups;
 }

--- a/app/packages/registration-schema/index.ts
+++ b/app/packages/registration-schema/index.ts
@@ -2,3 +2,5 @@ export { getPages } from './get-pages';
 export { getSchemaBlockGroup } from './get-schema-block-group';
 export { SchemaBlock, SchemaBlockType } from './schema-block';
 export { SchemaBlockGroup } from './schema-block-group';
+export { buildValidation } from './validations';
+export { PageResponse } from './page-response';

--- a/app/packages/registration-schema/index.ts
+++ b/app/packages/registration-schema/index.ts
@@ -1,5 +1,5 @@
 export { getPages } from './get-pages';
-export { getSchemaBlockGroup } from './get-schema-block-group';
+export { getSchemaBlockGroups } from './get-schema-block-group';
 export { SchemaBlock, SchemaBlockType } from './schema-block';
 export { SchemaBlockGroup } from './schema-block-group';
 export { buildValidation } from './validations';

--- a/app/packages/registration-schema/page-response.ts
+++ b/app/packages/registration-schema/page-response.ts
@@ -1,0 +1,7 @@
+interface FileReference {
+    id: string;
+    name: string;
+}
+type ResponseValue = string | string[] | FileReference[] | null;
+
+export type PageResponse = Record<string, ResponseValue>;

--- a/app/packages/registration-schema/schema-block-group.ts
+++ b/app/packages/registration-schema/schema-block-group.ts
@@ -6,4 +6,5 @@ export interface SchemaBlockGroup {
     optionBlocks?: SchemaBlock[];
     schemaBlockGroupKey?: string;
     registrationResponseKey?: string;
+    groupType?: string;
   }

--- a/app/packages/registration-schema/schema-block-group.ts
+++ b/app/packages/registration-schema/schema-block-group.ts
@@ -7,4 +7,5 @@ export interface SchemaBlockGroup {
     schemaBlockGroupKey?: string;
     registrationResponseKey?: string;
     groupType?: string;
+    blocks?: SchemaBlock[];
   }

--- a/app/packages/registration-schema/validations.ts
+++ b/app/packages/registration-schema/validations.ts
@@ -1,0 +1,98 @@
+import { assert } from '@ember/debug';
+import { ValidationObject, ValidatorFunction } from 'ember-changeset-validations';
+import { validateLength, validatePresence } from 'ember-changeset-validations/validators';
+import translations from 'ember-osf-web/locales/en/translations';
+import { PageResponse } from 'ember-osf-web/packages/registration-schema';
+import { SchemaBlockGroup } from 'ember-osf-web/packages/registration-schema/schema-block-group';
+import { validateResponseFormat } from 'ember-osf-web/validators/validate-response-format';
+
+export function buildValidation(groups: SchemaBlockGroup[]) {
+    const ret: ValidationObject<PageResponse> = {};
+    groups.forEach((group: SchemaBlockGroup) => {
+        let validationForResponse: ValidatorFunction[] = [];
+        const responseKey = group.registrationResponseKey;
+        assert(`no response key for group ${group.schemaBlockGroupKey}`,
+            responseKey !== '' || responseKey !== undefined || responseKey !== null);
+        // only validating groups with actual inputs and not groups that are headings/labels only
+        if (group.inputBlock) {
+            const { inputBlock } = group;
+            switch (group.groupType) {
+            case 'short-text-input':
+            case 'long-text-input':
+                if (inputBlock.required) {
+                    validationForResponse = [
+                        validatePresence({
+                            presence: true,
+                            ignoreBlank: true,
+                            allowBlank: false,
+                            allowNone: false,
+                            message: translations.validationErrors.blank,
+                        }),
+                    ];
+                } else {
+                    validationForResponse = [
+                        validatePresence({ ignoreBlank: true }),
+                        validateLength({
+                            allowBlank: true,
+                            allowNone: true,
+                        }),
+                    ];
+                }
+                break;
+            case 'contributors-input':
+                if (inputBlock.required) {
+                    validationForResponse = [
+                        validatePresence({
+                            presence: true,
+                            allowBlank: false,
+                            message: translations.validationErrors.empty,
+                        }),
+                    ];
+                }
+                validationForResponse = [
+                    ...(validationForResponse || []),
+                    validateResponseFormat({ format: 'contributor' }),
+                ];
+                break;
+            case 'file-input':
+                if (inputBlock.required) {
+                    validationForResponse = [
+                        validatePresence({
+                            presence: true,
+                            message: translations.validationErrors.empty,
+                        }),
+                    ];
+                }
+                validationForResponse = [
+                    ...(validationForResponse || []),
+                    validateResponseFormat({ format: 'file' }),
+                ];
+                break;
+            case 'single-select-input':
+            case 'multi-select-input':
+                if (inputBlock.required) {
+                    validationForResponse = [
+                        validateLength({
+                            min: 1,
+                            allowBlank: false,
+                        }),
+                        validatePresence({
+                            presence: true,
+                            message: translations.validationErrors.empty,
+                        }),
+                    ];
+                } else {
+                    validationForResponse = [
+                        validateLength({ allowBlank: true }),
+                    ];
+                }
+                break;
+            default:
+                break;
+            }
+            ret[responseKey!] = {};
+            ret[responseKey!].response = validationForResponse;
+        }
+    });
+    return ret;
+}

--- a/app/packages/registration-schema/validations.ts
+++ b/app/packages/registration-schema/validations.ts
@@ -9,12 +9,12 @@ import { validateResponseFormat } from 'ember-osf-web/validators/validate-respon
 export function buildValidation(groups: SchemaBlockGroup[]) {
     const ret: ValidationObject<PageResponse> = {};
     groups.forEach((group: SchemaBlockGroup) => {
-        let validationForResponse: ValidatorFunction[] = [];
-        const responseKey = group.registrationResponseKey;
-        assert(`no response key for group ${group.schemaBlockGroupKey}`,
-            responseKey !== '' || responseKey !== undefined || responseKey !== null);
         // only validating groups with actual inputs and not groups that are headings/labels only
         if (group.inputBlock) {
+            let validationForResponse: ValidatorFunction[] = [];
+            const responseKey = group.registrationResponseKey;
+            assert(`no response key for group ${group.schemaBlockGroupKey}`,
+                responseKey !== '' || responseKey !== undefined || responseKey !== null);
             const { inputBlock } = group;
             switch (group.groupType) {
             case 'short-text-input':

--- a/app/packages/registration-schema/validations.ts
+++ b/app/packages/registration-schema/validations.ts
@@ -13,8 +13,7 @@ export function buildValidation(groups: SchemaBlockGroup[]) {
         if (group.inputBlock) {
             let validationForResponse: ValidatorFunction[] = [];
             const responseKey = group.registrationResponseKey;
-            assert(`no response key for group ${group.schemaBlockGroupKey}`,
-                responseKey !== '' || responseKey !== undefined || responseKey !== null);
+            assert(`no response key for group ${group.schemaBlockGroupKey}`, Boolean(responseKey));
             const { inputBlock } = group;
             switch (group.groupType) {
             case 'short-text-input':

--- a/app/packages/registration-schema/validations.ts
+++ b/app/packages/registration-schema/validations.ts
@@ -6,6 +6,8 @@ import { PageResponse } from 'ember-osf-web/packages/registration-schema';
 import { SchemaBlockGroup } from 'ember-osf-web/packages/registration-schema/schema-block-group';
 import { validateResponseFormat } from 'ember-osf-web/validators/validate-response-format';
 
+// TODO: find a way to use i18n to translate error messages
+
 export function buildValidation(groups: SchemaBlockGroup[]) {
     const ret: ValidationObject<PageResponse> = {};
     groups.forEach((group: SchemaBlockGroup) => {
@@ -30,7 +32,6 @@ export function buildValidation(groups: SchemaBlockGroup[]) {
                     ];
                 } else {
                     validationForResponse = [
-                        validatePresence({ ignoreBlank: true }),
                         validateLength({
                             allowBlank: true,
                             allowNone: true,
@@ -89,8 +90,7 @@ export function buildValidation(groups: SchemaBlockGroup[]) {
             default:
                 break;
             }
-            ret[responseKey!] = {};
-            ret[responseKey!].response = validationForResponse;
+            ret[responseKey!] = validationForResponse;
         }
     });
     return ret;

--- a/app/validators/validate-response-format.ts
+++ b/app/validators/validate-response-format.ts
@@ -1,0 +1,34 @@
+import ContributorModel from 'ember-osf-web/models/contributor';
+
+function isEmptyString(checkString: string) {
+    if (checkString === undefined || checkString === null || checkString === '') {
+        return true;
+    }
+    return false;
+}
+
+// tslint:disable-next-line: variable-name
+const isContributorModel = (_input: any): _input is ContributorModel => true;
+
+export function validateResponseFormat(opts: {format: string}) {
+    return (value: any) => {
+        if (opts.format) {
+            switch (opts.format) {
+            case 'file':
+                if (!isEmptyString(value.id) && !isEmptyString(value.name)) {
+                    return true;
+                }
+                return 'Not a valid file';
+            case 'contributor':
+                if (isContributorModel && !isEmptyString(value.id)) {
+                    return true;
+                }
+                return 'Not a valid contributor';
+            default:
+                return 'Invalid format';
+            }
+        } else {
+            return 'Need a format';
+        }
+    };
+}

--- a/app/validators/validate-response-format.ts
+++ b/app/validators/validate-response-format.ts
@@ -1,26 +1,25 @@
+import { isEmpty } from '@ember/utils';
 import ContributorModel from 'ember-osf-web/models/contributor';
 
-function isEmptyString(checkString: string) {
-    if (checkString === undefined || checkString === null || checkString === '') {
+// tslint:disable-next-line: variable-name
+const isContributorModel = (_input: any) => {
+    if (_input instanceof ContributorModel) {
         return true;
     }
     return false;
-}
-
-// tslint:disable-next-line: variable-name
-const isContributorModel = (_input: any): _input is ContributorModel => true;
+};
 
 export function validateResponseFormat(opts: {format: string}) {
     return (value: any) => {
         if (opts.format) {
             switch (opts.format) {
             case 'file':
-                if (!isEmptyString(value.id) && !isEmptyString(value.name)) {
+                if (!isEmpty(value.id) && !isEmpty(value.name)) {
                     return true;
                 }
                 return 'Not a valid file';
             case 'contributor':
-                if (isContributorModel && !isEmptyString(value.id)) {
+                if (isContributorModel(value) && !isEmpty(value.id)) {
                     return true;
                 }
                 return 'Not a valid contributor';

--- a/app/validators/validate-response-format.ts
+++ b/app/validators/validate-response-format.ts
@@ -1,9 +1,8 @@
 import { isEmpty } from '@ember/utils';
 import ContributorModel from 'ember-osf-web/models/contributor';
 
-// tslint:disable-next-line: variable-name
-const isContributorModel = (_input: any) => {
-    if (_input instanceof ContributorModel) {
+const isContributorModel = (input: any) => {
+    if (input instanceof ContributorModel) {
         return true;
     }
     return false;

--- a/tests/unit/packages/registration-schema/get-schema-block-group-test.ts
+++ b/tests/unit/packages/registration-schema/get-schema-block-group-test.ts
@@ -79,26 +79,31 @@ module('Unit | Packages | registration-schema | get-schema-block-group', () => {
         // section heading
         assert.ok(!result[0].registrationResponseKey, 'section heading has proper registrationResponseKey (none)');
         assert.ok(result[0].labelBlock, 'section heading has labelBlock');
+        assert.equal(result[0].blocks!.length, 1, 'section heading has proper blocks length (1)');
         // standalone text input
         assert.equal(result[1].registrationResponseKey, 'a1',
             'standalone text input has proper registrationResponseKey');
         assert.equal(result[1].schemaBlockGroupKey, 'q1',
             'standalone text input has proper schemaBlockGroupKey');
         assert.ok(!result[1].optionBlocks, 'standalone text input has proper optionBlocks (none)');
+        assert.equal(result[1].blocks!.length, 1, 'standalone text input has proper blocks length (1)');
         // subsection heading
         assert.ok(!result[2].registrationResponseKey, 'subsection heading has proper registrationResponseKey (none');
         assert.ok(result[2].labelBlock, 'subsection heading has labelBlock');
+        assert.equal(result[2].blocks!.length, 1, 'subsection heading has proper blocks length (1)');
         // multi select
         assert.equal(result[3].registrationResponseKey, 'testMultiAnswer',
             'multi select has proper registrationResponseKey');
         assert.equal(result[3].schemaBlockGroupKey, 'testMulti',
             'multi select has proper schemaBlockGroupKey');
         assert.equal(result[3].optionBlocks!.length, 3, 'multi select has proper optionBlocks');
+        assert.equal(result[3].blocks!.length, 5, 'multi select has proper blocks length (5)');
         // single select
         assert.equal(result[4].registrationResponseKey, 'testSingleAnswer',
             'single select has proper registrationResponseKey');
         assert.equal(result[4].schemaBlockGroupKey, 'testSingle',
             'single select has proper schemaBlockGroupKey');
         assert.equal(result[4].optionBlocks!.length, 2, 'single select has proper optionsBlocks');
+        assert.equal(result[4].blocks!.length, 4, 'single select has proper blocks length (4)');
     });
 });

--- a/tests/unit/packages/registration-schema/get-schema-block-group-test.ts
+++ b/tests/unit/packages/registration-schema/get-schema-block-group-test.ts
@@ -1,9 +1,9 @@
-import { getSchemaBlockGroup, SchemaBlock } from 'ember-osf-web/packages/registration-schema';
+import { getSchemaBlockGroups, SchemaBlock } from 'ember-osf-web/packages/registration-schema';
 import { module, test } from 'qunit';
 
 module('Unit | Packages | registration-schema | get-schema-block-group', () => {
-    test('Group stand alone input as question group', assert => {
-        const standAloneSchema: SchemaBlock[] = [
+    test('Get groups from a schema', assert => {
+        const testSchema: SchemaBlock[] = [
             {
                 blockType: 'section-heading',
                 displayText: 'Section in the First Page',
@@ -15,87 +15,90 @@ module('Unit | Packages | registration-schema | get-schema-block-group', () => {
                 registrationResponseKey: 'a1',
                 index: 1,
             },
-        ];
-        const result = getSchemaBlockGroup(standAloneSchema, 'q1');
-        assert.equal(result.registrationResponseKey, 'a1', 'has proper registrationResponseKey');
-        assert.equal(result.schemaBlockGroupKey, 'q1', 'has proper schemaBlockGroupKey');
-        assert.ok(!result.optionBlocks, 'has proper optionBlocks');
-    });
-
-    test('Group multiple choice question as schema block group', assert => {
-        const mulitSelectSchema: SchemaBlock[] = [
             {
-                blockType: 'section-heading',
-                displayText: 'Extraneous heading',
-                index: 0,
+                blockType: 'subsection-heading',
+                displayText: 'Subsection after first input',
+                index: 2,
             },
             {
                 blockType: 'question-label',
                 displayText: 'Multi Select',
                 schemaBlockGroupKey: 'testMulti',
-                index: 1,
+                index: 3,
             },
             {
                 blockType: 'multi-select-input',
                 schemaBlockGroupKey: 'testMulti',
                 registrationResponseKey: 'testMultiAnswer',
-                index: 2,
-            },
-            {
-                blockType: 'select-input-option',
-                schemaBlockGroupKey: 'testMulti',
-                displayText: 'Multi-option 1',
-                index: 3,
-            },
-            {
-                blockType: 'select-input-option',
-                schemaBlockGroupKey: 'testMulti',
-                displayText: 'Multi-option 2',
                 index: 4,
             },
             {
                 blockType: 'select-input-option',
                 schemaBlockGroupKey: 'testMulti',
-                displayText: 'Multi-option 3',
+                displayText: 'Multi-option 1',
                 index: 5,
             },
-        ];
-        const result = getSchemaBlockGroup(mulitSelectSchema, 'testMulti');
-        assert.equal(result.registrationResponseKey, 'testMultiAnswer', 'has proper registrationResponseKey');
-        assert.equal(result.schemaBlockGroupKey, 'testMulti', 'has proper schemaBlockGroupKey');
-        assert.equal(result.optionBlocks!.length, 3, 'has proper optionBlocks');
-    });
-
-    test('Group single choice question as schema block group', assert => {
-        const mulitSelectSchema: SchemaBlock[] = [
+            {
+                blockType: 'select-input-option',
+                schemaBlockGroupKey: 'testMulti',
+                displayText: 'Multi-option 2',
+                index: 6,
+            },
+            {
+                blockType: 'select-input-option',
+                schemaBlockGroupKey: 'testMulti',
+                displayText: 'Multi-option 3',
+                index: 7,
+            },
             {
                 blockType: 'question-label',
                 displayText: 'Single Select',
                 schemaBlockGroupKey: 'testSingle',
-                index: 0,
+                index: 8,
             },
             {
                 blockType: 'single-select-input',
                 schemaBlockGroupKey: 'testSingle',
                 registrationResponseKey: 'testSingleAnswer',
-                index: 1,
+                index: 9,
             },
             {
                 blockType: 'select-input-option',
                 schemaBlockGroupKey: 'testSingle',
                 displayText: 'single-option 1',
-                index: 2,
+                index: 10,
             },
             {
                 blockType: 'select-input-option',
                 schemaBlockGroupKey: 'testSingle',
                 displayText: 'single-option 2',
-                index: 3,
+                index: 11,
             },
         ];
-        const result = getSchemaBlockGroup(mulitSelectSchema, 'testSingle');
-        assert.equal(result.registrationResponseKey, 'testSingleAnswer', 'has proper registrationResponseKey');
-        assert.equal(result.schemaBlockGroupKey, 'testSingle', 'has proper schemaBlockGroupKey');
-        assert.equal(result.optionBlocks!.length, 2, 'has proper optionsBlocks');
+        const result = getSchemaBlockGroups(testSchema);
+        // section heading
+        assert.ok(!result[0].registrationResponseKey, 'section heading has proper registrationResponseKey (none)');
+        assert.ok(result[0].labelBlock, 'section heading has labelBlock');
+        // standalone text input
+        assert.equal(result[1].registrationResponseKey, 'a1',
+            'standalone text input has proper registrationResponseKey');
+        assert.equal(result[1].schemaBlockGroupKey, 'q1',
+            'standalone text input has proper schemaBlockGroupKey');
+        assert.ok(!result[1].optionBlocks, 'standalone text input has proper optionBlocks (none)');
+        // subsection heading
+        assert.ok(!result[2].registrationResponseKey, 'subsection heading has proper registrationResponseKey (none');
+        assert.ok(result[2].labelBlock, 'subsection heading has labelBlock');
+        // multi select
+        assert.equal(result[3].registrationResponseKey, 'testMultiAnswer',
+            'multi select has proper registrationResponseKey');
+        assert.equal(result[3].schemaBlockGroupKey, 'testMulti',
+            'multi select has proper schemaBlockGroupKey');
+        assert.equal(result[3].optionBlocks!.length, 3, 'multi select has proper optionBlocks');
+        // single select
+        assert.equal(result[4].registrationResponseKey, 'testSingleAnswer',
+            'single select has proper registrationResponseKey');
+        assert.equal(result[4].schemaBlockGroupKey, 'testSingle',
+            'single select has proper schemaBlockGroupKey');
+        assert.equal(result[4].optionBlocks!.length, 2, 'single select has proper optionsBlocks');
     });
 });

--- a/tests/unit/packages/registration-schema/validations-test.ts
+++ b/tests/unit/packages/registration-schema/validations-test.ts
@@ -88,13 +88,13 @@ module('Unit | Packages | registration-schema | validations', () => {
             },
         ];
         const result = buildValidation(groups);
-        assert.equal(result.q1ShortTextRequired.response.length, 1,
+        assert.equal(result[groups[1].registrationResponseKey!].response.length, 1,
             'has 1 validation for required short text input');
-        assert.equal(result.q2ShortTextOptional.response.length, 2,
+        assert.equal(result[groups[2].registrationResponseKey!].response.length, 2,
             'has 2 validations for optional short text input');
-        assert.equal(result.q3LongTextRequired.response.length, 1,
+        assert.equal(result[groups[3].registrationResponseKey!].response.length, 1,
             'has 1 validation for required long text input');
-        assert.equal(result.q4LongTextOptional.response.length, 2,
+        assert.equal(result[groups[4].registrationResponseKey!].response.length, 2,
             'has 2 validations for optional long text input');
     });
 
@@ -146,9 +146,9 @@ module('Unit | Packages | registration-schema | validations', () => {
             },
         ];
         const result = buildValidation(groups);
-        assert.equal(result.q1ContributorsRequired.response.length, 2,
+        assert.equal(result[groups[1].registrationResponseKey!].response.length, 2,
             'has 2 validation for required contributor input');
-        assert.equal(result.q2ContributorsOptional.response.length, 1,
+        assert.equal(result[groups[2].registrationResponseKey!].response.length, 1,
             'has 1 validations for optional contributor input');
     });
 
@@ -200,9 +200,9 @@ module('Unit | Packages | registration-schema | validations', () => {
             },
         ];
         const result = buildValidation(groups);
-        assert.equal(result.q1FileRequired.response.length, 2,
+        assert.equal(result[groups[1].registrationResponseKey!].response.length, 2,
             'has 2 validation for required file input');
-        assert.equal(result.q2FileOptional.response.length, 1,
+        assert.equal(result[groups[2].registrationResponseKey!].response.length, 1,
             'has 1 validations for optional file input');
     });
 
@@ -351,13 +351,13 @@ module('Unit | Packages | registration-schema | validations', () => {
             },
         ];
         const result = buildValidation(groups);
-        assert.equal(result.q1SingleSelectRequired.response.length, 2,
+        assert.equal(result[groups[1].registrationResponseKey!].response.length, 2,
             'has 2 validation for required Single-Selector input');
-        assert.equal(result.q2SingleSelectOptional.response.length, 1,
+        assert.equal(result[groups[2].registrationResponseKey!].response.length, 1,
             'has 1 validations for optional Single-Select input');
-        assert.equal(result.q3MultiSelectRequired.response.length, 2,
+        assert.equal(result[groups[3].registrationResponseKey!].response.length, 2,
             'has 2 validation for required Multi-Select input');
-        assert.equal(result.q4MultiSelectOptional.response.length, 1,
+        assert.equal(result[groups[4].registrationResponseKey!].response.length, 1,
             'has 1 validations for optional Multi-Select input');
     });
 });

--- a/tests/unit/packages/registration-schema/validations-test.ts
+++ b/tests/unit/packages/registration-schema/validations-test.ts
@@ -88,14 +88,14 @@ module('Unit | Packages | registration-schema | validations', () => {
             },
         ];
         const result = buildValidation(groups);
-        assert.equal(result[groups[1].registrationResponseKey!].response.length, 1,
+        assert.equal(result[groups[1].registrationResponseKey!].length, 1,
             'has 1 validation for required short text input');
-        assert.equal(result[groups[2].registrationResponseKey!].response.length, 2,
-            'has 2 validations for optional short text input');
-        assert.equal(result[groups[3].registrationResponseKey!].response.length, 1,
+        assert.equal(result[groups[2].registrationResponseKey!].length, 1,
+            'has 1 validations for optional short text input');
+        assert.equal(result[groups[3].registrationResponseKey!].length, 1,
             'has 1 validation for required long text input');
-        assert.equal(result[groups[4].registrationResponseKey!].response.length, 2,
-            'has 2 validations for optional long text input');
+        assert.equal(result[groups[4].registrationResponseKey!].length, 1,
+            'has 1 validations for optional long text input');
     });
 
     test('validate contributor inputs', assert => {
@@ -146,9 +146,9 @@ module('Unit | Packages | registration-schema | validations', () => {
             },
         ];
         const result = buildValidation(groups);
-        assert.equal(result[groups[1].registrationResponseKey!].response.length, 2,
+        assert.equal(result[groups[1].registrationResponseKey!].length, 2,
             'has 2 validation for required contributor input');
-        assert.equal(result[groups[2].registrationResponseKey!].response.length, 1,
+        assert.equal(result[groups[2].registrationResponseKey!].length, 1,
             'has 1 validations for optional contributor input');
     });
 
@@ -200,9 +200,9 @@ module('Unit | Packages | registration-schema | validations', () => {
             },
         ];
         const result = buildValidation(groups);
-        assert.equal(result[groups[1].registrationResponseKey!].response.length, 2,
+        assert.equal(result[groups[1].registrationResponseKey!].length, 2,
             'has 2 validation for required file input');
-        assert.equal(result[groups[2].registrationResponseKey!].response.length, 1,
+        assert.equal(result[groups[2].registrationResponseKey!].length, 1,
             'has 1 validations for optional file input');
     });
 
@@ -351,13 +351,13 @@ module('Unit | Packages | registration-schema | validations', () => {
             },
         ];
         const result = buildValidation(groups);
-        assert.equal(result[groups[1].registrationResponseKey!].response.length, 2,
+        assert.equal(result[groups[1].registrationResponseKey!].length, 2,
             'has 2 validation for required Single-Selector input');
-        assert.equal(result[groups[2].registrationResponseKey!].response.length, 1,
+        assert.equal(result[groups[2].registrationResponseKey!].length, 1,
             'has 1 validations for optional Single-Select input');
-        assert.equal(result[groups[3].registrationResponseKey!].response.length, 2,
+        assert.equal(result[groups[3].registrationResponseKey!].length, 2,
             'has 2 validation for required Multi-Select input');
-        assert.equal(result[groups[4].registrationResponseKey!].response.length, 1,
+        assert.equal(result[groups[4].registrationResponseKey!].length, 1,
             'has 1 validations for optional Multi-Select input');
     });
 });

--- a/tests/unit/packages/registration-schema/validations-test.ts
+++ b/tests/unit/packages/registration-schema/validations-test.ts
@@ -1,0 +1,363 @@
+import { buildValidation, SchemaBlockGroup } from 'ember-osf-web/packages/registration-schema';
+import { module, test } from 'qunit';
+
+module('Unit | Packages | registration-schema | validations', () => {
+    test('validate text inputs', assert => {
+        const groups: SchemaBlockGroup[] = [
+            {
+                labelBlock: {
+                    blockType: 'section-heading',
+                    displayText: 'Test for Text Inputs',
+                    index: 0,
+                },
+                groupType: 'section-heading',
+            },
+            // Short Text Inputs
+            {
+                labelBlock: {
+                    blockType: 'question-label',
+                    displayText: 'Short Text: Required',
+                    index: 1,
+                    schemaBlockGroupKey: 'q1',
+                },
+                inputBlock: {
+                    blockType: 'short-text-input',
+                    index: 2,
+                    schemaBlockGroupKey: 'q1',
+                    registrationResponseKey: 'q1ShortTextRequired',
+                    required: true,
+                },
+                schemaBlockGroupKey: 'q1',
+                registrationResponseKey: 'q1ShortTextRequired',
+                groupType: 'short-text-input',
+            },
+            {
+                labelBlock: {
+                    blockType: 'question-label',
+                    displayText: 'Short Text: Optional',
+                    index: 3,
+                    schemaBlockGroupKey: 'q2',
+                },
+                inputBlock: {
+                    blockType: 'short-text-input',
+                    index: 4,
+                    schemaBlockGroupKey: 'q2',
+                    registrationResponseKey: 'q2ShortTextOptional',
+                    required: false,
+                },
+                schemaBlockGroupKey: 'q2',
+                registrationResponseKey: 'q2ShortTextOptional',
+                groupType: 'short-text-input',
+            },
+            // Long Text Inputs
+            {
+                labelBlock: {
+                    blockType: 'question-label',
+                    displayText: 'Long Text: Required',
+                    index: 5,
+                    schemaBlockGroupKey: 'q3',
+                },
+                inputBlock: {
+                    blockType: 'long-text-input',
+                    index: 6,
+                    schemaBlockGroupKey: 'q3',
+                    registrationResponseKey: 'q3LongTextRequired',
+                    required: true,
+                },
+                schemaBlockGroupKey: 'q3',
+                registrationResponseKey: 'q3LongTextRequired',
+                groupType: 'long-text-input',
+            },
+            {
+                labelBlock: {
+                    blockType: 'question-label',
+                    displayText: 'Long Text: Optional',
+                    index: 7,
+                    schemaBlockGroupKey: 'q4',
+                },
+                inputBlock: {
+                    blockType: 'long-text-input',
+                    index: 8,
+                    schemaBlockGroupKey: 'q4',
+                    registrationResponseKey: 'q4LongTextOptional',
+                    required: false,
+                },
+                schemaBlockGroupKey: 'q4',
+                registrationResponseKey: 'q4LongTextOptional',
+                groupType: 'long-text-input',
+            },
+        ];
+        const result = buildValidation(groups);
+        assert.equal(result.q1ShortTextRequired.response.length, 1,
+            'has 1 validation for required short text input');
+        assert.equal(result.q2ShortTextOptional.response.length, 2,
+            'has 2 validations for optional short text input');
+        assert.equal(result.q3LongTextRequired.response.length, 1,
+            'has 1 validation for required long text input');
+        assert.equal(result.q4LongTextOptional.response.length, 2,
+            'has 2 validations for optional long text input');
+    });
+
+    test('validate contributor inputs', assert => {
+        const groups: SchemaBlockGroup[] = [
+            {
+                labelBlock: {
+                    blockType: 'section-heading',
+                    displayText: 'Test for Contributor Inputs',
+                    index: 0,
+                },
+                groupType: 'section-heading',
+            },
+            {
+                labelBlock: {
+                    blockType: 'question-label',
+                    displayText: 'Contributors: Required',
+                    index: 1,
+                    schemaBlockGroupKey: 'q1',
+                },
+                inputBlock: {
+                    blockType: 'contributors-input',
+                    index: 2,
+                    schemaBlockGroupKey: 'q1',
+                    registrationResponseKey: 'q1ContributorsRequired',
+                    required: true,
+                },
+                schemaBlockGroupKey: 'q1',
+                registrationResponseKey: 'q1ContributorsRequired',
+                groupType: 'contributors-input',
+            },
+            {
+                labelBlock: {
+                    blockType: 'question-label',
+                    displayText: 'Contributors: Optional',
+                    index: 3,
+                    schemaBlockGroupKey: 'q2',
+                },
+                inputBlock: {
+                    blockType: 'contributors-input',
+                    index: 4,
+                    schemaBlockGroupKey: 'q2',
+                    registrationResponseKey: 'q2ContributorsOptional',
+                    required: false,
+                },
+                schemaBlockGroupKey: 'q2',
+                registrationResponseKey: 'q2ContributorsOptional',
+                groupType: 'contributors-input',
+            },
+        ];
+        const result = buildValidation(groups);
+        assert.equal(result.q1ContributorsRequired.response.length, 2,
+            'has 2 validation for required contributor input');
+        assert.equal(result.q2ContributorsOptional.response.length, 1,
+            'has 1 validations for optional contributor input');
+    });
+
+    test('validate file inputs', assert => {
+        const groups: SchemaBlockGroup[] = [
+            {
+                labelBlock: {
+                    blockType: 'section-heading',
+                    displayText: 'Test for File Inputs',
+                    index: 0,
+                },
+                groupType: 'section-heading',
+            },
+            {
+                labelBlock: {
+                    blockType: 'question-label',
+                    displayText: 'File: Required',
+                    index: 1,
+                    schemaBlockGroupKey: 'q1',
+                },
+                inputBlock: {
+                    blockType: 'file-input',
+                    index: 2,
+                    schemaBlockGroupKey: 'q1',
+                    registrationResponseKey: 'q1FileRequired',
+                    required: true,
+                },
+                schemaBlockGroupKey: 'q1',
+                registrationResponseKey: 'q1FileRequired',
+                groupType: 'file-input',
+            },
+            {
+                labelBlock: {
+                    blockType: 'question-label',
+                    displayText: 'File: Optional',
+                    index: 3,
+                    schemaBlockGroupKey: 'q2',
+                },
+                inputBlock: {
+                    blockType: 'file-input',
+                    index: 4,
+                    schemaBlockGroupKey: 'q2',
+                    registrationResponseKey: 'q2FileOptional',
+                    required: false,
+                },
+                schemaBlockGroupKey: 'q2',
+                registrationResponseKey: 'q2FileOptional',
+                groupType: 'file-input',
+            },
+        ];
+        const result = buildValidation(groups);
+        assert.equal(result.q1FileRequired.response.length, 2,
+            'has 2 validation for required file input');
+        assert.equal(result.q2FileOptional.response.length, 1,
+            'has 1 validations for optional file input');
+    });
+
+    test('validate select inputs', assert => {
+        const groups: SchemaBlockGroup[] = [
+            {
+                labelBlock: {
+                    blockType: 'section-heading',
+                    displayText: 'Test for Select Inputs',
+                    index: 0,
+                },
+                groupType: 'section-heading',
+            },
+            // Single Select: Required
+            {
+                labelBlock: {
+                    blockType: 'question-label',
+                    displayText: 'Single Select: Required',
+                    index: 1,
+                    schemaBlockGroupKey: 'q1',
+                },
+                inputBlock: {
+                    blockType: 'single-select-input',
+                    index: 2,
+                    schemaBlockGroupKey: 'q1',
+                    registrationResponseKey: 'q1SingleSelectRequired',
+                    required: true,
+                },
+                optionBlocks: [
+                    {
+                        blockType: 'select-input-option',
+                        index: 3,
+                        schemaBlockGroupKey: 'q1',
+                        displayText: 'option1 required single select',
+                    },
+                    {
+                        blockType: 'select-input-option',
+                        index: 4,
+                        schemaBlockGroupKey: 'q1',
+                        displayText: 'option2 required single-select',
+                    },
+                ],
+                schemaBlockGroupKey: 'q1',
+                registrationResponseKey: 'q1SingleSelectRequired',
+                groupType: 'single-select-input',
+            },
+            // Single Select: Optional
+            {
+                labelBlock: {
+                    blockType: 'question-label',
+                    displayText: 'Single Select: Optional',
+                    index: 5,
+                    schemaBlockGroupKey: 'q2',
+                },
+                inputBlock: {
+                    blockType: 'single-select-input',
+                    index: 6,
+                    schemaBlockGroupKey: 'q2',
+                    registrationResponseKey: 'q2SingleSelectOptional',
+                    required: false,
+                },
+                optionBlocks: [
+                    {
+                        blockType: 'select-input-option',
+                        index: 7,
+                        schemaBlockGroupKey: 'q2',
+                        displayText: 'option1 optional single-select',
+                    },
+                    {
+                        blockType: 'select-input-option',
+                        index: 8,
+                        schemaBlockGroupKey: 'q2',
+                        displayText: 'option2 optional single-select',
+                    },
+                ],
+                schemaBlockGroupKey: 'q2',
+                registrationResponseKey: 'q2SingleSelectOptional',
+                groupType: 'single-select-input',
+            },
+
+            // Multiple Select: Required
+            {
+                labelBlock: {
+                    blockType: 'question-label',
+                    displayText: 'Multi Select: Required',
+                    index: 9,
+                    schemaBlockGroupKey: 'q3',
+                },
+                inputBlock: {
+                    blockType: 'multi-select-input',
+                    index: 9,
+                    schemaBlockGroupKey: 'q3',
+                    registrationResponseKey: 'q3MultiSelectRequired',
+                    required: true,
+                },
+                optionBlocks: [
+                    {
+                        blockType: 'select-input-option',
+                        index: 10,
+                        schemaBlockGroupKey: 'q3',
+                        displayText: 'option1 required multi select',
+                    },
+                    {
+                        blockType: 'select-input-option',
+                        index: 11,
+                        schemaBlockGroupKey: 'q3',
+                        displayText: 'option2 required multi-select',
+                    },
+                ],
+                schemaBlockGroupKey: 'q3',
+                registrationResponseKey: 'q3MultiSelectRequired',
+                groupType: 'multi-select-input',
+            },
+            // Multi Select: Optional
+            {
+                labelBlock: {
+                    blockType: 'question-label',
+                    displayText: 'Multi Select: Optional',
+                    index: 12,
+                    schemaBlockGroupKey: 'q4',
+                },
+                inputBlock: {
+                    blockType: 'multi-select-input',
+                    index: 13,
+                    schemaBlockGroupKey: 'q4',
+                    registrationResponseKey: 'q4MultiSelectOptional',
+                    required: false,
+                },
+                optionBlocks: [
+                    {
+                        blockType: 'select-input-option',
+                        index: 14,
+                        schemaBlockGroupKey: 'q4',
+                        displayText: 'option1 optional multi-select',
+                    },
+                    {
+                        blockType: 'select-input-option',
+                        index: 15,
+                        schemaBlockGroupKey: 'q4',
+                        displayText: 'option2 optional multi-select',
+                    },
+                ],
+                schemaBlockGroupKey: 'q4',
+                registrationResponseKey: 'q4MultiSelectOptional',
+                groupType: 'single-select-input',
+            },
+        ];
+        const result = buildValidation(groups);
+        assert.equal(result.q1SingleSelectRequired.response.length, 2,
+            'has 2 validation for required Single-Selector input');
+        assert.equal(result.q2SingleSelectOptional.response.length, 1,
+            'has 1 validations for optional Single-Select input');
+        assert.equal(result.q3MultiSelectRequired.response.length, 2,
+            'has 2 validation for required Multi-Select input');
+        assert.equal(result.q4MultiSelectOptional.response.length, 1,
+            'has 1 validations for optional Multi-Select input');
+    });
+});

--- a/tests/unit/validators/validate-response-format-test.ts
+++ b/tests/unit/validators/validate-response-format-test.ts
@@ -1,0 +1,31 @@
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { validateResponseFormat } from 'ember-osf-web/validators/validate-response-format';
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Validator | validate-response-format', hooks => {
+    setupTest(hooks);
+    setupMirage(hooks);
+
+    test('validates contributor response format', assert => {
+        const options = { format: 'contributor' };
+        const validator = validateResponseFormat(options);
+        const currentUser = server.create('user', 'loggedIn');
+        assert.ok(validator(currentUser), 'returns true for valid contributor');
+        assert.equal(validator({ break: 'bang!' }), 'Not a valid contributor',
+            'returns error message for invalid contributor');
+    });
+
+    test('validates file response format', assert => {
+        const options = { format: 'file' };
+        const validator = validateResponseFormat(options);
+        const currentUser = server.create('user', 'loggedIn');
+        const fileOne = server.create('file', {
+            name: 'testFile.txt',
+            user: currentUser,
+        });
+        assert.ok(validator(fileOne), 'returns true for valid contributor');
+        assert.equal(validator({ break: 'bang!' }), 'Not a valid file',
+            'returns error message for invalid file');
+    });
+});


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-734]
- Feature flag: n/a

## Purpose

<!-- Describe the purpose of your changes. -->
Build a validations helper to build validations for a given schema page
## Summary of Changes

<!-- Briefly describe or list your changes. -->
Added a `validations` helper that takes in an array of `SchemaBlock`s and returns a validation object based on the inputs in that array. The validation object will use the `registrationResponseKey` to assign validations to each input.

Added a custom validator to check if `file-input` has the format expected with `id` and `name`.

Added `PageResponse` type. This is the model that the validations are built for.

Added `groupType` property on `SchemaBlockGroup`. This property is the same as `SchemaBlockGroup.inputBlock.blockType`

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->
`N/A`
## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
`N/A`

[ENG-734]: https://openscience.atlassian.net/browse/ENG-734