### PR TITLE
[no ticket] Darken osf-dialog background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         - folders should always use folder icon
     - `sort-button`
         - suppress box-shadow when active
+    - `osf-dialog`
+        - darken background overlay
 - Tests
     - renamed `taxonomy` to `subject` in `preprint-provider` FactoryGuy factory
     - Unit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         - added splattributes because this is template-only
     - `registries/sharing-icons/popover`
         - added splattributes because this is template-only
+- Handbook
+    - `osf-dialog` `demo-is-open` needs component file because it muts `isOpen`
 
 ## [19.9.0] - 2019-09-06
 ### Added

--- a/lib/handbook/addon/docs/components/osf-dialog/-components/demo-is-open/component.ts
+++ b/lib/handbook/addon/docs/components/osf-dialog/-components/demo-is-open/component.ts
@@ -1,0 +1,7 @@
+import { tagName } from '@ember-decorators/component';
+import Component from '@ember/component';
+
+@tagName('')
+export default class DemoIsOpen extends Component {
+    isOpen = false;
+}

--- a/lib/osf-components/addon/components/osf-dialog/styles.scss
+++ b/lib/osf-components/addon/components/osf-dialog/styles.scss
@@ -12,6 +12,7 @@
     justify-content: center;
 
     z-index: 900;
+    background-color: rgba(0, 0, 0, 0.5);
 }
 
 .Unclickable {


### PR DESCRIPTION
- Ticket: n/a
- Feature flag: n/a

## Purpose

Darken the osf-dialog background overlay

## Summary of Changes

### Changed
- Components
    - `osf-dialog`
        - darken background overlay

### Fixed
- Handbook
    - `osf-dialog` `demo-is-open` needs component file because it muts `isOpen`

## Side Effects

None expected.

## QA Notes

Can be tested with the subject picker.
