### PR TITLE
Remove data-test-* from BsDropdown menu

### DIFF
--- a/lib/registries/addon/components/registries-navbar/template.hbs
+++ b/lib/registries/addon/components/registries-navbar/template.hbs
@@ -17,6 +17,7 @@
             />
 
             <BsDropdown
+                data-test-service-list
                 data-analytics-scope='Services dropdown'
                 as |dropdown|
             >
@@ -31,7 +32,6 @@
                 </dropdown.toggle>
 
                 <dropdown.menu
-                    data-test-service-list
                     @classNames={{local-class 'ServiceDropdownMenu DropdownMenu'}}
                     as |menu|
                 >
@@ -111,6 +111,7 @@
             {{/unless}}
 
             <BsDropdown
+                data-test-auth-dropdown
                 data-analytics-scope='User dropdown'
                 local-class='AuthDropdown'
                 as |dropdown|
@@ -138,7 +139,6 @@
                 </dropdown.toggle>
 
                 <dropdown.menu
-                    data-test-auth-dropdown
                     class='dropdown-menu-right'
                     local-class='AuthDropdownMenu DropdownMenu'
                     as |menu|

--- a/tests/engines/registries/integration/components/registries-navbar/component-test.ts
+++ b/tests/engines/registries/integration/components/registries-navbar/component-test.ts
@@ -259,11 +259,11 @@ module('Registries | Integration | Component | registries-navbar', hooks => {
     test('service list', async assert => {
         await render(hbs`<RegistriesNavbar />`);
 
-        assert.dom('[data-test-service-list]').isNotVisible();
+        assert.dom('[data-test-service-list] ul').isNotVisible();
 
         await click('[data-test-service]');
 
-        assert.dom('[data-test-service-list]').isVisible();
+        assert.dom('[data-test-service-list] ul').isVisible();
     });
 
     test('auth dropdown', async function(assert) {
@@ -271,10 +271,10 @@ module('Registries | Integration | Component | registries-navbar', hooks => {
 
         await render(hbs`<RegistriesNavbar />`);
 
-        assert.dom('[data-test-auth-dropdown]').isNotVisible();
+        assert.dom('[data-test-auth-dropdown] ul').isNotVisible();
 
         await click('[data-test-gravatar]');
 
-        assert.dom('[data-test-auth-dropdown]').isVisible();
+        assert.dom('[data-test-auth-dropdown] ul').isVisible();
     });
 });


### PR DESCRIPTION
- Ticket: []
- Feature flag: n/a

## Purpose

New version 3.8.1, ember-bootstrap > dropdown.menu  does not seem to support splattributes.

## Summary of Changes

Fix tests.
