### PR TITLE
Filter storage providers list by name

### DIFF
--- a/lib/osf-components/addon/components/files/manager/component.ts
+++ b/lib/osf-components/addon/components/files/manager/component.ts
@@ -50,7 +50,8 @@ export default class FilesManagerComponent extends Component.extend({
         assert('@node is required', Boolean(this.node));
 
         const fileProviders = yield this.node.files;
-        const fileProvider = fileProviders.firstObject as FileProvider;
+        const fileProvider = fileProviders.findBy('name', 'osfstorage') as FileProvider;
+
         const rootFolder = yield fileProvider.rootFolder;
 
         yield rootFolder.files;


### PR DESCRIPTION
- Ticket: []
- Feature flag: n/a

## Purpose

Fix issue where files-widget breaks when user has linked multiple addons
to their project.

## Summary of Changes

Filter list of storage addons by name.


## QA Notes
- Enable multiple storage addons.
- Check and see if files widget can pull node files.
