### PR TITLE
Make sure checkboxes load as checked for PAT test snapshot

### DIFF
--- a/lib/osf-components/addon/components/validated-input/checkboxes/x-checkbox/component.ts
+++ b/lib/osf-components/addon/components/validated-input/checkboxes/x-checkbox/component.ts
@@ -1,6 +1,7 @@
 import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import DS from 'ember-data';
 
 import { layout } from 'ember-osf-web/decorators/component';
 
@@ -10,26 +11,37 @@ import template from './template';
 @tagName('')
 export default class ValidatedInputCheckboxesXCheckbox<T> extends Component {
     // Required arguments
-    relationArray?: T[];
+    relationArray?: DS.PromiseArray<T> | T[];
     option!: T;
     checkboxName!: string;
     ariaLabel!: string;
     disabled!: boolean;
     checkboxId!: string;
 
-    @computed('option', 'relationArray.[]')
+    @computed('option', '_relationArray.[]')
     get checked(): boolean {
-        return Array.isArray(this.relationArray) && this.relationArray.includes(this.option);
+        return Array.isArray(this._relationArray) && this._relationArray.includes(this.option);
     }
 
     set checked(checked: boolean) {
-        if (Array.isArray(this.relationArray)) {
+        if (Array.isArray(this._relationArray)) {
             if (checked && !this.checked) {
-                this.relationArray.pushObject(this.option);
+                this._relationArray.pushObject(this.option);
             }
             if (!checked && this.checked) {
-                this.relationArray.removeObject(this.option);
+                this._relationArray.removeObject(this.option);
             }
         }
+    }
+
+    @computed('relationArray')
+    get _relationArray() {
+        if (this.relationArray) {
+            if (Array.isArray(this.relationArray)) {
+                return this.relationArray;
+            }
+            return this.relationArray.toArray();
+        }
+        return [];
     }
 }

--- a/lib/osf-components/addon/components/validated-input/checkboxes/x-checkbox/component.ts
+++ b/lib/osf-components/addon/components/validated-input/checkboxes/x-checkbox/component.ts
@@ -20,22 +20,20 @@ export default class ValidatedInputCheckboxesXCheckbox<T> extends Component {
 
     @computed('option', '_relationArray.[]')
     get checked(): boolean {
-        return Array.isArray(this._relationArray) && this._relationArray.includes(this.option);
+        return this._relationArray.includes(this.option);
     }
 
     set checked(checked: boolean) {
-        if (Array.isArray(this._relationArray)) {
-            if (checked && !this.checked) {
-                this._relationArray.pushObject(this.option);
-            }
-            if (!checked && this.checked) {
-                this._relationArray.removeObject(this.option);
-            }
+        if (checked && !this.checked) {
+            this._relationArray.pushObject(this.option);
+        }
+        if (!checked && this.checked) {
+            this._relationArray.removeObject(this.option);
         }
     }
 
-    @computed('relationArray')
-    get _relationArray() {
+    @computed('relationArray.[]')
+    get _relationArray(): T[] {
         if (this.relationArray) {
             if (Array.isArray(this.relationArray)) {
                 return this.relationArray;


### PR DESCRIPTION
- Ticket: [N/A]
- Feature flag: n/a

## Purpose
- Fix unchecked checkbox in Personal Access Token test's Percy snapshot
- Make sure the parameters used in checkbox are the types we expect them to be

## Summary of Changes
- handle cases when the relation array is a promise and force it into an array

## Side Effects
`n/a`

## QA Notes

- Please keep an eye on checkbox behavior (I doubt this should adversely effect existing things, but just in case 👀 )