### PR TITLE
[no ticket] Fix linting errors with CRLF vs LF on Windows machines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ root = true
 
 
 [*]
-end_of_line = lf
+# end_of_line = lf (https://github.com/editorconfig/editorconfig/issues/226)
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,6 +43,7 @@ module.exports = {
             asyncArrow: 'always',
         }],
         'no-underscore-dangle': 'off',
+        'linebreak-style': ['error', (process.platform === 'win32' ? 'windows' : 'unix')],
     },
     overrides: [
         {


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: n/a
- Feature flag: n/a

## Purpose

On Windows machines, Git installer's default is to checkout to CRLF line endings and commit LF. This was causing linting errors within the project. These changes just ensure linting matches to the machine it's running on.

## Summary of Changes

Added check for linebreak style in .eslintrc.js and removed forced LF in .editorconfig.