### PR TITLE
[ENG-1131] Add onContinue hook to partial-registration-modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `validated-input`
         - Modified components to take in `onInput` callback.
             - added `withStatSummary` trait
+    - `registries/partial-registration-modal`
+        - added `onContinue` hook
 - Mirage
     - Factories
         - `institution`

--- a/lib/osf-components/addon/components/registries/partial-registration-modal/component.ts
+++ b/lib/osf-components/addon/components/registries/partial-registration-modal/component.ts
@@ -1,10 +1,8 @@
-import Component from '@ember/component';
-
 import { tagName } from '@ember-decorators/component';
 import { action } from '@ember-decorators/object';
+import Component from '@ember/component';
 import { layout } from 'ember-osf-web/decorators/component';
 import NodeModel from 'ember-osf-web/models/node';
-
 import { HierarchicalListManager } from 'osf-components/components/registries/hierarchical-list';
 
 import styles from './styles';

--- a/lib/osf-components/addon/components/registries/partial-registration-modal/component.ts
+++ b/lib/osf-components/addon/components/registries/partial-registration-modal/component.ts
@@ -1,9 +1,12 @@
 import Component from '@ember/component';
 
 import { tagName } from '@ember-decorators/component';
+import { action } from '@ember-decorators/object';
 import { layout } from 'ember-osf-web/decorators/component';
+import NodeModel from 'ember-osf-web/models/node';
 
 import { HierarchicalListManager } from 'osf-components/components/registries/hierarchical-list';
+
 import styles from './styles';
 import template from './template';
 
@@ -11,4 +14,14 @@ import template from './template';
 @tagName('')
 export default class PartialRegistrationModal extends Component {
     modalManager!: HierarchicalListManager;
+
+    onContinue?: (nodes: NodeModel[]) => void;
+
+    @action
+    continue() {
+        const nodes = this.modalManager.selectedNodes;
+        if (this.onContinue) {
+            this.onContinue(nodes);
+        }
+    }
 }

--- a/lib/osf-components/addon/components/registries/partial-registration-modal/template.hbs
+++ b/lib/osf-components/addon/components/registries/partial-registration-modal/template.hbs
@@ -34,7 +34,11 @@
         {{/if}}
     </dialog.main>
     <dialog.footer>
-        <OsfButton data-test-continue-registration-button @type='primary' @onClick={{action this.continue}}>
+        <OsfButton
+            data-test-continue-registration-button
+            @type='primary'
+            @onClick={{action this.continue}}
+        >
             {{t 'registries.partialRegistrationModal.continueButton'}}
         </OsfButton>
         <OsfButton @type='default'>

--- a/lib/osf-components/addon/components/registries/partial-registration-modal/template.hbs
+++ b/lib/osf-components/addon/components/registries/partial-registration-modal/template.hbs
@@ -34,7 +34,7 @@
         {{/if}}
     </dialog.main>
     <dialog.footer>
-        <OsfButton @type='primary'>
+        <OsfButton data-test-continue-registration-button @type='primary' @onClick={{action this.continue}}>
             {{t 'registries.partialRegistrationModal.continueButton'}}
         </OsfButton>
         <OsfButton @type='default'>

