### PR TITLE
Remove borders & whitespace cleanup

### DIFF
--- a/app/locales/en/translations.ts
+++ b/app/locales/en/translations.ts
@@ -1678,10 +1678,12 @@ export default {
                 showExample: 'Show example',
                 hideExample: 'Hide example',
             },
+            'schema-block-renderer/editable/files': {
+                instructions: 'You may attach up to 5 file(s) to this question. You may attach files that you already have in OSF Storage in this <a href={{nodeUrl}}>{{projectOrComponent}}</a> or upload (drag and drop) a new file from your computer. Uploaded files will automatically be added to this <a href={{nodeUrl}}>{{projectOrComponent}}</a> so that they can be registered. To attach files from other components or an add-on, first add them to this <a href={{nodeUrl}}>{{projectOrComponent}}</a>.',
+            },
         },
         'files-widget': {
             drag_drop_files: 'Drag and drop files here to upload files to this folder',
-            message: 'You may attach up to 5 file(s) to this question. You may attach files that you already have in OSF Storage in this <a href={{nodeUrl}}>{{projectOrComponent}}</a> or upload (drag and drop) a new file from your computer. Uploaded files will automatically be added to this <a href={{nodeUrl}}>{{projectOrComponent}}</a> so that they can be registered. To attach files from other components or an add-on, first add them to this <a href={{nodeUrl}}>{{projectOrComponent}}</a>.',
             load_more: 'Load more files',
             unselect_file: 'Unselect file',
         },

--- a/lib/osf-components/addon/components/files/selected-list/component.ts
+++ b/lib/osf-components/addon/components/files/selected-list/component.ts
@@ -1,38 +1,19 @@
 import { tagName } from '@ember-decorators/component';
-import { computed } from '@ember-decorators/object';
 import Component from '@ember/component';
-import { assert } from '@ember/debug';
-
 import { parallel } from 'ember-animated';
 import Sprite from 'ember-animated/-private/sprite';
 import { easeIn } from 'ember-animated/easings/cosine';
 import move from 'ember-animated/motions/move';
 import { fadeIn, fadeOut } from 'ember-animated/motions/opacity';
-import config from 'ember-get-config';
 
 import { layout } from 'ember-osf-web/decorators/component';
-import Node from 'ember-osf-web/models/node';
-import pathJoin from 'ember-osf-web/utils/path-join';
 
 import styles from './styles';
 import template from './template';
 
