### PR TITLE
[ENG-1211] Make files-widget more aa

### DIFF
--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -1682,7 +1682,9 @@ export default {
         },
         'files-widget': {
             drag_drop_files: 'Drag and drop files here to upload files to this folder',
-            message: 'You may attach up to 5 file(s) to this question. You may attach files that you already have in OSF Storage in this <a href={{nodeUrl}}>{{projectOrComponent}}</a> or upload (drag and drop) a new file from your computer. Uploaded files will automatically be added to this project so that they can be registered. To attach files from other components or an add-on, first add them to this <a href={{nodeUrl}}>{{projectOrComponent}}</a>.',
+            message: 'You may attach up to 5 file(s) to this question. You may attach files that you already have in OSF Storage in this <a href={{nodeUrl}}>{{projectOrComponent}}</a> or upload (drag and drop) a new file from your computer. Uploaded files will automatically be added to this <a href={{nodeUrl}}>{{projectOrComponent}}</a> so that they can be registered. To attach files from other components or an add-on, first add them to this <a href={{nodeUrl}}>{{projectOrComponent}}</a>.',
+            load_more: 'Load more files',
+            unselect_file: 'Unselect file',
         },
         subjects: {
             browse: {

--- a/lib/osf-components/addon/components/files/browse/styles.scss
+++ b/lib/osf-components/addon/components/files/browse/styles.scss
@@ -48,9 +48,16 @@
     align-items: center;
     justify-content: center;
     color: $color-text-blue-dark;
+    height: 20px;
 
-    &:hover {
-        cursor: pointer;
-        background-color: $color-bg-gray-light;
+    .load-more-button {
+        padding: 0;
+
+        &:hover,
+        &:active,
+        &:focus {
+            background-color: $color-bg-gray-light;
+            text-decoration: none;
+        }
     }
 }

--- a/lib/osf-components/addon/components/files/browse/template.hbs
+++ b/lib/osf-components/addon/components/files/browse/template.hbs
@@ -69,15 +69,21 @@
             </div>
 
             {{#if this.shouldShowLoadMoreButton}}
-                <div
-                    data-test-load-more-items
-                    local-class='load-more'
-                    {{on 'click' (action @filesManager.loadMore)}}
-                >
+                <div local-class='load-more'>
                     {{#if @filesManager.loadingMore}}
                         <LoadingIndicator @inline={{true}} @dark={{true}} />
                     {{else}}
-                        <FaIcon @icon='chevron-down' @fixedWith={{true}}/>
+                        <OsfButton
+                            data-test-load-more-items
+                            local-class='load-more-button'
+                            class='btn-block'
+                            aria-label={{t 'osf-components.files-widget.load_more'}}
+                            tabindex='0'
+                            @type='link'
+                            @onClick={{@filesManager.loadMore}}
+                        >
+                            <FaIcon @icon='chevron-down' @fixedWidth={{true}} />
+                        </OsfButton>
                     {{/if}}
                 </div>
             {{/if}}

--- a/lib/osf-components/addon/components/files/item/component.ts
+++ b/lib/osf-components/addon/components/files/item/component.ts
@@ -65,4 +65,11 @@ export default class FileBrowserItem extends Component {
             this.filesManager.onSelectFile(this.item);
         }
     }
+
+    @action
+    onKeyPress(event: KeyboardEvent) {
+        if (event.keyCode === 13) {
+            this.onClick();
+        }
+    }
 }

--- a/lib/osf-components/addon/components/files/item/template.hbs
+++ b/lib/osf-components/addon/components/files/item/template.hbs
@@ -1,7 +1,10 @@
 <div
     data-test-file-browser-item='{{this.item.id}}'
     local-class='file-row {{if this.shouldIndent 'indent'}}'
+    role='button'
+    tabindex='0'
     {{on 'click' (action this.onClick)}}
+    {{on 'keypress' (action this.onKeyPress)}}
 >
     {{#if this.isCurrentFolder}}
         <div data-test-current-folder local-class='name-container'>

--- a/lib/osf-components/addon/components/files/selected-list/styles.scss
+++ b/lib/osf-components/addon/components/files/selected-list/styles.scss
@@ -25,7 +25,8 @@
     color: $color-text-black;
     cursor: default;
     max-width: 100%;
-    overflow-wrap: break-word;
+    overflow: hidden;
+    white-space: nowrap;
     margin-right: 5px;
     margin-bottom: 4px;
     padding: 5px 10px;
@@ -37,7 +38,6 @@
         &:hover,
         &:active,
         &:focus {
-            outline: none;
             text-decoration: none;
         }
     }

--- a/lib/osf-components/addon/components/files/selected-list/template.hbs
+++ b/lib/osf-components/addon/components/files/selected-list/template.hbs
@@ -27,6 +27,8 @@
                         data-test-unselect-file
                         data-analytics-name='Unselect file'
                         local-class='unselect'
+                        aria-label={{t 'osf-components.files-widget.unselect_file'}}
+                        tabindex='0'
                         @onClick={{action @unselect file}}
                         @type='link'
                     >


### PR DESCRIPTION
- Ticket: [ENG-1211](https://openscience.atlassian.net/browse/ENG-1211)
- Feature flag: n/a

## Purpose

Make files-widget more aa
Minor: Fix overflow wrap when unselecting a file

## Changes

- Make file items tab-focusable and respond to [enter] keypress event.
- Add aria-labels to button with no text, just an icon.