### PR TITLE
[No ticket]Wrap display text in div for whitespace formatting and trim white-space

### DIFF
--- a/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/styles.scss
@@ -1,5 +1,10 @@
 .Required {
     color: $brand-danger;
+    margin-left: 5px;
+}
+
+.LabelWrapper {
+    white-space: pre-wrap;
 }
 
 .HelpText {

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/styles.scss
@@ -1,13 +1,15 @@
-.Required {
-    color: $brand-danger;
-    margin-left: 5px;
-}
-
-.LabelWrapper {
+.DisplayText {
     white-space: pre-wrap;
 }
 
+.Required {
+    color: $brand-danger;
+    margin-left: 0.25em;
+}
+
+
 .HelpText {
+    white-space: pre-wrap;
     font-weight: 400;
     margin-top: 10px;
 }
@@ -19,6 +21,7 @@
 }
 
 .ExampleText {
+    white-space: pre-wrap;
     font-weight: 400;
     margin-top: 10px;
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/template.hbs
@@ -1,11 +1,11 @@
 {{assert @schemaBlock 'Registries::SchemaBlockRenderer::Label::LabelContent requires a @schemaBlock'}}
 <span data-test-label-content ...attributes>
-    <div local-class='LabelWrapper'>
+    <p local-class='DisplayText'>
         {{~@schemaBlock.displayText~}}
-        {{#if (and @isRequired (not @readonly))~}}
+        {{~#if (and @isRequired (not @readonly))~}}
             <span local-class='Required'>*</span>
-        {{~/if}}
-    </div>
+        {{~/if~}}
+    </p>
     {{#if @isEditableForm}}
         <div local-class='HelpText'>
             {{~@schemaBlock.helpText~}}
@@ -24,7 +24,7 @@
             </OsfButton>
             {{#if this.shouldShowExample}}
                 <p local-class='ExampleText'>
-                    {{this.schemaBlock.exampleText}}
+                    {{~this.schemaBlock.exampleText~}}
                 </p>
             {{/if}}
         {{/if}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/template.hbs
@@ -1,12 +1,14 @@
 {{assert @schemaBlock 'Registries::SchemaBlockRenderer::Label::LabelContent requires a @schemaBlock'}}
 <span data-test-label-content ...attributes>
-    {{@schemaBlock.displayText}}
-    {{#if (and @isRequired (not @readonly))}}
-        <span local-class='Required'>*</span>
-    {{/if}}
+    <div local-class='LabelWrapper'>
+        {{~@schemaBlock.displayText~}}
+        {{#if (and @isRequired (not @readonly))~}}
+            <span local-class='Required'>*</span>
+        {{~/if}}
+    </div>
     {{#if @isEditableForm}}
         <div local-class='HelpText'>
-            {{@schemaBlock.helpText}}
+            {{~@schemaBlock.helpText~}}
         </div>
         {{#if @schemaBlock.exampleText}}
             <OsfButton


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [N/A]
- Feature flag: n/a

## Purpose

<!-- Describe the purpose of your changes. -->
Preserve whitespace for display text formatting. (See Prereg in Social Psych > B. Methods - Essential elements > Design)
## Summary of Changes

<!-- Briefly describe or list your changes. -->
- Wrap display text in div and put `white-space: prewrap` on div
- Trim whitespace using hbs `~` helper

## Side Effects
`N/A`
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
`N/A`
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