--- a/tests/integration/components/registries/partial-registration-modal/component-test.ts
+++ b/tests/integration/components/registries/partial-registration-modal/component-test.ts
@@ -9,18 +9,34 @@ module('Integration | Component | partial-registration-modal', hooks => {
     setupMirage(hooks);
 
     test('it renders a hierarchical list with root already selected', async function(assert) {
-        assert.expect(5);
+        assert.expect(8);
         this.store = this.owner.lookup('service:store');
         const root = server.create('node');
         const child = server.create('node', { parent: root });
         const grandChild = server.create('node', { parent: child });
 
         const rootNode = await this.store.findRecord('node', root.id);
+        const childNode = await this.store.findRecord('node', child.id);
+        const grandChildNode = await this.store.findRecord('node', grandChild.id);
         this.set('rootNode', rootNode);
         this.set('isOpen', false);
-        const nodes = [];
-        this.set('onContinue', () => {
-            assert.ok(nodes.length = 1);
+        this.set('onContinue', (selectedNodes: any) => {
+            assert.ok(
+                selectedNodes.length === 3,
+                `expected 3 but instead got ${selectedNodes.length}`,
+            );
+            assert.ok(
+                selectedNodes.includes(rootNode),
+                'root node is included in nodes list sent to onContinue hook',
+            );
+            assert.ok(
+                selectedNodes.includes(childNode),
+                'child node is included in nodes list sent to onContinue hook',
+            );
+            assert.ok(
+                selectedNodes.includes(grandChildNode),
+                'grandchild node is included in nodes list sent to onContinue hook',
+            );
         });
         await render(hbs`
             <Registries::PartialRegistrationModal::Manager
@@ -47,16 +63,34 @@ module('Integration | Component | partial-registration-modal', hooks => {
     });
 
     test('select child selects parent; deselect parent deselects children', async function(assert) {
+        assert.expect(10);
         this.store = this.owner.lookup('service:store');
         const root = server.create('node');
         const child = server.create('node', { parent: root });
         const grandChild = server.create('node', { parent: child });
+
         const rootNode = await this.store.findRecord('node', root.id);
+        const childNode = await this.store.findRecord('node', child.id);
+        const grandChildNode = await this.store.findRecord('node', grandChild.id);
         this.set('rootNode', rootNode);
         this.set('isOpen', false);
-        const nodes = [];
-        this.set('onContinue', () => {
-            assert.ok(nodes.length = 3);
+        this.set('onContinue', (selectedNodes: any) => {
+            assert.ok(
+                selectedNodes.length === 3,
+                `expected 3 but instead got ${selectedNodes.length}`,
+            );
+            assert.ok(
+                selectedNodes.includes(rootNode),
+                'root node is included in nodes list sent to onContinue hook',
+            );
+            assert.ok(
+                selectedNodes.includes(childNode),
+                'child node is included in nodes list sent to onContinue hook',
+            );
+            assert.ok(
+                selectedNodes.includes(grandChildNode),
+                'grandchild node is included in nodes list sent to onContinue hook',
+            );
         });
         await render(hbs`
             <Registries::PartialRegistrationModal::Manager
@@ -87,16 +121,34 @@ module('Integration | Component | partial-registration-modal', hooks => {
     });
 
     test('select all works, while clear all should not clear root node', async function(assert) {
+        assert.expect(13);
         this.store = this.owner.lookup('service:store');
         const root = server.create('node');
         const child = server.create('node', { parent: root });
         const grandChild = server.create('node', { parent: child });
+
         const rootNode = await this.store.findRecord('node', root.id);
+        const childNode = await this.store.findRecord('node', child.id);
+        const grandChildNode = await this.store.findRecord('node', grandChild.id);
         this.set('rootNode', rootNode);
         this.set('isOpen', false);
-        const nodes = [];
-        this.set('onContinue', () => {
-            assert.ok(nodes.length = 3);
+        this.set('onContinue', (selectedNodes: any) => {
+            assert.ok(
+                selectedNodes.length === 3,
+                `expected 3 but instead got ${selectedNodes.length}`,
+            );
+            assert.ok(
+                selectedNodes.includes(rootNode),
+                'root node is included in nodes list sent to onContinue hook',
+            );
+            assert.ok(
+                selectedNodes.includes(childNode),
+                'child node is included in nodes list sent to onContinue hook',
+            );
+            assert.ok(
+                selectedNodes.includes(grandChildNode),
+                'grandchild node is included in nodes list sent to onContinue hook',
+            );
         });
         await render(hbs`
             <Registries::PartialRegistrationModal::Manager
@@ -124,6 +176,61 @@ module('Integration | Component | partial-registration-modal', hooks => {
         assert.dom(`[data-test-item="${root.id}"] input`).isChecked();
         assert.dom(`[data-test-item="${grandChild.id}"] input`).isChecked();
         assert.dom(`[data-test-item="${child.id}"] input`).isChecked();
+        await click('[data-test-continue-registration-button]');
+        this.set('isOpen', false);
+        await settled();
+    });
+
+    test('selectedNodes captures deselect children', async function(assert) {
+        assert.expect(8);
+        this.store = this.owner.lookup('service:store');
+        const root = server.create('node');
+        const child = server.create('node', { parent: root });
+        const grandChild = server.create('node', { parent: child });
+
+        const rootNode = await this.store.findRecord('node', root.id);
+        const childNode = await this.store.findRecord('node', child.id);
+        const grandChildNode = await this.store.findRecord('node', grandChild.id);
+        this.set('rootNode', rootNode);
+        this.set('isOpen', false);
+        this.set('onContinue', (selectedNodes: any) => {
+            assert.ok(
+                selectedNodes.length === 1,
+                `expected 1 but instead got ${selectedNodes.length}`,
+            );
+            assert.ok(
+                selectedNodes.includes(rootNode),
+                'root node should be included in nodes list sent to onContinue hook',
+            );
+            assert.notOk(
+                selectedNodes.includes(childNode),
+                'child node should not be included in nodes list sent to onContinue hook',
+            );
+            assert.notOk(
+                selectedNodes.includes(grandChildNode),
+                'grandchild node should not be included in nodes list sent to onContinue hook',
+            );
+        });
+        await render(hbs`
+            <Registries::PartialRegistrationModal::Manager
+                @rootNode={{this.rootNode}}
+                @isOpen={{this.isOpen}}
+                @renderInPlace={{true}}
+                as |modalManager|
+            >
+                <Registries::PartialRegistrationModal
+                    @modalManager={{modalManager}}
+                    @onContinue={{action this.onContinue}}
+                />
+            </Registries::PartialRegistrationModal::Manager>
+        `);
+        this.set('isOpen', true);
+        await settled();
+        assert.dom(`[data-test-item="${grandChild.id}"] input`).isChecked();
+        assert.dom(`[data-test-item="${child.id}"] input`).isChecked();
+        await click(`[data-test-item="${child.id}"] input`);
+        assert.dom(`[data-test-item="${grandChild.id}"] input`).isNotChecked();
+        assert.dom(`[data-test-item="${child.id}"] input`).isNotChecked();
         await click('[data-test-continue-registration-button]');
         this.set('isOpen', false);
         await settled();

--- a/tests/integration/components/registries/partial-registration-modal/component-test.ts
+++ b/tests/integration/components/registries/partial-registration-modal/component-test.ts
@@ -9,6 +9,7 @@ module('Integration | Component | partial-registration-modal', hooks => {
     setupMirage(hooks);
 
     test('it renders a hierarchical list with root already selected', async function(assert) {
+        assert.expect(5);
         this.store = this.owner.lookup('service:store');
         const root = server.create('node');
         const child = server.create('node', { parent: root });
@@ -17,6 +18,10 @@ module('Integration | Component | partial-registration-modal', hooks => {
         const rootNode = await this.store.findRecord('node', root.id);
         this.set('rootNode', rootNode);
         this.set('isOpen', false);
+        const nodes = [];
+        this.set('onContinue', () => {
+            assert.ok(nodes.length = 1);
+        });
         await render(hbs`
             <Registries::PartialRegistrationModal::Manager
                 @rootNode={{this.rootNode}}
@@ -24,7 +29,10 @@ module('Integration | Component | partial-registration-modal', hooks => {
                 @renderInPlace={{true}}
                 as |modalManager|
             >
-                <Registries::PartialRegistrationModal @modalManager={{modalManager}} />
+                <Registries::PartialRegistrationModal
+                    @modalManager={{modalManager}}
+                    @onContinue={{action this.onContinue}}
+                />
             </Registries::PartialRegistrationModal::Manager>
         `);
         this.set('isOpen', true);
@@ -33,6 +41,7 @@ module('Integration | Component | partial-registration-modal', hooks => {
         assert.dom(`[data-test-item="${child.id}"]`).exists();
         assert.dom(`[data-test-item="${grandChild.id}"]`).exists();
         assert.dom(`[data-test-item="${root.id}"] input`).isChecked();
+        await click('[data-test-continue-registration-button]');
         this.set('isOpen', false);
         await settled();
     });
@@ -45,6 +54,10 @@ module('Integration | Component | partial-registration-modal', hooks => {
         const rootNode = await this.store.findRecord('node', root.id);
         this.set('rootNode', rootNode);
         this.set('isOpen', false);
+        const nodes = [];
+        this.set('onContinue', () => {
+            assert.ok(nodes.length = 3);
+        });
         await render(hbs`
             <Registries::PartialRegistrationModal::Manager
                 @rootNode={{this.rootNode}}
@@ -52,7 +65,10 @@ module('Integration | Component | partial-registration-modal', hooks => {
                 @renderInPlace={{true}}
                 as |modalManager|
             >
-                <Registries::PartialRegistrationModal @modalManager={{modalManager}} />
+                <Registries::PartialRegistrationModal
+                    @modalManager={{modalManager}}
+                    @onContinue={{action this.onContinue}}
+                />
             </Registries::PartialRegistrationModal::Manager>
         `);
         this.set('isOpen', true);
@@ -65,6 +81,7 @@ module('Integration | Component | partial-registration-modal', hooks => {
         await click(`[data-test-item="${grandChild.id}"] input`);
         assert.dom(`[data-test-item="${grandChild.id}"] input`).isChecked();
         assert.dom(`[data-test-item="${child.id}"] input`).isChecked();
+        await click('[data-test-continue-registration-button]');
         this.set('isOpen', false);
         await settled();
     });
@@ -77,6 +94,10 @@ module('Integration | Component | partial-registration-modal', hooks => {
         const rootNode = await this.store.findRecord('node', root.id);
         this.set('rootNode', rootNode);
         this.set('isOpen', false);
+        const nodes = [];
+        this.set('onContinue', () => {
+            assert.ok(nodes.length = 3);
+        });
         await render(hbs`
             <Registries::PartialRegistrationModal::Manager
                 @rootNode={{this.rootNode}}
@@ -84,7 +105,10 @@ module('Integration | Component | partial-registration-modal', hooks => {
                 @renderInPlace={{true}}
                 as |modalManager|
             >
-                <Registries::PartialRegistrationModal @modalManager={{modalManager}} />
+                <Registries::PartialRegistrationModal
+                    @modalManager={{modalManager}}
+                    @onContinue={{action this.onContinue}}
+                />
             </Registries::PartialRegistrationModal::Manager>
         `);
         this.set('isOpen', true);
@@ -100,6 +124,7 @@ module('Integration | Component | partial-registration-modal', hooks => {
         assert.dom(`[data-test-item="${root.id}"] input`).isChecked();
         assert.dom(`[data-test-item="${grandChild.id}"] input`).isChecked();
         assert.dom(`[data-test-item="${child.id}"] input`).isChecked();
+        await click('[data-test-continue-registration-button]');
         this.set('isOpen', false);
         await settled();
     });

--- a/tests/integration/components/registries/partial-registration-modal/component-test.ts
+++ b/tests/integration/components/registries/partial-registration-modal/component-test.ts
@@ -1,5 +1,6 @@
 import { click, render, settled } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import NodeModel from 'ember-osf-web/models/node';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
@@ -20,7 +21,7 @@ module('Integration | Component | partial-registration-modal', hooks => {
         const grandChildNode = await this.store.findRecord('node', grandChild.id);
         this.set('rootNode', rootNode);
         this.set('isOpen', false);
-        this.set('onContinue', (selectedNodes: any) => {
+        this.set('onContinue', (selectedNodes: NodeModel[]) => {
             assert.ok(
                 selectedNodes.length === 3,
                 `expected 3 but instead got ${selectedNodes.length}`,
@@ -74,7 +75,7 @@ module('Integration | Component | partial-registration-modal', hooks => {
         const grandChildNode = await this.store.findRecord('node', grandChild.id);
         this.set('rootNode', rootNode);
         this.set('isOpen', false);
-        this.set('onContinue', (selectedNodes: any) => {
+        this.set('onContinue', (selectedNodes: NodeModel[]) => {
             assert.ok(
                 selectedNodes.length === 3,
                 `expected 3 but instead got ${selectedNodes.length}`,
@@ -132,7 +133,7 @@ module('Integration | Component | partial-registration-modal', hooks => {
         const grandChildNode = await this.store.findRecord('node', grandChild.id);
         this.set('rootNode', rootNode);
         this.set('isOpen', false);
-        this.set('onContinue', (selectedNodes: any) => {
+        this.set('onContinue', (selectedNodes: NodeModel[]) => {
             assert.ok(
                 selectedNodes.length === 3,
                 `expected 3 but instead got ${selectedNodes.length}`,
@@ -193,7 +194,7 @@ module('Integration | Component | partial-registration-modal', hooks => {
         const grandChildNode = await this.store.findRecord('node', grandChild.id);
         this.set('rootNode', rootNode);
         this.set('isOpen', false);
-        this.set('onContinue', (selectedNodes: any) => {
+        this.set('onContinue', (selectedNodes: NodeModel[]) => {
             assert.ok(
                 selectedNodes.length === 1,
                 `expected 1 but instead got ${selectedNodes.length}`,


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-1131
- Feature flag: n/a

## Purpose

To add an `onContinue` hook to the `partial-registration-modal`

## Summary of Changes

- Add `continue` action and `onContinue` hook
- Updated tests to check for `continue` call

## Side Effects

`N/A`

## QA Notes

`N/A`
