### PR TITLE
[ENG-1211] Files widget improvements

### DIFF
--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -1673,7 +1673,7 @@ export default {
             },
         },
         'files-widget': {
-            no_files: 'Drag and drop files here to upload files to this folder',
+            drag_drop_files: 'Drag and drop files here to upload files to this folder',
             message: 'Only files from root project on OSF Storage are available to attach. To attach files from components or non "OSF Storage" addons, first add them to your root project files.',
         },
         subjects: {

--- a/app/models/file.ts
+++ b/app/models/file.ts
@@ -2,6 +2,7 @@ import { attr, belongsTo, hasMany } from '@ember-decorators/data';
 import DS from 'ember-data';
 import { Link } from 'jsonapi-typescript';
 
+import { FileReference } from 'ember-osf-web/packages/registration-schema';
 import getHref from 'ember-osf-web/utils/get-href';
 
 import BaseFileItem from './base-file-item';
@@ -80,6 +81,20 @@ export default class FileModel extends BaseFileItem {
             });
         }
         return Promise.reject(Error('Can only get the contents of files.'));
+    }
+
+    toFileReference(): FileReference {
+        return {
+            file_id: this.id,
+            file_name: this.name,
+            file_urls: {
+                html: (this.links.html as string),
+                download: (this.links.download as string),
+            },
+            file_hashes: {
+                sha256: this.extra.hashes.sha256,
+            },
+        };
     }
 
     async rename(newName: string, conflict = 'replace'): Promise<void> {

--- a/lib/osf-components/addon/components/files/browse/component.ts
+++ b/lib/osf-components/addon/components/files/browse/component.ts
@@ -23,9 +23,7 @@ export default class FileBrowser extends Component {
         const { newItems: [newFolder], oldItems: [oldFolder] } = context;
 
         if (oldFolder) {
-            const parentFolderId = oldFolder.belongsTo('parentFolder').id();
-
-            if (!newFolder || (newFolder.id === parentFolderId)) {
+            if (!newFolder || oldFolder.materializedPath.includes(newFolder.materializedPath)) {
                 return toRight;
             }
         }

--- a/lib/osf-components/addon/components/files/browse/styles.scss
+++ b/lib/osf-components/addon/components/files/browse/styles.scss
@@ -25,6 +25,7 @@
 
     .uploading {
         padding: 15px;
+        border-bottom: 1px solid $color-border-gray;
     }
 }
 

--- a/lib/osf-components/addon/components/files/browse/template.hbs
+++ b/lib/osf-components/addon/components/files/browse/template.hbs
@@ -38,30 +38,34 @@
             {{/if}}
 
             <div local-class='files-list'>
-                <AnimatedContainer>
-                    <AnimatedEach
-                        @items={{uploadZone.uploading}}
-                        @use={{this.transition}}
-                        @duration=1000
-                        as |item|
-                    >
-                        <div local-class='uploading'>
-                            <div class='progress'>
-                                <div id='uploading-{{item.size}}' class='progress-bar' role='progressbar'></div>
-                            </div>
+                <AnimatedEach
+                    @items={{uploadZone.uploading}}
+                    @use={{this.transition}}
+                    @duration=1000
+                    as |item|
+                >
+                    <div local-class='uploading'>
+                        <div class='progress'>
+                            <div id='uploading-{{item.size}}' class='progress-bar' role='progressbar'></div>
                         </div>
-                    </AnimatedEach>
-                    <AnimatedValue
-                        @value={{@filesManager.currentFolder}}
-                        @rules={{this.rules}}
-                        @duration=500
-                    >
-                        <Files::List
-                            @items={{this.sortedItems}}
-                            @filesManager={{@filesManager}}
-                        />
-                    </AnimatedValue>
-                </AnimatedContainer>
+                    </div>
+                </AnimatedEach>
+                {{#if @filesManager.loadingFolderItems}}
+                    <LoadingIndicator @dark={{true}} />
+                {{else}}
+                    <AnimatedContainer>
+                        <AnimatedValue
+                            @value={{@filesManager.currentFolder}}
+                            @rules={{this.rules}}
+                            @duration=500
+                        >
+                            <Files::List
+                                @items={{this.sortedItems}}
+                                @filesManager={{@filesManager}}
+                            />
+                        </AnimatedValue>
+                    </AnimatedContainer>
+                {{/if}}
             </div>
 
             {{#if this.shouldShowLoadMoreButton}}
@@ -70,7 +74,11 @@
                     local-class='load-more'
                     {{on 'click' (action @filesManager.loadMore)}}
                 >
-                    <FaIcon @icon='chevron-down' @fixedWith={{true}}/>
+                    {{#if @filesManager.loadingMore}}
+                        <LoadingIndicator @inline={{true}} @dark={{true}} />
+                    {{else}}
+                        <FaIcon @icon='chevron-down' @fixedWith={{true}}/>
+                    {{/if}}
                 </div>
             {{/if}}
         {{/if}}

--- a/lib/osf-components/addon/components/files/item/component.ts
+++ b/lib/osf-components/addon/components/files/item/component.ts
@@ -38,23 +38,6 @@ export default class FileBrowserItem extends Component {
     }
 
     @action
-    onClickFile(currentItem: File) {
-        const isSelected = this.filesManager.selectedItems.includes(currentItem);
-
-        this.analytics.trackFromElement(this.element, {
-            name: `${isSelected ? 'Unselect file' : 'Select file'}`,
-            category: 'button',
-            action: 'click',
-        });
-
-        if (isSelected) {
-            this.filesManager.unselectItem(currentItem);
-        } else {
-            this.filesManager.selectItem(currentItem);
-        }
-    }
-
-    @action
     onClick() {
         if (this.item.isFolder) {
             if (this.isCurrentFolder) {
@@ -73,8 +56,8 @@ export default class FileBrowserItem extends Component {
                 });
                 this.filesManager.goToFolder(this.item);
             }
-        } else {
-            this.onClickFile(this.item);
+        } else if (this.filesManager.onSelectFile) {
+            this.filesManager.onSelectFile(this.item);
         }
     }
 }

--- a/lib/osf-components/addon/components/files/item/template.hbs
+++ b/lib/osf-components/addon/components/files/item/template.hbs
@@ -1,5 +1,5 @@
 <div
-    data-test-file-browser-item
+    data-test-file-browser-item='{{this.item.id}}'
     local-class='file-row {{if this.shouldIndent 'indent'}}'
     {{on 'click' (action this.onClick)}}
 >
@@ -13,8 +13,10 @@
             <FileIcon @item={{this.item}} />
             <span data-test-file-name local-class='filename'>{{this.item.itemName}}</span>
         </div>
-        <time data-test-file-date-modified>
-            {{this.date}}
-        </time>
+        {{#unless this.item.isFolder}}
+            <time data-test-file-date-modified>
+                {{this.date}}
+            </time>
+        {{/unless}}
     {{/if}}
 </div>

--- a/lib/osf-components/addon/components/files/list/template.hbs
+++ b/lib/osf-components/addon/components/files/list/template.hbs
@@ -9,7 +9,7 @@
         {{#if @filesManager.canEdit}}
             <div data-test-no-files-placeholder local-class='placeholder'>
                 <FaIcon @icon='upload' @size=4 />
-                {{t 'osf-components.files-widget.no_files'}}
+                {{t 'osf-components.files-widget.drag_drop_files'}}
             </div>
         {{/if}}
     {{/each}}

--- a/lib/osf-components/addon/components/files/manager/template.hbs
+++ b/lib/osf-components/addon/components/files/manager/template.hbs
@@ -1,14 +1,13 @@
 {{yield (hash
-    canEdit=this.canEdit
     loading=this.loading
+    loadingFolderItems=this.loadingFolderItems
+    loadingMore=this.loadingMore
+    canEdit=this.canEdit
+    hasMore=this.hasMore
     currentFolder=this.currentFolder
     displayedItems=this.displayedItems
-    selectedItems=this.selectedItems
     fileProvider=this.fileProvider
-    hasMore=this.hasMore
-    loadingFolderItems=this.loadingFolderItems
-    unselectItem=(action this.unselectItem)
-    selectItem=(action this.selectItem)
+    onSelectFile=@onSelectFile
     goToFolder=(action this.goToFolder)
     goToParentFolder=(action this.goToParentFolder)
     addFile=(perform this.addFile)

--- a/lib/osf-components/addon/components/files/selected-list/component.ts
+++ b/lib/osf-components/addon/components/files/selected-list/component.ts
@@ -8,7 +8,6 @@ import move from 'ember-animated/motions/move';
 import { fadeIn, fadeOut } from 'ember-animated/motions/opacity';
 
 import { layout } from 'ember-osf-web/decorators/component';
-import { FilesManager } from 'osf-components/components/files/manager/component';
 
 import styles from './styles';
 import template from './template';
@@ -16,9 +15,6 @@ import template from './template';
 @layout(template, styles)
 @tagName('')
 export default class SelectedFilesList extends Component {
-    // Required
-    filesManager!: FilesManager;
-
     *transition(context: { insertedSprites: Sprite[], keptSprites: Sprite[], removedSprites: Sprite[] }) {
         const { insertedSprites, keptSprites, removedSprites } = context;
 

--- a/lib/osf-components/addon/components/files/selected-list/template.hbs
+++ b/lib/osf-components/addon/components/files/selected-list/template.hbs
@@ -1,23 +1,24 @@
-{{#if @filesManager.selectedItems}}
+{{#if @selectedFiles}}
     <div data-test-selected-files
         local-class='selected-list'
     >
         <AnimatedContainer>
             <AnimatedEach
-                @items={{@filesManager.selectedItems}}
+                @items={{@selectedFiles}}
                 @use={{this.transition}}
                 @duration=500
-                as |item|
+                as |file|
             >
-                <div data-test-selected-file
+                <div
+                    data-test-selected-file='{{file.file_id}}'
                     local-class='selected-item'
                 >
-                    <span>{{item.itemName}}</span>
+                    <span>{{file.file_name}}</span>
                     <OsfButton
                         data-test-unselect-file
                         data-analytics-name='Unselect file'
                         local-class='unselect'
-                        @onClick={{action @filesManager.unselectItem item}}
+                        @onClick={{action @unselect file}}
                         @type='link'
                     >
                         <FaIcon @icon='times' @fixedWith={{true}} />

--- a/lib/osf-components/addon/components/files/upload-zone/component.ts
+++ b/lib/osf-components/addon/components/files/upload-zone/component.ts
@@ -57,10 +57,10 @@ export default class UploadZone extends Component.extend({
         acceptDirectories: false,
     };
 
-    @alias('manager.canEdit') enable!: boolean;
+    @alias('filesManager.canEdit') enable!: boolean;
     @notEmpty('uploading') isUploading!: boolean;
 
-    @computed('manager.{currentFolder,fileProvider}')
+    @computed('filesManager.{currentFolder,fileProvider}')
     get uploadUrl() {
         const folder = this.filesManager.currentFolder || this.filesManager.fileProvider;
         return folder ? folder.links.upload : undefined;
@@ -86,6 +86,8 @@ export default class UploadZone extends Component.extend({
     @action
     buildUrl(files: File[]) {
         const { name } = files[0];
-        return this.uploadUrl ? `${this.uploadUrl}?${$.param({ name })}` : undefined;
+        const existingFile = this.filesManager.displayedItems.findBy('itemName', name);
+
+        return existingFile ? existingFile.links.upload : `${this.uploadUrl}?${$.param({ name })}`;
     }
 }

--- a/lib/osf-components/addon/components/files/widget/template.hbs
+++ b/lib/osf-components/addon/components/files/widget/template.hbs
@@ -1,6 +1,9 @@
 <div ...attributes>
-    <Files::Manager @node={{@node}} @onSelect={{@onSelect}} @onUnselect={{@onUnselect}} as |filesManager|>
-        <Files::SelectedList @filesManager={{filesManager}} />
+    <Files::Manager
+        @node={{@node}}
+        @onSelectFile={{@onSelectFile}}
+        as |filesManager|
+    >
         <Files::Browse @filesManager={{filesManager}} />
     </Files::Manager>
 </div>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/component.ts
@@ -1,6 +1,7 @@
 import { tagName } from '@ember-decorators/component';
 import { action } from '@ember-decorators/object';
 import { alias } from '@ember-decorators/object/computed';
+import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
 import { assert } from '@ember/debug';
 
@@ -8,6 +9,7 @@ import { ChangesetDef } from 'ember-changeset/types';
 import File from 'ember-osf-web/models/file';
 import NodeModel from 'ember-osf-web/models/node';
 import { FileReference, SchemaBlock } from 'ember-osf-web/packages/registration-schema';
+import Analytics from 'ember-osf-web/services/analytics';
 
 import { layout } from 'ember-osf-web/decorators/component';
 
@@ -16,6 +18,8 @@ import template from './template';
 @layout(template)
 @tagName('')
 export default class Files extends Component {
+    @service analytics!: Analytics;
+
     // Required param
     changeset!: ChangesetDef;
     node!: NodeModel;
@@ -43,33 +47,42 @@ export default class Files extends Component {
             'Registries::SchemaBlockRenderer::Editable::Files requires a schemaBlock to render',
             Boolean(this.schemaBlock),
         );
+
+        this.set('selectedFiles', this.changeset.get(this.valuePath) || []);
     }
 
     @action
-    onSelect(file: File) {
-        const newFile: FileReference = {
-            file_id: file.id,
-            file_name: file.name,
-            file_urls: {
-                html: (file.links.html as string),
-                download: (file.links.download as string),
-            },
-            file_hashes: {
-                sha256: file.extra.hashes.sha256,
-            },
-        };
-        this.selectedFiles.pushObject(newFile);
+    select(file: FileReference) {
+        this.selectedFiles.pushObject(file);
         this.changeset.set(this.valuePath, this.selectedFiles);
         this.onInput();
     }
 
     @action
-    onUnselect(file: File) {
+    unselect(file: FileReference) {
         const newSelectedFiles = this.selectedFiles.filter(
-            (selectedFile: FileReference) => selectedFile.file_id !== file.id,
+            (selectedFile: FileReference) => selectedFile.file_id !== file.file_id,
         );
         this.set('selectedFiles', newSelectedFiles);
         this.changeset.set(this.valuePath, this.selectedFiles);
         this.onInput();
+    }
+
+    @action
+    onSelectFile(file: File) {
+        const fileRef = file.toFileReference();
+        const isSelected = this.selectedFiles.includes(fileRef);
+
+        this.analytics.trackFromElement(this.element, {
+            name: `${isSelected ? 'Unselect file' : 'Select file'}`,
+            category: 'button',
+            action: 'click',
+        });
+
+        if (isSelected) {
+            this.unselect(fileRef);
+        } else {
+            this.select(fileRef);
+        }
     }
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/template.hbs
@@ -1,7 +1,10 @@
+<Files::SelectedList
+    @selectedFiles={{this.selectedFiles}}
+    @unselect={{action this.unselect}}
+/>
 <Files::Widget
     data-test-editable-file-widget
     @node={{@node}}
-    @onSelect={{action this.onSelect}}
-    @onUnselect={{action this.onUnselect}}
+    @onSelectFile={{action this.onSelectFile}}
     ...attributes
 />

--- a/tests/integration/components/files-widget/component-test.ts
+++ b/tests/integration/components/files-widget/component-test.ts
@@ -93,35 +93,13 @@ module('Integration | Component | files-widget', hooks => {
 
         assert.dom('[data-test-ascending-sort="dateModified"]').isVisible();
         await click('[data-test-ascending-sort="dateModified"]');
-        expected = [folderOne, fileTwo, fileOne].map(convertDate);
+        expected = [fileTwo, fileOne].map(convertDate);
         assertOrdered(assert, 'date-modified', 'ascending', expected);
 
         assert.dom('[data-test-descending-sort="dateModified"]').isVisible();
         await click('[data-test-descending-sort="dateModified"]');
-        expected = [folderOne, fileOne, fileTwo].map(convertDate);
+        expected = [fileOne, fileTwo].map(convertDate);
         assertOrdered(assert, 'date-modified', 'descending', expected);
-    });
-
-    test('show selected items', async function(this: ThisTestContext, assert) {
-        const mirageNode = server.create('node', { currentUserPermissions: Object.values(Permission) }, 'withFiles');
-        const node = await this.store.findRecord('node', mirageNode.id);
-
-        this.set('node', node);
-
-        await render(hbs`<Files::Widget @node={{this.node}} />`);
-
-        assert.dom('[data-test-file-row]:first-child').isVisible();
-
-        await click('[data-test-file-browser-item]:first-child');
-        await animationsSettled();
-
-        assert.dom('[data-test-selected-files]').isVisible();
-        assert.dom('[data-test-selected-file]').exists({ count: 1 });
-
-        await click('[data-test-unselect-file]');
-        await animationsSettled();
-
-        assert.dom('[data-test-selected-file]').doesNotExist();
     });
 
     test('navigate between folders', async function(this: ThisTestContext, assert) {
@@ -143,7 +121,7 @@ module('Integration | Component | files-widget', hooks => {
         assert.dom('[data-test-file-row]').exists({ count: osfstorage.files.models.length });
 
         // Navigate to child folder.
-        await click('[data-test-file-browser-item]:first-child');
+        await click(`[data-test-file-browser-item="${folder.id}"]`);
         await animationsSettled();
 
         assert.dom('[data-test-file-row]').exists({ count: folderItems.length });
@@ -154,7 +132,7 @@ module('Integration | Component | files-widget', hooks => {
         assert.deepEqual(actualfolderItems.sort(), folderItems.mapBy('name').sort());
 
         // Navigate back to root folder.
-        await click('[data-test-file-browser-item]:first-child');
+        await click(`[data-test-file-browser-item="${folder.id}"]`);
         await animationsSettled();
 
         actualfolderItems = getItemAttr('name');

--- a/tests/integration/components/registries/schema-block-group-renderer/component-test.ts
+++ b/tests/integration/components/registries/schema-block-group-renderer/component-test.ts
@@ -163,13 +163,24 @@ module('Integration | Component | schema-block-group-renderer', hooks => {
         ];
 
         const schemaBlockGroups = getSchemaBlockGroups(schemaBlocks);
+        const testFile = {
+            file_name: 'testFile.txt',
+            file_id: 'xkcds',
+            file_urls: {
+                html: 'fakehtml',
+                download: 'fakedownloadUrl',
+            },
+            file_hashes: {
+                sha256: '234322',
+            },
+        };
 
         const registrationResponse = {
             'page-one_short-text': '',
             'page-one_long-text': '',
             'page-one_single-select-two': '',
             'page-one_multi-select': [],
-            'page-one_file-input': [],
+            'page-one_file-input': [testFile],
         };
         const registrationResponseChangeset = new Changeset(registrationResponse);
         this.store = this.owner.lookup('service:store');
@@ -206,5 +217,7 @@ module('Integration | Component | schema-block-group-renderer', hooks => {
         assert.dom('[data-test-multi-select-input]').exists();
         assert.dom('[data-test-read-only-contributors-list]').exists();
         assert.dom('[data-test-editable-file-widget]').exists();
+        assert.dom('[data-test-selected-files]').exists();
+        assert.dom(`[data-test-selected-file="${testFile.file_id}"]`).exists();
     });
 });


### PR DESCRIPTION
- Ticket: [ENG-1211]
- Feature flag: n/a

## Purpose

- Show previously selected file as selected upon reloading the draft
- Check uploading multiple versions of the same file in draft — should replace file on draft, don't list both versions
- File widget folders:
     - transition slides the wrong way when navigating up/back to non-root folders
     - "invalid date"
- Upload to any folder
- Uploading a file refreshes other node files in other files-widgets

## Summary of Changes


[ENG-1211]: https://openscience.atlassian.net/browse/ENG-1211