-const { OSF: { url: baseURL } } = config;
-
 @layout(template, styles)
 @tagName('')
 export default class SelectedFilesList extends Component {
-    node!: Node;
-
-    didReceiveAttrs() {
-        assert('Files::SelectedList requires @node!', Boolean(this.node));
-    }
-
-    @computed('node')
-    get nodeUrl() {
-        return this.node && pathJoin(baseURL, this.node.id);
-    }
-
     *transition(context: { insertedSprites: Sprite[], keptSprites: Sprite[], removedSprites: Sprite[] }) {
         const { insertedSprites, keptSprites, removedSprites } = context;
 

--- a/lib/osf-components/addon/components/files/selected-list/styles.scss
+++ b/lib/osf-components/addon/components/files/selected-list/styles.scss
@@ -1,18 +1,11 @@
 .selected-list {
     display: flex;
     flex-wrap: wrap;
-    margin: 10px 0 0;
 
     :global(.animated-container) {
         display: flex;
         flex-wrap: wrap;
     }
-}
-
-.info {
-    color: $color-text-gray-light;
-    font-size: small;
-    margin: 10px 0 0;
 }
 
 .selected-item {

--- a/lib/osf-components/addon/components/files/selected-list/styles.scss
+++ b/lib/osf-components/addon/components/files/selected-list/styles.scss
@@ -1,7 +1,7 @@
 .selected-list {
     display: flex;
     flex-wrap: wrap;
-    margin: 10px 0;
+    margin: 10px 0 0;
 
     :global(.animated-container) {
         display: flex;
@@ -12,7 +12,7 @@
 .info {
     color: $color-text-gray-light;
     font-size: small;
-    margin: 15px 0;
+    margin: 10px 0 0;
 }
 
 .selected-item {

--- a/lib/osf-components/addon/components/files/selected-list/template.hbs
+++ b/lib/osf-components/addon/components/files/selected-list/template.hbs
@@ -1,15 +1,7 @@
-<div data-test-files-info local-class='info'>
-    <span>
-        {{t 'osf-components.files-widget.message'
-            projectOrComponent=(if @node.isRoot 'project' 'component')
-            nodeUrl=this.nodeUrl
-        }}
-    </span>
-</div>
-
 {{#if @selectedFiles}}
     <div data-test-selected-files
         local-class='selected-list'
+        ...attributes
     >
         <AnimatedContainer>
             <AnimatedEach

--- a/lib/osf-components/addon/components/registries/schema-block-group-renderer/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-group-renderer/component.ts
@@ -8,9 +8,11 @@ import { layout } from 'ember-osf-web/decorators/component';
 import { SchemaBlock, SchemaBlockGroup } from 'ember-osf-web/packages/registration-schema';
 import defaultTo from 'ember-osf-web/utils/default-to';
 import { uniqueId } from 'osf-components/helpers/unique-id';
+
+import styles from './styles';
 import template from './template';
 
-@layout(template)
+@layout(template, styles)
 @tagName('')
 export default class SchemaBlockGroupRenderer extends Component {
     // Required parameters

--- a/lib/osf-components/addon/components/registries/schema-block-group-renderer/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-group-renderer/styles.scss
@@ -1,0 +1,3 @@
+.Fieldset {
+    composes: Heading from '../schema-block-renderer/styles';
+}

--- a/lib/osf-components/addon/components/registries/schema-block-group-renderer/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-group-renderer/template.hbs
@@ -1,5 +1,5 @@
 {{#if this.isFieldsetGroup}}
-    <fieldset>
+    <fieldset local-class='Fieldset'>
         {{#each this.nonOptionBlocks as |block|}}
             <Registries::SchemaBlockRenderer
                 @schemaBlock={{block}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/base/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/base/styles.scss
@@ -1,5 +1,18 @@
 .input-flexbox {
     display: flex;
+    margin: 10px 0 0;
+
+    &:first-child {
+        margin: 0;
+    }
+
+    :global(.form-group) {
+        margin: 0;
+    }
+
+    :global(.help-block) {
+        margin: 2px 0 0;
+    }
 }
 
 .input-box {

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/base/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/base/styles.scss
@@ -1,6 +1,7 @@
 .input-flexbox {
+    composes: Element from '../../styles';
+
     display: flex;
-    margin: 10px 0 0;
 
     &:first-child {
         margin: 0;

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/component.ts
@@ -1,20 +1,23 @@
 import { tagName } from '@ember-decorators/component';
-import { action } from '@ember-decorators/object';
+import { action, computed } from '@ember-decorators/object';
 import { alias } from '@ember-decorators/object/computed';
 import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
 import { assert } from '@ember/debug';
-
 import { ChangesetDef } from 'ember-changeset/types';
+import config from 'ember-get-config';
+
+import { layout } from 'ember-osf-web/decorators/component';
 import File from 'ember-osf-web/models/file';
 import NodeModel from 'ember-osf-web/models/node';
 import { FileReference, SchemaBlock } from 'ember-osf-web/packages/registration-schema';
 import Analytics from 'ember-osf-web/services/analytics';
-
-import { layout } from 'ember-osf-web/decorators/component';
+import pathJoin from 'ember-osf-web/utils/path-join';
 
 import styles from './styles';
 import template from './template';
+
+const { OSF: { url: baseURL } } = config;
 
 @layout(template, styles)
 @tagName('')
@@ -30,6 +33,11 @@ export default class Files extends Component {
     valuePath!: string;
     selectedFiles: FileReference[] = [];
     onInput!: () => void;
+
+    @computed('node')
+    get nodeUrl() {
+        return this.node && pathJoin(baseURL, this.node.id);
+    }
 
     didReceiveAttrs() {
         assert(

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/styles.scss
@@ -1,3 +1,7 @@
 .ValidationErrors {
     margin: 20px 0 21px;
 }
+
+.FilesWidget {
+    margin: 10px 0 0;
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/styles.scss
@@ -1,5 +1,14 @@
+.FilesInstructions {
+    color: $color-text-gray-light;
+    margin: 10px 0 0;
+}
+
+.SelectedList {
+    margin: 10px 0 0;
+}
+
 .ValidationErrors {
-    margin: 20px 0 21px;
+    margin: 10px 0 0;
 }
 
 .FilesWidget {

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/styles.scss
@@ -1,16 +1,17 @@
 .FilesInstructions {
+    composes: Element from '../../styles';
+
     color: $color-text-gray-light;
-    margin: 10px 0 0;
 }
 
 .SelectedList {
-    margin: 10px 0 0;
+    composes: Element from '../../styles';
 }
 
 .ValidationErrors {
-    margin: 10px 0 0;
+    composes: Element from '../../styles';
 }
 
 .FilesWidget {
-    margin: 10px 0 0;
+    composes: Element from '../../styles';
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/template.hbs
@@ -10,6 +10,7 @@
 />
 <Files::Widget
     data-test-editable-file-widget
+    local-class='FilesWidget'
     @node={{@node}}
     @onSelectFile={{action this.onSelectFile}}
     @onAddFile={{action this.onAddFile}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/template.hbs
@@ -1,4 +1,14 @@
+<p
+    data-test-files-instructions
+    local-class='FilesInstructions'
+>
+    {{t 'osf-components.registries.schema-block-renderer/editable/files.instructions'
+        projectOrComponent=(if @node.isRoot 'project' 'component')
+        nodeUrl=this.nodeUrl
+    }}
+</p>
 <Files::SelectedList
+    local-class='SelectedList'
     @selectedFiles={{this.selectedFiles}}
     @unselect={{action this.unselect}}
     @node={{@node}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/styles.scss
@@ -9,19 +9,24 @@
 
 
 .HelpText {
+    composes: Element from '../../styles';
+
     white-space: pre-wrap;
     font-weight: 400;
-    margin: 10px 0 0;
 }
 
-.ExampleButton:global(.btn) {
-    padding: 0;
-    border: 0;
-    margin: 10px 0 0;
+.ExampleButton {
+    composes: Element from '../../styles';
+
+    &:global(.btn) {
+        padding: 0;
+        border: 0;
+    }
 }
 
 .ExampleText {
+    composes: Element from '../../styles';
+
     white-space: pre-wrap;
     font-weight: 400;
-    margin: 10px 0 0;
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/styles.scss
@@ -11,17 +11,17 @@
 .HelpText {
     white-space: pre-wrap;
     font-weight: 400;
-    margin-top: 10px;
+    margin: 10px 0 0;
 }
 
 .ExampleButton:global(.btn) {
     padding: 0;
     border: 0;
-    margin-top: 10px;
+    margin: 10px 0 0;
 }
 
 .ExampleText {
     white-space: pre-wrap;
     font-weight: 400;
-    margin-top: 10px;
+    margin: 10px 0 0;
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/label/label-content/template.hbs
@@ -1,32 +1,30 @@
-{{assert @schemaBlock 'Registries::SchemaBlockRenderer::Label::LabelContent requires a @schemaBlock'}}
-<span data-test-label-content ...attributes>
-    <p local-class='DisplayText'>
-        {{~@schemaBlock.displayText~}}
-        {{~#if (and @isRequired (not @readonly))~}}
-            <span local-class='Required'>*</span>
-        {{~/if~}}
+{{assert 'Registries::SchemaBlockRenderer::Label::LabelContent requires a @schemaBlock' @schemaBlock}}
+<p local-class='DisplayText'>
+    {{~@schemaBlock.displayText~}}
+    {{~#if (and @isRequired (not @readonly))~}}
+        <span local-class='Required'>*</span>
+    {{~/if~}}
+</p>
+{{#if @isEditableForm}}
+    <p local-class='HelpText'>
+        {{~@schemaBlock.helpText~}}
     </p>
-    {{#if @isEditableForm}}
-        <div local-class='HelpText'>
-            {{~@schemaBlock.helpText~}}
-        </div>
-        {{#if @schemaBlock.exampleText}}
-            <OsfButton
-                local-class='ExampleButton'
-                @type='link'
-                @onClick={{action this.toggleShouldShowExample}}
-            >
-                {{#if this.shouldShowExample}}
-                    {{t 'osf-components.registries.schema-block-renderer/label.hideExample'}}
-                {{else}}
-                    {{t 'osf-components.registries.schema-block-renderer/label.showExample'}}
-                {{/if}}
-            </OsfButton>
+    {{#if @schemaBlock.exampleText}}
+        <OsfButton
+            local-class='ExampleButton'
+            @type='link'
+            @onClick={{action this.toggleShouldShowExample}}
+        >
             {{#if this.shouldShowExample}}
-                <p local-class='ExampleText'>
-                    {{~this.schemaBlock.exampleText~}}
-                </p>
+                {{t 'osf-components.registries.schema-block-renderer/label.hideExample'}}
+            {{else}}
+                {{t 'osf-components.registries.schema-block-renderer/label.showExample'}}
             {{/if}}
+        </OsfButton>
+        {{#if this.shouldShowExample}}
+            <p local-class='ExampleText'>
+                {{~this.schemaBlock.exampleText~}}
+            </p>
         {{/if}}
     {{/if}}
-</span>
+{{/if}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/label/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/label/styles.scss
@@ -1,12 +1,8 @@
-.QuestionLabel {
+.Label {
+    composes: Heading from '../styles';
+
     color: $color-text-gray-blue;
     width: 100%;
-    border-top: $color-border-gray 1px solid;
-    padding-top: 24px;
-    margin: 20px 0 10px;
-}
-
-.QuestionLegend {
     border-bottom: 0;
     font-weight: 700;
     font-size: 14px;

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/label/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/label/template.hbs
@@ -1,28 +1,30 @@
-{{#if @isFieldsetGroup}}
-    <legend
-        data-test-question-label
-        local-class='QuestionLabel QuestionLegend'
-        ...attributes
-    >
-        <Registries::SchemaBlockRenderer::Label::LabelContent
-            @schemaBlock={{@schemaBlock}}
-            @isRequired={{@isRequired}}
-            @readonly={{@readonly}}
-            @isEditableForm={{@isEditableForm}}
-        />
-    </legend>
-{{else}}
-    <label
-        data-test-question-label
-        local-class='QuestionLabel'
-        for={{@uniqueID}}
-        ...attributes
-    >
-        <Registries::SchemaBlockRenderer::Label::LabelContent
-            @schemaBlock={{@schemaBlock}}
-            @isRequired={{@isRequired}}
-            @readonly={{@readonly}}
-            @isEditableForm={{@isEditableForm}}
-        />
-    </label>
+{{#if (or @schemaBlock.displayText @schemaBlock.helpText @schemaBlock.exampleText)}}
+    {{#if @isFieldsetGroup}}
+        <legend
+            data-test-question-label
+            local-class='Label'
+            ...attributes
+        >
+            <Registries::SchemaBlockRenderer::Label::LabelContent
+                @schemaBlock={{@schemaBlock}}
+                @isRequired={{@isRequired}}
+                @readonly={{@readonly}}
+                @isEditableForm={{@isEditableForm}}
+            />
+        </legend>
+    {{else}}
+        <label
+            data-test-question-label
+            local-class='Label'
+            for={{@uniqueID}}
+            ...attributes
+        >
+            <Registries::SchemaBlockRenderer::Label::LabelContent
+                @schemaBlock={{@schemaBlock}}
+                @isRequired={{@isRequired}}
+                @readonly={{@readonly}}
+                @isEditableForm={{@isEditableForm}}
+            />
+        </label>
+    {{/if}}
 {{/if}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/page-heading/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/page-heading/styles.scss
@@ -1,11 +1,5 @@
 .PageHeading {
-    color: $color-text-gray-blue;
-    border-top: $color-text-slate-gray 3px solid;
-    padding-top: 25px;
-    margin: 30px 0 20px;
+    composes: Heading from '../styles';
 
-    &:first-child {
-        border-top: 0;
-        padding-top: 0;
-    }
+    color: $color-text-gray-blue;
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only-contributor-list/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only-contributor-list/component.ts
@@ -1,11 +1,13 @@
 import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
-
 import config from 'ember-get-config';
+
 import { layout } from 'ember-osf-web/decorators/component';
+
+import styles from './styles';
 import template from './template';
 
-@layout(template)
+@layout(template, styles)
 @tagName('')
 export default class ReadOnlyContributorList extends Component {
     osfUrl = config.OSF.url;

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only-contributor-list/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only-contributor-list/styles.scss
@@ -1,0 +1,3 @@
+.EditContributors {
+    margin: 10px 0 0;
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only-contributor-list/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only-contributor-list/styles.scss
@@ -1,3 +1,3 @@
 .EditContributors {
-    margin: 10px 0 0;
+    composes: Element from '../styles';
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only-contributor-list/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only-contributor-list/template.hbs
@@ -9,7 +9,10 @@
         <Registries::SchemaBlockRenderer::HelperTextIcon @helpText={{this.schemaBlock.helpText}} />
     {{/if}}
 </div>
-<div data-test-edit-contributors>
+<div
+    data-test-edit-contributors
+    local-class='EditContributors'
+>
     <!-- TODO: change link to a route when we emberize contributors page -->
     <OsfLink
         data-test-to-contributors-page

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/section-heading/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/section-heading/styles.scss
@@ -1,5 +1,5 @@
 .SectionHeading {
+    composes: Heading from '../styles';
+
     color: $color-text-gray-blue;
-    border-top: $color-border-gray 2px solid;
-    padding-top: 24px;
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/styles.scss
@@ -6,3 +6,7 @@
         margin: 0;
     }
 }
+
+.Element {
+    margin: 10px 0 0;
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/styles.scss
@@ -1,0 +1,8 @@
+.Heading {
+    margin: 20px 0 0;
+    padding: 0;
+
+    &:first-child {
+        margin: 0;
+    }
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/subsection-heading/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/subsection-heading/styles.scss
@@ -1,5 +1,5 @@
 .SubsectionHeading {
+    composes: Heading from '../styles';
+
     color: $color-text-gray-blue;
-    border-top: $color-border-gray 1px solid;
-    padding-top: 24px;
 }

--- a/lib/registries/addon/drafts/draft/page/styles.scss
+++ b/lib/registries/addon/drafts/draft/page/styles.scss
@@ -13,11 +13,7 @@
 
 .Main {
     background: $white;
-    padding: 0 30px 30px;
-
-    & > *:last-child {
-        margin-bottom: 0;
-    }
+    padding: 30px;
 }
 
 .Right {


### PR DESCRIPTION
- Ticket: []
- Feature flag: n/a

## Purpose

This removes all border between questions and cleans up whitespace so that it is consistent. It also pulls the instructions for files out of `Files::SelectedList` for better whitespace control (and because these instructions are specific to registries submission).

For whitespace between elements, I've [defined two CSS classes](https://github.com/CenterForOpenScience/ember-osf-web/pull/877/files#diff-afbe43ac228fb8ba6922a0dfad750483) for all schema blocks:
* `Heading` - sets 20px of top margin except for the first child. It also removes any padding. This class is used for headings, labels, and fieldsets.
* `Element` - set a 10px top margin. This is used for all non-label elements.

CSS modules `composes` is used to bring these classes into local classes with components.

## Summary of Changes

<!-- Briefly describe or list your changes. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
