### PR TITLE
[ENG-610]Add debounce component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `OsfLayout::RegistriesSideNav::Label`
     - `OsfLayout::RegistriesSideNav::XLink`
     - `PageLink`
+    - `Debouncer`
 - Mirage
     - Factories
         - `institutional-user`

--- a/lib/osf-components/addon/components/debouncer/component.ts
+++ b/lib/osf-components/addon/components/debouncer/component.ts
@@ -1,0 +1,35 @@
+import Component from '@ember/component';
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+import { timeout } from 'ember-concurrency';
+import { task } from 'ember-concurrency-decorators';
+
+import { layout } from 'ember-osf-web/decorators/component';
+
+import template from './template';
+
+@layout(template)
+export default class Debouncer extends Component {
+    fn!: () => void;
+    timeoutInterval!: number;
+
+    @task({ restartable: true })
+    doFnDebounce = task(function *(this: Debouncer) {
+        yield timeout(this.timeoutInterval);
+        try {
+            yield this.fn();
+        } catch (error) {
+            throw error;
+        }
+    });
+
+    @action
+    doFnNow() {
+        this.fn();
+    }
+
+    didReceiveAttrs() {
+        assert('Debouncer needs a function input', Boolean(this.fn));
+        assert('Debouncer needs a timeout interval', Boolean(this.timeoutInterval));
+    }
+}

--- a/lib/osf-components/addon/components/debouncer/component.ts
+++ b/lib/osf-components/addon/components/debouncer/component.ts
@@ -22,10 +22,6 @@ export default class Debouncer extends Component {
         }
     });
 
-    doFnNow() {
-        this.fn();
-    }
-
     didReceiveAttrs() {
         assert('Debouncer needs a function input', Boolean(this.fn));
     }

--- a/lib/osf-components/addon/components/debouncer/component.ts
+++ b/lib/osf-components/addon/components/debouncer/component.ts
@@ -1,6 +1,5 @@
 import Component from '@ember/component';
 import { assert } from '@ember/debug';
-import { action } from '@ember/object';
 import { timeout } from 'ember-concurrency';
 import { task } from 'ember-concurrency-decorators';
 
@@ -11,7 +10,7 @@ import template from './template';
 @layout(template)
 export default class Debouncer extends Component {
     fn!: () => void;
-    timeoutInterval!: number;
+    timeoutInterval: number = 500;
 
     @task({ restartable: true })
     doFnDebounce = task(function *(this: Debouncer) {
@@ -23,13 +22,11 @@ export default class Debouncer extends Component {
         }
     });
 
-    @action
     doFnNow() {
         this.fn();
     }
 
     didReceiveAttrs() {
         assert('Debouncer needs a function input', Boolean(this.fn));
-        assert('Debouncer needs a timeout interval', Boolean(this.timeoutInterval));
     }
 }

--- a/lib/osf-components/addon/components/debouncer/template.hbs
+++ b/lib/osf-components/addon/components/debouncer/template.hbs
@@ -1,4 +1,4 @@
 {{yield (hash
     doFnDebounce=(perform this.doFnDebounce)
-    doFnNow=this.doFnNow
+    doFnNow=@fn
 )}}

--- a/lib/osf-components/addon/components/debouncer/template.hbs
+++ b/lib/osf-components/addon/components/debouncer/template.hbs
@@ -1,0 +1,4 @@
+{{yield (hash
+    doFnDebounce=(perform this.doFnDebounce)
+    doFnNow=this.doFnNow
+)}}

--- a/lib/osf-components/app/components/debouncer/component.js
+++ b/lib/osf-components/app/components/debouncer/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/debouncer/component';

--- a/lib/registries/addon/drafts/draft/page/template.hbs
+++ b/lib/registries/addon/drafts/draft/page/template.hbs
@@ -23,147 +23,153 @@
                 <LoadingIndicator @dark={{true}} />
             </div>
         {{else}}
