### PR TITLE
[no ticket] replace routes instead of transition

### DIFF
--- a/app/guid-node/drafts/route.ts
+++ b/app/guid-node/drafts/route.ts
@@ -2,6 +2,6 @@ import Route from '@ember/routing/route';
 
 export default class GuidNodeDrafts extends Route {
     model(params: { draftId: string }) {
-        this.transitionTo('registries.drafts.draft-shim', params.draftId);
+        this.replaceWith('registries.drafts.draft-shim', params.draftId);
     }
 }

--- a/lib/registries/addon/drafts/draft/controller.ts
+++ b/lib/registries/addon/drafts/draft/controller.ts
@@ -37,7 +37,7 @@ export default class RegistriesDrat extends Controller {
     updateRoute(headingText: string) {
         if (this.page && this.shouldAppendPageSlug) {
             const pageSlug = getPageParam(this.pageIndex, headingText);
-            this.transitionToRoute('drafts.draft', this.draftId, pageSlug);
+            this.replaceRoute('drafts.draft', this.draftId, pageSlug);
         }
     }
 


### PR DESCRIPTION
- Ticket: n/a
- Feature flag: n/a

## Purpose

Replace routes instead of transition for better back-button behavior.

## Summary of Changes

Replace routes instead of transition for better back-button behavior.

## Side Effects

None expected.

## QA Notes

n/a
