### PR TITLE
[ENG-1211] Update DraftRegistrationCard buttons to transition to registries/drafts

### DIFF
--- a/app/guid-node/drafts/index/route.ts
+++ b/app/guid-node/drafts/index/route.ts
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class GuidNodeDraftsIndex extends Route {
+    model() {
+        this.replaceWith('registries.drafts.draft-shim', this.modelFor('guid-node.drafts'));
+    }
+}

--- a/app/guid-node/drafts/register/route.ts
+++ b/app/guid-node/drafts/register/route.ts
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class GuidNodeDraftsRegister extends Route {
+    model() {
+        this.replaceWith('registries.drafts.draft', this.modelFor('guid-node.drafts'), 'review');
+    }
+}

--- a/app/guid-node/drafts/route.ts
+++ b/app/guid-node/drafts/route.ts
@@ -2,6 +2,6 @@ import Route from '@ember/routing/route';
 
 export default class GuidNodeDrafts extends Route {
     model(params: { draftId: string }) {
-        this.replaceWith('registries.drafts.draft-shim', params.draftId);
+        return params.draftId;
     }
 }

--- a/app/router.ts
+++ b/app/router.ts
@@ -142,7 +142,9 @@ Router.map(function() {
         this.mount('analytics-page', { as: 'analytics' });
         this.route('forks');
         this.route('registrations');
-        this.route('drafts', { path: '/drafts/:draftId' });
+        this.route('drafts', { path: '/drafts/:draftId' }, function() {
+            this.route('register');
+        });
     });
 
     this.route('guid-preprint', { path: '--preprint/:guid' });

--- a/config/environment.js
+++ b/config/environment.js
@@ -238,7 +238,8 @@ module.exports = function(environment) {
         featureFlagNames: {
             routes: {
                 'guid-node.index': 'ember_project_detail_page',
-                'guid-node.drafts': 'ember_edit_draft_registration_page',
+                'guid-node.drafts.index': 'ember_edit_draft_registration_page',
+                'guid-node.drafts.register': 'ember_edit_draft_registration_page',
                 'guid-user.index': 'ember_user_profile_page',
                 'guid-registration.index': 'ember_old_registration_detail_page',
                 settings: 'ember_user_settings_page',

--- a/lib/osf-components/addon/components/draft-registration-card/component.ts
+++ b/lib/osf-components/addon/components/draft-registration-card/component.ts
@@ -2,24 +2,22 @@ import { tagName } from '@ember-decorators/component';
 import { action, computed } from '@ember-decorators/object';
 import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
+import RouterService from '@ember/routing/router-service';
 import { htmlSafe } from '@ember/string';
-import config from 'ember-get-config';
 
 import { layout } from 'ember-osf-web/decorators/component';
 import DraftRegistration from 'ember-osf-web/models/draft-registration';
 import { RegistrationMetadata } from 'ember-osf-web/models/registration-schema';
 import Analytics from 'ember-osf-web/services/analytics';
-import pathJoin from 'ember-osf-web/utils/path-join';
 
 import styles from './styles';
 import template from './template';
-
-const { OSF: { url: baseURL } } = config;
 
 @layout(template, styles)
 @tagName('')
 export default class DraftRegistrationCard extends Component {
     @service analytics!: Analytics;
+    @service router!: RouterService;
 
     // Required arguments
     draftRegistration!: DraftRegistration;
@@ -30,11 +28,6 @@ export default class DraftRegistrationCard extends Component {
 
     // Private properties
     deleteModalOpen = false;
-
-    @computed('draftRegistration.{branchedFrom.id,id}')
-    get draftRegistrationUrl() {
-        return pathJoin(baseURL, this.draftRegistration.branchedFrom.get('id'), 'drafts', this.draftRegistration.id);
-    }
 
     @computed('draftRegistration.{registrationSchema,registrationMetadata}')
     get percentComplete() {
@@ -106,7 +99,11 @@ export default class DraftRegistrationCard extends Component {
 
     @action
     edit() {
-        window.location.assign(this.draftRegistrationUrl);
+        this.router.transitionTo(
+            'guid-node.drafts',
+            this.draftRegistration.branchedFrom.get('id'),
+            this.draftRegistration.id,
+        );
     }
 
     @action
@@ -130,6 +127,10 @@ export default class DraftRegistrationCard extends Component {
 
     @action
     register() {
-        window.location.assign(pathJoin(this.draftRegistrationUrl, 'register'));
+        this.router.transitionTo(
+            'guid-node.drafts.register',
+            this.draftRegistration.branchedFrom.get('id'),
+            this.draftRegistration.id,
+        );
     }
 }

--- a/mirage/serializers/draft-registration.ts
+++ b/mirage/serializers/draft-registration.ts
@@ -9,6 +9,10 @@ export default class DraftRegistrationSerializer extends ApplicationSerializer<D
     buildRelationships(model: ModelInstance<DraftRegistration>) {
         return {
             branchedFrom: {
+                data: {
+                    id: model.branchedFrom.id,
+                    type: 'nodes',
+                },
                 links: {
                     related: {
                         href: `${apiUrl}/v2/nodes/${model.branchedFrom.id}`,
@@ -17,6 +21,10 @@ export default class DraftRegistrationSerializer extends ApplicationSerializer<D
                 },
             },
             initiator: {
+                data: {
+                    id: model.initiator.id,
+                    type: 'users',
+                },
                 links: {
                     related: {
                         href: `${apiUrl}/v2/users/${model.initiator.id}`,


### PR DESCRIPTION
- Ticket: [ENG-1211]
- Feature flag: n/a

## Purpose

Update the actions for the Edit and Register buttons on draft registration cards so that they transition to routes instead of load URLs.

## Summary of Changes

- add `branchedFrom` and `initiator` resource linkage to draft-registration mirage serializer (to match API)
- add `index` and `register` routes under `guid-node.drafts`
- transition to routes when clicking edit/register buttons in `DraftRegistrationCard`

## Side Effects

None expected.

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-1211]: https://openscience.atlassian.net/browse/ENG-1211