### PR TITLE
[Feature][ENG-1180] Add styling for schema-blocks

### DIFF
--- a/lib/osf-components/addon/components/form-controls/template.hbs
+++ b/lib/osf-components/addon/components/form-controls/template.hbs
@@ -44,6 +44,8 @@
         shouldShowMessages=this.shouldShowMessages
         disabled=this.disabled
         onchange=@onchange
+        searchField=@searchField
+        searchEnabled=@searchEnabled
     )
     custom=(
         component

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/multi-select-input/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/multi-select-input/component.ts
@@ -5,9 +5,10 @@ import { assert } from '@ember/debug';
 import { computed } from '@ember-decorators/object';
 import { layout } from 'ember-osf-web/decorators/component';
 import { SchemaBlock } from 'ember-osf-web/packages/registration-schema';
+import styles from './styles';
 import template from './template';
 
-@layout(template)
+@layout(template, styles)
 @tagName('')
 export default class MultiSelectInput extends Component {
     // Required param

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/multi-select-input/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/multi-select-input/styles.scss
@@ -1,0 +1,5 @@
+.schema-block-multi-select {
+    :global(label) {
+        font-weight: normal;
+    }
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/multi-select-input/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/multi-select-input/template.hbs
@@ -7,6 +7,7 @@
     >
         <form.checkboxes
             data-test-multi-select-input
+            local-class='schema-block-multi-select'
             @id={{@uniqueID}}
             @valuePath={{@schemaBlock.registrationResponseKey}}
             @options={{this.optionBlockValuesAndHelpText}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/single-select-input/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/single-select-input/component.ts
@@ -6,9 +6,10 @@ import { assert } from '@ember/debug';
 import { layout } from 'ember-osf-web/decorators/component';
 import { SchemaBlock } from 'ember-osf-web/packages/registration-schema';
 
+import styles from './styles';
 import template from './template';
 
-@layout(template)
+@layout(template, styles)
 @tagName('')
 export default class SingleSelectInput extends Component {
     // Required param

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/single-select-input/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/single-select-input/styles.scss
@@ -1,0 +1,12 @@
+.schema-power-select {
+    :global(.ember-power-select-trigger) {
+        height: 40px;
+        max-width: 254px;
+        line-height: 40px;
+        font-size: 14px;
+        color: #263947;
+        background-color: #ecf0f1;
+        border: 1px solid #ddd;
+        border-radius: 2px;
+    }
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/single-select-input/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/single-select-input/template.hbs
@@ -7,10 +7,12 @@
     >
         <form.select
             data-test-single-select-input
+            local-class='schema-power-select'
             @id={{@uniqueID}}
             @valuePath={{@schemaBlock.registrationResponseKey}}
             @options={{this.optionBlockValuesAndHelpText}}
             @onchange={{@onInput}}
+            @searchEnabled={{false}}
             as |option|
         >
             {{option.displayText}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/text/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/text/component.ts
@@ -2,9 +2,10 @@ import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 
 import { layout } from 'ember-osf-web/decorators/component';
+import styles from './styles';
 import template from './template';
 
-@layout(template)
+@layout(template, styles)
 @tagName('')
 export default class Text extends Component {
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/text/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/text/styles.scss
@@ -1,0 +1,9 @@
+.schema-block-input {
+    :global(input) {
+        height: 40px;
+        background-color: #ecf0f1;
+        color: #263947;
+        border-radius: 2px;
+        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);
+    }
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/text/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/text/template.hbs
@@ -7,6 +7,7 @@
     >
         <form.text
             data-test-text-input
+            local-class='schema-block-input'
             @id={{@uniqueID}}
             @valuePath={{@schemaBlock.registrationResponseKey}}
             @onKeyUp={{@onInput}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/textarea/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/textarea/component.ts
@@ -2,9 +2,10 @@ import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 
 import { layout } from 'ember-osf-web/decorators/component';
+import styles from './styles';
 import template from './template';
 
-@layout(template)
+@layout(template, styles)
 @tagName('')
 export default class Textarea extends Component {
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/textarea/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/textarea/styles.scss
@@ -1,0 +1,11 @@
+.schema-block-long-text {
+    :global(.form-control) {
+        min-height: 100px;
+        color: #263947;
+        background-color: #ecf0f1;
+        border: 1px solid #ddd;
+        border-radius: 2px;
+        font-size: 14px;
+        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);
+    }
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/textarea/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/textarea/template.hbs
@@ -7,6 +7,7 @@
     >
         <form.textarea
             data-test-textarea-input
+            local-class='schema-block-long-text'
             @id={{@uniqueID}}
             @valuePath={{@schemaBlock.registrationResponseKey}}
             @onKeyUp={{@onInput}}

--- a/lib/osf-components/addon/components/validated-input/power-select/template.hbs
+++ b/lib/osf-components/addon/components/validated-input/power-select/template.hbs
@@ -17,6 +17,7 @@
         @searchEnabled={{this.searchEnabled}}
         @placeholder={{this.placeholder}}
         @renderInPlace={{this.renderInPlace}}
+        @searchField={{@searchField}}
         as |option|
     >
         {{yield option}}


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-1180
- Feature flag: n/a

## Purpose

Add styling for editable schema-block components.

## Summary of Changes

- Add styling for schema-blocks
- Add params for powerselect for `searchField` (to allow searching of objects) and `searchEnabled` (to disable search box in registries submission powerselects)

## Side Effects

`N/A`

## QA Notes

Should only affect the styles for the schema-block input components.
