### PR TITLE
Hide partial reg modal if no children; outside click should not close dialog; 4 years to 1460 days.

### DIFF
--- a/lib/osf-components/addon/components/registries/finalize-registration-modal/component.ts
+++ b/lib/osf-components/addon/components/registries/finalize-registration-modal/component.ts
@@ -22,7 +22,7 @@ export default class FinalizeRegisrationModalComponent extends Component {
     // Private properties
     makePublicOption: string = '';
     embargoRangeStartDate: Date = moment().add(3, 'days').toDate();
-    embargoRangeEndDate: Date = moment().add(4, 'years').toDate();
+    embargoRangeEndDate: Date = moment().add(1460, 'days').toDate();
 
     didReceiveAttrs() {
         assert('finalize-registration-modal requires @manager!', Boolean(this.manager));

--- a/lib/osf-components/addon/components/registries/finalize-registration-modal/template.hbs
+++ b/lib/osf-components/addon/components/registries/finalize-registration-modal/template.hbs
@@ -1,6 +1,7 @@
 <OsfDialog
     @isOpen={{@isOpen}}
     @onClose={{@onClose}}
+    @closeOnOutsideClick={{false}}
     as |dialog|
 >
     <dialog.heading data-test-finalize-heading>

--- a/lib/osf-components/addon/components/registries/partial-registration-modal/template.hbs
+++ b/lib/osf-components/addon/components/registries/partial-registration-modal/template.hbs
@@ -1,6 +1,7 @@
 <OsfDialog
     @isOpen={{@isOpen}}
     @onClose={{@onClose}}
+    @closeOnOutsideClick={{false}}
     as |dialog|
 >
     <dialog.heading local-class='modal-title'>

--- a/lib/registries/addon/drafts/draft/-components/register/component.ts
+++ b/lib/registries/addon/drafts/draft/-components/register/component.ts
@@ -19,7 +19,6 @@ export default class Register extends Component.extend({
         if (this.draftRegistration) {
             const rootNode = yield this.draftRegistration.branchedFrom;
             this.setProperties({ rootNode });
-            yield rootNode.loadRelatedCount('children');
         }
     }).on('didReceiveAttrs').restartable(),
 }) {

--- a/lib/registries/addon/drafts/draft/-components/register/component.ts
+++ b/lib/registries/addon/drafts/draft/-components/register/component.ts
@@ -21,6 +21,16 @@ export default class Register extends Component.extend({
             this.setProperties({ rootNode });
         }
     }).on('didReceiveAttrs').restartable(),
