### PR TITLE
[ENG-1091] Add files widget to schema-block-renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         - `dashboard/panel`
         - `dashboard/projects-panel`
     - `Registries::DraftRegistrationManager`
+    - `Registries::SchemaBlockRenderer::Editable::Files`
+    - `Registries::SchemaBlockRenderer::ReadOnly::Files`
 - Mirage
     - Factories
         - `institutional-user`
@@ -52,6 +54,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - Factories
         - `institution`
             - added `withInstitutionalUsers` trait
+    - Scenarios
+        - `default`
+            - added `SchemaBlock` node with files and contributors
 - Models
     - `institution`
         - added `currentUserIsAdmin` boolean
@@ -63,6 +68,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         - moved to `index` folder
 - Types
     - Renamed `PageResponse` to `RegistrationResponse`
+- Tests
+    - `schema-block-renderer`
+        - added `files` block test
 
 ### Removed
 - Tests
@@ -72,7 +80,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `ember-data-factory-guy`
 - Types
     - `FactoryGuy` types
-
+            
 ## [19.10.0] - 2019-10-02
 ### Added
 - Models

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `ember-data-factory-guy`
 - Types
     - `FactoryGuy` types
-            
+       
 ## [19.10.0] - 2019-10-02
 ### Added
 - Models

--- a/app/packages/registration-schema/index.ts
+++ b/app/packages/registration-schema/index.ts
@@ -3,5 +3,5 @@ export { getSchemaBlockGroups } from './get-schema-block-group';
 export { SchemaBlock, SchemaBlockType } from './schema-block';
 export { SchemaBlockGroup } from './schema-block-group';
 export { buildValidation } from './validations';
-export { RegistrationResponse, ResponseValue } from './registration-response';
+export { FileReference, RegistrationResponse, ResponseValue } from './registration-response';
 export { PageManager } from './page-manager';

