### PR TITLE
[ENG-1069] Add SSO Users Connected panel to institutional users dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Components
     - `institutions`
         - `dashboard/institutional-users-list`
+        - `dashboard/panel`
     - `Registries::DraftRegistrationManager`
 - Mirage
     - Factories

--- a/app/institutions/dashboard/-components/panel/component.ts
+++ b/app/institutions/dashboard/-components/panel/component.ts
@@ -1,3 +1,0 @@
-import Component from '@ember/component';
-
-export default class Panel extends Component {}

--- a/app/institutions/dashboard/-components/panel/component.ts
+++ b/app/institutions/dashboard/-components/panel/component.ts
@@ -1,0 +1,3 @@
+import Component from '@ember/component';
+
+export default class Panel extends Component {}

--- a/app/institutions/dashboard/-components/panel/styles.scss
+++ b/app/institutions/dashboard/-components/panel/styles.scss
@@ -1,0 +1,32 @@
+.panel {
+    :global(.panel) {
+        border: 0;
+        margin-bottom: 30px;
+        box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    }
+
+    :global(.panel-heading) {
+        background: #365063;
+        padding: 15px;
+        border: 0;
+    }
+
+    :global(.panel-title) {
+        display: block;
+        float: none;
+        color: #fff;
+        font-size: 14px;
+        font-weight: bold;
+        text-align: center;
+        text-transform: uppercase;
+        line-height: 20px;
+    }
+
+    :global(.panel-body) {
+        text-align: center;
+        line-height: normal;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+}

--- a/app/institutions/dashboard/-components/panel/template.hbs
+++ b/app/institutions/dashboard/-components/panel/template.hbs
@@ -1,10 +1,10 @@
-<Panel local-class='panel' as |panel|>
-    <panel.heading @title='{{this.title}}' />
+<Panel local-class='panel' ...attributes as |panel|>
+    <panel.heading @title={{@title}} />
     <panel.body>
-        {{#if this.institution}}
-            {{yield}}
-        {{else}}
+        {{#if @isLoading}}
             <LoadingIndicator data-test-loading-indicator @dark={{true}} />
+        {{else}}
+            {{yield}}
         {{/if}}
     </panel.body>
 </Panel>

--- a/app/institutions/dashboard/-components/panel/template.hbs
+++ b/app/institutions/dashboard/-components/panel/template.hbs
@@ -1,0 +1,10 @@
+<Panel local-class='panel' as |panel|>
+    <panel.heading @title='{{this.title}}' />
+    <panel.body>
+        {{#if this.institution}}
+            {{yield}}
+        {{else}}
+            <LoadingIndicator data-test-loading-indicator @dark={{true}} />
+        {{/if}}
+    </panel.body>
+</Panel>

--- a/app/institutions/dashboard/styles.scss
+++ b/app/institutions/dashboard/styles.scss
@@ -11,4 +11,43 @@
     width: 25%;
     padding-top: 56px;
     padding-left: 15px;
+
+    :global(.panel) {
+        border: 0;
+        margin-bottom: 30px;
+        box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    }
+
+    :global(.panel-heading) {
+        background: #365063;
+        padding: 15px;
+        border: 0;
+    }
+
+    :global(.panel-title) {
+        display: block;
+        float: none;
+        color: #fff;
+        font-size: 14px;
+        font-weight: bold;
+        text-align: center;
+        text-transform: uppercase;
+        line-height: 20px;
+    }
+
+    :global(.panel-body) {
+        text-align: center;
+        line-height: normal;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+}
+
+.sso-users-connected {
+    :global(.panel-body) {
+        color: #263947;
+        font-size: 120px;
+        font-weight: bold;
+    }
 }

--- a/app/institutions/dashboard/styles.scss
+++ b/app/institutions/dashboard/styles.scss
@@ -11,37 +11,6 @@
     width: 25%;
     padding-top: 56px;
     padding-left: 15px;
-
-    :global(.panel) {
-        border: 0;
-        margin-bottom: 30px;
-        box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-    }
-
-    :global(.panel-heading) {
-        background: #365063;
-        padding: 15px;
-        border: 0;
-    }
-
-    :global(.panel-title) {
-        display: block;
-        float: none;
-        color: #fff;
-        font-size: 14px;
-        font-weight: bold;
-        text-align: center;
-        text-transform: uppercase;
-        line-height: 20px;
-    }
-
-    :global(.panel-body) {
-        text-align: center;
-        line-height: normal;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-    }
 }
 
 .sso-users-connected {

--- a/app/institutions/dashboard/template.hbs
+++ b/app/institutions/dashboard/template.hbs
@@ -7,12 +7,13 @@
             <Institutions::Dashboard::-Components::InstitutionalUsersList @model={{this.model}} />
         </div>
         <div local-class='panel-wrapper'>
-            <Panel local-class='sso-users-connected' as |panel|>
-                <panel.heading @title='{{t 'institutions.dashboard.users_connected_panel'}}' />
-                <panel.body>
-                    {{this.institution.statSummary.ssoUsersConnected}}
-                </panel.body>
-            </Panel>
+            <Institutions::Dashboard::-Components::Panel
+                    local-class='sso-users-connected'
+                    @title='{{t 'institutions.dashboard.users_connected_panel'}}'
+                    @institution={{this.institution}}
+            >
+                {{this.institution.statSummary.ssoUsersConnected}}
+            </Institutions::Dashboard::-Components::Panel>
             <Panel as |panel|>
                 <panel.heading @title='{{t 'institutions.dashboard.projects_panel'}}' />
                 <panel.body>

--- a/app/institutions/dashboard/template.hbs
+++ b/app/institutions/dashboard/template.hbs
@@ -7,10 +7,10 @@
             <Institutions::Dashboard::-Components::InstitutionalUsersList @model={{this.model}} />
         </div>
         <div local-class='panel-wrapper'>
-            <Panel as |panel|>
+            <Panel local-class='sso-users-connected' as |panel|>
                 <panel.heading @title='SSO Users Connected' />
                 <panel.body>
-                    <p></p>
+                    {{this.institution.statSummary.ssoUsersConnected}}
                 </panel.body>
             </Panel>
             <Panel as |panel|>

--- a/app/institutions/dashboard/template.hbs
+++ b/app/institutions/dashboard/template.hbs
@@ -8,19 +8,19 @@
         </div>
         <div local-class='panel-wrapper'>
             <Panel local-class='sso-users-connected' as |panel|>
-                <panel.heading @title='SSO Users Connected' />
+                <panel.heading @title='{{t 'institutions.dashboard.users_connected_panel'}}' />
                 <panel.body>
                     {{this.institution.statSummary.ssoUsersConnected}}
                 </panel.body>
             </Panel>
             <Panel as |panel|>
-                <panel.heading @title='Total Projects' />
+                <panel.heading @title='{{t 'institutions.dashboard.projects_panel'}}' />
                 <panel.body>
                     <p></p>
                 </panel.body>
             </Panel>
             <Panel as |panel|>
-                <panel.heading @title='Departments' />
+                <panel.heading @title='{{t 'institutions.dashboard.departments_panel'}}' />
                 <panel.body>
                     <p></p>
                 </panel.body>

--- a/app/institutions/dashboard/template.hbs
+++ b/app/institutions/dashboard/template.hbs
@@ -11,7 +11,6 @@
                     local-class='sso-users-connected'
                     @isLoading={{this.model.taskInstance.isRunning}}
                     @title={{t 'institutions.dashboard.users_connected_panel'}}
-                    @institution={{this.institution}}
             >
                 {{this.institution.statSummary.ssoUsersConnected}}
             </Institutions::Dashboard::-Components::Panel>

--- a/app/institutions/dashboard/template.hbs
+++ b/app/institutions/dashboard/template.hbs
@@ -9,7 +9,8 @@
         <div local-class='panel-wrapper'>
             <Institutions::Dashboard::-Components::Panel
                     local-class='sso-users-connected'
-                    @title='{{t 'institutions.dashboard.users_connected_panel'}}'
+                    @isLoading={{this.model.taskInstance.isRunning}}
+                    @title={{t 'institutions.dashboard.users_connected_panel'}}
                     @institution={{this.institution}}
             >
                 {{this.institution.statSummary.ssoUsersConnected}}

--- a/app/models/institution.ts
+++ b/app/models/institution.ts
@@ -18,6 +18,7 @@ export interface Assets {
 
 export interface StatSummary {
     departments: Department[];
+    ssoUsersConnected: number;
     numPrivateProjects: number;
     numPublicProjects: number;
 }

--- a/mirage/factories/institution.ts
+++ b/mirage/factories/institution.ts
@@ -35,6 +35,7 @@ export default Factory.extend<Institution & InstitutionTraits>({
                     name: department,
                     numUsers: faker.random.number({ min: 0, max: 99 }),
                 })),
+                ssoUsersConnected: faker.random.number({ min: 0, max: 999 }),
                 numPrivateProjects: faker.random.number({ min: 0, max: 999 }),
                 numPublicProjects: faker.random.number({ min: 0, max: 999 }),
             };

--- a/tests/integration/routes/institutions/dashboard/-components/panel/component-test.ts
+++ b/tests/integration/routes/institutions/dashboard/-components/panel/component-test.ts
@@ -1,0 +1,61 @@
+import { render } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { task } from 'ember-concurrency';
+import { setupRenderingTest } from 'ember-qunit';
+import { TestContext } from 'ember-test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+
+module('Integration | routes | institutions | dashboard | -components | panel', hooks => {
+    setupRenderingTest(hooks);
+    setupMirage(hooks);
+
+    hooks.beforeEach(function(this: TestContext) {
+        this.store = this.owner.lookup('service:store');
+    });
+
+    test('it renders without institution', async assert => {
+        await render(hbs`<Institutions::Dashboard::-Components::Panel @title='Test' />`);
+
+        assert.dom('[data-test-panel-title]')
+            .exists({ count: 1 }, '1 title');
+        assert.dom('[data-test-panel-title]')
+            .hasText('Test');
+        assert.dom('[data-test-panel-body]')
+            .exists({ count: 1 }, '1 body');
+        assert.dom('[data-test-panel-body]')
+            .hasText('');
+        assert.dom('[data-test-loading-indicator]')
+            .exists({ count: 1 }, '1 loading indicator');
+    });
+
+    test('it renders with institution', async function(assert) {
+        server.create('institution', { id: 'testinstitution' }, 'withStatSummary');
+
+        this.set('modelTask', task(function *(this: TestContext, institutionId: string) {
+            return yield this.get('store').findRecord('institution', institutionId);
+        }));
+
+        const model = {
+            taskInstance: this.get('modelTask').perform('testinstitution'),
+        };
+
+        this.set('model', model);
+        await render(hbs`
+            <Institutions::Dashboard::-Components::Panel @title='Test' @institution={{this.model.taskInstance.value}}>
+                Hello, World!
+            </Institutions::Dashboard::-Components::Panel>
+        `);
+
+        assert.dom('[data-test-panel-title]')
+            .exists({ count: 1 }, '1 title');
+        assert.dom('[data-test-panel-title]')
+            .hasText('Test');
+        assert.dom('[data-test-panel-body]')
+            .exists({ count: 1 }, '1 body');
+        assert.dom('[data-test-panel-body]')
+            .hasText('Hello, World!');
+        assert.dom('[data-test-loading-indicator]')
+            .doesNotExist();
+    });
+});

--- a/tests/integration/routes/institutions/dashboard/-components/panel/component-test.ts
+++ b/tests/integration/routes/institutions/dashboard/-components/panel/component-test.ts
@@ -1,6 +1,5 @@
 import { render } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { task } from 'ember-concurrency';
 import { setupRenderingTest } from 'ember-qunit';
 import { TestContext } from 'ember-test-helpers';
 import hbs from 'htmlbars-inline-precompile';
@@ -12,18 +11,6 @@ module('Integration | routes | institutions | dashboard | -components | panel', 
 
     hooks.beforeEach(function(this: TestContext) {
         this.store = this.owner.lookup('service:store');
-
-        server.create('institution', { id: 'testinstitution' }, 'withStatSummary');
-
-        this.set('modelTask', task(function *(this: TestContext, institutionId: string) {
-            return yield this.get('store').findRecord('institution', institutionId);
-        }));
-
-        const model = {
-            taskInstance: this.get('modelTask').perform('testinstitution'),
-        };
-
-        this.set('model', model);
     });
 
     test('it renders while loading', async assert => {
@@ -31,7 +18,6 @@ module('Integration | routes | institutions | dashboard | -components | panel', 
             <Institutions::Dashboard::-Components::Panel
                 @isLoading={{true}}
                 @title='Test'
-                @institution={{this.model.taskInstance.value}}
             >
                 Hello, World!
             </Institutions::Dashboard::-Components::Panel>`);
@@ -53,7 +39,6 @@ module('Integration | routes | institutions | dashboard | -components | panel', 
             <Institutions::Dashboard::-Components::Panel
                 @isLoading={{false}}
                 @title='Test'
-                @institution={{this.model.taskInstance.value}}
             >
                 Hello, World!
             </Institutions::Dashboard::-Components::Panel>`);


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-1069]
- Feature flag: Institutional Dashboard

## Purpose

To show the number of SSO users connected on the Institutional Users Dashboard.

## Summary of Changes

Added ssoUsersConnected to institution's stat summary. Updated styles for panels on the institutional users dashboard. Added SSO users connected to the page.


[ENG-1069]: https://openscience.atlassian.net/browse/ENG-1069