### PR TITLE
[ENG-1282] Update draft-registration model with metadata fields

### DIFF
--- a/app/models/draft-registration.ts
+++ b/app/models/draft-registration.ts
@@ -34,13 +34,13 @@ export default class DraftRegistrationModel extends OsfModel {
     @belongsTo('registration-schema', { inverse: null })
     registrationSchema!: DS.PromiseObject<RegistrationSchemaModel> & RegistrationSchemaModel;
 
-    @hasMany('institution', { inverse: null })
+    @hasMany('institution', { inverse: null, async: false })
     affiliatedInstitutions!: DS.PromiseManyArray<InstitutionModel>;
 
     @hasMany('subject', { inverse: null, async: false })
     subjects!: SubjectModel[];
 
-    @belongsTo('license', { inverse: null })
+    @belongsTo('license', { inverse: null, async: false })
     license!: DS.PromiseObject<LicenseModel> & LicenseModel;
 }
 

--- a/app/models/draft-registration.ts
+++ b/app/models/draft-registration.ts
@@ -2,7 +2,6 @@ import DS from 'ember-data';
 
 import { RegistrationResponse } from 'ember-osf-web/packages/registration-schema';
 
-import ContributorModel from './contributor';
 import InstitutionModel from './institution';
 import LicenseModel from './license';
 import NodeModel, { NodeCategory, NodeLicense } from './node';
@@ -22,8 +21,6 @@ export default class DraftRegistrationModel extends OsfModel {
 
     @attr('fixstring') title!: string;
     @attr('fixstring') description!: string;
-    @attr('fixstring') registrationDOI!: string | null;
-    @attr('fixstring') articleDOI!: string | null;
     @attr('fixstringarray') tags!: string[];
     @attr('node-license') nodeLicense!: NodeLicense | null;
     @attr('node-category') category!: NodeCategory;
@@ -37,14 +34,8 @@ export default class DraftRegistrationModel extends OsfModel {
     @belongsTo('registration-schema', { inverse: null })
     registrationSchema!: DS.PromiseObject<RegistrationSchemaModel> & RegistrationSchemaModel;
 
-    @hasMany('contributor', { inverse: 'node' })
-    contributors!: DS.PromiseManyArray<ContributorModel>;
-
-    @hasMany('contributor', { inverse: null })
-    bibliographicContributors!: DS.PromiseManyArray<ContributorModel>;
-
-    @hasMany('institution', { inverse: 'nodes' })
-    affiliatedInstitutions!: DS.PromiseManyArray<InstitutionModel> | InstitutionModel[];
+    @hasMany('institution', { inverse: null })
+    affiliatedInstitutions!: DS.PromiseManyArray<InstitutionModel>;
 
     @hasMany('subject', { inverse: null, async: false })
     subjects!: SubjectModel[];

--- a/app/models/draft-registration.ts
+++ b/app/models/draft-registration.ts
@@ -2,12 +2,16 @@ import DS from 'ember-data';
 
 import { RegistrationResponse } from 'ember-osf-web/packages/registration-schema';
 
-import NodeModel from './node';
+import ContributorModel from './contributor';
+import InstitutionModel from './institution';
+import LicenseModel from './license';
+import NodeModel, { NodeCategory, NodeLicense } from './node';
 import OsfModel from './osf-model';
 import RegistrationSchemaModel, { RegistrationMetadata } from './registration-schema';
+import SubjectModel from './subject';
 import UserModel from './user';
 
-const { attr, belongsTo } = DS;
+const { attr, belongsTo, hasMany } = DS;
 
 export default class DraftRegistrationModel extends OsfModel {
     @attr('fixstring') registrationSupplement!: string;
@@ -15,6 +19,14 @@ export default class DraftRegistrationModel extends OsfModel {
     @attr('registration-responses') registrationResponses!: RegistrationResponse;
     @attr('date') datetimeInitiated!: Date;
     @attr('date') datetimeUpdated!: Date;
+
+    @attr('fixstring') title!: string;
+    @attr('fixstring') description!: string;
+    @attr('fixstring') registrationDOI!: string | null;
+    @attr('fixstring') articleDOI!: string | null;
+    @attr('fixstringarray') tags!: string[];
+    @attr('node-license') nodeLicense!: NodeLicense | null;
+    @attr('node-category') category!: NodeCategory;
 
     @belongsTo('node', { inverse: 'draftRegistrations' })
     branchedFrom!: DS.PromiseObject<NodeModel> & NodeModel;
@@ -24,6 +36,21 @@ export default class DraftRegistrationModel extends OsfModel {
 
     @belongsTo('registration-schema', { inverse: null })
     registrationSchema!: DS.PromiseObject<RegistrationSchemaModel> & RegistrationSchemaModel;
+
+    @hasMany('contributor', { inverse: 'node' })
+    contributors!: DS.PromiseManyArray<ContributorModel>;
+
+    @hasMany('contributor', { inverse: null })
+    bibliographicContributors!: DS.PromiseManyArray<ContributorModel>;
+
+    @hasMany('institution', { inverse: 'nodes' })
+    affiliatedInstitutions!: DS.PromiseManyArray<InstitutionModel> | InstitutionModel[];
+
+    @hasMany('subject', { inverse: null, async: false })
+    subjects!: SubjectModel[];
+
+    @belongsTo('license', { inverse: null })
+    license!: DS.PromiseObject<LicenseModel> & LicenseModel;
 }
 
 declare module 'ember-data/types/registries/model' {


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-1282
- Feature flag: n/a

## Purpose

To update the `draft-registration` model with new fields and relationships to match metadata field additions on the backend.

## Summary of Changes

- Add fields to the `draft-registration` model

## Side Effects

- `N/A`

## QA Notes

There shouldn't be any noticeable changes.