--- a/app/packages/registration-schema/registration-response.ts
+++ b/app/packages/registration-schema/registration-response.ts
@@ -1,7 +1,17 @@
-interface FileReference {
-    id: string;
-    name: string;
+/* eslint-disable camelcase */
+export interface FileReference {
+    file_id: string;
+    file_name: string;
+    file_url: {
+        html: string,
+        download: string,
+    };
+    file_hashes: {
+        sha256: string,
+    };
 }
+/* eslint-enable camelcase */
+
 export type ResponseValue = string | string[] | FileReference[] | null;
 
 export type RegistrationResponse = Record<string, ResponseValue>;

--- a/lib/handbook/addon/docs/components/schema-block-group-renderer/controller.ts
+++ b/lib/handbook/addon/docs/components/schema-block-group-renderer/controller.ts
@@ -157,7 +157,7 @@ export default class SchemaBlockGroupRendererController extends Controller {
 
     schemaBlockGroups = getSchemaBlockGroups(this.schemaBlocks);
 
-    pageResponse = {
+    registrationResponse = {
         'page-one_single-select': '',
         'page-one_short-text': '',
         'page-one_long-text': '',
@@ -165,7 +165,7 @@ export default class SchemaBlockGroupRendererController extends Controller {
         'page-one_single-select-two': '',
         'page-one_file-input': [],
     };
-    pageResponseChangeset = new Changeset(this.pageResponse);
+    registrationResponseChangeset = new Changeset(this.registrationResponse);
 
     registrationResponses = {
         'page-one_single-select': 'tuna',

--- a/lib/handbook/addon/docs/components/schema-block-group-renderer/controller.ts
+++ b/lib/handbook/addon/docs/components/schema-block-group-renderer/controller.ts
@@ -175,16 +175,26 @@ export default class SchemaBlockGroupRendererController extends Controller {
         'page-one_single-select-two': 'Remember who was in NSync and who was in Backstreet Boys',
         'page-one_file-input': [
             {
-                fileID: 'ad552',
-                fileName: 'connecting_home_loan_account.mpe',
-                fileUrl: 'http://localhost:5000/files/osfstorage/ad552/',
-                sha256: 'be5fa974179240abad6772d850bd6e86',
+                file_id: 'ad552',
+                file_name: 'connecting_home_loan_account.mpe',
+                file_urls: {
+                    html: 'http://localhost:5000/files/osfstorage/ad552/',
+                    download: 'http://localhost:5000/files/osfstorage/ad552',
+                },
+                file_hashes: {
+                    sha256: 'be5fa974179240abad6772d850bd6e86',
+                },
             },
             {
-                fileID: 'gu5d4',
-                fileName: 'auto_loan_account.mp4',
-                fileUrl: 'http://localhost:5000/files/osfstorage/gu4d5',
-                sha256: 'be5fa974179240abad6772d850bd6e86',
+                file_id: 'gu5d4',
+                file_name: 'auto_loan_account.mp4',
+                file_urls: {
+                    html: 'http://localhost:5000/files/osfstorage/gu4d5',
+                    download: 'http://localhost:5000/files/osfstorage/gu4d5',
+                },
+                file_hashes: {
+                    sha256: 'be5fa974179240abad6772d850bd6e86',
+                },
             },
         ],
     };

--- a/lib/handbook/addon/docs/components/schema-block-group-renderer/controller.ts
+++ b/lib/handbook/addon/docs/components/schema-block-group-renderer/controller.ts
@@ -102,44 +102,56 @@ export default class SchemaBlockGroupRendererController extends Controller {
         {
             blockType: 'question-label',
             displayText: 'If I had a super power it would be:',
-            schemaBlockGroupKey: 'q6',
+            schemaBlockGroupKey: 'q5',
             index: 17,
         },
         {
             blockType: 'single-select-input',
             registrationResponseKey: 'page-one_single-select-two',
-            schemaBlockGroupKey: 'q6',
+            schemaBlockGroupKey: 'q5',
             index: 18,
         },
         {
             blockType: 'select-input-option',
             displayText: 'Always be on the proper beat while doing the macarena',
-            schemaBlockGroupKey: 'q6',
+            schemaBlockGroupKey: 'q5',
             index: 19,
         },
         {
             blockType: 'select-input-option',
             displayText: 'Remember who was in NSync and who was in Backstreet Boys',
-            schemaBlockGroupKey: 'q6',
+            schemaBlockGroupKey: 'q5',
             index: 20,
         },
         {
             blockType: 'select-other-option',
             displayText: 'Other',
-            schemaBlockGroupKey: 'q6',
+            schemaBlockGroupKey: 'q5',
             index: 21,
         },
         {
             blockType: 'question-label',
             displayText: 'Contributors:',
-            schemaBlockGroupKey: 'q5',
+            schemaBlockGroupKey: 'q6',
             index: 22,
         },
         {
             blockType: 'contributors-input',
             registrationResponseKey: 'page-one_contributors-input',
-            schemaBlockGroupKey: 'q5',
+            schemaBlockGroupKey: 'q6',
             index: 23,
+        },
+        {
+            blockType: 'question-label',
+            displayText: 'Files:',
+            schemaBlockGroupKey: 'q7',
+            index: 24,
+        },
+        {
+            blockType: 'file-input',
+            registrationResponseKey: 'page-one_file-input',
+            schemaBlockGroupKey: 'q7',
+            index: 25,
         },
     ];
 
@@ -151,6 +163,7 @@ export default class SchemaBlockGroupRendererController extends Controller {
         'page-one_long-text': '',
         'page-one_multi-select': [],
         'page-one_single-select-two': '',
+        'page-one_file-input': [],
     };
     pageResponseChangeset = new Changeset(this.pageResponse);
 
@@ -160,5 +173,19 @@ export default class SchemaBlockGroupRendererController extends Controller {
         'page-one_long-text': 'One is called a marsh, and one is called a swamp',
         'page-one_multi-select': ['crocs', 'Nickelback'],
         'page-one_single-select-two': 'Remember who was in NSync and who was in Backstreet Boys',
+        'page-one_file-input': [
+            {
+                fileID: 'ad552',
+                fileName: 'connecting_home_loan_account.mpe',
+                fileUrl: 'http://localhost:5000/files/osfstorage/ad552/',
+                sha256: 'be5fa974179240abad6772d850bd6e86',
+            },
+            {
+                fileID: 'gu5d4',
+                fileName: 'auto_loan_account.mp4',
+                fileUrl: 'http://localhost:5000/files/osfstorage/gu4d5',
+                sha256: 'be5fa974179240abad6772d850bd6e86',
+            },
+        ],
     };
 }

--- a/lib/handbook/addon/docs/components/schema-block-group-renderer/controller.ts
+++ b/lib/handbook/addon/docs/components/schema-block-group-renderer/controller.ts
@@ -2,7 +2,10 @@ import Changeset from 'ember-changeset';
 
 import Controller from '@ember/controller';
 
+import config from 'ember-get-config';
 import { getSchemaBlockGroups, SchemaBlock } from 'ember-osf-web/packages/registration-schema';
+
+const { OSF: { url } } = config;
 
 export default class SchemaBlockGroupRendererController extends Controller {
     schemaBlocks: SchemaBlock[] = [
@@ -178,8 +181,8 @@ export default class SchemaBlockGroupRendererController extends Controller {
                 file_id: 'ad552',
                 file_name: 'connecting_home_loan_account.mpe',
                 file_urls: {
-                    html: 'http://localhost:5000/files/osfstorage/ad552/',
-                    download: 'http://localhost:5000/files/osfstorage/ad552',
+                    html: `${url}files/osfstorage/ad552/`,
+                    download: `${url}files/osfstorage/ad552`,
                 },
                 file_hashes: {
                     sha256: 'be5fa974179240abad6772d850bd6e86',
@@ -189,8 +192,8 @@ export default class SchemaBlockGroupRendererController extends Controller {
                 file_id: 'gu5d4',
                 file_name: 'auto_loan_account.mp4',
                 file_urls: {
-                    html: 'http://localhost:5000/files/osfstorage/gu4d5',
-                    download: 'http://localhost:5000/files/osfstorage/gu4d5',
+                    html: `${url}files/osfstorage/gu4d5`,
+                    download: `${url}/files/osfstorage/gu4d5`,
                 },
                 file_hashes: {
                     sha256: 'be5fa974179240abad6772d850bd6e86',

--- a/lib/handbook/addon/docs/components/schema-block-group-renderer/route.ts
+++ b/lib/handbook/addon/docs/components/schema-block-group-renderer/route.ts
@@ -2,6 +2,6 @@ import Route from '@ember/routing/route';
 
 export default class extends Route {
     model() {
-        return this.store.findRecord('node', 'clst23', { include: 'bibliographic_contributors' });
+        return this.store.findRecord('node', 'dslt', { include: 'bibliographic_contributors' });
     }
 }

--- a/lib/handbook/addon/docs/components/schema-block-group-renderer/template.md
+++ b/lib/handbook/addon/docs/components/schema-block-group-renderer/template.md
@@ -19,7 +19,7 @@ To be used with Registries submission forms.  Given a schema group, changeset an
 ## Editable
 {{docs/components/schema-block-group-renderer/-components/editable
     schemaBlockGroups=this.schemaBlockGroups
-    changeset=this.pageResponseChangeset
+    changeset=this.registrationResponseChangeset
     node=this.model
 }}
 

--- a/lib/osf-components/addon/components/files/manager/component.ts
+++ b/lib/osf-components/addon/components/files/manager/component.ts
@@ -145,8 +145,8 @@ export default class FilesManagerComponent extends Component.extend({
     totalFolderItems!: number;
     totalRootItems!: number;
 
-    onSelect?: (file: File) => {};
-    onUnselect?: (file: File) => {};
+    onSelect?: (file: File) => void;
+    onUnselect?: (file: File) => void;
 
     @alias('node.userHasAdminPermission') canEdit!: boolean;
     @alias('getRootItems.isRunning') loading!: boolean;

--- a/lib/osf-components/addon/components/files/manager/component.ts
+++ b/lib/osf-components/addon/components/files/manager/component.ts
@@ -145,6 +145,9 @@ export default class FilesManagerComponent extends Component.extend({
     totalFolderItems!: number;
     totalRootItems!: number;
 
+    onSelect?: (file: File) => {};
+    onUnselect?: (file: File) => {};
+
     @alias('node.userHasAdminPermission') canEdit!: boolean;
     @alias('getRootItems.isRunning') loading!: boolean;
     @alias('getCurrentFolderItems.isRunning') loadingFolderFiles!: boolean;
@@ -162,11 +165,17 @@ export default class FilesManagerComponent extends Component.extend({
     @action
     selectItem(currentItem: File) {
         this.selectedItems.pushObject(currentItem);
+        if (this.onSelect) {
+            this.onSelect(currentItem);
+        }
     }
 
     @action
     unselectItem(item: File) {
         this.selectedItems.removeObject(item);
+        if (this.onUnselect) {
+            this.onUnselect(item);
+        }
     }
 
     @action

--- a/lib/osf-components/addon/components/files/widget/template.hbs
+++ b/lib/osf-components/addon/components/files/widget/template.hbs
@@ -1,5 +1,5 @@
 <div ...attributes>
-    <Files::Manager @node={{@node}} as |filesManager|>
+    <Files::Manager @node={{@node}} @onSelect={{@onSelect}} @onUnselect={{@onUnselect}} as |filesManager|>
         <Files::SelectedList @filesManager={{filesManager}} />
         <Files::Browse @filesManager={{filesManager}} />
     </Files::Manager>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/component.ts
@@ -1,0 +1,85 @@
+import { tagName } from '@ember-decorators/component';
+import { action } from '@ember-decorators/object';
+import { alias } from '@ember-decorators/object/computed';
+import Component from '@ember/component';
+import { assert } from '@ember/debug';
+
+import { ChangesetDef } from 'ember-changeset/types';
+import File from 'ember-osf-web/models/file';
+import NodeModel from 'ember-osf-web/models/node';
+
+import { layout } from 'ember-osf-web/decorators/component';
+import { SchemaBlock } from 'ember-osf-web/packages/registration-schema';
+
+import template from './template';
+
+interface FileObject {
+    fileID: string;
+    fileName: string;
+    fileUrl: string;
+    sha256: string;
+}
+
+@layout(template)
+@tagName('')
+export default class Files extends Component {
+    // Required param
+    changeset!: ChangesetDef;
+    node!: NodeModel;
+    schemaBlock!: SchemaBlock;
+
+    @alias('schemaBlock.registrationResponseKey')
+    valuePath!: string;
+    selectedFiles: unknown[] = [];
+
+    didReceiveAttrs() {
+        assert(
+            'schema-block-renderer::editable::files requires a changeset to render',
+            Boolean(this.changeset),
+        );
+        assert(
+            'schema-block-renderer::editable::files requires a node to render',
+            Boolean(this.node),
+        );
+        assert(
+            'schema-block-renderer::editable::files requires a valuePath to render',
+            Boolean(this.valuePath),
+        );
+        assert(
+            'schema-block-renderer::editable::files requires a schemaBlock to render',
+            Boolean(this.schemaBlock),
+        );
+    }
+
+    @action
+    onSelect(file: File) {
+        if (file) {
+            const newFile: FileObject = {
+                fileID: `${file.id}`,
+                fileName: `${file.name}`,
+                fileUrl: `${file.links.html}`,
+                sha256: `${file.extra.hashes.sha256}`,
+            };
+            this.selectedFiles.pushObject(newFile);
+            this.changeset.set(this.valuePath, this.selectedFiles);
+        }
+    }
+
+    @action
+    onUnselect(file: File) {
+        if (file) {
+            const newFile: FileObject = {
+                fileID: `${file.id}`,
+                fileName: `${file.name}`,
+                fileUrl: `${file.links.html}`,
+                sha256: `${file.extra.hashes.sha256}`,
+            };
+
+            const newSelectedFiles = this.selectedFiles.filter(
+                (result: FileObject) => result.fileID !== newFile.fileID,
+            );
+            this.set('selectedFiles', newSelectedFiles);
+            this.changeset.set(this.valuePath, this.selectedFiles);
+        }
+    }
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/template.hbs
@@ -1,1 +1,7 @@
-<Files::Widget data-test-editable-file-widget @node={{@node}} @onSelect={{action this.onSelect}} @onUnselect={{action this.onUnselect}} />
+<Files::Widget
+    data-test-editable-file-widget
+    @node={{@node}}
+    @onSelect={{action this.onSelect}}
+    @onUnselect={{action this.onUnselect}}
+    ...attributes
+/>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/template.hbs
@@ -1,0 +1,1 @@
+<Files::Widget data-test-editable-file-widget @node={{@node}} @onSelect={{action this.onSelect}} @onUnselect={{action this.onUnselect}} />

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/mapper/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/mapper/template.hbs
@@ -48,4 +48,10 @@
         'registries/schema-block-renderer/read-only-contributor-list'
         node=@node
     )
+    file-input=(
+        component
+        'registries/schema-block-renderer/editable/files'
+        changeset=@changeset
+        node=@node
+    )
 )}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/component.ts
@@ -1,4 +1,5 @@
 import { tagName } from '@ember-decorators/component';
+import { computed } from '@ember-decorators/object';
 import Component from '@ember/component';
 import { assert } from '@ember/debug';
 
@@ -10,35 +11,23 @@ import template from './template';
 @layout(template)
 @tagName('')
 export default class ReadOnlyFiles extends Component {
-    // Required param
+    // Required params
     schemaBlock!: SchemaBlock;
     registrationResponses!: PageResponse;
 
     didReceiveAttrs() {
         assert(
-            'schema-block-renderer/read-only/files requires a schemaBlock to render',
+            'Registries::SchemaBlockRenderer::ReadOnly::Files requires a schemaBlock to render',
             Boolean(this.schemaBlock),
         );
         assert(
-            'schema-block-renderer/read-only/files requires registrationResponses to render',
+            'Registries::SchemaBlockRenderer::ReadOnly::Files requires registrationResponses to render',
             Boolean(this.registrationResponses),
         );
     }
 
-    didRender() {
-        this.getFileList();
-    }
-
-    getFileList() {
-        const response = this.registrationResponses[this.schemaBlock.registrationResponseKey!];
-        let list = '';
-        if (Array.isArray(response)) {
-            const responseList: unknown[] = [];
-            response.forEach((file: any) => {
-                responseList.push(`<a href='${file.fileUrl}'>${file.fileName}</a>`);
-            });
-            list = responseList.join(', ');
-        }
-        (document.querySelector('[data-test-read-only-file-widget]') as HTMLElement).innerHTML = list;
+    @computed
+    get responses() {
+        return this.registrationResponses[this.schemaBlock.registrationResponseKey!];
     }
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/component.ts
@@ -1,7 +1,8 @@
 import { tagName } from '@ember-decorators/component';
-import { computed } from '@ember-decorators/object';
 import Component from '@ember/component';
 import { assert } from '@ember/debug';
+import { defineProperty } from '@ember/object';
+import { alias } from '@ember/object/computed';
 
 import { layout } from 'ember-osf-web/decorators/component';
 import { RegistrationResponse, SchemaBlock } from 'ember-osf-web/packages/registration-schema';
@@ -15,6 +16,8 @@ export default class ReadOnlyFiles extends Component {
     schemaBlock!: SchemaBlock;
     registrationResponses!: RegistrationResponse;
 
+    responses?: RegistrationResponse[keyof RegistrationResponse];
+
     didReceiveAttrs() {
         assert(
             'Registries::SchemaBlockRenderer::ReadOnly::Files requires a schemaBlock to render',
@@ -26,8 +29,8 @@ export default class ReadOnlyFiles extends Component {
         );
     }
 
-    @computed
-    get responses() {
-        return this.registrationResponses[this.schemaBlock.registrationResponseKey!];
+    init() {
+        super.init();
+        defineProperty(this, 'responses', alias(`registrationResponses.${this.schemaBlock.registrationResponseKey}`));
     }
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/component.ts
@@ -1,0 +1,44 @@
+import { tagName } from '@ember-decorators/component';
+import Component from '@ember/component';
+import { assert } from '@ember/debug';
+
+import { layout } from 'ember-osf-web/decorators/component';
+import { PageResponse, SchemaBlock } from 'ember-osf-web/packages/registration-schema';
+
+import template from './template';
+
+@layout(template)
+@tagName('')
+export default class ReadOnlyFiles extends Component {
+    // Required param
+    schemaBlock!: SchemaBlock;
+    registrationResponses!: PageResponse;
+
+    didReceiveAttrs() {
+        assert(
+            'schema-block-renderer/read-only/files requires a schemaBlock to render',
+            Boolean(this.schemaBlock),
+        );
+        assert(
+            'schema-block-renderer/read-only/files requires registrationResponses to render',
+            Boolean(this.registrationResponses),
+        );
+    }
+
+    didRender() {
+        this.getFileList();
+    }
+
+    getFileList() {
+        const response = this.registrationResponses[this.schemaBlock.registrationResponseKey!];
+        let list = '';
+        if (Array.isArray(response)) {
+            const responseList: unknown[] = [];
+            response.forEach((file: any) => {
+                responseList.push(`<a href='${file.fileUrl}'>${file.fileName}</a>`);
+            });
+            list = responseList.join(', ');
+        }
+        (document.querySelector('[data-test-read-only-file-widget]') as HTMLElement).innerHTML = list;
+    }
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/component.ts
@@ -4,7 +4,7 @@ import Component from '@ember/component';
 import { assert } from '@ember/debug';
 
 import { layout } from 'ember-osf-web/decorators/component';
-import { PageResponse, SchemaBlock } from 'ember-osf-web/packages/registration-schema';
+import { RegistrationResponse, SchemaBlock } from 'ember-osf-web/packages/registration-schema';
 
 import template from './template';
 
@@ -13,7 +13,7 @@ import template from './template';
 export default class ReadOnlyFiles extends Component {
     // Required params
     schemaBlock!: SchemaBlock;
-    registrationResponses!: PageResponse;
+    registrationResponses!: RegistrationResponse;
 
     didReceiveAttrs() {
         assert(

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/template.hbs
@@ -1,1 +1,1 @@
-<p data-test-read-only-file-widget></p>
+<p data-test-read-only-file-widget ...attributes></p>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/template.hbs
@@ -1,0 +1,1 @@
+<p data-test-read-only-file-widget></p>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/template.hbs
@@ -1,1 +1,9 @@
-<p data-test-read-only-file-widget ...attributes></p>
+<ul data-test-read-only-file-widget ...attributes>
+    {{#each this.responses as |response|}}
+        <li>
+            <a href={{response.file_urls.html}}>
+                {{response.file_name}}
+            </a>
+        </li>
+    {{/each}}
+</ul>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/template.hbs
@@ -1,9 +1,12 @@
 <ul data-test-read-only-file-widget ...attributes>
     {{#each this.responses as |response|}}
         <li>
-            <a href={{response.file_urls.html}}>
+            <OsfLink
+                @href={{response.file_urls.html}}
+                @target='_blank'
+            >
                 {{response.file_name}}
-            </a>
+            </OsfLink>
         </li>
     {{/each}}
 </ul>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/mapper/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/mapper/template.hbs
@@ -44,4 +44,9 @@
         'registries/schema-block-renderer/read-only-contributor-list'
         node=@node
     )
+    file-input=(
+        component
+        'registries/schema-block-renderer/read-only/files'
+        registrationResponses=@registrationResponses
+    )
 )}}

--- a/lib/osf-components/app/components/registries/review-form-renderer/component.js
+++ b/lib/osf-components/app/components/registries/review-form-renderer/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/registries/review-form-renderer/component';

--- a/lib/osf-components/app/components/registries/review-form-renderer/component.js
+++ b/lib/osf-components/app/components/registries/review-form-renderer/component.js
@@ -1,1 +1,0 @@
-export { default } from 'osf-components/components/registries/review-form-renderer/component';

--- a/lib/osf-components/app/components/registries/schema-block-renderer/editable/files/component.js
+++ b/lib/osf-components/app/components/registries/schema-block-renderer/editable/files/component.js
@@ -1,0 +1,2 @@
+export { default } from
+    'osf-components/components/registries/schema-block-renderer/editable/files/component';

--- a/lib/osf-components/app/components/registries/schema-block-renderer/read-only/files/component.js
+++ b/lib/osf-components/app/components/registries/schema-block-renderer/read-only/files/component.js
@@ -1,0 +1,2 @@
+export { default } from
+    'osf-components/components/registries/schema-block-renderer/read-only/files/component';

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -245,6 +245,23 @@ function handbookScenario(server: Server, currentUser: ModelInstance<User>) {
         subjects: server.schema.subjects.all().models,
     });
     server.create('registration', { id: 'subj' }, 'withSubjects');
+
+    // SchemaBlock Renderer
+    const schemaNode = server.create(
+        'node',
+        { id: 'dslt', currentUserPermissions: Object.values(Permission) },
+        'withFiles',
+    );
+
+    const folder = server.create('file', { target: schemaNode }, 'asFolder');
+    const providers = fileWidgetNode.files.models as Array<ModelInstance<FileProvider>>;
+    const storage = providers[0];
+    const providersFiles = storage.files.models;
+    storage.update({
+        files: [...providersFiles, folder],
+    });
+    server.createList('file', 15, { target: schemaNode, parentFolder: folder });
+    server.createList('contributor', 23, { node: schemaNode });
 }
 
 function settingsScenario(server: Server, currentUser: ModelInstance<User>) {

--- a/mirage/serializers/file.ts
+++ b/mirage/serializers/file.ts
@@ -4,7 +4,7 @@ import File from 'ember-osf-web/models/file';
 
 import ApplicationSerializer, { SerializedRelationships } from './application';
 
-const { OSF: { apiUrl } } = config;
+const { OSF: { apiUrl, url } } = config;
 
 export default class FileSerializer extends ApplicationSerializer<File> {
     buildRelationships(model: ModelInstance<File>) {
@@ -85,6 +85,7 @@ export default class FileSerializer extends ApplicationSerializer<File> {
             move: `${apiUrl}/wb/files/${id}/move/`,
             delete: `${apiUrl}/wb/files/${id}/delete/`,
             info: `${apiUrl}/v2/files/${id}/`,
+            html: `${url}files/osfstorage/${id}/`,
         };
     }
 }

--- a/tests/integration/components/registries/schema-block-group-renderer/component-test.ts
+++ b/tests/integration/components/registries/schema-block-group-renderer/component-test.ts
@@ -109,44 +109,56 @@ module('Integration | Component | schema-block-group-renderer', hooks => {
             {
                 blockType: 'question-label',
                 displayText: 'If I had a super power it would be:',
-                schemaBlockGroupKey: 'q6',
-                index: 17,
+                schemaBlockGroupKey: 'q5',
+                index: 16,
             },
             {
                 blockType: 'single-select-input',
                 registrationResponseKey: 'page-one_single-select-two',
-                schemaBlockGroupKey: 'q6',
-                index: 18,
+                schemaBlockGroupKey: 'q5',
+                index: 17,
             },
             {
                 blockType: 'select-input-option',
                 displayText: 'Always be on the proper beat while doing the macarena',
-                schemaBlockGroupKey: 'q6',
-                index: 19,
+                schemaBlockGroupKey: 'q5',
+                index: 18,
             },
             {
                 blockType: 'select-input-option',
                 displayText: 'Remember who was in NSync and who was in Backstreet Boys',
-                schemaBlockGroupKey: 'q6',
-                index: 20,
+                schemaBlockGroupKey: 'q5',
+                index: 19,
             },
             {
                 blockType: 'select-other-option',
                 displayText: 'Other',
-                schemaBlockGroupKey: 'q6',
-                index: 21,
+                schemaBlockGroupKey: 'q5',
+                index: 20,
             },
             {
                 blockType: 'question-label',
                 displayText: 'Contributors:',
-                schemaBlockGroupKey: 'q5',
-                index: 22,
+                schemaBlockGroupKey: 'q6',
+                index: 21,
             },
             {
                 blockType: 'contributors-input',
                 registrationResponseKey: 'page-one_contributors-input',
-                schemaBlockGroupKey: 'q5',
+                schemaBlockGroupKey: 'q6',
+                index: 22,
+            },
+            {
+                blockType: 'question-label',
+                displayText: 'Files:',
+                schemaBlockGroupKey: 'q7',
                 index: 23,
+            },
+            {
+                blockType: 'file-input',
+                registrationResponseKey: 'page-one_file-input',
+                schemaBlockGroupKey: 'q7',
+                index: 24,
             },
         ];
 
@@ -157,18 +169,18 @@ module('Integration | Component | schema-block-group-renderer', hooks => {
             'page-one_long-text': '',
             'page-one_single-select-two': '',
             'page-one_multi-select': [],
+            'page-one_file-input': [],
         };
         const pageResponseChangeset = new Changeset(pageResponse);
         this.store = this.owner.lookup('service:store');
+        const mirageNode = server.create('node', 'withFiles');
 
-        const node = server.create('node');
-
-        const reloadNode = this.store.findRecord('node', node.id, {
+        const node = await this.store.findRecord('node', mirageNode.id, {
             include: 'bibliographic_contributors',
             reload: true,
         });
 
-        this.set('node', await reloadNode);
+        this.set('node', await node);
         this.set('schemaBlockGroups', schemaBlockGroups);
         this.set('pageResponseChangeset', pageResponseChangeset);
         await render(hbs`
@@ -187,11 +199,12 @@ module('Integration | Component | schema-block-group-renderer', hooks => {
         assert.dom('[data-test-page-heading]').exists();
         assert.dom('[data-test-section-heading]').exists();
         assert.dom('[data-test-subsection-heading]').exists();
-        assert.dom('[data-test-question-label]').exists({ count: 6 });
+        assert.dom('[data-test-question-label]').exists({ count: 7 });
         assert.dom('[data-test-single-select-input]').exists({ count: 2 });
         assert.dom('[data-test-text-input]').exists();
         assert.dom('[data-test-textarea-input]').exists();
         assert.dom('[data-test-multi-select-input]').exists();
         assert.dom('[data-test-read-only-contributors-list]').exists();
+        assert.dom('[data-test-editable-file-widget]').exists();
     });
 });

--- a/tests/integration/components/registries/schema-block-group-renderer/component-test.ts
+++ b/tests/integration/components/registries/schema-block-group-renderer/component-test.ts
@@ -164,14 +164,14 @@ module('Integration | Component | schema-block-group-renderer', hooks => {
 
         const schemaBlockGroups = getSchemaBlockGroups(schemaBlocks);
 
-        const pageResponse = {
+        const registrationResponse = {
             'page-one_short-text': '',
             'page-one_long-text': '',
             'page-one_single-select-two': '',
             'page-one_multi-select': [],
             'page-one_file-input': [],
         };
-        const pageResponseChangeset = new Changeset(pageResponse);
+        const registrationResponseChangeset = new Changeset(registrationResponse);
         this.store = this.owner.lookup('service:store');
         const mirageNode = server.create('node', 'withFiles');
 
@@ -182,7 +182,7 @@ module('Integration | Component | schema-block-group-renderer', hooks => {
 
         this.set('node', await node);
         this.set('schemaBlockGroups', schemaBlockGroups);
-        this.set('pageResponseChangeset', pageResponseChangeset);
+        this.set('pageResponseChangeset', registrationResponseChangeset);
         await render(hbs`
             {{#each this.schemaBlockGroups as |group|}}
                 <Registries::SchemaBlockGroupRenderer


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-1091
- Feature flag: n/a

## Purpose

- To add `files-widget` to the `schema-block-renderer` component

## Summary of Changes

- Add check for `files-input` in read-only and editable mapper files
- Add components for `files` that renders the read-only and editable versions
- Update test to include `files` widget
- Add `SchemaBlockNode` to default scenario that includes both contributors and files

## Side Effects

`N/A`

## QA Notes

`N/A`
