### PR TITLE
[no ticket] fix: ensure seedrandom is there when needed

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -147,7 +147,7 @@ module.exports = function(defaults) {
         test: 'vendor/ember/ember-template-compiler.js',
     });
 
-    if (mirageEnabled) {
+    if (mirageEnabled || !IS_PROD) {
         app.import('node_modules/seedrandom/seedrandom.min.js', {
             using: [{ transformation: 'amd', as: 'seedrandom' }],
         });


### PR DESCRIPTION

<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: n/a
- Feature flag: n/a

## Purpose
- Mirage is included in all dev builds, even when disabled (this is required for `/tests` to run as expected).
- The `seedrandom` package is required only by our mirage utils, so in `ember-cli-build.js` we include it only when mirage is enabled.
- This causes an error when disabling mirage in dev mode.
<!-- Describe the purpose of your changes. -->

## Summary of Changes
Always include `seedrandom` in dev/test builds. Include it in prod builds only when mirage is explicitly enabled (e.g. for deploying to gh-pages)
<!-- Briefly describe or list your changes. -->

## Side Effects
n/a
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
n/a
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
