### PR TITLE
Upgrade ember-bootstrap to v3.0.0, fix broken styles

### DIFF
--- a/app/styles/_components.scss
+++ b/app/styles/_components.scss
@@ -811,7 +811,7 @@
         background-color: $osf-teal-navbar;
 
         &.service-dropdown {
-            top: 54px;
+            top: 17px;
             left: -120px;
             width: 200px;
 
@@ -821,7 +821,7 @@
         }
 
         &.auth-dropdown {
-            top: 60px;
+            top: 10px;
             right: -19px;
             width: 160px;
         }

--- a/lib/analytics-page/addon/application/template.hbs
+++ b/lib/analytics-page/addon/application/template.hbs
@@ -1,6 +1,7 @@
 {{! using unsafeTitle here to avoid double encoding because the title helper does its own }}
+{{! template-lint-disable no-implicit-this }}
 {{title (t 'analytics.pageTitle' nodeTitle=node.unsafeTitle)}}
-<div class="container">
+<div class='container'>
     <div local-class='Counts' class='row'>
         <div class='col-sm-4 panel panel-default' local-class='CountBox'>
             <div class='panel-body'>
@@ -36,7 +37,7 @@
                                 onHide=(action 'hideLinksModal')
                             }}
                                 {{#if this.node}}
-                                    <ul class="list-group">
+                                    <ul class='list-group'>
                                         {{#paginated-list/has-many
                                             model=this.node
                                             relationshipName='linkedByNodes'
@@ -83,31 +84,35 @@
             {{/bs-alert}}
         {{/unless}}
 
-        <div local-class="PickDateRange">
+        <div local-class='PickDateRange'>
             <label>
                 {{t 'analytics.showForDateRange'}}
-                {{#bs-dropdown as |dd|}}
-                    {{#dd.button
-                        (html-attributes aria-haspopup=true aria-expanded=false)
-                        class=(local-class 'DateRangeButton')
-                    }}
+                <BsDropdown as |dd|>
+                    <dd.button
+                        aria-haspopup=true
+                        aria-expanded=false
+                        local-class='DateRangeButton'
+                    >
                         {{t (concat 'analytics.dateRanges.' activeDateRange.key)}}
                         {{fa-icon 'caret-down'}}
-                    {{/dd.button}}
-                    {{#dd.menu class=(concat (local-class 'DateRangeMenu') ' dropdown-menu-right')}}
+                    </dd.button>
+                    <dd.menu
+                        local-class='DateRangeMenu'
+                        @align='right'
+                    >
                         {{#each dateRanges as |dateRange|}}
-                            <li role="menuitem">
+                            <li role='menuitem'>
                                 <a
-                                    role="button"
-                                    local-class="DateRangeOption"
+                                    role='button'
+                                    local-class='DateRangeOption'
                                     {{action 'setDateRange' dateRange}}
                                 >
                                     {{t (concat 'analytics.dateRanges.' dateRange.key)}}
                                 </a>
                             </li>
                         {{/each}}
-                    {{/dd.menu}}
-                {{/bs-dropdown}}
+                    </dd.menu>
+                </BsDropdown>
             </label>
         </div>
     {{else}}
@@ -129,3 +134,4 @@
         }}
     </div>
 </div>
+{{! template-lint-enable no-implicit-this }}

--- a/lib/collections/addon/components/discover-page/template.hbs
+++ b/lib/collections/addon/components/discover-page/template.hbs
@@ -94,10 +94,10 @@
 
         <div class='row p-v-sm'>
             <div class='col-sm-6 pull-right'>
-                <BsDropdown @classNames='dropdown pull-right' as |dd|>
+                <BsDropdown class='dropdown pull-right' as |dd|>
                     <dd.button
                         data-test-sort-by-button
-                        @classNames='btn btn-default'
+                        class='btn btn-default'
                     >
                         {{t 'collections.discover_page.sortBy'}}:
                         {{this.sortDisplay}}
@@ -108,8 +108,8 @@
                         </span>
                     </dd.button>
                     <dd.menu
-                        @classNames='dropdown-menu dropdown-menu-right'
                         local-class='sortByOptionList'
+                        @align='right'
                         as |ddm|
                     >
                         {{#each this.sortOptions as |sortChoice|}}

--- a/lib/osf-components/addon/components/delete-node-modal/template.hbs
+++ b/lib/osf-components/addon/components/delete-node-modal/template.hbs
@@ -5,7 +5,7 @@
     as |modal|
 >
     <modal.header>
-        <h3>{{t 'delete_modal.title' nodeType=(t this.nodeTypeKey)}}</h3>
+        <h3 data-test-delete-warning>{{t 'delete_modal.title' nodeType=(t this.nodeTypeKey)}}</h3>
     </modal.header>
     <modal.body class=componentCssClassName>
         <p>{{t 'delete_modal.body' nodeType=(t this.nodeTypeKey)}}</p>

--- a/lib/osf-components/addon/components/file-browser/component.ts
+++ b/lib/osf-components/addon/components/file-browser/component.ts
@@ -151,6 +151,12 @@ export default class FileBrowser extends Component {
     @or('showFilterClicked', 'showFilterInput') showFilter!: boolean;
     @or('items.length', 'filter', 'isUploading') showItems!: boolean;
 
+    @computed()
+    get renderInPlace() {
+        const wormholeElement = document.querySelector('#ember-bootstrap-wormhole');
+        return !wormholeElement;
+    }
+
     @computed('selectedItems.firstObject.guid')
     get link(): string | undefined {
         const { guid } = this.selectedItems.firstObject as unknown as File;

--- a/lib/osf-components/addon/components/file-browser/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/template.hbs
@@ -83,6 +83,7 @@
                             @placement='bottom'
                             @title={{t 'general.share'}}
                             @visible={{this.popupOpen}}
+                            @renderInPlace={{this.renderInPlace}}
                         >
                             {{#if this.link}}
                                 <CopyableText

--- a/lib/osf-components/addon/components/new-project-navigation-modal/template.hbs
+++ b/lib/osf-components/addon/components/new-project-navigation-modal/template.hbs
@@ -11,7 +11,7 @@
         >
             {{fa-icon 'times' size='sm'}}
         </OsfButton>
-        <h4 class='add-project-success text-success'>
+        <h4 data-test-modal-message class='add-project-success text-success'>
             {{this.title}}
         </h4>
     </modal.body>

--- a/lib/osf-components/addon/components/node-card/styles.scss
+++ b/lib/osf-components/addon/components/node-card/styles.scss
@@ -47,6 +47,7 @@
             background-color: $color-bg-gray-light;
             min-width: 180px;
             text-align: left;
+            padding: 3px 20px;
         }
 
         .NodeCard__dropdown-link:hover,
@@ -54,10 +55,6 @@
             cursor: pointer;
             background-image: none;
             background-color: $color-bg-gray-dark;
-        }
-
-        .btn.NodeCard__dropdown-link {
-            padding: 3px 20px;
         }
     }
 }

--- a/lib/osf-components/addon/components/node-card/styles.scss
+++ b/lib/osf-components/addon/components/node-card/styles.scss
@@ -16,7 +16,7 @@
     & > span {
         line-height: 1.5;
     }
-    
+
     :global(.label-info) {
         background-color: darken($brand-info, 15%);
     }
@@ -31,31 +31,35 @@
 
 .NodeCard__dropdown {
     padding-left: 5px;
-}
 
-.NodeCard__dropdown-list {
-    background-color: $color-bg-gray-light !important;
-    min-width: 180px;
-}
-
-.NodeCard__dropdown-link {
-    color: $color-link-black !important;
-    border-color: transparent !important;
-    background-color: $color-bg-gray-light !important;
-    min-width: 180px;
-    text-align: left;
-
-    &:hover,
-    &:focus {
-        cursor: pointer;
-        background-image: none !important;
-        background-color: $color-bg-gray-dark !important;
+    .NodeCard__dropdown-button {
+        padding: 4px 12px;
+        line-height: 0;
     }
-}
 
-.NodeCard__dropdown-button {
-    padding: 4px 12px;
-    line-height: 0;
+    .NodeCard__dropdown-list {
+        background-color: $color-bg-gray-light;
+        min-width: 180px;
+
+        .NodeCard__dropdown-link {
+            color: $color-link-black;
+            border-color: transparent;
+            background-color: $color-bg-gray-light;
+            min-width: 180px;
+            text-align: left;
+        }
+
+        .NodeCard__dropdown-link:hover,
+        .NodeCard__dropdown-link:focus {
+            cursor: pointer;
+            background-image: none;
+            background-color: $color-bg-gray-dark;
+        }
+
+        .btn.NodeCard__dropdown-link {
+            padding: 3px 20px;
+        }
+    }
 }
 
 .NodeCard__authors {

--- a/lib/osf-components/addon/components/node-card/template.hbs
+++ b/lib/osf-components/addon/components/node-card/template.hbs
@@ -52,8 +52,8 @@
                         <dd.button local-class='NodeCard__dropdown-button'>
                             <span aria-label={{t 'node_card.options'}} class='glyphicon glyphicon-option-horizontal'></span>
                         </dd.button>
-                        <dd.menu @class='dropdown-menu-right' local-class='NodeCard__dropdown-list'>
-                            <li role='menuitem'>
+                        <dd.menu @align='right' local-class='NodeCard__dropdown-list' as |menu|>
+                            <menu.item role='menuitem'>
                                 <OsfLink
                                     data-analytics-name='Manage Contributors'
                                     local-class='NodeCard__dropdown-link'
@@ -61,8 +61,8 @@
                                 >
                                     {{t 'node_card.fork.manage_contributors'}}
                                 </OsfLink>
-                            </li>
-                            <li role='menuitem'>
+                            </menu.item>
+                            <menu.item role='menuitem'>
                                 <OsfLink
                                     data-analytics-name='Settings'
                                     local-class='NodeCard__dropdown-link'
@@ -70,8 +70,8 @@
                                 >
                                     {{t 'general.settings'}}
                                 </OsfLink>
-                            </li>
-                            <li role='menuitem'>
+                            </menu.item>
+                            <menu.item role='menuitem'>
                                 <OsfButton
                                     data-analytics-scope='Delete'
                                     local-class='NodeCard__dropdown-link'
@@ -79,7 +79,7 @@
                                 >
                                     {{t 'general.delete'}}
                                 </OsfButton>
-                            </li>
+                            </menu.item>
                         </dd.menu>
                     </BsDropdown>
                 </div>

--- a/lib/osf-components/addon/components/osf-navbar/auth-dropdown/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/auth-dropdown/template.hbs
@@ -39,8 +39,9 @@
         </dd.toggle>
 
         <dd.menu
-            @classNames='auth-dropdown'
+            class='auth-dropdown'
             local-class='AuthDropdown'
+            @align='right'
             as |ddm|
         >
             {{#if @headline}}

--- a/lib/osf-components/addon/components/osf-navbar/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/template.hbs
@@ -28,7 +28,7 @@
                 {{! App list dropdown }}
                 <BsDropdown
                     data-analytics-scope='Primary dropdown'
-                    @classNames='dropdown primary-nav'
+                    class='primary-nav'
                     @onShow={{action this.onClickPrimaryDropdown}}
                     as |dd|
                 >
@@ -39,7 +39,7 @@
                     >
                         {{fa-icon 'caret-down' size='2'}}
                     </dd.toggle>
-                    <dd.menu @classNames='dropdown-menu service-dropdown' as |ddm| >
+                    <dd.menu class='service-dropdown' as |ddm|>
                         {{#each this.services as |service|}}
                             <ddm.item role='menuitem'>
                                 <OsfLink

--- a/lib/registries/addon/components/registries-header/template.hbs
+++ b/lib/registries/addon/components/registries-header/template.hbs
@@ -5,7 +5,7 @@
         <div class='text-center m-t-lg col-xs-12'>
             <div local-class='RegistriesHeader__Brand'></div>
             <p class='lead'>
-                {{yield 'lead'}}
+                {{yield (hash lead=(element ''))}}
             </p>
         </div>
     </div>
@@ -27,16 +27,18 @@
                 </span>
             </div>
             <p class='p-l-md text-left'>
-                {{t 'registries.header.searchable_as_of'
-                    registrations=(number-format searchable)
-                    today=(moment-format today 'MMMM D, YYYY')
-                }}
+                {{#if searchable}}
+                    {{t 'registries.header.searchable_as_of'
+                        registrations=(number-format searchable)
+                        today=(moment-format today 'MMMM D, YYYY')
+                    }}
+                {{/if}}
             </p>
         </div>
     </div>
 
     <div class='row p-v-sm'>
-        {{yield}}
+        {{yield (hash row=(element ''))}}
     </div>
 
     {{search-help-modal isOpen=(mut showingHelp)}}

--- a/lib/registries/addon/components/registries-navbar/styles.scss
+++ b/lib/registries/addon/components/registries-navbar/styles.scss
@@ -37,9 +37,7 @@
     background-color: $midnight-blue;
     border-radius: 2px;
     border: 0;
-    left: auto;
-    right: 0;
-    top: 35px;
+    top: 10px;
 
     // Override bootstrap/osf-style
     & > li > a:hover {

--- a/lib/registries/addon/components/registries-navbar/template.hbs
+++ b/lib/registries/addon/components/registries-navbar/template.hbs
@@ -32,7 +32,7 @@
                 </dropdown.toggle>
 
                 <dropdown.menu
-                    @classNames={{local-class 'ServiceDropdownMenu DropdownMenu'}}
+                    local-class='ServiceDropdownMenu DropdownMenu'
                     as |menu|
                 >
                     {{#each this.services as |service|}}
@@ -139,7 +139,7 @@
                 </dropdown.toggle>
 
                 <dropdown.menu
-                    class='dropdown-menu-right'
+                    @align='right'
                     local-class='AuthDropdownMenu DropdownMenu'
                     as |menu|
                 >

--- a/lib/registries/addon/discover/template.hbs
+++ b/lib/registries/addon/discover/template.hbs
@@ -2,27 +2,32 @@
 {{title (t 'registries.discover.page_title')}}
 
 {{#registries-header showHelp=true value=(mut query) onSearch=(action 'onSearch') searchable=searchable as |header|}}
-    {{#if (eq header 'lead')}}
+    {{#header.lead}}
         {{t 'registries.discover.powered_by' }}
         <a href='https://share.osf.io/' local-class='ShareLogo' data-test-share-logo title={{t 'registries.discover.SHARE'}} onclick={{action 'click' 'link' 'Discover - SHARE Logo' target=analytics}}></a>
-    {{else}}
+    {{/header.lead}}
+    {{#header.row}}
         <div class='col-sm-6 pull-right'>
-            {{#bs-dropdown class='pull-right' as |dd|}}
-                {{#dd.button (html-attributes data-test-sort-dropdown=true)}}
+            <BsDropdown class='pull-right' as |dd|>
+                <dd.button data-test-sort-dropdown=true>
                     {{t 'registries.discover.sort_by'}}: {{t searchOptions.order.display}}
                     <span aria-label='{{t 'registries.discover.sort_by'}}' class='caret'></span>
-                {{/dd.button}}
+                </dd.button>
 
-                {{#dd.menu class=(local-class 'SortDropDown__List') as |ddm|}}
+                <dd.menu
+                    local-class='SortDropDown__List'
+                    @align='right'
+                    as |ddm|
+                >
                     {{#each sortOptions as |option index|}}
-                        {{#ddm.item}}
+                        <ddm.item>
                             <button data-test-sort-option-id='{{index}}' class='btn' local-class='SortDropDown__Option' {{action 'setOrder' option}}>{{t option.display}}</button>
-                        {{/ddm.item}}
+                        </ddm.item>
                     {{/each}}
-                {{/dd.menu}}
-            {{/bs-dropdown}}
+                </dd.menu>
+            </BsDropdown>
         </div>
-    {{/if}}
+    {{/header.row}}
 {{/registries-header}}
 {{#registries-discover-search
     results=results

--- a/lib/registries/addon/index/template.hbs
+++ b/lib/registries/addon/index/template.hbs
@@ -1,19 +1,21 @@
+{{! template-lint-disable no-implicit-this }}
 {{scheduled-banner}}
 {{#registries-header onSearch=(action 'onSearch') searchable=searchableRegistrations as |header|}}
-    {{#if (eq header 'lead')}}
-        <span>{{t "registries.index.lead"}}</span>
-    {{else}}
-        <div class="text-center col-xs-12">
-            <div class="m-t-md">
+    {{#header.lead}}
+        <span>{{t 'registries.index.lead'}}</span>
+    {{/header.lead}}
+    {{#header.row}}
+        <div class='text-center col-xs-12'>
+            <div class='m-t-md'>
                 <a
-                    href="https://osf.io/jsznk/register/565fb3678c5e4a66b5582f67"
-                    onclick={{action "click" "link" "Index - See Example" "https://osf.io/jsznk/register/565fb3678c5e4a66b5582f67" target=analytics}}
+                    href='https://osf.io/jsznk/register/565fb3678c5e4a66b5582f67'
+                    onclick={{action 'click' 'link' 'Index - See Example' 'https://osf.io/jsznk/register/565fb3678c5e4a66b5582f67' target=analytics}}
                 >
-                    {{t "registries.index.see_example"}}
+                    {{t 'registries.index.see_example'}}
                 </a>
             </div>
         </div>
-    {{/if}}
+    {{/header.row}}
 {{/registries-header}}
 
 {{#if getRecentRegistrations.isRunning}}
@@ -25,3 +27,4 @@
 {{registries-services-list}}
 
 {{registries-advisory-board}}
+{{! template-lint-enable no-implicit-this }}

--- a/lib/registries/package.json
+++ b/lib/registries/package.json
@@ -25,6 +25,7 @@
     "ember-css-modules": "*",
     "ember-css-modules-sass": "*",
     "ember-decorators": "*",
+    "ember-element-helper": "*",
     "ember-flatpickr": "*",
     "ember-font-awesome": "*",
     "ember-i18n": "*",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "ember-animated": "^0.9.0",
     "ember-auto-import": "^1.5.3",
     "ember-basic-dropdown": "^1.0.3",
-    "ember-bootstrap": "^2.8.1",
+    "ember-bootstrap": "^3.0.0",
     "ember-bootstrap-datepicker": "^2.0.9",
     "ember-changeset": "^2.1.2",
     "ember-changeset-validations": "^2.1.0",

--- a/tests/integration/components/delete-node-modal/component-test.ts
+++ b/tests/integration/components/delete-node-modal/component-test.ts
@@ -1,4 +1,5 @@
 import { render } from '@ember/test-helpers';
+import { t } from 'ember-i18n/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 import { TestContext } from 'ember-test-helpers';
 import { module, test } from 'qunit';
@@ -18,8 +19,10 @@ module('Integration | Component | delete-node-modal', hooks => {
         assert.dom(this.element).hasText('');
     });
 
-    test('shown when openModal=true', async function(assert) {
+    test('shown when openModal=true', async assert => {
         await render(hbs`{{delete-node-modal closeModal=closeModal delete=delete openModal=true}}`);
-        assert.dom(this.element).includesText('Are you sure you want to delete this project?');
+        assert.dom('[data-test-delete-warning]').includesText(
+            t('delete_modal.title', { nodeType: 'project' }).toString(),
+        );
     });
 });

--- a/tests/integration/components/new-project-navigation-modal/component-test.ts
+++ b/tests/integration/components/new-project-navigation-modal/component-test.ts
@@ -1,4 +1,5 @@
 import { render } from '@ember/test-helpers';
+import { t } from 'ember-i18n/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 import { TestContext } from 'ember-test-helpers';
 
@@ -19,7 +20,7 @@ module('Integration | Component | new-project-navigation-modal', hooks => {
             },
         });
     });
-    test('it renders', async function(assert) {
+    test('it renders', async assert => {
         // Set any properties with this.set('myProperty', 'value');
         // Handle any actions with this.set('myAction', function(val) { ... });
         await render(hbs`<NewProjectNavigationModal
@@ -28,10 +29,11 @@ module('Integration | Component | new-project-navigation-modal', hooks => {
             @title="New project created successfully!"
         />`);
 
-        assert.dom(this.element)
-            .hasText('New project created successfully! Keep working here Go to project', 'Contents were correct');
-        assert.dom('[data-analytics-name="go_to_new_project"][href="/linkValue/"]')
-            .exists('Navigation link was correct');
+        assert.dom('[data-test-modal-message]').isVisible();
+        assert.dom('[data-test-stay-here]').hasText(t('new_project.stay_here').toString());
+        assert.dom('[data-test-go-to-new]').hasText(t('move_to_project.go_to_project').toString());
+        assert.dom('[data-test-go-to-new]').hasAttribute('href', '/linkValue/', 'Navigation link was correct');
+
         await click('[data-test-stay-here]');
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3613,7 +3613,7 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@~3.0.2:
+braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -6705,7 +6705,7 @@ ember-ajax@^5.0.0:
     ember-cli-babel "^7.5.0"
     najax "^1.0.3"
 
-"ember-angle-bracket-invocation-polyfill@^1.3.0 || ^2.0.0", ember-angle-bracket-invocation-polyfill@^2.0.2:
+"ember-angle-bracket-invocation-polyfill@^1.3.0 || ^2.0.0", ember-angle-bracket-invocation-polyfill@^2.0.1, ember-angle-bracket-invocation-polyfill@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ember-angle-bracket-invocation-polyfill/-/ember-angle-bracket-invocation-polyfill-2.0.2.tgz#117ab5238305f11046a2eb3a5bc026c98d2cf5c1"
   integrity sha512-HkG0xyTHtAhWVjU0Q5V/i4xe4FRvNIOaiUEgIvN815F3TIUboV/J0xhYgivm0uDZp9lAYUVF+U5PI1sCnlC3Og==
@@ -6749,14 +6749,6 @@ ember-asset-loader@^0.6.1:
     fs-extra "^7.0.1"
     object-assign "^4.1.0"
     walk-sync "^1.1.3"
-
-ember-assign-polyfill@^2.0.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/ember-assign-polyfill/-/ember-assign-polyfill-2.2.0.tgz#7953836e5ccd4da05b2493423d3efc00df80ca74"
-  integrity sha512-r6a0GlVjvMM6J8MP+kmywt9/gu7srN5Ufv1C4187zPyWKQnum9r2JEXtS06t8bvqa1JVlMRKJfu4dxOuelmr5g==
-  dependencies:
-    ember-cli-babel "^6.8.2"
-    ember-cli-version-checker "^2.0.0"
 
 ember-assign-polyfill@^2.6.0:
   version "2.6.0"
@@ -6838,7 +6830,7 @@ ember-auto-import@^1.2.19:
     walk-sync "^0.3.3"
     webpack "~4.28"
 
-ember-auto-import@^1.5.3:
+ember-auto-import@^1.4.1, ember-auto-import@^1.5.3:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.5.3.tgz#b32936f874d1ed7057ad2ed3f6116357820be44b"
   integrity sha512-7JfdunM1BmLy/lyUXu7uEoi0Gi4+dxkGM23FgIEyW5g7z4MidhP53Fc61t49oPSnq7+J4lLpbH1f6C+mDMgb4A==
@@ -6892,27 +6884,31 @@ ember-bootstrap-datepicker@^2.0.9:
     broccoli-stew "^1.5.0"
     ember-cli-babel "^6.6.0"
 
-ember-bootstrap@^2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/ember-bootstrap/-/ember-bootstrap-2.8.1.tgz#a0eaf7dca6f7c2e573077f6bc09b3b58c9569d89"
-  integrity sha512-USZLZLmwiu8OAiQ1MlH5xs/JxGEjLepE+L37HmgxPTYB6xF/+cFIBSBTB5+8y335aZZWsmmULibdSwhd9rBNmA==
+ember-bootstrap@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ember-bootstrap/-/ember-bootstrap-3.1.0.tgz#6152b029640f7eb9543049e0be6d1ba77e841a82"
+  integrity sha512-v9mUpdCdcFMJiKq0YdmI9IKyLmgM08ttQF5QXEFqHs6Dk4maEyZurhr/0zsWbrikzLft1d+Cky9EP0t/8X77Hg==
   dependencies:
     broccoli-debug "^0.6.3"
     broccoli-funnel "^2.0.0"
     broccoli-merge-trees "^3.0.1"
     broccoli-stew "^2.0.0"
     chalk "^2.1.0"
-    ember-assign-polyfill "^2.0.1"
-    ember-cli-babel "^6.16.0"
+    ember-angle-bracket-invocation-polyfill "^2.0.1"
+    ember-cli-babel "^7.7.3"
     ember-cli-build-config-editor "0.5.0"
-    ember-cli-htmlbars "^3.0.0"
+    ember-cli-htmlbars "^3.0.1"
     ember-cli-version-checker "^3.0.0"
-    ember-concurrency "^0.8.0 || ^0.9.0 || ^0.10.0"
-    ember-in-element-polyfill "^0.1.2"
-    ember-maybe-in-element "^0.1.3"
-    ember-popper "^0.9.0"
-    ember-runtime-enumerable-includes-polyfill "^2.0.0"
-    findup-sync "^3.0.0"
+    ember-concurrency "^1.0.0"
+    ember-decorators "^6.1.0"
+    ember-decorators-polyfill "^1.0.6"
+    ember-focus-trap "^0.3.2"
+    ember-let-polyfill "^0.1.0"
+    ember-maybe-in-element "^0.4.0"
+    ember-named-arguments-polyfill "^1.0.0"
+    ember-on-helper "^0.1.0"
+    ember-popper "^0.10.3"
+    findup-sync "^4.0.0"
     fs-extra "^7.0.1"
     resolve "^1.5.0"
     rsvp "^4.0.1"
@@ -7974,16 +7970,6 @@ ember-concurrency-decorators@^1.1.0-alpha.1:
     ember-cli-babel "^7.8.0"
     ember-cli-typescript "^2.0.2"
 
-"ember-concurrency@^0.8.0 || ^0.9.0 || ^0.10.0":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.10.1.tgz#aae4528540391a7278e2c193a146b5474cad5ec2"
-  integrity sha512-KdvR5TEfnLov4igeIZiVueFOL0kMjkabMQrioipegey+NF23SSYThc/y2rKv109D92lTAJgC6Vp7+j2RtXqD+w==
-  dependencies:
-    babel-core "^6.24.1"
-    ember-cli-babel "^6.8.2"
-    ember-compatibility-helpers "^1.2.0"
-    ember-maybe-import-regenerator "^0.1.5"
-
 ember-concurrency@^0.8.16:
   version "0.8.19"
   resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.8.19.tgz#71b9c175ba077865310029cb4bdb880e17d5155e"
@@ -7997,6 +7983,15 @@ ember-concurrency@^0.8.16:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-1.1.0.tgz#955f6961937c655ecc6ee4c3213e1191dc227ba3"
   integrity sha512-izwePurc0CMGSvyuZeEyjFrTVBTBQV2k7eYP/b+jYCdh5+J+ajSnx8UYIJ38E7lCukDzeTjDBrQjJxLCNzvDFg==
+  dependencies:
+    ember-cli-babel "^7.7.3"
+    ember-compatibility-helpers "^1.2.0"
+    ember-maybe-import-regenerator "^0.1.6"
+
+ember-concurrency@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-1.1.3.tgz#3e0a2c77eb5d2d8b8dc75f0ea91fdb97dfa3e6f1"
+  integrity sha512-U/a345q6OjkcRa3ziXHYFD9yB5V8guX68k1EAlLLtbtbswWAawvT/mKiPnhejuENiG6jICEc9AT0IXmVamu1+w==
   dependencies:
     ember-cli-babel "^7.7.3"
     ember-compatibility-helpers "^1.2.0"
@@ -8127,7 +8122,16 @@ ember-data@^3.14.0:
     ember-cli-typescript "^3.0.0"
     ember-inflector "^3.0.1"
 
-ember-decorators@^6.1.1:
+ember-decorators-polyfill@^1.0.6:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ember-decorators-polyfill/-/ember-decorators-polyfill-1.1.1.tgz#6ff8e57a516e04c583451305574020c34e6ad4bc"
+  integrity sha512-ZIB3uNcquNyRm+eWUbDeeE5BtH/D7oXIX9pdiEHx4TXaTnAY6z4wDrw6Ge0xP9wx/nlC4Qd/i8rdlwBOT5C6lw==
+  dependencies:
+    ember-cli-babel "^7.1.2"
+    ember-cli-version-checker "^3.1.3"
+    ember-compatibility-helpers "^1.2.0"
+
+ember-decorators@^6.1.0, ember-decorators@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/ember-decorators/-/ember-decorators-6.1.1.tgz#6d770f8999cf5a413a1ee459afd520838c0fc470"
   integrity sha512-63vZPntPn1aqMyeNRLoYjJD+8A8obd+c2iZkJflswpDRNVIsp2m7aQdSCtPt4G0U/TEq2251g+N10maHX3rnJQ==
@@ -8261,6 +8265,16 @@ ember-flatpickr@^2.15.0:
     fastboot-transform "^0.1.3"
     flatpickr "^4.6.3"
 
+ember-focus-trap@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/ember-focus-trap/-/ember-focus-trap-0.3.2.tgz#575239d2a2018b0cf17f825562396f15beb23c1b"
+  integrity sha512-tjJDZw1NJm0m6dlKswY/DuGTYD22yMUw8j3ZMsv5EbZ+/U+gB1ktyq2w5/mgvFVzRB4QmYxSr3h/tOGCkXy1yA==
+  dependencies:
+    ember-auto-import "^1.4.1"
+    ember-cli-babel "^7.11.0"
+    ember-modifier-manager-polyfill "^1.1.0"
+    focus-trap "^5.0.1"
+
 ember-font-awesome@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/ember-font-awesome/-/ember-font-awesome-3.1.1.tgz#f4bd5ece8e36417ae3ea76ca9bccfc96e5154d9a"
@@ -8341,16 +8355,6 @@ ember-ignore-children-helper@^1.0.0:
   dependencies:
     ember-cli-babel "^6.8.2"
 
-ember-in-element-polyfill@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/ember-in-element-polyfill/-/ember-in-element-polyfill-0.1.2.tgz#6a73423869e0f330c40a48d75a71d1c36161cbd6"
-  integrity sha1-anNCOGng8zDECkjXWnHRw2Fhy9Y=
-  dependencies:
-    debug "^3.1.0"
-    ember-cli-babel "^6.6.0"
-    ember-cli-version-checker "^2.1.0"
-    ember-wormhole "^0.5.4"
-
 ember-in-viewport@^3.5.8:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/ember-in-viewport/-/ember-in-viewport-3.6.0.tgz#acaeb8ddc2cc07a5f69efcb7fbd3baf62c054068"
@@ -8425,17 +8429,17 @@ ember-maybe-import-regenerator@^0.1.5, ember-maybe-import-regenerator@^0.1.6:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
-ember-maybe-in-element@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/ember-maybe-in-element/-/ember-maybe-in-element-0.1.3.tgz#1c89be49246e580c1090336ad8be31e373f71b60"
-  integrity sha512-cAiG6N9HwvoPsMIePgwECilPrKRrIdfKqx9g8qWHKPS4vwrgS2PTeLmOcJvVYbBTXkHaFZmecDRpf6xAj6zk7A==
-  dependencies:
-    ember-cli-babel "^6.11.0"
-
 ember-maybe-in-element@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/ember-maybe-in-element/-/ember-maybe-in-element-0.2.0.tgz#9ac51cbbd9d83d6230ad996c11e33f0eca3032e0"
   integrity sha512-R5e6N8yDbfNbA/3lMZsFs2KEzv/jt80TsATiKMCqdqKuSG82KrD25cRdU5VkaE8dTQbziyBeuJs90bBiqOnakQ==
+  dependencies:
+    ember-cli-babel "^7.1.0"
+
+ember-maybe-in-element@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/ember-maybe-in-element/-/ember-maybe-in-element-0.4.0.tgz#fe1994c60ee64527d2b2f3b4479ebf8806928bd8"
+  integrity sha512-ADQ9jewz46Y2MWiTAKrheIukHiU6p0QHn3xqz1BBDDOmubW1WdAjSrvtkEWsJQ08DyxIn3RdMuNDzAUo6HN6qw==
   dependencies:
     ember-cli-babel "^7.1.0"
 
@@ -8469,21 +8473,21 @@ ember-modal-dialog@2.4.3:
     ember-ignore-children-helper "^1.0.0"
     ember-wormhole "^0.5.1"
 
+ember-modifier-manager-polyfill@^1.0.1, ember-modifier-manager-polyfill@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz#cf4444e11a42ac84f5c8badd85e635df57565dda"
+  integrity sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==
+  dependencies:
+    ember-cli-babel "^7.10.0"
+    ember-cli-version-checker "^2.1.2"
+    ember-compatibility-helpers "^1.2.0"
+
 ember-modifier-manager-polyfill@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.0.3.tgz#6554b70d09a7d3b80d366b72ed482fb9a3e813c0"
   integrity sha512-d8Uz0BhAZaqzttF4NXTwJ/A8uPrgd7fMho5jh89BfzJAHu5WZfGewX9cbjh3m6f512ZyxkIeeolw3Z5/Jyaujg==
   dependencies:
     ember-cli-babel "^7.4.2"
-    ember-cli-version-checker "^2.1.2"
-    ember-compatibility-helpers "^1.2.0"
-
-ember-modifier-manager-polyfill@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz#cf4444e11a42ac84f5c8badd85e635df57565dda"
-  integrity sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==
-  dependencies:
-    ember-cli-babel "^7.10.0"
     ember-cli-version-checker "^2.1.2"
     ember-compatibility-helpers "^1.2.0"
 
@@ -8503,6 +8507,13 @@ ember-named-arguments-polyfill@^1.0.0:
   dependencies:
     ember-cli-babel "^6.6.0"
     ember-cli-version-checker "^2.1.2"
+
+ember-on-helper@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ember-on-helper/-/ember-on-helper-0.1.0.tgz#c8b1fef9173fc8546c4933b57ecd7ffbcebad99e"
+  integrity sha512-jjafBnWfoA4VSSje476ft5G+urlvvuSDddwAJjKDCjKY9mbe3hAEsJiMBAaPObJRMm1FOglCuKjQZfwDDls6MQ==
+  dependencies:
+    ember-cli-babel "^7.7.3"
 
 ember-onbeforeunload@^1.2.0:
   version "1.2.0"
@@ -8547,18 +8558,20 @@ ember-percy@^1.5.0:
     percy-client "^3.0.13"
     walk "^2.3.9"
 
-ember-popper@^0.9.0:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/ember-popper/-/ember-popper-0.9.2.tgz#a09298c2c2dcb66e3299b38e3729d8d2a1d08ad5"
-  integrity sha512-Umm3NCOAnDqaBUcjlfA8alaDqcZIiNaLzpisFPQ/DMrc8lVUGBhmB6HTmshfAoU22ljZ8FSLk6aUUW10VL/3pg==
+ember-popper@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/ember-popper/-/ember-popper-0.10.3.tgz#222ecce35a6777364bec7ec293437f27a28713a1"
+  integrity sha512-mSSUHIVGFYr8yYDjPhnIlma/vxMptm7a3pySZWK29YSEDDgsEviL7sAhOiNxvV8/uaRmCbJj/2M68dYYGed1Dw==
   dependencies:
     babel6-plugin-strip-class-callcheck "^6.0.0"
-    ember-cli-babel "^6.10.0"
-    ember-cli-htmlbars "^2.0.3"
+    ember-angle-bracket-invocation-polyfill "^2.0.2"
+    ember-cli-babel "^7.1.2"
+    ember-cli-htmlbars "^3.0.0"
     ember-cli-node-assets "^0.2.2"
-    ember-in-element-polyfill "^0.1.2"
-    ember-maybe-in-element "^0.1.3"
+    ember-maybe-in-element "^0.4.0"
+    ember-named-arguments-polyfill "^1.0.0"
     ember-raf-scheduler "^0.1.0"
+    ember-ref-modifier "^0.1.2"
     fastboot-transform "^0.1.0"
     popper.js "^1.14.1"
 
@@ -8615,6 +8628,14 @@ ember-raf-scheduler@^0.1.0:
   integrity sha1-oioC0jjDdEmSMcA6ucW5iHxyqFM=
   dependencies:
     ember-cli-babel "^6.6.0"
+
+ember-ref-modifier@^0.1.2:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/ember-ref-modifier/-/ember-ref-modifier-0.1.3.tgz#ae7eb9825ebf5a9a291677fa188a2c0eaf94f38d"
+  integrity sha512-ebZE8/DvDp7JktUXDZ4T3aACYMRsoLvKx8QhXCDTKgZu5hJIGBoq2nIuYstJHBQVBU0su0T5QZb4Bcz2GZI3yQ==
+  dependencies:
+    ember-cli-babel "^7.10.0"
+    ember-modifier-manager-polyfill "^1.0.1"
 
 ember-require-module@^0.3.0:
   version "0.3.0"
@@ -10006,14 +10027,14 @@ findup-sync@2.0.0, findup-sync@^2.0.0:
     micromatch "^3.0.4"
     resolve-dir "^1.0.1"
 
-findup-sync@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-3.0.0.tgz#17b108f9ee512dfb7a5c7f3c8b27ea9e1a9c08d1"
-  integrity sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==
+findup-sync@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-4.0.0.tgz#956c9cdde804052b881b428512905c4a5f2cdef0"
+  integrity sha512-6jvvn/12IC4quLBL1KNokxC7wWTvYncaVUYSoxWw7YykPLuRrnv4qdHcSOywOI5RpkOVGeQRtWM8/q+G6W6qfQ==
   dependencies:
     detect-file "^1.0.0"
     is-glob "^4.0.0"
-    micromatch "^3.0.4"
+    micromatch "^4.0.2"
     resolve-dir "^1.0.1"
 
 fireworm@^0.7.0:
@@ -10083,6 +10104,14 @@ fn-name@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
   integrity sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
+
+focus-trap@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-5.1.0.tgz#64a0bfabd95c382103397dbc96bfef3a3cf8e5ad"
+  integrity sha512-CkB/nrO55069QAUjWFBpX6oc+9V90Qhgpe6fBWApzruMq5gnlh90Oo7iSSDK7pKiV5ugG6OY2AXM5mxcmL3lwQ==
+  dependencies:
+    tabbable "^4.0.0"
+    xtend "^4.0.1"
 
 follow-redirects@^1.0.0:
   version "1.7.0"
@@ -13772,6 +13801,14 @@ micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
+micromatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
+  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.0.5"
+
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -15319,6 +15356,11 @@ picomatch@^2.0.4:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
   integrity sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==
+
+picomatch@^2.0.5:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.1.1.tgz#ecdfbea7704adb5fe6fb47f9866c4c0e15e905c5"
+  integrity sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -18259,6 +18301,11 @@ synchronous-promise@^2.0.6:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.10.tgz#e64c6fd3afd25f423963353043f4a68ebd397fd8"
   integrity sha512-6PC+JRGmNjiG3kJ56ZMNWDPL8hjyghF5cMXIFOKg+NiwwEZZIvxTWd0pinWKyD227odg9ygF8xVhhz7gb8Uq7A==
+
+tabbable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-4.0.0.tgz#5bff1d1135df1482cf0f0206434f15eadbeb9261"
+  integrity sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ==
 
 table@^4.0.1:
   version "4.0.3"


### PR DESCRIPTION


- Ticket: []
- Feature flag: n/a

## Purpose

Upgrade ember-bootstrap to 3.0.0, fix styles broken in latest upgrade to 2.8.1.
versions: 1.2.2 -> 2.8.1 -> 3.0.0

Somewhere between 1.2.2 -> 2.8.1, ember-bootstrap started using ember-popper (at least for `BsDropdown`) to absolute position the menu. This change broke styles that were initially lifted
from `osf-style`.

## Summary of Changes

-  Update dropdown styles.
-  Add percy to registries-navbar
