### PR TITLE
Prevent outside click from interrupting upload

### DIFF
--- a/lib/osf-components/addon/components/files/menu/component.ts
+++ b/lib/osf-components/addon/components/files/menu/component.ts
@@ -100,6 +100,11 @@ export default class FilesMenu extends Component.extend({
     }
 
     @action
+    onCloseMenu(isUploading: boolean) {
+        return !isUploading;
+    }
+
+    @action
     openDialog(options: { onOpenDialog?: () => void }) {
         const { onOpenDialog } = options;
 

--- a/lib/osf-components/addon/components/files/menu/template.hbs
+++ b/lib/osf-components/addon/components/files/menu/template.hbs
@@ -1,5 +1,6 @@
 <ResponsiveDropdown
     @disabled={{not this.canEdit}}
+    @onClose={{action this.onCloseMenu @isUploading}}
     as |dropdownMenu|
 >
     <div local-class='actions-menu-trigger'>

--- a/lib/osf-components/addon/components/files/upload-zone/component.ts
+++ b/lib/osf-components/addon/components/files/upload-zone/component.ts
@@ -115,10 +115,6 @@ export default class UploadZone extends Component.extend({
 
     @action
     error(_: unknown, __: unknown, file: File & DropzoneFileUpload, response: UploadResponse | string) {
-        if (file.accepted && file.status === 'canceled') {
-            return;
-        }
-
         this.uploading.removeObject(file);
         this.toast.error((typeof response === 'string') ? response : (response.message_long || response.message));
     }

--- a/lib/osf-components/addon/components/files/upload-zone/template.hbs
+++ b/lib/osf-components/addon/components/files/upload-zone/template.hbs
@@ -12,7 +12,7 @@
             @id={{dropzoneId}}
             @clickable={{this.clickable}}
             @uploadprogress={{action this.uploadProgress}}
-            @success={{queue menu.close (perform this.success)}}
+            @success={{queue (perform this.success) menu.close}}
             @preUpload={{perform this.preUpload}}
             @error={{action this.error}}
             @buildUrl={{action this.buildUrl}}

--- a/lib/osf-components/addon/components/responsive-dropdown/component.ts
+++ b/lib/osf-components/addon/components/responsive-dropdown/component.ts
@@ -33,12 +33,16 @@ export default class ResponsiveDropdown extends Component {
     }
 
     @action
-    closeDropdown(this: ResponsiveDropdown): void {
+    closeDropdown(this: ResponsiveDropdown, onClose?: () => boolean): boolean {
         // Enable scroll in case a modal was used
         const bodyCls = document.querySelector('body')!.classList;
         if (bodyCls.contains('modal-open')) {
             bodyCls.remove('modal-open');
         }
+        if (onClose) {
+            return onClose();
+        }
+        return true;
     }
 
     @action

--- a/lib/osf-components/addon/components/responsive-dropdown/template.hbs
+++ b/lib/osf-components/addon/components/responsive-dropdown/template.hbs
@@ -3,7 +3,7 @@
     @horizontalPosition={{this.horizontalPosition}}
     @calculatePosition={{action this.calculatePosition}}
     @disabled={{@disabled}}
-    @onClose={{action this.closeDropdown}}
+    @onClose={{action this.closeDropdown @onClose}}
     @renderInPlace={{this.shouldRenderInPlace}}
     @initiallyOpened={{@initiallyOpened}}
     as |dd|


### PR DESCRIPTION
- Ticket: []
- Feature flag: n/a

## Purpose

Follow up bug fix: to [ENG-1292](https://openscience.atlassian.net/browse/ENG-1292).

Prevent outside click from interrupting ongoing upload

## Summary of Changes

- Update `ResponsiveDropdown` to take `onClose` callback.

## QA Notes

- Files widget >> upload file button >> select file (preferably a big file)
- Right after selecting file to upload from file browser, click outside the menu continually. The menu should not close.
