### PR TITLE
[ENG-1211] Clean up files-widget

### DIFF
--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -1676,7 +1676,7 @@ export default {
         },
         'files-widget': {
             drag_drop_files: 'Drag and drop files here to upload files to this folder',
-            message: 'Only files from root project on OSF Storage are available to attach. To attach files from components or non "OSF Storage" addons, first add them to your root project files.',
+            message: 'You may attach up to 5 file(s) to this question. You may attach files that you already have in OSF Storage in this <a href={{nodeUrl}}>{{projectOrComponent}}</a> or upload (drag and drop) a new file from your computer. Uploaded files will automatically be added to this project so that they can be registered. To attach files from other components or an add-on, first add them to this <a href={{nodeUrl}}>{{projectOrComponent}}</a>.',
         },
         subjects: {
             browse: {

--- a/app/models/file-provider.ts
+++ b/app/models/file-provider.ts
@@ -1,11 +1,22 @@
 import { attr, belongsTo } from '@ember-decorators/data';
 import DS from 'ember-data';
+import { Link } from 'jsonapi-typescript';
 
 import BaseFileItem from './base-file-item';
 import FileModel from './file';
 import NodeModel from './node';
+import { OsfLinks } from './osf-model';
+
+export interface FileProviderLinks extends OsfLinks {
+    upload: Link;
+    storage_addons: Link; // eslint-disable-line camelcase
+
+    // only for folders
+    new_folder?: Link; // eslint-disable-line camelcase
+}
 
 export default class FileProviderModel extends BaseFileItem {
+    @attr() links!: FileProviderLinks;
     @attr('fixstring') name!: string;
     @attr('string') path!: string;
     @attr('fixstring') provider!: string;

--- a/app/models/file-provider.ts
+++ b/app/models/file-provider.ts
@@ -1,4 +1,4 @@
-import { attr, belongsTo, hasMany } from '@ember-decorators/data';
+import { attr, belongsTo } from '@ember-decorators/data';
 import DS from 'ember-data';
 
 import BaseFileItem from './base-file-item';
@@ -10,8 +10,8 @@ export default class FileProviderModel extends BaseFileItem {
     @attr('string') path!: string;
     @attr('fixstring') provider!: string;
 
-    @hasMany('file')
-    files!: DS.PromiseManyArray<FileModel>;
+    @belongsTo('file')
+    rootFolder!: DS.PromiseObject<FileModel> & FileModel;
 
     @belongsTo('node')
     node!: DS.PromiseObject<NodeModel> & NodeModel;

--- a/lib/osf-components/addon/components/files/browse/component.ts
+++ b/lib/osf-components/addon/components/files/browse/component.ts
@@ -1,5 +1,4 @@
-import { computed } from '@ember-decorators/object';
-import { A } from '@ember/array';
+import { action, computed } from '@ember-decorators/object';
 import Component from '@ember/component';
 
 import fade from 'ember-animated/transitions/fade';
@@ -31,6 +30,12 @@ export default class FileBrowser extends Component {
         return toLeft;
     }
 
+    @computed('filesManager.currentFolder')
+    get notInRootFolder() {
+        const { currentFolder } = this.filesManager;
+        return currentFolder && currentFolder.belongsTo('parentFolder').id();
+    }
+
     @computed('filesManager.{hasMore,loadingFolderItems}')
     get shouldShowLoadMoreButton() {
         return this.filesManager.hasMore && !this.filesManager.loadingFolderItems;
@@ -38,24 +43,16 @@ export default class FileBrowser extends Component {
 
     @computed('filesManager.displayedItems.[]', 'sort')
     get sortedItems() {
-        let sortedItems = this.filesManager.displayedItems || [];
-
-        if (this.sort) {
-            const regex = /^(-?)([-\w]+)/;
-            const groups = regex.exec(this.sort)!;
-
-            groups.shift();
-            const [reverse, sortKey] = groups.slice(0, 2);
-
-            sortedItems = A(sortedItems).sortBy(sortKey);
-
-            if (reverse) {
-                sortedItems = sortedItems.reverse();
-            }
-        }
-
+        const sortedItems = this.filesManager.displayedItems || [];
         const folders = sortedItems.filterBy('kind', 'folder');
 
         return [...folders, ...sortedItems.filter(item => item.kind !== 'folder')];
+    }
+
+    @action
+    sortItems(sort: string) {
+        this.setProperties({ sort });
+
+        this.filesManager.sortFolderItems(sort);
     }
 }

--- a/lib/osf-components/addon/components/files/browse/template.hbs
+++ b/lib/osf-components/addon/components/files/browse/template.hbs
@@ -11,8 +11,8 @@
                 <div local-class='column'>
                     <span local-class='sortable-column'>{{t 'general.name'}}</span>
                     <SortButton
-                        @sortAction={{action this.sortItems}}
-                        @sort={{this.sort}}
+                        @sortAction={{@filesManager.sortItems}}
+                        @sort={{@filesManager.sort}}
                         @sortBy='name'
                         local-class='sort-by'
                     />
@@ -21,8 +21,8 @@
                 <div local-class='column'>
                     <span local-class='sortable-column'>{{t 'general.last_modified'}}</span>
                     <SortButton
-                        @sortAction={{action this.sortItems}}
-                        @sort={{this.sort}}
+                        @sortAction={{@filesManager.sortItems}}
+                        @sort={{@filesManager.sort}}
                         @sortBy='date_modified'
                         local-class='sort-by'
                     />
@@ -60,7 +60,7 @@
                             @duration=500
                         >
                             <Files::List
-                                @items={{this.sortedItems}}
+                                @items={{@filesManager.displayedItems}}
                                 @filesManager={{@filesManager}}
                             />
                         </AnimatedValue>

--- a/lib/osf-components/addon/components/files/browse/template.hbs
+++ b/lib/osf-components/addon/components/files/browse/template.hbs
@@ -11,7 +11,7 @@
                 <div local-class='column'>
                     <span local-class='sortable-column'>{{t 'general.name'}}</span>
                     <SortButton
-                        @sortAction={{action (mut this.sort)}}
+                        @sortAction={{action this.sortItems}}
                         @sort={{this.sort}}
                         @sortBy='name'
                         local-class='sort-by'
@@ -21,15 +21,15 @@
                 <div local-class='column'>
                     <span local-class='sortable-column'>{{t 'general.last_modified'}}</span>
                     <SortButton
-                        @sortAction={{action (mut this.sort)}}
+                        @sortAction={{action this.sortItems}}
                         @sort={{this.sort}}
-                        @sortBy='dateModified'
+                        @sortBy='date_modified'
                         local-class='sort-by'
                     />
                 </div>
             </div>
 
-            {{#if @filesManager.currentFolder}}
+            {{#if this.notInRootFolder}}
                 <Files::Item
                     @item={{@filesManager.currentFolder}}
                     @filesManager={{@filesManager}}

--- a/lib/osf-components/addon/components/files/item/component.ts
+++ b/lib/osf-components/addon/components/files/item/component.ts
@@ -1,6 +1,7 @@
 import { action, computed } from '@ember-decorators/object';
 import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
+import { assert } from '@ember/debug';
 import moment from 'moment';
 
 import { layout } from 'ember-osf-web/decorators/component';
@@ -18,18 +19,22 @@ export default class FileBrowserItem extends Component {
     filesManager!: FilesManager;
     item!: File;
 
-    @computed('item', 'filesManager.currentFolder')
+    didReceiveAttrs() {
+        assert('Files::Item requires @filesManager!', Boolean(this.filesManager));
+    }
+
+    @computed('item', 'filesManager.{currentFolder,inRootFolder}')
     get isCurrentFolder(): boolean {
-        if (!this.filesManager.currentFolder || !this.item) {
+        if (this.filesManager.inRootFolder) {
             return false;
         }
 
         return this.item.id === this.filesManager.currentFolder.id;
     }
 
-    @computed('isCurrentFolder', 'manager.currentFolder')
+    @computed('isCurrentFolder', 'filesManager.currentFolder')
     get shouldIndent() {
-        return this.filesManager.currentFolder && !this.isCurrentFolder;
+        return !this.filesManager.inRootFolder && !this.isCurrentFolder;
     }
 
     @computed('item.dateModified')

--- a/lib/osf-components/addon/components/files/item/styles.scss
+++ b/lib/osf-components/addon/components/files/item/styles.scss
@@ -17,14 +17,21 @@
     &.indent {
         padding-left: 35px;
     }
-}
 
-.name-container {
-    display: flex;
-    width: 75%;
-    align-items: center;
+    .name-container {
+        display: flex;
+        flex-grow: 1;
+        align-items: center;
 
-    span {
-        padding-right: 10px;
+        span {
+            padding-right: 10px;
+        }
+    }
+
+    .date-modified {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        width: 40%;
     }
 }

--- a/lib/osf-components/addon/components/files/item/template.hbs
+++ b/lib/osf-components/addon/components/files/item/template.hbs
@@ -4,7 +4,7 @@
     {{on 'click' (action this.onClick)}}
 >
     {{#if this.isCurrentFolder}}
-        <div data-test-current-folder local-cass='name-container'>
+        <div data-test-current-folder local-class='name-container'>
             <FaIcon @icon='angle-left' @fixedWidth={{true}} />
             <span local-class='filename'>{{this.item.itemName}}</span>
         </div>
@@ -14,7 +14,7 @@
             <span data-test-file-name local-class='filename'>{{this.item.itemName}}</span>
         </div>
         {{#unless this.item.isFolder}}
-            <time data-test-file-date-modified>
+            <time local-class='date-modified' data-test-file-date-modified>
                 {{this.date}}
             </time>
         {{/unless}}

--- a/lib/osf-components/addon/components/files/manager/template.hbs
+++ b/lib/osf-components/addon/components/files/manager/template.hbs
@@ -5,11 +5,12 @@
     canEdit=this.canEdit
     hasMore=this.hasMore
     currentFolder=this.currentFolder
-    displayedItems=this.displayedItems
-    fileProvider=this.fileProvider
+    displayedItems=this.currentFolder.files
+    rootFolder=this.rootFolder
     onSelectFile=@onSelectFile
     goToFolder=(action this.goToFolder)
     goToParentFolder=(action this.goToParentFolder)
     addFile=(perform this.addFile)
     loadMore=(perform this.loadMore)
+    sortFolderItems=(perform this.sortFolderItems)
 )}}

--- a/lib/osf-components/addon/components/files/manager/template.hbs
+++ b/lib/osf-components/addon/components/files/manager/template.hbs
@@ -4,13 +4,16 @@
     loadingMore=this.loadingMore
     canEdit=this.canEdit
     hasMore=this.hasMore
+    sort=this.sort
     currentFolder=this.currentFolder
-    displayedItems=this.currentFolder.files
+    displayedItems=this.displayedItems
     rootFolder=this.rootFolder
+    inRootFolder=this.inRootFolder
     onSelectFile=@onSelectFile
+    fileProvider=this.fileProvider
     goToFolder=(action this.goToFolder)
     goToParentFolder=(action this.goToParentFolder)
     addFile=(perform this.addFile)
     loadMore=(perform this.loadMore)
-    sortFolderItems=(perform this.sortFolderItems)
+    sortItems=(action this.sortItems)
 )}}

--- a/lib/osf-components/addon/components/files/selected-list/component.ts
+++ b/lib/osf-components/addon/components/files/selected-list/component.ts
@@ -1,20 +1,38 @@
 import { tagName } from '@ember-decorators/component';
+import { computed } from '@ember-decorators/object';
 import Component from '@ember/component';
+import { assert } from '@ember/debug';
 
 import { parallel } from 'ember-animated';
 import Sprite from 'ember-animated/-private/sprite';
 import { easeIn } from 'ember-animated/easings/cosine';
 import move from 'ember-animated/motions/move';
 import { fadeIn, fadeOut } from 'ember-animated/motions/opacity';
+import config from 'ember-get-config';
 
 import { layout } from 'ember-osf-web/decorators/component';
+import Node from 'ember-osf-web/models/node';
+import pathJoin from 'ember-osf-web/utils/path-join';
 
 import styles from './styles';
 import template from './template';
 
+const { OSF: { url: baseURL } } = config;
+
 @layout(template, styles)
 @tagName('')
 export default class SelectedFilesList extends Component {
+    node!: Node;
+
+    didReceiveAttrs() {
+        assert('Files::SelectedList requires @node!', Boolean(this.node));
+    }
+
+    @computed('node')
+    get nodeUrl() {
+        return this.node && pathJoin(baseURL, this.node.id);
+    }
+
     *transition(context: { insertedSprites: Sprite[], keptSprites: Sprite[], removedSprites: Sprite[] }) {
         const { insertedSprites, keptSprites, removedSprites } = context;
 

--- a/lib/osf-components/addon/components/files/selected-list/template.hbs
+++ b/lib/osf-components/addon/components/files/selected-list/template.hbs
@@ -1,3 +1,12 @@
+<div data-test-files-info local-class='info'>
+    <span>
+        {{t 'osf-components.files-widget.message'
+            projectOrComponent=(if @node.isRoot 'project' 'component')
+            nodeUrl=this.nodeUrl
+        }}
+    </span>
+</div>
+
 {{#if @selectedFiles}}
     <div data-test-selected-files
         local-class='selected-list'
@@ -26,9 +35,5 @@
                 </div>
             </AnimatedEach>
         </AnimatedContainer>
-    </div>
-{{else}}
-    <div data-test-files-info local-class='info'>
-        <span>{{t 'osf-components.files-widget.message'}}</span>
     </div>
 {{/if}}

--- a/lib/osf-components/addon/components/files/upload-zone/component.ts
+++ b/lib/osf-components/addon/components/files/upload-zone/component.ts
@@ -60,9 +60,9 @@ export default class UploadZone extends Component.extend({
     @alias('filesManager.canEdit') enable!: boolean;
     @notEmpty('uploading') isUploading!: boolean;
 
-    @computed('filesManager.{currentFolder,fileProvider}')
+    @computed('filesManager.{currentFolder,rootFolder}')
     get uploadUrl() {
-        const folder = this.filesManager.currentFolder || this.filesManager.fileProvider;
+        const folder = this.filesManager.currentFolder || this.filesManager.rootFolder;
         return folder ? folder.links.upload : undefined;
     }
 

--- a/lib/osf-components/addon/components/files/upload-zone/component.ts
+++ b/lib/osf-components/addon/components/files/upload-zone/component.ts
@@ -4,6 +4,7 @@ import { service } from '@ember-decorators/service';
 import { A } from '@ember/array';
 import MutableArray from '@ember/array/mutable';
 import Component from '@ember/component';
+import { assert } from '@ember/debug';
 import { task } from 'ember-concurrency';
 import I18N from 'ember-i18n/services/i18n';
 import Toast from 'ember-toastr/services/toast';
@@ -60,9 +61,15 @@ export default class UploadZone extends Component.extend({
     @alias('filesManager.canEdit') enable!: boolean;
     @notEmpty('uploading') isUploading!: boolean;
 
-    @computed('filesManager.{currentFolder,rootFolder}')
+    didReceiveAttrs() {
+        assert('Files::UploadZone requires @filesManager!', Boolean(this.filesManager));
+    }
+
+    @computed('filesManager.{currentFolder,fileProvider,inRootFolder}')
     get uploadUrl() {
-        const folder = this.filesManager.currentFolder || this.filesManager.rootFolder;
+        // Waterbutler does not allow uploading to fileProvider.rootFolder
+        const { inRootFolder, currentFolder, fileProvider } = this.filesManager;
+        const folder = inRootFolder ? fileProvider : currentFolder;
         return folder ? folder.links.upload : undefined;
     }
 

--- a/lib/osf-components/addon/components/files/upload-zone/template.hbs
+++ b/lib/osf-components/addon/components/files/upload-zone/template.hbs
@@ -1,9 +1,9 @@
-{{#let (unique-id) as |dropzoneId|}}
+{{#let (unique-id 'dropzone-widget') as |dropzoneId|}}
     <DropzoneWidget
         @options={{this.dropzoneOptions}}
         @dropzone={{false}}
         @enable={{this.enable}}
-        @id={{concat 'dropzone-widget' dropzoneId}}
+        @id={{dropzoneId}}
         @clickable={{this.clickable}}
         @uploadprogress={{action this.uploadProgress}}
         @success={{perform this.success}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/component.ts
@@ -69,9 +69,9 @@ export default class Files extends Component {
     }
 
     @action
-    onSelectFile(file: File) {
-        const fileRef = file.toFileReference();
-        const isSelected = this.selectedFiles.includes(fileRef);
+    onSelectFile(selectedFile: File) {
+        const selectedfileRef = selectedFile.toFileReference();
+        const isSelected = this.selectedFiles.some(fileRef => selectedfileRef.file_id === fileRef.file_id);
 
         this.analytics.trackFromElement(this.element, {
             name: `${isSelected ? 'Unselect file' : 'Select file'}`,
@@ -80,9 +80,9 @@ export default class Files extends Component {
         });
 
         if (isSelected) {
-            this.unselect(fileRef);
+            this.unselect(selectedfileRef);
         } else {
-            this.select(fileRef);
+            this.select(selectedfileRef);
         }
     }
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/template.hbs
@@ -1,6 +1,7 @@
 <Files::SelectedList
     @selectedFiles={{this.selectedFiles}}
     @unselect={{action this.unselect}}
+    @node={{@node}}
 />
 <Files::Widget
     data-test-editable-file-widget

--- a/mirage/factories/file-provider.ts
+++ b/mirage/factories/file-provider.ts
@@ -10,12 +10,14 @@ export default Factory.extend<MirageFileProvider>({
     name: 'osfstorage',
     path: '/',
     provider: 'osfstorage',
-    afterCreate(provider) {
+    afterCreate(provider, server) {
         if (provider.node) {
             provider.update({
                 providerId: `${provider.node.id}:${provider.name}`,
             });
         }
+        const rootFolder = server.create('file', 'asFolder');
+        provider.update({ rootFolder });
     },
     node: association() as FileProviderModel['node'],
 });

--- a/mirage/factories/node.ts
+++ b/mirage/factories/node.ts
@@ -156,7 +156,7 @@ export default Factory.extend<MirageNode & NodeTraits>({
             const osfstorage = server.create('file-provider', { node });
             const files = server.createList('file', count, { target: node });
 
-            osfstorage.update({ files });
+            osfstorage.rootFolder.update({ files });
         },
     }),
 

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -237,7 +237,7 @@ function handbookScenario(server: Server, currentUser: ModelInstance<User>) {
 
     const fileProviders = fileWidgetNode.files.models as Array<ModelInstance<FileProvider>>;
     const osfstorage = fileProviders[0];
-    const providerFiles = osfstorage.files.models;
+    const providerFiles = osfstorage.rootFolder.files.models;
 
     osfstorage.update({
         files: [...providerFiles, folderA],
@@ -270,7 +270,7 @@ function handbookScenario(server: Server, currentUser: ModelInstance<User>) {
     const folder = server.create('file', { target: schemaNode }, 'asFolder');
     const providers = fileWidgetNode.files.models as Array<ModelInstance<FileProvider>>;
     const storage = providers[0];
-    const providersFiles = storage.files.models;
+    const providersFiles = storage.rootFolder.files.models;
     storage.update({
         files: [...providersFiles, folder],
     });

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -236,10 +236,10 @@ function handbookScenario(server: Server, currentUser: ModelInstance<User>) {
     const folderA = server.create('file', { target: fileWidgetNode }, 'asFolder');
 
     const fileProviders = fileWidgetNode.files.models as Array<ModelInstance<FileProvider>>;
-    const osfstorage = fileProviders[0];
+    const [osfstorage] = fileProviders;
     const providerFiles = osfstorage.rootFolder.files.models;
 
-    osfstorage.update({
+    osfstorage.rootFolder.update({
         files: [...providerFiles, folderA],
     });
 

--- a/mirage/serializers/file-provider.ts
+++ b/mirage/serializers/file-provider.ts
@@ -8,17 +8,21 @@ const { OSF: { apiUrl } } = config;
 
 export default class FileSerializer extends ApplicationSerializer<FileProviderModel> {
     buildRelationships(model: ModelInstance<FileProviderModel>) {
-        const typeKey = this.typeKeyForModel(model.node);
-        const relationships: SerializedRelationships<FileProviderModel> = {
-            files: {
+        const relationships: SerializedRelationships<FileProviderModel> = {};
+        if (model.rootFolder) {
+            relationships.rootFolder = {
+                data: {
+                    id: model.rootFolder.id,
+                    type: this.typeKeyForModel(model.rootFolder),
+                },
                 links: {
                     related: {
-                        href: `${apiUrl}/v2/${typeKey}/${model.node.id}/files/${model.name}`,
-                        meta: this.buildRelatedLinkMeta(model, 'files'),
+                        href: `${apiUrl}/v2/files/${model.rootFolder.id}`,
+                        meta: {},
                     },
                 },
-            },
-        };
+            };
+        }
         return relationships;
     }
 

--- a/mirage/views/file.ts
+++ b/mirage/views/file.ts
@@ -40,6 +40,7 @@ export function uploadToRoot(this: HandlerContext, schema: Schema) {
     const { name } = this.request.queryParams;
     const node = schema.nodes.find(parentID);
     const fileProvider = schema.fileProviders.findBy({ providerId: `${node.id}:${fileProviderId}` });
+    const { rootFolder } = fileProvider;
     const randomNum = faker.random.number();
     const fileGuid = guid('file');
     const id = fileGuid(randomNum);
@@ -59,8 +60,8 @@ export function uploadToRoot(this: HandlerContext, schema: Schema) {
         provider: 'osfstorage',
     });
 
-    fileProvider.files.models.pushObject(uploadedFile);
-    fileProvider.save();
+    rootFolder.files.models.pushObject(uploadedFile);
+    rootFolder.save();
 
     return uploadedFile;
 }
@@ -75,7 +76,8 @@ export function nodeFilesListForProvider(this: HandlerContext, schema: Schema) {
     const { parentID, fileProviderId } = this.request.params;
     const node = schema.nodes.find(parentID);
     const fileProvider = schema.fileProviders.findBy({ providerId: `${node.id}:${fileProviderId}` });
-    return process(schema, this.request, this, fileProvider.files.models.map(file => this.serialize(file).data));
+    const { rootFolder } = fileProvider;
+    return process(schema, this.request, this, rootFolder.files.models.map(file => this.serialize(file).data));
 }
 
 export function nodeFileProviderList(this: HandlerContext, schema: Schema) {


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-1211
- Feature flag: n/a

## Purpose

File widgets improvements

## Summary of Changes
- Utilize ember-data to sync up files across files-widget
- Add `rootFolder` relationship to file-provider model
- Use `rootFolder` on the files-widget manager.
- Update tests to use `rootFolder`
- Update mirage setup for file-provider, submission acceptance tests.
- Update language for text on top of the files-widget.