-            <OsfLayout @backgroundClass={{local-class 'ContentBackground'}} as |layout|>
-                <layout.heading local-class='Heading'>
-                    <div local-class='Title'>
-                        <OsfLink
-                            data-analytics-name='Go to project'
-                            local-class='BreadCrumb'
-                            @route='guid-node'
-                            @models={{array this.draftRegistration.branchedFrom.id}}
-                        >
-                            {{this.draftRegistration.branchedFrom.title}} >
-                        </OsfLink>
-                        <h1>
-                            {{t 'registries.drafts.draft.form.new_registration'}}
-                        </h1>
-                    </div>
-                </layout.heading>
-                {{#if this.showMobileView}}
-                    <Drafts::Draft::-Components::TopNav
-                        @layout={{layout}}
-                        @inReview={{this.inReview}}
-                        @draftManager={{draftManager}}
-                        @draftRegistration={{this.draftRegistration}}
-                        @onSubmitRedirect={{action this.onSubmitRedirect}}
-                        @pageIndex={{this.pageIndex}}
-                        @node={{this.node}}
-                    />
-                {{/if}}
-                <layout.leftNav as |leftNav|>
-                    {{#each draftManager.pageManagers as |pageManager index|}}
+            <Debouncer
+                @timeoutInterval=5000
+                @fn={{action draftManager.onInput}}
+                as |saveDraft|
+            >
+                <OsfLayout @backgroundClass={{local-class 'ContentBackground'}} as |layout|>
+                    <layout.heading local-class='Heading'>
+                        <div local-class='Title'>
+                            <OsfLink
+                                data-analytics-name='Go to project'
+                                local-class='BreadCrumb'
+                                @route='guid-node'
+                                @models={{array this.draftRegistration.branchedFrom.id}}
+                            >
+                                {{this.draftRegistration.branchedFrom.title}} >
+                            </OsfLink>
+                            <h1>
+                                {{t 'registries.drafts.draft.form.new_registration'}}
+                            </h1>
+                        </div>
+                    </layout.heading>
+                    {{#if this.showMobileView}}
+                        <Drafts::Draft::-Components::TopNav
+                            @layout={{layout}}
+                            @inReview={{this.inReview}}
+                            @draftManager={{draftManager}}
+                            @draftRegistration={{this.draftRegistration}}
+                            @onSubmitRedirect={{action this.onSubmitRedirect}}
+                            @pageIndex={{this.pageIndex}}
+                            @node={{this.node}}
+                        />
+                    {{/if}}
+                    <layout.leftNav as |leftNav|>
+                        {{#each draftManager.pageManagers as |pageManager index|}}
+                            <PageLink
+                                @link={{component leftNav.link}}
+                                @draftId={{draftManager.draftId}}
+                                @pageManager={{pageManager}}
+                                @pageIndex={{index}}
+                                @currentPageIndex={{draftManager.currentPage}}
+                                @navMode={{leftNav.leftGutterMode}}
+                            />
+                        {{/each}}
                         <PageLink
                             @link={{component leftNav.link}}
                             @draftId={{draftManager.draftId}}
-                            @pageManager={{pageManager}}
-                            @pageIndex={{index}}
-                            @currentPageIndex={{draftManager.currentPage}}
+                            @pageName='review'
+                            @currentPageName={{this.model.page}}
+                            @label='{{t 'registries.drafts.draft.review.page_label'}}'
                             @navMode={{leftNav.leftGutterMode}}
                         />
-                    {{/each}}
-                    <PageLink
-                        @link={{component leftNav.link}}
-                        @draftId={{draftManager.draftId}}
-                        @pageName='review'
-                        @currentPageName={{this.model.page}}
-                        @label='{{t 'registries.drafts.draft.review.page_label'}}'
-                        @navMode={{leftNav.leftGutterMode}}
-                    />
-                </layout.leftNav>
-                <layout.main local-class='Main'>
-                    <main
-                        {{did-insert draftManager.onPageChange this.pageIndex this.inReview}}
-                        {{did-update draftManager.onPageChange this.pageIndex this.inReview}}
-                    >
-                        {{#if this.inReview}}
-                            {{#if (and draftManager.hasInvalidResponses this.showMobileView)}}
-                                <div
-                                    data-test-invalid-responses-text
-                                    local-class='WarningMessage'
-                                    class='text-danger'
-                                >
-                                    {{t 'registries.drafts.draft.review.invalid_warning'}}
-                                </div>
+                    </layout.leftNav>
+                    <layout.main local-class='Main'>
+                        <main
+                            {{did-insert draftManager.onPageChange this.pageIndex this.inReview}}
+                            {{did-update draftManager.onPageChange this.pageIndex this.inReview}}
+                        >
+                            {{#if this.inReview}}
+                                {{#if (and draftManager.hasInvalidResponses this.showMobileView)}}
+                                    <div
+                                        data-test-invalid-responses-text
+                                        local-class='WarningMessage'
+                                        class='text-danger'
+                                    >
+                                        {{t 'registries.drafts.draft.review.invalid_warning'}}
+                                    </div>
+                                {{/if}}
+                                <Registries::ReviewFormRenderer
+                                    @draftManager={{draftManager}}
+                                    @node={{this.node}}
+                                />
+                            {{else}}
+                                <Registries::PageRenderer
+                                    @pageManager={{draftManager.currentPageManager}}
+                                    @onInput={{saveDraft.doFnDebounce}}
+                                    @node={{this.node}}
+                                />
                             {{/if}}
-                            <Registries::ReviewFormRenderer
-                                @draftManager={{draftManager}}
-                                @node={{this.node}}
-                            />
-                        {{else}}
-                            <Registries::PageRenderer
-                                @pageManager={{draftManager.currentPageManager}}
-                                @onInput={{draftManager.onInput}}
-                                @node={{this.node}}
-                            />
-                        {{/if}}
-                    </main>
-                </layout.main>
-                <layout.right local-class='Right'>
-                    <div local-class='RightWrapper'>
-                        {{#if this.inReview}}
-                            <Drafts::Draft::-Components::Register
-                                @draftRegistration={{this.draftRegistration}}
-                                @draftManager={{draftManager}}
-                                @onSubmitRedirect={{action this.onSubmitRedirect}}
-                                @node={{this.node}}
-                            />
-                        {{/if}}
-                        {{#if (eq draftManager.lastPage this.pageIndex)}}
-                            <OsfLink
-                                data-test-goto-review
-                                data-analytics-name='Go to review'
-                                local-class='ReviewButton'
-                                class='btn btn-primary'
-                                @type='button'
-                                @route='registries.drafts.draft.page'
-                                @models={{array draftManager.draftId 'review'}}
-                            >
-                                {{t 'registries.drafts.draft.review.start_review'}}
-                            </OsfLink>
-                        {{/if}}
-                        {{#if draftManager.nextPageParam}}
-                            <OsfLink
-                                data-test-goto-next-page
-                                data-analytics-name='Go to next page'
-                                local-class='NextButton'
-                                class='btn btn-primary'
-                                @type='button'
-                                @route='registries.drafts.draft.page'
-                                @models={{array draftManager.draftId draftManager.nextPageParam}}
-                            >
-                                {{t 'registries.drafts.draft.form.next'}}
-                                <FaIcon @icon='arrow-right' @fixedWidth={{true}} />
-                            </OsfLink>
-                        {{/if}}
-                        {{#if draftManager.prevPageParam}}
-                            <OsfLink
-                                data-test-goto-previous-page
-                                data-analytics-name='Go to previous page'
-                                local-class='BackButton'
-                                class='btn btn-default'
-                                @type='button'
-                                @route='registries.drafts.draft.page'
-                                @models={{array draftManager.draftId draftManager.prevPageParam}}
-                            >
-                                <FaIcon @icon='arrow-left' @fixedWidth={{true}} />
-                                {{t 'registries.drafts.draft.form.back'}}
-                            </OsfLink>
-                        {{/if}}
+                        </main>
+                    </layout.main>
+                    <layout.right local-class='Right'>
+                        <div local-class='RightWrapper'>
+                            {{#if this.inReview}}
+                                <Drafts::Draft::-Components::Register
+                                    @draftRegistration={{this.draftRegistration}}
+                                    @draftManager={{draftManager}}
+                                    @onSubmitRedirect={{action this.onSubmitRedirect}}
+                                    @node={{this.node}}
+                                />
+                            {{/if}}
+                            {{#if (eq draftManager.lastPage this.pageIndex)}}
+                                <OsfLink
+                                    data-test-goto-review
+                                    data-analytics-name='Go to review'
+                                    local-class='ReviewButton'
+                                    class='btn btn-primary'
+                                    @type='button'
+                                    @route='registries.drafts.draft.page'
+                                    @models={{array draftManager.draftId 'review'}}
+                                >
+                                    {{t 'registries.drafts.draft.review.start_review'}}
+                                </OsfLink>
+                            {{/if}}
+                            {{#if draftManager.nextPageParam}}
+                                <OsfLink
+                                    data-test-goto-next-page
+                                    data-analytics-name='Go to next page'
+                                    local-class='NextButton'
+                                    class='btn btn-primary'
+                                    @type='button'
+                                    @route='registries.drafts.draft.page'
+                                    @models={{array draftManager.draftId draftManager.nextPageParam}}
+                                >
+                                    {{t 'registries.drafts.draft.form.next'}}
+                                    <FaIcon @icon='arrow-right' @fixedWidth={{true}} />
+                                </OsfLink>
+                            {{/if}}
+                            {{#if draftManager.prevPageParam}}
+                                <OsfLink
+                                    data-test-goto-previous-page
+                                    data-analytics-name='Go to previous page'
+                                    local-class='BackButton'
+                                    class='btn btn-default'
+                                    @type='button'
+                                    @route='registries.drafts.draft.page'
+                                    @models={{array draftManager.draftId draftManager.prevPageParam}}
+                                >
+                                    <FaIcon @icon='arrow-left' @fixedWidth={{true}} />
+                                    {{t 'registries.drafts.draft.form.back'}}
+                                </OsfLink>
+                            {{/if}}
 
-                        {{#if draftManager.lastSaveFailed}}
-                            <span local-class='SaveFailed'>
-                                {{t 'registries.drafts.draft.form.save_failed'}}
+                            {{#if draftManager.lastSaveFailed}}
+                                <span local-class='SaveFailed'>
+                                    {{t 'registries.drafts.draft.form.save_failed'}}
+                                </span>
+                            {{/if}}
+                            <span local-class='SaveMessage'>
+                                {{t 'registries.drafts.draft.form.last_saved'}}
+                                <TimeSince
+                                    @date={{this.draftRegistration.datetimeUpdated}}
+                                />
                             </span>
-                        {{/if}}
-                        <span local-class='SaveMessage'>
-                            {{t 'registries.drafts.draft.form.last_saved'}}
-                            <TimeSince
-                                @date={{this.draftRegistration.datetimeUpdated}}
-                            />
-                        </span>
-                    </div>
-                </layout.right>
-            </OsfLayout>
+                        </div>
+                    </layout.right>
+                </OsfLayout>
+            </Debouncer>
         {{/if}}
     </Registries::DraftRegistrationManager>
 {{/if}}

--- a/lib/registries/addon/drafts/draft/page/template.hbs
+++ b/lib/registries/addon/drafts/draft/page/template.hbs
@@ -23,153 +23,147 @@
                 <LoadingIndicator @dark={{true}} />
             </div>
         {{else}}
-            <Debouncer
-                @timeoutInterval=5000
-                @fn={{action draftManager.onInput}}
-                as |saveDraft|
-            >
-                <OsfLayout @backgroundClass={{local-class 'ContentBackground'}} as |layout|>
-                    <layout.heading local-class='Heading'>
-                        <div local-class='Title'>
-                            <OsfLink
-                                data-analytics-name='Go to project'
-                                local-class='BreadCrumb'
-                                @route='guid-node'
-                                @models={{array this.draftRegistration.branchedFrom.id}}
-                            >
-                                {{this.draftRegistration.branchedFrom.title}} >
-                            </OsfLink>
-                            <h1>
-                                {{t 'registries.drafts.draft.form.new_registration'}}
-                            </h1>
-                        </div>
-                    </layout.heading>
-                    {{#if this.showMobileView}}
-                        <Drafts::Draft::-Components::TopNav
-                            @layout={{layout}}
-                            @inReview={{this.inReview}}
-                            @draftManager={{draftManager}}
-                            @draftRegistration={{this.draftRegistration}}
-                            @onSubmitRedirect={{action this.onSubmitRedirect}}
-                            @pageIndex={{this.pageIndex}}
-                            @node={{this.node}}
-                        />
-                    {{/if}}
-                    <layout.leftNav as |leftNav|>
-                        {{#each draftManager.pageManagers as |pageManager index|}}
-                            <PageLink
-                                @link={{component leftNav.link}}
-                                @draftId={{draftManager.draftId}}
-                                @pageManager={{pageManager}}
-                                @pageIndex={{index}}
-                                @currentPageIndex={{draftManager.currentPage}}
-                                @navMode={{leftNav.leftGutterMode}}
-                            />
-                        {{/each}}
+            <OsfLayout @backgroundClass={{local-class 'ContentBackground'}} as |layout|>
+                <layout.heading local-class='Heading'>
+                    <div local-class='Title'>
+                        <OsfLink
+                            data-analytics-name='Go to project'
+                            local-class='BreadCrumb'
+                            @route='guid-node'
+                            @models={{array this.draftRegistration.branchedFrom.id}}
+                        >
+                            {{this.draftRegistration.branchedFrom.title}} >
+                        </OsfLink>
+                        <h1>
+                            {{t 'registries.drafts.draft.form.new_registration'}}
+                        </h1>
+                    </div>
+                </layout.heading>
+                {{#if this.showMobileView}}
+                    <Drafts::Draft::-Components::TopNav
+                        @layout={{layout}}
+                        @inReview={{this.inReview}}
+                        @draftManager={{draftManager}}
+                        @draftRegistration={{this.draftRegistration}}
+                        @onSubmitRedirect={{action this.onSubmitRedirect}}
+                        @pageIndex={{this.pageIndex}}
+                        @node={{this.node}}
+                    />
+                {{/if}}
+                <layout.leftNav as |leftNav|>
+                    {{#each draftManager.pageManagers as |pageManager index|}}
                         <PageLink
                             @link={{component leftNav.link}}
                             @draftId={{draftManager.draftId}}
-                            @pageName='review'
-                            @currentPageName={{this.model.page}}
-                            @label='{{t 'registries.drafts.draft.review.page_label'}}'
+                            @pageManager={{pageManager}}
+                            @pageIndex={{index}}
+                            @currentPageIndex={{draftManager.currentPage}}
                             @navMode={{leftNav.leftGutterMode}}
                         />
-                    </layout.leftNav>
-                    <layout.main local-class='Main'>
-                        <main
-                            {{did-insert draftManager.onPageChange this.pageIndex this.inReview}}
-                            {{did-update draftManager.onPageChange this.pageIndex this.inReview}}
-                        >
-                            {{#if this.inReview}}
-                                {{#if (and draftManager.hasInvalidResponses this.showMobileView)}}
-                                    <div
-                                        data-test-invalid-responses-text
-                                        local-class='WarningMessage'
-                                        class='text-danger'
-                                    >
-                                        {{t 'registries.drafts.draft.review.invalid_warning'}}
-                                    </div>
-                                {{/if}}
-                                <Registries::ReviewFormRenderer
-                                    @draftManager={{draftManager}}
-                                    @node={{this.node}}
-                                />
-                            {{else}}
-                                <Registries::PageRenderer
-                                    @pageManager={{draftManager.currentPageManager}}
-                                    @onInput={{saveDraft.doFnDebounce}}
-                                    @node={{this.node}}
-                                />
-                            {{/if}}
-                        </main>
-                    </layout.main>
-                    <layout.right local-class='Right'>
-                        <div local-class='RightWrapper'>
-                            {{#if this.inReview}}
-                                <Drafts::Draft::-Components::Register
-                                    @draftRegistration={{this.draftRegistration}}
-                                    @draftManager={{draftManager}}
-                                    @onSubmitRedirect={{action this.onSubmitRedirect}}
-                                    @node={{this.node}}
-                                />
-                            {{/if}}
-                            {{#if (eq draftManager.lastPage this.pageIndex)}}
-                                <OsfLink
-                                    data-test-goto-review
-                                    data-analytics-name='Go to review'
-                                    local-class='ReviewButton'
-                                    class='btn btn-primary'
-                                    @type='button'
-                                    @route='registries.drafts.draft.page'
-                                    @models={{array draftManager.draftId 'review'}}
+                    {{/each}}
+                    <PageLink
+                        @link={{component leftNav.link}}
+                        @draftId={{draftManager.draftId}}
+                        @pageName='review'
+                        @currentPageName={{this.model.page}}
+                        @label='{{t 'registries.drafts.draft.review.page_label'}}'
+                        @navMode={{leftNav.leftGutterMode}}
+                    />
+                </layout.leftNav>
+                <layout.main local-class='Main'>
+                    <main
+                        {{did-insert draftManager.onPageChange this.pageIndex this.inReview}}
+                        {{did-update draftManager.onPageChange this.pageIndex this.inReview}}
+                    >
+                        {{#if this.inReview}}
+                            {{#if (and draftManager.hasInvalidResponses this.showMobileView)}}
+                                <div
+                                    data-test-invalid-responses-text
+                                    local-class='WarningMessage'
+                                    class='text-danger'
                                 >
-                                    {{t 'registries.drafts.draft.review.start_review'}}
-                                </OsfLink>
+                                    {{t 'registries.drafts.draft.review.invalid_warning'}}
+                                </div>
                             {{/if}}
-                            {{#if draftManager.nextPageParam}}
-                                <OsfLink
-                                    data-test-goto-next-page
-                                    data-analytics-name='Go to next page'
-                                    local-class='NextButton'
-                                    class='btn btn-primary'
-                                    @type='button'
-                                    @route='registries.drafts.draft.page'
-                                    @models={{array draftManager.draftId draftManager.nextPageParam}}
-                                >
-                                    {{t 'registries.drafts.draft.form.next'}}
-                                    <FaIcon @icon='arrow-right' @fixedWidth={{true}} />
-                                </OsfLink>
-                            {{/if}}
-                            {{#if draftManager.prevPageParam}}
-                                <OsfLink
-                                    data-test-goto-previous-page
-                                    data-analytics-name='Go to previous page'
-                                    local-class='BackButton'
-                                    class='btn btn-default'
-                                    @type='button'
-                                    @route='registries.drafts.draft.page'
-                                    @models={{array draftManager.draftId draftManager.prevPageParam}}
-                                >
-                                    <FaIcon @icon='arrow-left' @fixedWidth={{true}} />
-                                    {{t 'registries.drafts.draft.form.back'}}
-                                </OsfLink>
-                            {{/if}}
+                            <Registries::ReviewFormRenderer
+                                @draftManager={{draftManager}}
+                                @node={{this.node}}
+                            />
+                        {{else}}
+                            <Registries::PageRenderer
+                                @pageManager={{draftManager.currentPageManager}}
+                                @onInput={{draftManager.onInput}}
+                                @node={{this.node}}
+                            />
+                        {{/if}}
+                    </main>
+                </layout.main>
+                <layout.right local-class='Right'>
+                    <div local-class='RightWrapper'>
+                        {{#if this.inReview}}
+                            <Drafts::Draft::-Components::Register
+                                @draftRegistration={{this.draftRegistration}}
+                                @draftManager={{draftManager}}
+                                @onSubmitRedirect={{action this.onSubmitRedirect}}
+                                @node={{this.node}}
+                            />
+                        {{/if}}
+                        {{#if (eq draftManager.lastPage this.pageIndex)}}
+                            <OsfLink
+                                data-test-goto-review
+                                data-analytics-name='Go to review'
+                                local-class='ReviewButton'
+                                class='btn btn-primary'
+                                @type='button'
+                                @route='registries.drafts.draft.page'
+                                @models={{array draftManager.draftId 'review'}}
+                            >
+                                {{t 'registries.drafts.draft.review.start_review'}}
+                            </OsfLink>
+                        {{/if}}
+                        {{#if draftManager.nextPageParam}}
+                            <OsfLink
+                                data-test-goto-next-page
+                                data-analytics-name='Go to next page'
+                                local-class='NextButton'
+                                class='btn btn-primary'
+                                @type='button'
+                                @route='registries.drafts.draft.page'
+                                @models={{array draftManager.draftId draftManager.nextPageParam}}
+                            >
+                                {{t 'registries.drafts.draft.form.next'}}
+                                <FaIcon @icon='arrow-right' @fixedWidth={{true}} />
+                            </OsfLink>
+                        {{/if}}
+                        {{#if draftManager.prevPageParam}}
+                            <OsfLink
+                                data-test-goto-previous-page
+                                data-analytics-name='Go to previous page'
+                                local-class='BackButton'
+                                class='btn btn-default'
+                                @type='button'
+                                @route='registries.drafts.draft.page'
+                                @models={{array draftManager.draftId draftManager.prevPageParam}}
+                            >
+                                <FaIcon @icon='arrow-left' @fixedWidth={{true}} />
+                                {{t 'registries.drafts.draft.form.back'}}
+                            </OsfLink>
+                        {{/if}}
 
-                            {{#if draftManager.lastSaveFailed}}
-                                <span local-class='SaveFailed'>
-                                    {{t 'registries.drafts.draft.form.save_failed'}}
-                                </span>
-                            {{/if}}
-                            <span local-class='SaveMessage'>
-                                {{t 'registries.drafts.draft.form.last_saved'}}
-                                <TimeSince
-                                    @date={{this.draftRegistration.datetimeUpdated}}
-                                />
+                        {{#if draftManager.lastSaveFailed}}
+                            <span local-class='SaveFailed'>
+                                {{t 'registries.drafts.draft.form.save_failed'}}
                             </span>
-                        </div>
-                    </layout.right>
-                </OsfLayout>
-            </Debouncer>
+                        {{/if}}
+                        <span local-class='SaveMessage'>
+                            {{t 'registries.drafts.draft.form.last_saved'}}
+                            <TimeSince
+                                @date={{this.draftRegistration.datetimeUpdated}}
+                            />
+                        </span>
+                    </div>
+                </layout.right>
+            </OsfLayout>
         {{/if}}
     </Registries::DraftRegistrationManager>
 {{/if}}

--- a/tests/integration/components/debouncer/component-test.ts
+++ b/tests/integration/components/debouncer/component-test.ts
@@ -1,0 +1,46 @@
+import { click, render } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+// import { Moment } from 'moment';
+// import NodeModel from 'ember-osf-web/models/node';
+
+module('Integration | Component | debouncer', hooks => {
+    setupRenderingTest(hooks);
+    setupMirage(hooks);
+
+    test('it renders and performs the functions', async function(assert) {
+        const dummyFunction = async () => {
+            assert.ok('ok');
+        };
+
+        // this.set('node', project);
+        this.set('dummyFunction', dummyFunction);
+
+        await render(hbs`
+            <Debouncer
+                @fn={{action this.dummyFunction}}
+                @timeoutInterval=777
+                as |debouncer|
+            >
+                <div data-test-debounced onclick={{debouncer.doFnDebounce}}>1, 2, 3...</div>
+                <div data-test-now onclick={{debouncer.doFnNow}}>GO!</div>
+            </Debouncer>
+        `);
+
+        click('[data-test-debounced]');
+        assert.expect(0);
+        click('[data-test-debounced]');
+        assert.expect(0);
+        click('[data-test-debounced]');
+        assert.expect(1);
+
+        click('[data-test-now]');
+        assert.expect(2);
+        click('[data-test-now]');
+        assert.expect(3);
+        click('[data-test-now]');
+        assert.expect(4);
+    });
+});

--- a/tests/integration/components/debouncer/component-test.ts
+++ b/tests/integration/components/debouncer/component-test.ts
@@ -3,8 +3,6 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
-// import { Moment } from 'moment';
-// import NodeModel from 'ember-osf-web/models/node';
 
 module('Integration | Component | debouncer', hooks => {
     setupRenderingTest(hooks);
@@ -14,8 +12,6 @@ module('Integration | Component | debouncer', hooks => {
         const dummyFunction = async () => {
             assert.ok('ok');
         };
-
-        // this.set('node', project);
         this.set('dummyFunction', dummyFunction);
 
         await render(hbs`

--- a/tests/integration/components/debouncer/component-test.ts
+++ b/tests/integration/components/debouncer/component-test.ts
@@ -29,7 +29,7 @@ module('Integration | Component | debouncer', hooks => {
         assert.expect(0);
         click('[data-test-debounced]');
         assert.expect(0);
-        click('[data-test-debounced]');
+        await click('[data-test-debounced]');
         assert.expect(1);
 
         click('[data-test-now]');


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-610]
- Feature flag: n/a

## Purpose
Add a debounce component that will take care of the save debouncing behavior

## Summary of Changes
- added a component `debouncer` that has functions `doFnDebounce` and `doFnNow`
- use `debouncer` in `draft/page` template

## Side Effects
N/A: additive change

## QA Notes
- What pages should be tested?
    - The draft registration workflow should be tested to see if the save behavior is consistent throughout. Save should wait until about 5 seconds after the latest user input.
- Is cross-browser testing required/recommended?
    - no
- What edge cases should QA be aware of?
    - If a user makes a change and navigates away from the page before the changes are saved, I'm not too sure what happens...
- What level of risk would you expect these changes to have?
    - not very big (localized only to the draft registration stuff and save behavior within there)
- For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
    - `N/A`


[ENG-610]: https://openscience.atlassian.net/browse/ENG-610