### PR TITLE
[ENG-1181][ENG-1182] Rework validations, increase autosave debounce 5s

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -59,7 +59,7 @@ module.exports = function(defaults) {
             importBootstrapCSS: false,
         },
         'ember-composable-helpers': {
-            only: ['contains', 'range'],
+            only: ['compose', 'contains', 'range'],
         },
         'ember-cli-password-strength': {
             bundleZxcvbn: !IS_PROD,

--- a/lib/osf-components/addon/components/registries/draft-registration-manager/template.hbs
+++ b/lib/osf-components/addon/components/registries/draft-registration-manager/template.hbs
@@ -12,7 +12,6 @@
     lastPage=this.lastPage
     initializing=this.initializing
 
+    onPageChange=(action this.onPageChange)
     onInput=(perform this.onInput)
-    submitDraftRegistration=(perform this.submitRegistration)
-    validateRegistrationResponses=(action this.validateRegistrationResponses)
 )}}

--- a/lib/registries/addon/drafts/draft/-components/register/component.ts
+++ b/lib/registries/addon/drafts/draft/-components/register/component.ts
@@ -35,7 +35,10 @@ export default class Register extends Component.extend({
     didReceiveAttrs() {
         assert('@draftManager is required!', Boolean(this.draftManager));
         assert('@draftRegistration is required!', Boolean(this.draftRegistration));
+    }
 
+    @action
+    onRegister() {
         if (!this.registration) {
             const registration = this.store.createRecord('registration', {
                 draftRegistration: this.draftRegistration,
@@ -43,6 +46,7 @@ export default class Register extends Component.extend({
 
             this.setProperties({ registration });
         }
+        this.showPartialRegDialog();
     }
 
     @action

--- a/lib/registries/addon/drafts/draft/-components/register/template.hbs
+++ b/lib/registries/addon/drafts/draft/-components/register/template.hbs
@@ -1,7 +1,7 @@
 <OsfButton
     data-test-goto-register
     @type='success'
-    @onClick={{action this.showPartialRegDialog}}
+    @onClick={{action this.onRegister}}
     @disabled={{not this.draftManager.registrationResponsesIsValid}}
 >
     {{t 'registries.drafts.draft.register'}}

--- a/lib/registries/addon/drafts/draft/template.hbs
+++ b/lib/registries/addon/drafts/draft/template.hbs
@@ -17,34 +17,36 @@
         @onPageNotFound={{action this.onPageNotFound}}
         as |draftManager|
     >
-        <OsfLayout @backgroundClass={{local-class 'ContentBackground'}} as |layout|>
-            <layout.heading local-class='Heading'>
-                <div local-class='Title'>{{t 'registries.drafts.draft.form.new_registration'}}</div>
-            </layout.heading>
+        {{#if draftManager.initializing}}
+            <div local-class='ContentBackground Loading'>
+                <LoadingIndicator @dark={{true}} />
+            </div>
+        {{else}}
+            {{compute draftManager.onPageChange this.pageIndex this.inReview}}
 
-            <layout.leftNav as |leftNav|>
-                {{#each draftManager.pageManagers as |pageManager index|}}
+            <OsfLayout @backgroundClass={{local-class 'ContentBackground'}} as |layout|>
+                <layout.heading local-class='Heading'>
+                    <div local-class='Title'>{{t 'registries.drafts.draft.form.new_registration'}}</div>
+                </layout.heading>
+                <layout.leftNav as |leftNav|>
+                    {{#each draftManager.pageManagers as |pageManager index|}}
+                        <PageLink
+                            @link={{component leftNav.link}}
+                            @draftId={{draftManager.draftId}}
+                            @pageManager={{pageManager}}
+                            @pageIndex={{index}}
+                            @currentPageIndex={{draftManager.currentPage}}
+                        />
+                    {{/each}}
                     <PageLink
                         @link={{component leftNav.link}}
                         @draftId={{draftManager.draftId}}
-                        @pageManager={{pageManager}}
-                        @pageIndex={{index}}
-                        @currentPageIndex={{draftManager.currentPage}}
+                        @pageName='review'
+                        @currentPageName={{this.model.page}}
+                        @label='Review'
                     />
-                {{/each}}
-                <PageLink
-                    @link={{component leftNav.link}}
-                    @draftId={{draftManager.draftId}}
-                    @pageName='review'
-                    @currentPageName={{this.model.page}}
-                    @label='Review'
-                />
-            </layout.leftNav>
-
-            <layout.main local-class='Main'>
-                {{#if draftManager.initializing}}
-                    <LoadingIndicator @dark={{true}} />
-                {{else}}
+                </layout.leftNav>
+                <layout.main local-class='Main'>
                     {{#if this.inReview}}
                         <Registries::ReviewFormRenderer
                             @schemaBlocks={{draftManager.schemaBlocks}}
@@ -57,51 +59,50 @@
                             @node={{this.node}}
                         />
                     {{/if}}
-                {{/if}}
-            </layout.main>
-            <layout.right local-class='Right'>
-                {{#if this.inReview}}
-                    <Drafts::Draft::-Components::Register
-                        @draftRegistration={{this.draftRegistration}}
-                        @draftManager={{draftManager}}
-                        @onSubmitRedirect={{action this.onSubmitRedirect}}
-                    />
-                {{/if}}
-                {{#if (eq draftManager.lastPage this.pageIndex)}}
-                    <OsfLink
-                        data-test-goto-review
-                        class='btn btn-primary'
-                        @type='button'
-                        @route='registries.drafts.draft'
-                        @models={{array draftManager.draftId 'review'}}
-                    >
-                        {{t 'registries.drafts.draft.review.start_review'}}
-                    </OsfLink>
-                {{/if}}
-                {{#if draftManager.nextPageParam}}
-                    <OsfLink
-                        data-test-goto-next-page
-                        @type='button'
-                        class='btn btn-default'
-                        @route='registries.drafts.draft'
-                        @models={{array draftManager.draftId draftManager.nextPageParam}}
-                        @onClick={{draftManager.setPageIsVisited}}
-                    >
-                        {{t 'registries.drafts.draft.form.next'}}
-                    </OsfLink>
-                {{/if}}
-                {{#if draftManager.prevPageParam}}
-                    <OsfLink
-                        data-test-goto-previous-page
-                        @type='button'
-                        class='btn btn-default'
-                        @route='registries.drafts.draft'
-                        @models={{array draftManager.draftId draftManager.prevPageParam}}
-                    >
-                        {{t 'registries.drafts.draft.form.back'}}
-                    </OsfLink>
-                {{/if}}
-            </layout.right>
-        </OsfLayout>
+                </layout.main>
+                <layout.right local-class='Right'>
+                    {{#if this.inReview}}
+                        <Drafts::Draft::-Components::Register
+                            @draftRegistration={{this.draftRegistration}}
+                            @draftManager={{draftManager}}
+                            @onSubmitRedirect={{action this.onSubmitRedirect}}
+                        />
+                    {{/if}}
+                    {{#if (eq draftManager.lastPage this.pageIndex)}}
+                        <OsfLink
+                            data-test-goto-review
+                            class='btn btn-primary'
+                            @type='button'
+                            @route='registries.drafts.draft'
+                            @models={{array draftManager.draftId 'review'}}
+                        >
+                            {{t 'registries.drafts.draft.review.start_review'}}
+                        </OsfLink>
+                    {{/if}}
+                    {{#if draftManager.nextPageParam}}
+                        <OsfLink
+                            data-test-goto-next-page
+                            @type='button'
+                            class='btn btn-default'
+                            @route='registries.drafts.draft'
+                            @models={{array draftManager.draftId draftManager.nextPageParam}}
+                        >
+                            {{t 'registries.drafts.draft.form.next'}}
+                        </OsfLink>
+                    {{/if}}
+                    {{#if draftManager.prevPageParam}}
+                        <OsfLink
+                            data-test-goto-previous-page
+                            @type='button'
+                            class='btn btn-default'
+                            @route='registries.drafts.draft'
+                            @models={{array draftManager.draftId draftManager.prevPageParam}}
+                        >
+                            {{t 'registries.drafts.draft.form.back'}}
+                        </OsfLink>
+                    {{/if}}
+                </layout.right>
+            </OsfLayout>
+        {{/if}}
     </Registries::DraftRegistrationManager>
 {{/if}}


### PR DESCRIPTION
- Ticket: [ENG-1181](https://openscience.atlassian.net/browse/ENG-1181)
- Feature flag: n/a

## Purpose

Rework validations and bump autosave debounce to 5s

## Summary of Changes

- Now validate all visited pages on current page load
- Now validate marks all pages as visited upon entering review route and validates all
- Add validation tests
- Bump autosave debounce to 5s

