### PR TITLE
[No Ticket] Add link in embargo modal

### DIFF
--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -1428,9 +1428,9 @@ export default {
                         The content and version history of Wiki and OSF Storage will be copied to the registration.
                     </li>
                     <li>
-                        This project contains links to other projects.These links will be copied into your registration, but the
-                        projects that they link to will not be registered.If you wish to register the linked projects, they must be
-                        registered separately.Learn more about links.
+                        This project contains links to other projects. These links will be copied into your registration, but the
+                        projects that they link to will not be registered. If you wish to register the linked projects, they must be
+                        registered separately. <a href='https://help.osf.io/hc/en-us/articles/360019930313-Link-to-a-Project'>Learn more about links</a>.
                     </li>
                 </ul>`,
             immediateOption: 'Make registration public immediately',

--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -1,5 +1,6 @@
-/* tslint:disable:object-literal-sort-keys max-line-length */
+import config from 'ember-get-config';
 
+/* tslint:disable:object-literal-sort-keys max-line-length */
 export default {
     documentType: {
         default: {
@@ -1430,7 +1431,7 @@ export default {
                     <li>
                         This project contains links to other projects. These links will be copied into your registration, but the
                         projects that they link to will not be registered. If you wish to register the linked projects, they must be
-                        registered separately. <a href='https://help.osf.io/hc/en-us/articles/360019930313-Link-to-a-Project'>Learn more about links</a>.
+                        registered separately. <a href='${config.helpLinks.linkToAProject}' target='_blank' rel='noopener'>Learn more about links</a>.
                     </li>
                 </ul>`,
             immediateOption: 'Make registration public immediately',

--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -146,6 +146,9 @@ declare const config: {
         facebookUrl: string;
         githubUrl: string;
     };
+    helpLinks: {
+        linkToAProject: string;
+    };
     dashboard: {
         popularNode: string;
         noteworthyNode: string;

--- a/config/environment.js
+++ b/config/environment.js
@@ -228,6 +228,9 @@ module.exports = function(environment) {
             facebookUrl: 'https://www.facebook.com/CenterForOpenScience/',
             githubUrl: 'https://github.com/centerforopenscience',
         },
+        helpLinks: {
+            linkToAProject: 'https://help.osf.io/hc/en-us/articles/360019930313-Link-to-a-Project',
+        },
         dashboard: {
             popularNode,
             noteworthyNode,


### PR DESCRIPTION
- Ticket: n/a
- Feature flag: n/a

## Purpose

To add a link to the `Learn more about links` in the embargo modal

## Summary of Changes

- Turn `Learn more about links` into a link
- Add spaces after sentences

## Side Effects

`N/A`

## QA Notes

`N/A`
