### PR TITLE
[eng-1390] fix: handle case where registration_responses is null

### DIFF
--- a/app/transforms/registration-responses.ts
+++ b/app/transforms/registration-responses.ts
@@ -5,8 +5,15 @@ import { deserializeResponseKey, serializeResponseKey } from './registration-res
 
 const { Transform } = DS;
 
+function isResponse(obj: unknown): obj is Record<string, unknown> {
+    return typeof obj === 'object' && obj !== null && Object.keys(obj).every(key => typeof key === 'string');
+}
+
 export default class RegistrationResponsesTransform extends Transform {
-    deserialize(obj: any) {
+    deserialize(obj: unknown) {
+        if (!isResponse(obj)) {
+            return {};
+        }
         return mapKeysAndValues(
             obj,
             key => deserializeResponseKey(key),

--- a/tests/unit/transforms/registration-responses-test.ts
+++ b/tests/unit/transforms/registration-responses-test.ts
@@ -1,0 +1,58 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import { responseKeyPrefix } from 'ember-osf-web/transforms/registration-response-key';
+import RegistrationResponsesTransform from 'ember-osf-web/transforms/registration-responses';
+
+module('Unit | Transform | registration-responses', hooks => {
+    setupTest(hooks);
+
+    test('deserialize', function(assert) {
+        const transform: RegistrationResponsesTransform = this.owner.lookup('transform:registration-responses');
+
+        assert.deepEqual(
+            transform.deserialize({ foo: 'baz' }),
+            { [`${responseKeyPrefix}foo`]: 'baz' },
+            'adds response key prefix',
+        );
+
+        assert.deepEqual(
+            transform.deserialize({ 'foo.bar': 'baz' }),
+            { [`${responseKeyPrefix}foo|bar`]: 'baz' },
+            'adds response key prefix and transforms dots to pipes',
+        );
+
+        assert.deepEqual(
+            transform.deserialize(null),
+            {},
+            'transforms null to empty object',
+        );
+
+        assert.deepEqual(
+            transform.deserialize({ a: 'foo', [Symbol('Sym')]: 'bar' }),
+            { [`${responseKeyPrefix}a`]: 'foo' },
+            'symbol-keyed properties are removed',
+        );
+    });
+
+    test('serialize', function(assert) {
+        const transform: RegistrationResponsesTransform = this.owner.lookup('transform:registration-responses');
+
+        assert.deepEqual(
+            transform.serialize({ [`${responseKeyPrefix}foo`]: 'baz' }),
+            { foo: 'baz' },
+            'removes response key prefix',
+        );
+
+        assert.deepEqual(
+            transform.serialize({ [`${responseKeyPrefix}foo|bar`]: 'baz' }),
+            { 'foo.bar': 'baz' },
+            'removes response key prefix and transforms pipes to dots',
+        );
+
+        assert.throws(
+            () => transform.serialize({ foo: 'bar' }),
+            'throws exception when response key prefix is missing',
+        );
+    });
+});


### PR DESCRIPTION
- Ticket: [ENG-1390]
- Feature flag: n/a

## Purpose

When the API returns `null` for `registration_responses`, the registration-responses transform causes an exception because it passes the value to `mapKeysAndValues`, which expects an object. `registration_responses` being `null` is not an expected state, but there is at least [one registration on staging2](https://api.staging2.osf.io/v2/registrations/b29hf/) for which this is the case.

## Summary of Changes

* add a custom typeguard that tests for an object with string keys.
* if registration_responses fails the typeguard, return an empty object.
* added unit test for registration-responses transform

## Side Effects

None expected.

## QA Notes

It *should* be impossible, normally, to get a registration into a state where `registration_responses` is `null`, but there is at least one registration in this state on staging2 (possibly due to a bad migration). We discovered the issue on the [registrations tab for ax8bd](https://staging2.osf.io/ax8bd/registrations):

![Screen Shot 2020-01-16 at 1 16 17 PM](https://user-images.githubusercontent.com/348630/72551225-6e7f2c00-3862-11ea-9c74-39a306e7c439.png)

This is also causing the [registration overview page](https://staging2.osf.io/b29hf) to not load:

![Screen Shot 2020-01-16 at 1 20 32 PM](https://user-images.githubusercontent.com/348630/72551542-08df6f80-3863-11ea-8789-63781509274f.png)


[ENG-1390]: https://openscience.atlassian.net/browse/ENG-1390