### PR TITLE
[No ticket] Update how the help text is accessed in single/multi select

### DIFF
--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/multi-select-input/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/multi-select-input/component.ts
@@ -14,15 +14,18 @@ export default class MultiSelectInput extends Component {
     // Required param
     optionBlocks!: SchemaBlock[];
 
+    // Private properties
+    helpTextMapping: any = {};
+
     didReceiveAttrs() {
         assert('multi-select-input requires optionBlocks to render', Boolean(this.optionBlocks));
+        this.optionBlocks.forEach(option => {
+            this.helpTextMapping[option.displayText!] = option.helpText;
+        });
     }
 
     @computed('optionBlocks')
-    get optionBlockValuesAndHelpText() {
-        return this.optionBlocks.map(item => ({
-            displayText: item.displayText,
-            helpText: item.helpText,
-        }));
+    get optionBlockValues() {
+        return this.optionBlocks.map(item => item.displayText);
     }
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/multi-select-input/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/multi-select-input/template.hbs
@@ -10,16 +10,16 @@
             local-class='schema-block-multi-select'
             @id={{@uniqueID}}
             @valuePath={{@schemaBlock.registrationResponseKey}}
-            @options={{this.optionBlockValuesAndHelpText}}
+            @options={{this.optionBlockValues}}
             @onCheckCallback={{@onInput}}
             as |cb|
         >
-            <div data-test-multiple-select-option={{cb.option.displayText}}>
+            <div data-test-multiple-select-option={{cb.option}}>
                 {{cb.checkbox}}
                 <label for={{cb.checkboxId}}>
                     <div data-test-scope-description>
-                        {{cb.option.displayText}}
-                        <Registries::SchemaBlockRenderer::HelperTextIcon @helpText={{cb.option.helpText}} />
+                        {{cb.option}}
+                        <Registries::SchemaBlockRenderer::HelperTextIcon @helpText={{get this.helpTextMapping cb.option}} />
                     </div>
                 </label>
             </div>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/single-select-input/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/single-select-input/component.ts
@@ -15,15 +15,18 @@ export default class SingleSelectInput extends Component {
     // Required param
     optionBlocks!: SchemaBlock[];
 
+    // Private properties
+    helpTextMapping: any = {};
+
     didReceiveAttrs() {
         assert('single-select-input requires optionBlocks to render', Boolean(this.optionBlocks));
+        this.optionBlocks.forEach(option => {
+            this.helpTextMapping[option.displayText!] = option.helpText;
+        });
     }
 
     @computed('optionBlocks')
-    get optionBlockValuesAndHelpText() {
-        return this.optionBlocks.map(item => ({
-            displayText: item.displayText,
-            helpText: item.helpText,
-        }));
+    get optionBlockValues() {
+        return this.optionBlocks.map(item => item.displayText);
     }
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/single-select-input/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/single-select-input/template.hbs
@@ -10,13 +10,13 @@
             local-class='schema-power-select'
             @id={{@uniqueID}}
             @valuePath={{@schemaBlock.registrationResponseKey}}
-            @options={{this.optionBlockValuesAndHelpText}}
+            @options={{this.optionBlockValues}}
             @onchange={{@onInput}}
             @searchEnabled={{false}}
             as |option|
         >
-            {{option.displayText}}
-            <Registries::SchemaBlockRenderer::HelperTextIcon @helpText={{option.helpText}} />
+            {{option}}
+            <Registries::SchemaBlockRenderer::HelperTextIcon @helpText={{get this.helpTextMapping option}} />
         </form.select>
     </FormControls>
 </Registries::SchemaBlockRenderer::Editable::Base>


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [N/A]
- Feature flag: n/a

## Purpose

<!-- Describe the purpose of your changes. -->
Fix how help text is handled for single and multi select
## Summary of Changes

<!-- Briefly describe or list your changes. -->
only handle strings for display text and use a mapping object to get help text
## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
