### PR TITLE
[Feature][ENG-875] Update logged-out homepage to use version A and alter text

### DIFF
--- a/app/home/-components/hero-banner/component.ts
+++ b/app/home/-components/hero-banner/component.ts
@@ -1,5 +1,5 @@
 import { tagName } from '@ember-decorators/component';
-import { action, computed } from '@ember-decorators/object';
+import { action } from '@ember-decorators/object';
 import { alias } from '@ember-decorators/object/computed';
 import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
@@ -23,11 +23,6 @@ export default class HomeHeroBanner extends Component {
 
     @alias(`features.${camelize(ABTesting.homePageVersionB)}`)
     shouldShowVersionB!: boolean;
-
-    @computed('shouldShowVersionB')
-    get version(): string {
-        return this.shouldShowVersionB ? 'versionB' : 'versionA';
-    }
 
     @action
     search(query: string) {

--- a/app/home/-components/hero-banner/component.ts
+++ b/app/home/-components/hero-banner/component.ts
@@ -21,7 +21,7 @@ const { featureFlagNames: { ABTesting } } = config;
 export default class HomeHeroBanner extends Component {
     @service features!: Features;
 
-    @alias(`features.${camelize(ABTesting.homePageVersionB)}`)
+    @alias(`features.${camelize(ABTesting.homePageHeroTextVersionB)}`)
     shouldShowVersionB!: boolean;
 
     @action

--- a/app/home/-components/hero-banner/styles.scss
+++ b/app/home/-components/hero-banner/styles.scss
@@ -65,35 +65,6 @@
     }
 }
 
-.hero .versionB {
-    max-width: 1000px;
-    margin: 84px auto 0;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-
-    .addResearch,
-    .discoverResearch {
-        display: inline-block;
-        max-width: 349px;
-        padding: 0 5px;
-    }
-
-    h3 {
-        font-size: 24px;
-        max-width: 350px;
-    }
-
-    h4 {
-        font-size: 20px;
-        max-width: 350px;
-    }
-
-    .searchBar {
-        padding-top: 35px;
-    }
-}
-
 @media(max-width: 768px) {
     .hero {
         min-height: 500px;
@@ -128,35 +99,11 @@
             max-width: 335px;
         }
     }
-
-    .hero .versionB {
-        h3 {
-            font-size: 20px;
-            max-width: 335px;
-        }
-
-        h4 {
-            font-size: 18px;
-            max-width: 335px;
-        }
-    }
 }
 
 @media(max-width: 737px) {
     .hero .discoverResearch {
         margin-top: 15px;
-    }
-
-    .hero .versionB {
-        margin-top: 32px;
-
-        .getStartedButton {
-            margin: 15px auto 35px;
-        }
-
-        .searchBar {
-            padding-top: 0;
-        }
     }
 }
 

--- a/app/home/-components/hero-banner/template.hbs
+++ b/app/home/-components/hero-banner/template.hbs
@@ -4,21 +4,17 @@
 >
     <header local-class='heroHeader'>
         <h1 data-test-hero-heading>
