### PR TITLE
Add better percy snapshots for osf-navbar

### DIFF
--- a/lib/osf-components/addon/components/osf-navbar/auth-dropdown/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/auth-dropdown/template.hbs
@@ -28,9 +28,9 @@
         local-class='DropdownContainer'
         @tagName='li'
         @classNames='dropdown secondary-nav-dropdown'
-        as |dd| 
+        as |dd|
     >
-        <dd.toggle @classNames='btn-link'>
+        <dd.toggle data-test-auth-dropdown-toggle @classNames='btn-link'>
             <div class='osf-profile-image'>
                 <img src='{{this.user.profileImage}}&s=25' alt='{{t 'auth_dropdown.user_gravatar'}}'>
             </div>

--- a/lib/osf-components/addon/components/osf-navbar/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/template.hbs
@@ -33,6 +33,7 @@
                     as |dd|
                 >
                     <dd.toggle
+                        data-test-service-dropdown
                         aria-label={{t 'navbar.other_views'}}
                         @class={{concat 'btn-link ' (local-class 'PrimaryNav__toggle')}}
                     >

--- a/tests/integration/components/osf-navbar/auth-dropdown/component-test.ts
+++ b/tests/integration/components/osf-navbar/auth-dropdown/component-test.ts
@@ -1,6 +1,5 @@
 import Service from '@ember/service';
 import { render } from '@ember/test-helpers';
-import { percySnapshot } from 'ember-percy';
 import { setupRenderingTest } from 'ember-qunit';
 import { TestContext } from 'ember-test-helpers';
 import hbs from 'htmlbars-inline-precompile';
@@ -42,7 +41,6 @@ module('Integration | Component | osf-navbar/auth-dropdown', hooks => {
         }));
 
         await render(hbs`{{osf-navbar/auth-dropdown}}`);
-        await percySnapshot(assert);
 
         assert.ok(!this.owner.lookup('service:currentUser').loginCalled, 'login has not been called');
         await click('[data-analytics-name="SignIn"]');

--- a/tests/integration/components/osf-navbar/component-test.ts
+++ b/tests/integration/components/osf-navbar/component-test.ts
@@ -1,5 +1,6 @@
 import Service from '@ember/service';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
+import { percySnapshot } from 'ember-percy';
 import { setupRenderingTest } from 'ember-qunit';
 import { TestContext } from 'ember-test-helpers';
 import hbs from 'htmlbars-inline-precompile';
@@ -23,10 +24,43 @@ module('Integration | Component | osf-navbar', hooks => {
         this.owner.register('service:router', routerStub);
     });
 
-    test('it renders', async function(assert) {
-        this.set('loginAction', () => { /* stub */ });
-        await render(hbs`{{osf-navbar loginAction=loginAction}}`);
+    test('it renders', async assert => {
+        await render(hbs`{{osf-navbar}}`);
         assert.dom('.service-name').includesText('OSF');
         assert.dom('.current-service').hasText('HOME');
+    });
+
+    test('service-dropdown: logged in', async function(assert) {
+        this.owner.lookup('service:session').set('isAuthenticated', true);
+        await render(hbs`{{osf-navbar}}`);
+
+        assert.dom('[data-test-service-dropdown]').exists();
+
+        await click('[data-test-service-dropdown]');
+        await percySnapshot(assert);
+    });
+
+    test('auth-dropdown: logged in', async function(assert) {
+        this.owner.lookup('service:session').set('isAuthenticated', true);
+
+        await render(hbs`{{osf-navbar}}`);
+
+        assert.dom('[data-test-auth-dropdown-toggle]').exists();
+        await click('[data-test-auth-dropdown-toggle]');
+        await percySnapshot(assert);
+    });
+
+    test('osf-navbar: logged out', async function(assert) {
+        this.owner.lookup('service:session').set('isAuthenticated', false);
+
+        await render(hbs`{{osf-navbar}}`);
+        assert.dom('[data-test-service-dropdown]').exists();
+
+        assert.dom('[data-test-auth-dropdown-toggle]').doesNotExist();
+        assert.dom('[data-test-ad-sign-up-button]').exists();
+        assert.dom('[data-test-sign-in-button]').exists();
+
+        await click('[data-test-service-dropdown]');
+        await percySnapshot(assert);
     });
 });


### PR DESCRIPTION
## Purpose

More Percy snapshots for `osf-navbar`.

## Summary of Changes

Add and update tests.