### PR TITLE
[ENG-1059] Eng 1059/institutional dashboard route

### DIFF
--- a/app/institutions/dashboard/controller.ts
+++ b/app/institutions/dashboard/controller.ts
@@ -1,6 +1,11 @@
-import Controller from '@ember/controller';
+import { alias } from '@ember-decorators/object/computed';
 
-export default class InstitutionsDashboardController extends Controller {}
+import Controller from '@ember/controller';
+import InstitutionModel from 'ember-osf-web/models/institution';
+
+export default class InstitutionsDashboardController extends Controller {
+    @alias('model.taskInstance.value') institution!: InstitutionModel;
+}
 
 declare module '@ember/controller' {
     interface Registry {

--- a/app/institutions/dashboard/route.ts
+++ b/app/institutions/dashboard/route.ts
@@ -2,14 +2,12 @@ import { action } from '@ember-decorators/object';
 import { service } from '@ember-decorators/service';
 import Route from '@ember/routing/route';
 
+import RouterService from '@ember/routing/router-service';
 import { task } from 'ember-concurrency';
 import Analytics from 'ember-osf-web/services/analytics';
 
-export default class InstitutionsDashboardRoute extends Route {
-    @service analytics!: Analytics;
-    @service router!: any;
-
-    loadInstitutionsDashboardRoute = task(function *(this: InstitutionsDashboardRoute, institutionId: string) {
+export default class InstitutionsDashboardRoute extends Route.extend({
+    modelTask: task(function *(this: InstitutionsDashboardRoute, institutionId: string) {
         try {
             const institution = yield this.get('store').findRecord('institution', institutionId);
             if (!institution.get('currentUserIsAdmin')) {
@@ -20,17 +18,20 @@ export default class InstitutionsDashboardRoute extends Route {
             this.transitionTo('not-found', this.get('router').get('currentURL').slice(1));
             return undefined;
         }
-    });
+    }),
+}) {
+    @service analytics!: Analytics;
+    @service router!: RouterService;
 
-    // TODO Will need to check user permission to access institutional dashboard
-    model(this: InstitutionsDashboardRoute, params: Record<string, string>) {
+    // eslint-disable-next-line camelcase
+    model(params: { institution_id: string }) {
         return {
-            taskInstance: this.get('loadInstitutionsDashboardRoute').perform(params.institution_id),
+            taskInstance: this.modelTask.perform(params.institution_id),
         };
     }
 
     @action
     didTransition() {
-        this.get('analytics').trackPage();
+        this.analytics.trackPage();
     }
 }

--- a/app/institutions/dashboard/route.ts
+++ b/app/institutions/dashboard/route.ts
@@ -1,21 +1,36 @@
 import { action } from '@ember-decorators/object';
 import { service } from '@ember-decorators/service';
 import Route from '@ember/routing/route';
-import DS from 'ember-data';
 
+import { task } from 'ember-concurrency';
 import Analytics from 'ember-osf-web/services/analytics';
 
 export default class InstitutionsDashboardRoute extends Route {
     @service analytics!: Analytics;
-    @service store!: DS.Store;
+    @service router!: any;
 
-    // eslint-disable-next-line camelcase
-    model(params: { institution_id: string }) {
-        return this.store.findRecord('institution', params.institution_id);
+    loadInstitutionsDashboardRoute = task(function *(this: InstitutionsDashboardRoute, institutionId: string) {
+        try {
+            const institution = yield this.get('store').findRecord('institution', institutionId);
+            if (!institution.get('currentUserIsAdmin')) {
+                throw new Error('Current user is not admin.');
+            }
+            return institution;
+        } catch (error) {
+            this.transitionTo('not-found', this.get('router').get('currentURL').slice(1));
+            return undefined;
+        }
+    });
+
+    // TODO Will need to check user permission to access institutional dashboard
+    model(this: InstitutionsDashboardRoute, params: Record<string, string>) {
+        return {
+            taskInstance: this.get('loadInstitutionsDashboardRoute').perform(params.institution_id),
+        };
     }
 
     @action
     didTransition() {
-        this.analytics.trackPage();
+        this.get('analytics').trackPage();
     }
 }

--- a/app/institutions/dashboard/template.hbs
+++ b/app/institutions/dashboard/template.hbs
@@ -1,3 +1,9 @@
 <div>
-    {{this.model.name}}
+    <img src='{{this.institution.assets.logo}}' alt='{{this.institution.name}}'>
+    {{this.institution.name}}
+    <ul>
+        {{#each this.institution.institutionalUsers as |user|}}
+            <li>{{user.fullName}}</li>
+        {{/each}}
+    </ul>
 </div>

--- a/app/institutions/dashboard/template.hbs
+++ b/app/institutions/dashboard/template.hbs
@@ -1,5 +1,5 @@
 <div>
-    <img src='{{this.institution.assets.logo}}' alt='{{this.institution.name}}'>
+    <img src='{{this.institution.assets.banner}}' alt='{{this.institution.name}}'>
     {{this.institution.name}}
     <ul>
         {{#each this.institution.institutionalUsers as |user|}}

--- a/app/models/institution.ts
+++ b/app/models/institution.ts
@@ -21,6 +21,7 @@ export default class InstitutionModel extends OsfModel {
     @attr('string') logoPath!: string;
     @attr('string') authUrl!: string;
     @attr('object') assets!: Partial<Assets>;
+    @attr('boolean') currentUserIsAdmin!: boolean;
 
     @hasMany('institutional-user', { inverse: 'institution' })
     institutionalUsers!: DS.PromiseManyArray<InstitutionalUserModel>;

--- a/app/models/institution.ts
+++ b/app/models/institution.ts
@@ -22,7 +22,7 @@ export default class InstitutionModel extends OsfModel {
     @attr('string') logoPath!: string;
     @attr('string') authUrl!: string;
     @attr('object') assets!: Partial<Assets>;
-    @attr('boolean') currentUserIsAdmin!: boolean;
+    @attr('boolean', { defaultValue: false }) currentUserIsAdmin!: boolean;
 
     @hasMany('institutional-user', { inverse: 'institution' })
     institutionalUsers!: DS.PromiseManyArray<InstitutionalUserModel>;

--- a/app/models/institution.ts
+++ b/app/models/institution.ts
@@ -10,6 +10,7 @@ import UserModel from './user';
 
 /* eslint-disable camelcase */
 export interface Assets {
+    banner: string;
     logo: string;
     logo_rounded: string;
 }

--- a/mirage/factories/institution.ts
+++ b/mirage/factories/institution.ts
@@ -1,8 +1,8 @@
-import { Factory, faker, Trait, trait } from 'ember-cli-mirage';
+import { Factory, faker, trait, Trait } from 'ember-cli-mirage';
 
 import Institution from 'ember-osf-web/models/institution';
 
-import { randomGravatar } from '../utils';
+import { placekitten, randomGravatar } from '../utils';
 
 export interface InstitutionTraits {
     withInstitutionalUsers: Trait;
@@ -17,12 +17,13 @@ export default Factory.extend<Institution & InstitutionTraits>({
     },
     assets() {
         return {
+            banner: placekitten(512, 128),
             logo: randomGravatar(100),
         };
     },
     withInstitutionalUsers: trait<Institution>({
         afterCreate(institution, server) {
-            server.createList('institutional-user', 10, { institution });
+            server.createList('institutional-user', 5, { institution });
         },
     }),
     currentUserIsAdmin: true,

--- a/mirage/factories/institution.ts
+++ b/mirage/factories/institution.ts
@@ -25,6 +25,7 @@ export default Factory.extend<Institution & InstitutionTraits>({
             server.createList('institutional-user', 10, { institution });
         },
     }),
+    currentUserIsAdmin: true,
 });
 
 declare module 'ember-cli-mirage/types/registries/schema' {

--- a/mirage/factories/node.ts
+++ b/mirage/factories/node.ts
@@ -136,8 +136,7 @@ export default Factory.extend<MirageNode & NodeTraits>({
 
     withAffiliatedInstitutions: trait<MirageNode>({
         afterCreate(node, server) {
-            const affiliatedInstitutionCount = faker.random.number({ min: 4, max: 5 });
-            server.createList('institution', affiliatedInstitutionCount, {
+            server.createList('institution', 5, {
                 nodes: [node],
             });
         },

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -161,7 +161,7 @@ function dashboardScenario(server: Server, currentUser: ModelInstance<User>) {
     // NOTE: Some institutions are already created by this point
     server.createList('institution', 20);
     // Create a specific institution to test institutional dashboard with; should be ID 29 at this point
-    server.create('institution', 'withInstitutionalUsers');
+    server.create('institution', { id: 'has-users' }, 'withInstitutionalUsers');
 }
 
 function forksScenario(server: Server, currentUser: ModelInstance<User>) {

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -157,7 +157,7 @@ function dashboardScenario(server: Server, currentUser: ModelInstance<User>) {
     for (const node of nodes.slice(4, 10)) {
         server.create('contributor', { node, users: currentUser, index: 11 });
     }
-    server.createList('institution', 20);
+    server.createList('institution', 20, 'withInstitutionalUsers');
 }
 
 function forksScenario(server: Server, currentUser: ModelInstance<User>) {

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -157,7 +157,11 @@ function dashboardScenario(server: Server, currentUser: ModelInstance<User>) {
     for (const node of nodes.slice(4, 10)) {
         server.create('contributor', { node, users: currentUser, index: 11 });
     }
-    server.createList('institution', 20, 'withInstitutionalUsers');
+
+    // NOTE: Some institutions are already created by this point
+    server.createList('institution', 20);
+    // Create a specific institution to test institutional dashboard with; should be ID 29 at this point
+    server.create('institution', 'withInstitutionalUsers');
 }
 
 function forksScenario(server: Server, currentUser: ModelInstance<User>) {

--- a/mirage/utils.ts
+++ b/mirage/utils.ts
@@ -1,5 +1,9 @@
 import { faker } from 'ember-cli-mirage';
 
+export function placekitten(width: number, height: number) {
+    return `https://placekitten.com/${width}/${height}`;
+}
+
 export function randomGravatar(size?: number) {
     let url = `https://www.gravatar.com/avatar/${faker.random.uuid().replace(/-/g, '')}?d=identicon`;
     if (size) {


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-1059]
- Feature flag: Institutional Dashboard

## Purpose

Add a protected route for the institutional dashboard. This route only allows admins of an institution to view it. Also pulls in institutional user data from the institution model.

## Summary of Changes

Updated institution routes to look for `currentUserIsAdmin` on the institution. Added specific institution to Mirage for testing institutional dashboard with (ID 29). Added placekitten placeholder image for an institution's banner image.

## QA Notes

/institutions/29/dashboard is the current route for testing the institutional dashboard.


[ENG-1059]: https://openscience.atlassian.net/browse/ENG-1059