-            {{t 'osf-components.hero-banner.heading'}}
+            {{#if this.shouldShowVersionB}}
+                {{t 'osf-components.hero-banner.headingB'}}
+            {{else}}
+                {{t 'osf-components.hero-banner.headingA'}}
+            {{/if}}
         </h1>
         <h2 data-test-hero-subheading>
             {{t 'osf-components.hero-banner.subheading'}}
         </h2>
-        <div data-test-hero-container local-class='{{this.version}}'>
+        <div data-test-hero-container>
             <div data-test-add-research local-class='addResearch'>
-                {{#if this.shouldShowVersionB}}
-                    <h3 data-test-add-research-heading>
-                        {{t 'osf-components.hero-banner.add_your_research.heading'}}
-                    </h3>
-                    <h4 data-test-add-research-subheading>
-                        {{t 'osf-components.hero-banner.add_your_research.subheading'}}
-                    </h4>
-                {{/if}}
                 <GetStartedButton local-class='getStartedButton' />
             </div>
             <div data-test-discover local-class='discoverResearch'>

--- a/app/home/-components/integrations-section/component.ts
+++ b/app/home/-components/integrations-section/component.ts
@@ -12,6 +12,6 @@ const { featureFlagNames: { ABTesting } } = config;
 export default class IntegrationsSection extends Component {
     @service features!: Features;
 
-    @alias(`features.${camelize(ABTesting.homePageVersionB)}`)
+    @alias(`features.${camelize(ABTesting.homePageHeroTextVersionB)}`)
     shouldShowVersionB!: boolean;
 }

--- a/app/home/controller.ts
+++ b/app/home/controller.ts
@@ -1,4 +1,3 @@
-import { computed } from '@ember-decorators/object';
 import { alias } from '@ember-decorators/object/computed';
 import { service } from '@ember-decorators/service';
 import Controller from '@ember/controller';
@@ -13,11 +12,6 @@ export default class Home extends Controller {
 
     @alias(`features.${camelize(ABTesting.homePageVersionB)}`)
     shouldShowVersionB!: boolean;
-
-    @computed('shouldShowVersionB')
-    get version(): string {
-        return this.shouldShowVersionB ? 'versionB' : 'versionA';
-    }
 }
 
 declare module '@ember/controller' {

--- a/app/home/controller.ts
+++ b/app/home/controller.ts
@@ -10,7 +10,7 @@ const { featureFlagNames: { ABTesting } } = config;
 export default class Home extends Controller {
     @service features!: Features;
 
-    @alias(`features.${camelize(ABTesting.homePageVersionB)}`)
+    @alias(`features.${camelize(ABTesting.homePageHeroTextVersionB)}`)
     shouldShowVersionB!: boolean;
 }
 

--- a/app/home/route.ts
+++ b/app/home/route.ts
@@ -25,7 +25,7 @@ export default class Home extends Route {
 
   @action
   didTransition() {
-      const shouldShowVersionB = this.features.isEnabled(ABTesting.homePageVersionB);
+      const shouldShowVersionB = this.features.isEnabled(ABTesting.homePageHeroTextVersionB);
       const version = shouldShowVersionB ? 'versionB' : 'versionA';
       this.analytics.trackPage(undefined, undefined, undefined, version);
   }

--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -1646,7 +1646,8 @@ export default {
             search: 'Search',
         },
         'hero-banner': {
-            heading: 'The place to share your research',
+            headingA: 'The place to share your research',
+            headingB: 'There’s a better way to manage your research',
             subheading: 'OSF is a free, open platform to support your research and enable collaboration.',
             add_your_research: {
                 heading: 'Add your research',

--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -158,7 +158,7 @@ declare const config: {
             institutions: string;
         };
         ABTesting: {
-            homePageVersionB: string;
+            homePageHeroTextVersionB: string;
         };
         storageI18n: string;
         enableInactiveSchemas: string;

--- a/config/environment.js
+++ b/config/environment.js
@@ -276,7 +276,7 @@ module.exports = function(environment) {
             enableInactiveSchemas: 'enable_inactive_schemas',
             verifyEmailModals: 'ember_verify_email_modals',
             ABTesting: {
-                homePageVersionB: 'ab_testing_home_page_version_b',
+                homePageHeroTextVersionB: 'ab_testing_home_page_hero_text_version_b',
             },
         },
         gReCaptcha: {

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "ember-data": "~3.4.0",
     "ember-decorators": "^3.0.0",
     "ember-diff-attrs": "^0.2.1",
-    "ember-element-helper": "https://github.com/rwjblue/ember-element-helper#fix-engines",
+    "ember-element-helper": "^0.2.0",
     "ember-engines": "https://github.com/cos-forks/ember-engines#v0.5.20+cos1",
     "ember-event-helpers": "^0.1.0",
     "ember-export-application-global": "^2.0.0",

--- a/tests/acceptance/logged-out-homepage-test.ts
+++ b/tests/acceptance/logged-out-homepage-test.ts
@@ -79,7 +79,7 @@ module('Acceptance | logged-out home page test', hooks => {
         await visit('/');
         const features = this.owner.lookup('service:features') as Features;
 
-        features.enable(ABTesting.homePageVersionB);
+        features.enable(ABTesting.homePageHeroTextVersionB);
 
         await settled();
         assert.dom('[data-test-hero-heading]')

--- a/tests/acceptance/logged-out-homepage-test.ts
+++ b/tests/acceptance/logged-out-homepage-test.ts
@@ -25,10 +25,9 @@ module('Acceptance | logged-out home page test', hooks => {
 
         // Check hero
         assert.dom('[data-test-hero-heading]')
-            .containsText(t('osf-components.hero-banner.heading').toString());
+            .containsText(t('osf-components.hero-banner.headingA').toString());
         assert.dom('[data-test-hero-subheading]')
             .containsText(t('osf-components.hero-banner.subheading').toString());
-        assert.notOk(document.querySelector('[data-test-hero-container]')!.className.includes('versionB'));
 
         // Check support
         assert.dom('[data-test-support-heading]').hasText('How OSF supports your research');
@@ -83,9 +82,8 @@ module('Acceptance | logged-out home page test', hooks => {
         features.enable(ABTesting.homePageVersionB);
 
         await settled();
-        assert.dom('[data-test-add-research-heading]').exists();
-        assert.dom('[data-test-add-research-subheading]').exists();
-        assert.ok(document.querySelector('[data-test-hero-container]')!.className.includes('versionB'));
+        assert.dom('[data-test-hero-heading]')
+            .containsText(t('osf-components.hero-banner.headingB').toString());
         assert.dom('[data-test-get-started-button]').exists({ count: 1 });
 
         await a11yAudit();

--- a/tests/integration/components/hero-banner/component-test.ts
+++ b/tests/integration/components/hero-banner/component-test.ts
@@ -38,7 +38,7 @@ module('Integration | Component | Hero banner', hooks => {
         router.setupRouter();
 
         // Set feature flag to show version B
-        features.enable(ABTesting.homePageVersionB);
+        features.enable(ABTesting.homePageHeroTextVersionB);
 
         await render(hbs`<Home::-Components::HeroBanner />`);
 

--- a/tests/integration/components/hero-banner/component-test.ts
+++ b/tests/integration/components/hero-banner/component-test.ts
@@ -19,14 +19,10 @@ module('Integration | Component | Hero banner', hooks => {
         router.setupRouter();
 
         await render(hbs`<Home::-Components::HeroBanner />`);
-        assert.dom('[data-test-add-research-heading]').doesNotExist();
-        assert.dom('[data-test-add-research-subheading]').doesNotExist();
         assert.dom('[data-test-hero-heading]')
-            .containsText(t('osf-components.hero-banner.heading').toString());
+            .containsText(t('osf-components.hero-banner.headingA').toString());
         assert.dom('[data-test-hero-subheading]')
             .containsText(t('osf-components.hero-banner.subheading').toString());
-
-        assert.notOk(document.querySelector('[data-test-hero-container]')!.className.includes('versionB'));
 
         assert.dom('[data-test-add-research]').exists();
         assert.dom('[data-test-discover]').exists();
@@ -46,9 +42,8 @@ module('Integration | Component | Hero banner', hooks => {
 
         await render(hbs`<Home::-Components::HeroBanner />`);
 
-        assert.dom('[data-test-add-research-heading]').exists();
-        assert.dom('[data-test-add-research-subheading]').exists();
-        assert.ok(document.querySelector('[data-test-hero-container]')!.className.includes('versionB'));
+        assert.dom('[data-test-hero-heading]')
+            .containsText(t('osf-components.hero-banner.headingB').toString());
 
         await a11yAudit(this.element);
         assert.ok(true, 'No a11y errors on page');

--- a/yarn.lock
+++ b/yarn.lock
@@ -7666,9 +7666,10 @@ ember-element-helper@^0.1.1:
   dependencies:
     ember-cli-babel "^6.16.0"
 
-"ember-element-helper@https://github.com/rwjblue/ember-element-helper#fix-engines":
-  version "0.1.1"
-  resolved "https://github.com/rwjblue/ember-element-helper#36e9ac481488992f1f744253de6f2a2cb0191473"
+ember-element-helper@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ember-element-helper/-/ember-element-helper-0.2.0.tgz#eacdf4d8507d6708812623206e24ad37bad487e7"
+  integrity sha512-/WV0PNLyxDvLX/YETb/8KICFTr719OYqFWXqV5XUkh9YhhBGDU/mr1OtlQaWOlsx+sHm42HD2UAICecqex8ziw==
   dependencies:
     ember-cli-babel "^6.16.0"
 


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-875
- Feature flag: n/a

## Purpose

To do round 2 AB testing changes to the logged-out homepage

## Summary of Changes

- Use layout A (Calls to Action stacked)
- Change version A headline to: The place to share your research
- Add version B headline to: There's a better way to manage your research

## Side Effects

`N/A`

## QA Notes

Logged-out homepage should now only be using version A layout without the only other difference being the headline text between versions A and B.