+    fetchNodeChildrenRelatedCounts: task(function *(this: Register) {
+        if (this.rootNode) {
+            yield this.rootNode.loadRelatedCount('children');
+        }
+        if (this.rootNode && this.rootNode.relatedCounts.children > 0) {
+            this.showPartialRegDialog();
+        } else {
+            this.showFinalizeRegDialog();
+        }
+    }),
 }) {
     @service store!: DS.Store;
 
@@ -30,7 +40,7 @@ export default class Register extends Component.extend({
 
     // Private
     registration!: Registration;
-    rootNode!: NodeModel;
+    rootNode?: NodeModel;
     onSubmitRedirect?: (registrationId: string) => void;
     @alias('draftManager.hasInvalidResponses') isInvalid?: boolean;
 
@@ -52,11 +62,7 @@ export default class Register extends Component.extend({
 
             this.setProperties({ registration });
         }
-        if (this.rootNode && this.rootNode.relatedCounts.children > 0) {
-            this.showPartialRegDialog();
-        } else {
-            this.showFinalizeRegDialog();
-        }
+        this.fetchNodeChildrenRelatedCounts.perform();
     }
 
     @action
@@ -108,7 +114,7 @@ export default class Register extends Component.extend({
     @action
     onBack() {
         this.closeFinalizeRegDialog();
-        if (this.rootNode.relatedCounts.children > 0) {
+        if (this.rootNode && this.rootNode.relatedCounts.children > 0) {
             run.next(this, () => {
                 this.showPartialRegDialog();
             });

--- a/lib/registries/addon/drafts/draft/-components/register/component.ts
+++ b/lib/registries/addon/drafts/draft/-components/register/component.ts
@@ -21,7 +21,15 @@ export default class Register extends Component.extend({
             this.setProperties({ rootNode });
         }
     }).on('didReceiveAttrs').restartable(),
-    fetchNodeChildrenRelatedCounts: task(function *(this: Register) {
+    onClickRegister: task(function *(this: Register) {
+        if (!this.registration) {
+            const registration = this.store.createRecord('registration', {
+                draftRegistrationId: this.draftRegistration.id,
+                registeredFrom: this.draftRegistration.branchedFrom,
+            });
+
+            this.setProperties({ registration });
+        }
         if (this.rootNode) {
             yield this.rootNode.loadRelatedCount('children');
         }
@@ -50,19 +58,6 @@ export default class Register extends Component.extend({
     didReceiveAttrs() {
         assert('@draftManager is required!', Boolean(this.draftManager));
         assert('@draftRegistration is required!', Boolean(this.draftRegistration));
-    }
-
-    @action
-    onRegister() {
-        if (!this.registration) {
-            const registration = this.store.createRecord('registration', {
-                draftRegistrationId: this.draftRegistration.id,
-                registeredFrom: this.draftRegistration.branchedFrom,
-            });
-
-            this.setProperties({ registration });
-        }
-        this.fetchNodeChildrenRelatedCounts.perform();
     }
 
     @action

--- a/lib/registries/addon/drafts/draft/-components/register/template.hbs
+++ b/lib/registries/addon/drafts/draft/-components/register/template.hbs
@@ -3,10 +3,10 @@
     data-analytics-name='Go to register'
     local-class='registerButton {{if @showMobileView 'mobileReviewButtonItem'}}'
     @type='success'
-    @onClick={{action this.onRegister}}
+    @onClick={{perform this.onClickRegister}}
     @disabled={{not this.draftManager.registrationResponsesIsValid}}
 >
-    {{#if this.fetchNodeChildrenRelatedCounts.isRunning}}
+    {{#if this.onClickRegister.isRunning}}
         <LoadingIndicator @inline={{true}} />
     {{else}}
         {{t 'registries.drafts.draft.register'}}

--- a/lib/registries/addon/drafts/draft/-components/register/template.hbs
+++ b/lib/registries/addon/drafts/draft/-components/register/template.hbs
@@ -6,7 +6,11 @@
     @onClick={{action this.onRegister}}
     @disabled={{not this.draftManager.registrationResponsesIsValid}}
 >
-    {{t 'registries.drafts.draft.register'}}
+    {{#if this.fetchNodeChildrenRelatedCounts.isRunning}}
+        <LoadingIndicator @inline={{true}} />
+    {{else}}
+        {{t 'registries.drafts.draft.register'}}
+    {{/if}}
 </OsfButton>
 {{#if (and this.isInvalid (not @showMobileView))}}
     <div data-test-invalid-responses-text class='text-danger'>

--- a/lib/registries/addon/drafts/draft/route.ts
+++ b/lib/registries/addon/drafts/draft/route.ts
@@ -27,6 +27,7 @@ export default class DraftRegistrationRoute extends Route.extend({
                 { adapterOptions: { include: 'branched_from' } },
             );
             const node = yield draftRegistration.branchedFrom;
+            yield node.loadRelatedCount('children');
             return { draftRegistration, node };
         } catch (error) {
             this.transitionTo('page-not-found', this.router.currentURL.slice(1));

--- a/lib/registries/addon/drafts/draft/route.ts
+++ b/lib/registries/addon/drafts/draft/route.ts
@@ -27,7 +27,6 @@ export default class DraftRegistrationRoute extends Route.extend({
                 { adapterOptions: { include: 'branched_from' } },
             );
             const node = yield draftRegistration.branchedFrom;
-            yield node.loadRelatedCount('children');
             return { draftRegistration, node };
         } catch (error) {
             this.transitionTo('page-not-found', this.router.currentURL.slice(1));


### PR DESCRIPTION
This PR changes 3 things:
1. Partial registration modal is hidden if the node has no children.
2. Outside click for partial registration modal and finalize registration model does not close the dialog
3. Change 4 years to 1460 days for maximum embargo length to match backend.