### PR TITLE
[ENG-1333] Use list for selects

### DIFF
--- a/lib/osf-components/addon/components/registries/draft-registration-manager/component.ts
+++ b/lib/osf-components/addon/components/registries/draft-registration-manager/component.ts
@@ -4,6 +4,7 @@ import { alias, not } from '@ember-decorators/object/computed';
 import { service } from '@ember-decorators/service';
 import Component from '@ember/component';
 import { assert } from '@ember/debug';
+import { set } from '@ember/object';
 import { task, TaskInstance, timeout } from 'ember-concurrency';
 import Toast from 'ember-toastr/services/toast';
 
@@ -223,9 +224,10 @@ export default class DraftRegistrationManagerComponent extends Component.extend(
                 .mapBy('registrationResponseKey')
                 .filter(Boolean)
                 .forEach(registrationResponseKey => {
-                    Object.assign(
+                    set(
                         registrationResponses,
-                        { [registrationResponseKey]: changeset!.get(registrationResponseKey) },
+                        registrationResponseKey,
+                        changeset!.get(registrationResponseKey),
                     );
                 });
         }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/mapper/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/mapper/template.hbs
@@ -41,7 +41,7 @@
     )
     multi-select-input=(
         component
-        'registries/schema-block-renderer/read-only/response'
+        'registries/schema-block-renderer/read-only/multi-select'
         registrationResponses=@registrationResponses
         changeset=@changeset
     )

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/multi-select/styles.scss
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/multi-select/styles.scss
@@ -1,0 +1,19 @@
+.List {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.ResponseValue {
+    composes: Element from '../../styles.scss';
+}
+
+.NoResponse {
+    composes: Element from '../../styles.scss';
+
+    font-style: italic;
+}
+
+.ValidationErrors {
+    composes: Element from '../../styles.scss';
+}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/multi-select/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/multi-select/template.hbs
@@ -1,0 +1,35 @@
+{{assert 'schema-block-renderer/read-only/list requires a registrationResponses' @registrationResponses}}
+{{assert 'schema-block-renderer/read-only/list requires a schemaBlock' @schemaBlock}}
+{{assert 'schema-block-renderer/read-only/list requires optionBlocks' @optionBlocks}}
+
+{{#let (get @registrationResponses @schemaBlock.registrationResponseKey) as |selectedOptions|}}
+    {{#if selectedOptions}}
+        <ul
+            data-test-read-only-multi-select={{@schemaBlock.registrationResponseKey}}
+            local-class='List'
+        >
+            {{#each @optionBlocks as |optionBlock|}}
+                {{#if (contains optionBlock.displayText selectedOptions)}}
+                    <li
+                        data-test-read-only-multi-select-value={{optionBlock.displayText}}
+                        local-class='ResponseValue'
+                    >
+                        {{optionBlock.displayText}}
+                    </li>
+                {{/if}}
+            {{/each}}
+        </ul>
+    {{else}}
+        <p
+            data-test-read-only-multi-select-no-response
+            local-class='NoResponse'
+        >
+            {{t 'osf-components.registries.schema-block-renderer/read-only/response.noResponse'}}
+        </p>
+    {{/if}}
+    <ValidationErrors
+        local-class='ValidationErrors'
+        @changeset={{@changeset}}
+        @key={{@schemaBlock.registrationResponseKey}}
+    />
+{{/let}}

--- a/lib/osf-components/app/components/registries/schema-block-renderer/read-only/multi-select/template.js
+++ b/lib/osf-components/app/components/registries/schema-block-renderer/read-only/multi-select/template.js
@@ -1,0 +1,2 @@
+export { default } from
+    'osf-components/components/registries/schema-block-renderer/read-only/multi-select/template';


### PR DESCRIPTION
- Ticket: [ENG-1333]
- Feature flag: n/a

## Purpose

On registries draft review page and overview page, display selected multi-select options as an unstyled list.

## Summary of Changes

* add read-only multi-select schema-block-renderer
* use schema-block-renderer/read-only/multi-select

## Side Effects

None expected.

## QA Notes

This affects the registries draft review page and the registries overview page. When multiple options are selected in a multi-select question (e.g. Design plan -> Blinding on OSF Prereg) instead of being displayed as a comma-separated list the options should be displayed on separate lines separated by whitespace.

[ENG-1333]: https://openscience.atlassian.net/browse/ENG-1333