### PR TITLE
[ENG-1211] sufficiently unique response keys

### DIFF
--- a/app/transforms/registration-responses.ts
+++ b/app/transforms/registration-responses.ts
@@ -1,13 +1,15 @@
 import DS from 'ember-data';
 import { mapKeysAndValues } from 'ember-osf-web/utils/map-keys';
 
+import { deserializeResponseKey, serializeResponseKey } from './registration-response-key';
+
 const { Transform } = DS;
 
 export default class RegistrationResponsesTransform extends Transform {
     deserialize(obj: any) {
         return mapKeysAndValues(
             obj,
-            key => key.replace(/\./g, '|'),
+            key => deserializeResponseKey(key),
             value => value,
         );
     }
@@ -15,7 +17,7 @@ export default class RegistrationResponsesTransform extends Transform {
     serialize(obj: any) {
         return mapKeysAndValues(
             obj,
-            key => key.replace(/\|/g, '.'),
+            key => serializeResponseKey(key),
             value => value,
         );
     }

--- a/tests/engines/registries/acceptance/draft/draft-test.ts
+++ b/tests/engines/registries/acceptance/draft/draft-test.ts
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 
 import { visit } from 'ember-osf-web/tests/helpers';
 import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
+import { deserializeResponseKey } from 'ember-osf-web/transforms/registration-response-key';
 
 const currentUserStub = Service.extend();
 const storeStub = Service.extend();
@@ -143,8 +144,8 @@ module('Registries | Acceptance | draft form', hooks => {
 
         await visit(`/registries/drafts/${registration.id}/review`);
         assert.ok(currentURL().includes(`/registries/drafts/${registration.id}/review`), 'At review page');
-        assert.dom('[data-test-validation-errors="page-one_short-text"]').exists();
-        assert.dom('[data-test-validation-errors="page-one_long-text"]').doesNotExist();
+        assert.dom(`[data-test-validation-errors="${deserializeResponseKey('page-one_short-text')}"]`).exists();
+        assert.dom(`[data-test-validation-errors="${deserializeResponseKey('page-one_long-text')}"]`).doesNotExist();
     });
 
     test('validations: cannot register with empty registrationResponses', async assert => {
@@ -274,9 +275,10 @@ module('Registries | Acceptance | draft form', hooks => {
 
         await visit(`/registries/drafts/${registration.id}/1`);
 
-        assert.dom('input[name="page-one_short-text"] + div')
+        const shortTextKey = deserializeResponseKey('page-one_short-text');
+        assert.dom(`input[name="${shortTextKey}"] + div`)
             .hasClass('help-block', 'page-one_short-text has validation errors');
-        await fillIn('input[name="page-one_short-text"]', 'ditto');
+        await fillIn(`input[name="${shortTextKey}"]`, 'ditto');
 
         await visit(`/registries/drafts/${registration.id}/2`);
         assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-1211]
- Feature flag: n/a

## Purpose
Questions with a `registration_response_key` that collides with a changeset property will cause erroneous behavior (e.g. the first question on Preregistration Template from AsPredicted.org has key `data`, and cannot be filled out)
<!-- Describe the purpose of your changes. -->

## Summary of Changes
We already have transforms to make response keys changeset-friends (replacing `.` by `|`). This extends those transforms to also add a nice, unique prefix.
<!-- Briefly describe or list your changes. -->

## Side Effects
n/a
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
This is, fortunately, neither a migration nor a data issue. This should work fine now:
![Screen Shot 2019-11-14 at 11 47 47](https://user-images.githubusercontent.com/6776190/68877811-adfb9180-06d4-11ea-874a-2b12913967f4.png)

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-1211]: https://openscience.atlassian.net/browse/ENG-1211