### PR TITLE
[ENG-1211][Feature] Use `fieldset` and `legend` for multi-select and single-select inputs

### DIFF
--- a/lib/osf-components/addon/components/registries/schema-block-group-renderer/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-group-renderer/component.ts
@@ -47,4 +47,12 @@ export default class SchemaBlockGroupRenderer extends Component {
                     block.blockType !== 'select-other-option',
             );
     }
+
+    @computed('schemaBlockGroup.groupType')
+    get isFieldsetGroup(): boolean {
+        return (
+            this.schemaBlockGroup.groupType === 'single-select-input' ||
+            this.schemaBlockGroup.groupType === 'multi-select-input'
+        );
+    }
 }

--- a/lib/osf-components/addon/components/registries/schema-block-group-renderer/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-group-renderer/template.hbs
@@ -1,9 +1,25 @@
-{{#each this.nonOptionBlocks as |block|}}
-    <Registries::SchemaBlockRenderer
-        @schemaBlock={{block}}
-        @optionBlocks={{this.optionBlocks}}
-        @uniqueID={{this.uniqueID}}
-        @renderStrategy={{@renderStrategy}}
-        @isRequired={{this.isRequired}}
-    />
-{{/each}}
+{{#if this.isFieldsetGroup}}
+    <fieldset>
+        {{#each this.nonOptionBlocks as |block|}}
+            <Registries::SchemaBlockRenderer
+                @schemaBlock={{block}}
+                @optionBlocks={{this.optionBlocks}}
+                @uniqueID={{this.uniqueID}}
+                @renderStrategy={{@renderStrategy}}
+                @isRequired={{this.isRequired}}
+                @isFieldsetGroup={{true}}
+            />
+        {{/each}}
+    </fieldset>
+{{else}}
+    {{#each this.nonOptionBlocks as |block|}}
+        <Registries::SchemaBlockRenderer
+            @schemaBlock={{block}}
+            @optionBlocks={{this.optionBlocks}}
+            @uniqueID={{this.uniqueID}}
+            @renderStrategy={{@renderStrategy}}
+            @isRequired={{this.isRequired}}
+            @isFieldsetGroup={{false}}
+        />
+    {{/each}}
+{{/if}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/styles.scss
@@ -1,0 +1,5 @@
+.Required {
+    color: $brand-danger;
+    font-size: 10px;
+    margin-left: 1em;
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/template.hbs
@@ -1,0 +1,20 @@
+<span data-test-label-content ...attributes>
+    {{@schemaBlock.displayText}}
+    {{#if (and @isRequired (not @readonly))}}
+        <span local-class='Required'>
+            {{t 'osf-components.registries.schema-block-renderer/label.required'}}
+        </span>
+    {{/if}}
+    {{#if @isEditableForm}}
+        <Registries::SchemaBlockRenderer::HelperTextIcon @helpText={{@schemaBlock.helpText}} />
+        {{#if @schemaBlock.exampleText}}
+            <OsfButton @type='link' @onClick={{action this.toggleShouldShowExample}}>
+                {{#if this.shouldShowExample}}
+                    {{t 'osf-components.registries.schema-block-renderer/label.hideExample'}}
+                {{else}}
+                    {{t 'osf-components.registries.schema-block-renderer/label.showExample'}}
+                {{/if}}
+            </OsfButton>
+        {{/if}}
+    {{/if}}
+</span>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/template.hbs
@@ -8,8 +8,8 @@
     {{#if @isEditableForm}}
         <Registries::SchemaBlockRenderer::HelperTextIcon @helpText={{@schemaBlock.helpText}} />
         {{#if @schemaBlock.exampleText}}
-            <OsfButton @type='link' @onClick={{action this.toggleShouldShowExample}}>
-                {{#if this.shouldShowExample}}
+            <OsfButton @type='link' @onClick={{@toggleShouldShowExample}}>
+                {{#if @shouldShowExample}}
                     {{t 'osf-components.registries.schema-block-renderer/label.hideExample'}}
                 {{else}}
                     {{t 'osf-components.registries.schema-block-renderer/label.showExample'}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/label/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/label/styles.scss
@@ -6,8 +6,8 @@
     margin: 20px 0 10px;
 }
 
-.Required {
-    color: $brand-danger;
-    font-size: 10px;
-    margin-left: 1em;
+.QuestionLegend {
+    border-bottom: 0;
+    font-weight: 700;
+    font-size: 14px;
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/label/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/label/template.hbs
@@ -1,28 +1,34 @@
-<label
-    local-class='QuestionLabel'
-    data-test-question-label
-    for={{@uniqueID}}
-    ...attributes
->
-    {{@schemaBlock.displayText}}
-    {{#if (and @isRequired (not @readonly))}}
-        <span local-class='Required'>
-            {{t 'osf-components.registries.schema-block-renderer/label.required'}}
-        </span>
-    {{/if}}
-    {{#if this.isEditableForm}}
-        <Registries::SchemaBlockRenderer::HelperTextIcon @helpText={{this.schemaBlock.helpText}} />
-        {{#if this.schemaBlock.exampleText}}
-            <OsfButton @type='link' @onClick={{action this.toggleShouldShowExample}}>
-                {{#if this.shouldShowExample}}
-                    {{t 'osf-components.registries.schema-block-renderer/label.hideExample'}}
-                {{else}}
-                    {{t 'osf-components.registries.schema-block-renderer/label.showExample'}}
-                {{/if}}
-            </OsfButton>
-        {{/if}}
-    {{/if}}
-</label>
+{{#if @isFieldsetGroup}}
+    <legend
+        local-class='QuestionLabel QuestionLegend'
+        data-test-question-label
+        for={{@uniqueID}}
+        ...attributes
+    >
+        <Registries::SchemaBlockRenderer::Label::LabelContent
+            @schemaBlock={{@schemaBlock}}
+            @isRequired={{@isRequired}}
+            @readonly={{@readonly}}
+            @isEditableForm={{this.isEditableForm}}
+            @toggleShouldShowExample={{this.toggleShouldShowExample}}
+        />
+    </legend>
+{{else}}
+    <label
+        local-class='QuestionLabel'
+        data-test-question-label
+        for={{@uniqueID}}
+        ...attributes
+    >
+        <Registries::SchemaBlockRenderer::Label::LabelContent
+            @schemaBlock={{@schemaBlock}}
+            @isRequired={{@isRequired}}
+            @readonly={{@readonly}}
+            @isEditableForm={{this.isEditableForm}}
+            @toggleShouldShowExample={{this.toggleShouldShowExample}}
+        />
+    </label>
+{{/if}}
 {{#if this.isEditableForm}}
     {{#if (and this.shouldShowExample this.schemaBlock.exampleText)}}
         <p>

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/label/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/label/template.hbs
@@ -1,8 +1,7 @@
 {{#if @isFieldsetGroup}}
     <legend
-        local-class='QuestionLabel QuestionLegend'
         data-test-question-label
-        for={{@uniqueID}}
+        local-class='QuestionLabel QuestionLegend'
         ...attributes
     >
         <Registries::SchemaBlockRenderer::Label::LabelContent
@@ -11,12 +10,13 @@
             @readonly={{@readonly}}
             @isEditableForm={{this.isEditableForm}}
             @toggleShouldShowExample={{this.toggleShouldShowExample}}
+            @shouldShowExample={{this.shouldShowExample}}
         />
     </legend>
 {{else}}
     <label
-        local-class='QuestionLabel'
         data-test-question-label
+        local-class='QuestionLabel'
         for={{@uniqueID}}
         ...attributes
     >
@@ -26,6 +26,7 @@
             @readonly={{@readonly}}
             @isEditableForm={{this.isEditableForm}}
             @toggleShouldShowExample={{this.toggleShouldShowExample}}
+            @shouldShowExample={{this.shouldShowExample}}
         />
     </label>
 {{/if}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/template.hbs
@@ -8,6 +8,7 @@
                 @shouldShowMessages={{this.shouldShowMessages}}
                 @uniqueID={{@uniqueID}}
                 @isRequired={{@isRequired}}
+                @isFieldsetGroup={{@isFieldsetGroup}}
             />
         {{/let}}
     </Mapper>

--- a/lib/osf-components/app/components/registries/schema-block-renderer/label/label-content/template.js
+++ b/lib/osf-components/app/components/registries/schema-block-renderer/label/label-content/template.js
@@ -1,0 +1,3 @@
+export { default } from
+    'osf-components/components/registries/schema-block-renderer/label/label-content/template';
+


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-1211
- Feature flag: n/a

## Purpose

Any input that has a group of options should be contained in a `<fieldset>` and use a `<legend>`.  This adds those to only `single-select-input` and `multi-select-input` blocks.

## Summary of Changes

- Use `<fieldset>` and `<legend>` on single and multi select blocks and style to match labels
- Create new component under `label` that contains the template and styling for inner label content

## Side Effects

`n/a`

## QA Notes

`n/a`
