### PR TITLE
Use osfLink `active` class for left sidenav

### DIFF
--- a/lib/osf-components/addon/components/osf-layout/registries-side-nav/template.hbs
+++ b/lib/osf-components/addon/components/osf-layout/registries-side-nav/template.hbs
@@ -11,7 +11,6 @@
                 model=@model
                 href=@href
                 onClick=@onLinkClicked
-                isCurrentPage=@isCurrentPage
                 isCollapsed=this.isCollapsed
             )
         )}}
@@ -22,7 +21,7 @@
             <ExpandButton
                 data-analytics-name={{if this.isCollapsed 'Expand' 'Collapse'}}
                 local-class='Toggle'
-                aria-label={{if this.isCollapsed 
+                aria-label={{if this.isCollapsed
                     (t 'osf-components.registries-side-nav.expandSideNav')
                     (t 'osf-components.registries-side-nav.collapseSideNav')
                 }}

--- a/lib/osf-components/addon/components/osf-layout/registries-side-nav/x-link/component.ts
+++ b/lib/osf-components/addon/components/osf-layout/registries-side-nav/x-link/component.ts
@@ -19,7 +19,6 @@ export default class XLink extends Component {
     count?: number;
     guid?: string;
     isCollapsed: boolean = defaultTo(this.isCollapsed, false);
-    isCurrentPage: boolean = defaultTo(this.isCurrentPage, false);
     isDrawer?: boolean = defaultTo(this.isDrawer, false);
 
     onClick?: () => void;

--- a/lib/osf-components/addon/components/osf-layout/registries-side-nav/x-link/styles.scss
+++ b/lib/osf-components/addon/components/osf-layout/registries-side-nav/x-link/styles.scss
@@ -11,7 +11,7 @@
     white-space: nowrap;
     z-index: 1000;
 
-    &.CurrentPage {
+    &:global(.active) {
         color: $color-text-black;
         box-shadow: -2px 1px 5px -2px $color-border-gray;
         border: $color-border-gray 1px solid;
@@ -40,7 +40,7 @@
 .Collapsed {
     width: $width-collapsed;
 
-    &.CurrentPage {
+    &:global(.active) {
         width: $width-collapsed + 1px;
     }
 
@@ -63,7 +63,7 @@
     white-space: normal;
     align-items: flex-start;
 
-    &.CurrentPage {
+    &:global(.active) {
         border: 0;
         box-shadow: none;
     }

--- a/lib/osf-components/addon/components/osf-layout/registries-side-nav/x-link/template.hbs
+++ b/lib/osf-components/addon/components/osf-layout/registries-side-nav/x-link/template.hbs
@@ -1,10 +1,7 @@
 {{#if this.isButton}}
     <OsfButton
         data-test-collapsed={{this.isCollapsed}}
-        local-class='Link
-            {{if this.isCollapsed 'Collapsed'}}
-            {{if this.isCurrentPage 'CurrentPage'}}
-            {{if this.isDrawer 'Drawer'}}'
+        local-class='Link {{if this.isCollapsed 'Collapsed'}} {{if this.isDrawer 'Drawer'}}'
         @onClick={{@onClick}}
         @type='link'
         ...attributes
@@ -24,15 +21,13 @@
 {{else}}
     <OsfLink
         data-test-collapsed={{this.isCollapsed}}
-        local-class='Link
-            {{if this.isCollapsed 'Collapsed'}}
-            {{if this.isCurrentPage 'CurrentPage'}}
-            {{if this.isDrawer 'Drawer'}}'
+        local-class='Link {{if this.isCollapsed 'Collapsed'}} {{if this.isDrawer 'Drawer'}}'
         @route={{@route}}
         @models={{@models}}
         @href={{@href}}
         @onClick={{@onClick}}
         ...attributes
+        as |link|
     >
         {{yield (hash
             label=(component 'osf-layout/registries-side-nav/label'
@@ -44,6 +39,7 @@
                 fixedWidth=true
                 icon=@icon
             )
+            isActive=link.active
         )}}
     </OsfLink>
 {{/if}}

--- a/lib/registries/addon/components/page-link/component.ts
+++ b/lib/registries/addon/components/page-link/component.ts
@@ -1,7 +1,7 @@
 import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import { assert } from '@ember/debug';
-import { computed } from '@ember/object';
+import { action, computed } from '@ember/object';
 
 import { layout } from 'ember-osf-web/decorators/component';
 import { PageManager } from 'ember-osf-web/packages/registration-schema';
@@ -26,11 +26,10 @@ export default class PageLinkComponent extends Component {
     // Optional
     pageManager?: PageManager;
     pageIndex?: number;
-    currentPageIndex?: number;
     pageName?: string;
-    currentPageName?: string;
     label?: string;
     navMode?: string;
+    pageIsActive?: boolean;
 
     @computed('pageName', 'pageIndex', 'pageManager', 'pageManager.pageHeadingText')
     get page(): string | undefined {
@@ -59,8 +58,8 @@ export default class PageLinkComponent extends Component {
     @computed('pageState')
     get pageClass(): string {
         switch (this.pageState) {
-        case PageState.Active:
-            return 'Active';
+        // case PageState.Active:
+        //     return 'Active';
         case PageState.Unvisited:
             return 'Unvisited';
         case PageState.Invalid:
@@ -96,17 +95,6 @@ export default class PageLinkComponent extends Component {
         return this.pageManager ? this.pageManager.pageHeadingText : undefined;
     }
 
-    @computed('pageName', 'currentPageName', 'pageIndex', 'currentPageIndex')
-    get pageIsActive(): boolean {
-        if (this.pageName && this.currentPageName) {
-            return this.pageName === this.currentPageName;
-        }
-        if (typeof this.pageIndex === 'number' && typeof this.currentPageIndex === 'number') {
-            return this.pageIndex === this.currentPageIndex;
-        }
-        return false;
-    }
-
     @computed('navMode')
     get isDrawer() {
         return this.navMode === 'drawer';
@@ -115,9 +103,10 @@ export default class PageLinkComponent extends Component {
     didReceiveAttrs() {
         assert('Registries::PageLink: @link is required', Boolean(this.link));
         assert('Registries::PageLink: @draftId is required', Boolean(this.draftId));
-        assert(
-            'Registries::PageLink: @pageName and @pageLabel or @pageIndex and @pageManager are required',
-            Boolean((this.pageName && this.pageLabel) || (typeof this.pageIndex === 'number' && this.pageManager)),
-        );
+    }
+
+    @action
+    setIsActive(pageIsActive: boolean) {
+        this.setProperties({ pageIsActive });
     }
 }

--- a/lib/registries/addon/components/page-link/styles.scss
+++ b/lib/registries/addon/components/page-link/styles.scss
@@ -18,6 +18,6 @@
     }
 }
 
-.Active {
+:global(.active) {
     color: $black;
 }

--- a/lib/registries/addon/components/page-link/template.hbs
+++ b/lib/registries/addon/components/page-link/template.hbs
@@ -6,10 +6,11 @@
     @models={{array this.draftId this.page}}
     @icon={{this.pageIcon}}
     @label={{this.pageLabel}}
-    @isCurrentPage={{this.pageIsActive}}
     @isDrawer={{this.isDrawer}}
     as |link|
 >
+    {{compute (fn this.setIsActive) link.isActive}}
+
     <link.icon />
     <link.label local-class='Label' />
 </@link>


### PR DESCRIPTION
- Ticket: []
- Feature flag: n/a

## Purpose

To facilitate work on the draft layout across 'review', 'metadata', 'page' routes.
Remove `currentPage` hack. Use osfLink `active` class for left sidenav.

## Summary of Changes


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
