### PR TITLE
[ENG-1316] fix: preserve whitespace formatting in read-only response

### DIFF
--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/response/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/response/styles.scss
@@ -1,5 +1,6 @@
 .ResponseValue {
     composes: Element from '../../styles.scss';
+    white-space: pre-wrap;
 }
 
 .NoResponse {

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/response/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/response/template.hbs
@@ -2,7 +2,7 @@
     data-test-read-only-response={{this.schemaBlock.registrationResponseKey}}
     local-class='ResponseValue {{unless this.readOnlyValue 'NoResponse'}}'
 >
-    {{if this.readOnlyValue this.readOnlyValue (t 'osf-components.registries.schema-block-renderer/read-only/response.noResponse')}}
+    {{~if this.readOnlyValue this.readOnlyValue (t 'osf-components.registries.schema-block-renderer/read-only/response.noResponse')~}}
 </p>
 <ValidationErrors
     local-class='ValidationErrors'


### PR DESCRIPTION
- Ticket: [ENG-1316]
- Feature flag: n/a

## Purpose

Whitespace in user-entered responses should be preserved on the registration draft review page and overview page.

## Summary of Changes

* Add `whitespace: pre-wrap` to response paragraph
* Eat up whitespace surrounding the response

## Side Effects

None expected.

## QA Notes

Make sure whitespace (e.g. paragraphs) is preserved on the registration draft review page during registration and overview page after registration.


[ENG-1316]: https://openscience.atlassian.net/browse/ENG-1316