### PR TITLE
Update tests after turning refreshModel: false

### DIFF
--- a/app/application/route.ts
+++ b/app/application/route.ts
@@ -28,7 +28,7 @@ export default class ApplicationRoute extends Route.extend(
 
     queryParams = {
         viewOnlyToken: {
-            refreshModel: true,
+            refreshModel: false,
         },
     };
 

--- a/app/utils/window-location.ts
+++ b/app/utils/window-location.ts
@@ -1,0 +1,22 @@
+import { assert } from '@ember/debug';
+import Ember from 'ember';
+
+const WindowLocation = {
+    assignLocation(url: string) {
+        assert(
+            'WindowLocation.assignLocation should not be used in a testing environment. Stub it instead.',
+            !Ember.testing,
+        );
+        window.location.assign(url);
+    },
+
+    reloadPage() {
+        assert(
+            'WindowLocation.reloadPage should not be used in a testing environment. Stub it instead.',
+            !Ember.testing,
+        );
+        window.location.reload();
+    },
+};
+
+export default WindowLocation;

--- a/lib/osf-components/addon/components/banners/view-only-link/component.ts
+++ b/lib/osf-components/addon/components/banners/view-only-link/component.ts
@@ -6,6 +6,7 @@ import { inject as service } from '@ember/service';
 
 import { layout } from 'ember-osf-web/decorators/component';
 import CurrentUser from 'ember-osf-web/services/current-user';
+import WindowLocation from 'ember-osf-web/utils/window-location';
 
 import styles from './styles';
 import template from './template';
@@ -19,6 +20,7 @@ export default class BannersViewOnlyLink extends Component {
 
     @action
     stopViewOnly() {
-        this.router.transitionTo('home', { queryParams: { view_only: '' } });
+        const destinationPage = this.router.urlFor('home', { queryParams: { view_only: '' } });
+        WindowLocation.assignLocation(destinationPage);
     }
 }

--- a/tests/acceptance/guid-file/file-detail-test.ts
+++ b/tests/acceptance/guid-file/file-detail-test.ts
@@ -1,5 +1,6 @@
 import {
     click as untrackedClick,
+    currentRouteName,
     currentURL,
     fillIn,
     settled,
@@ -114,11 +115,13 @@ module('Acceptance | guid file', hooks => {
                 },
             );
             await visit(`/--file/${fileOne.id}`);
-            assert.equal(currentURL(), `/--file/${fileOne.guid}`);
+            assert.equal(currentRouteName(), 'guid-file', 'current route is guid-file');
+            assert.ok(currentURL().includes(`${fileOne.guid}`), 'current URL includes fileOne guid');
             assert.dom('[data-test-file-title-header]').containsText(fileOne.name);
             assert.dom(`[data-test-file-item-link="${fileTwo.name}"]`).exists();
             await click(`[data-test-file-item-link="${fileTwo.name}"]`);
-            assert.equal(currentURL(), `/--file/${fileTwo.guid}`);
+            assert.equal(currentRouteName(), 'guid-file', 'current route is guid-file');
+            assert.ok(currentURL().includes(`${fileTwo.guid}`), 'current URL includes fileTwo guid');
             assert.dom('[data-test-file-title-header]').containsText(fileTwo.name);
         });
 
@@ -310,11 +313,13 @@ module('Acceptance | guid file', hooks => {
                 },
             );
             await visit(`/--file/${fileOne.id}`);
-            assert.equal(currentURL(), `/--file/${fileOne.guid}`);
+            assert.equal(currentRouteName(), 'guid-file', 'current route is guid-file');
+            assert.ok(currentURL().includes(`${fileOne.guid}`), 'current URL includes fileOne guid');
             assert.dom('[data-test-file-title-header]').containsText(fileOne.name);
             assert.dom(`[data-test-file-item-link="${fileTwo.name}"]`).exists();
             await click(`[data-test-file-item-link="${fileTwo.name}"]`);
-            assert.equal(currentURL(), `/--file/${fileTwo.guid}`);
+            assert.equal(currentRouteName(), 'guid-file', 'current route is guid-file');
+            assert.ok(currentURL().includes(`${fileTwo.guid}`), 'current URL includes fileTwo guid');
             assert.dom('[data-test-file-title-header]').containsText(fileTwo.name);
         });
 

--- a/tests/acceptance/logged-out-homepage-test.ts
+++ b/tests/acceptance/logged-out-homepage-test.ts
@@ -1,4 +1,4 @@
-import { currentURL, settled, visit } from '@ember/test-helpers';
+import { currentRouteName, currentURL, settled, visit } from '@ember/test-helpers';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import Features from 'ember-feature-flags';
@@ -94,6 +94,6 @@ module('Acceptance | logged-out home page test', hooks => {
         await visit('/');
 
         await click('[data-test-get-started-button]');
-        assert.equal(currentURL(), '/register');
+        assert.equal(currentRouteName(), 'register', 'current route is register');
     });
 });

--- a/tests/acceptance/settings/developer-apps-page-test.ts
+++ b/tests/acceptance/settings/developer-apps-page-test.ts
@@ -1,4 +1,4 @@
-import { currentURL, fillIn, settled, visit, waitFor } from '@ember/test-helpers';
+import { currentRouteName, currentURL, fillIn, settled, visit, waitFor } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { percySnapshot } from 'ember-percy';
 import { module, test } from 'qunit';
@@ -83,14 +83,17 @@ module('Acceptance | settings | developer apps', hooks => {
         const input = '[data-test-developer-app-name] input';
         await waitFor(`${input}:enabled`);
 
-        assert.equal(currentURL(), `/settings/applications/${app.id}`);
+        assert.equal(currentRouteName(), 'settings.developer-apps.edit',
+            'current route is settings.developer-apps.edit');
+        assert.ok(currentURL().includes(`${app.id}`), 'current URL includes app id');
 
         assert.dom(input).hasValue(oldName);
         await fillIn(input, newName);
         await percySnapshot(assert);
         await click('[data-test-save-developer-app-button]');
 
-        assert.equal(currentURL(), '/settings/applications');
+        assert.equal(currentRouteName(), 'settings.developer-apps.index',
+            'current route is settings.developer-apps.index');
 
         assert.dom(link).exists({ count: 1 });
         assert.dom(link).containsText(newName);

--- a/tests/acceptance/settings/tokens-page-test.ts
+++ b/tests/acceptance/settings/tokens-page-test.ts
@@ -1,4 +1,4 @@
-import { click as untrackedClick, currentURL, fillIn, visit, waitFor } from '@ember/test-helpers';
+import { click as untrackedClick, currentRouteName, currentURL, fillIn, visit, waitFor } from '@ember/test-helpers';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { percySnapshot } from 'ember-percy';
@@ -85,14 +85,15 @@ module('Acceptance | settings | personal access tokens', hooks => {
         const input = '[data-test-token-name] input';
         await waitFor(`${input}:enabled`);
 
-        assert.equal(currentURL(), `/settings/tokens/${token.id}`);
+        assert.equal(currentRouteName(), 'settings.tokens.edit', 'current route is settings.tokens.edit');
+        assert.ok(currentURL().includes(`${token.id}`), 'current URL has token id');
 
         assert.dom(input).hasValue(oldName);
         await fillIn(input, newName);
         await percySnapshot(assert);
         await click('[data-analytics-name="Save"]');
 
-        assert.equal(currentURL(), '/settings/tokens');
+        assert.equal(currentRouteName(), 'settings.tokens.index', 'current route is settings.tokens.index');
 
         assert.dom(link).exists({ count: 1 });
         assert.dom(link).containsText(newName);

--- a/tests/engines/registries/acceptance/overview/index-test.ts
+++ b/tests/engines/registries/acceptance/overview/index-test.ts
@@ -76,7 +76,6 @@ module('Registries | Acceptance | overview.index', hooks => {
             await click(`[data-analytics-name="${testCase.name}"]`);
             await percySnapshot(`Registries sidenav - ${testCase.name}`);
 
-            assert.equal(currentURL(), testCase.url, 'At the correct URL');
             assert.equal(currentRouteName(), testCase.route, 'At the correct route');
         }
     });

--- a/tests/unit/utils/window-location-test.ts
+++ b/tests/unit/utils/window-location-test.ts
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+
+import WindowLocation from 'ember-osf-web/utils/window-location';
+
+module('Unit | Utility | window-location', () => {
+    test('assignLocation throws an error in tests', assert => {
+        assert.throws(() =>
+            WindowLocation.assignLocation('https://github.com'), 'assignLocation throws an error in test environment');
+    });
+
+    test('reloadPage throws an error in tests', assert => {
+        assert.throws(() => WindowLocation.reloadPage(), 'reloadPage throws an error in test environment');
+    });
+});


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [None]
- Feature flag: n/a

## Purpose
- turn `refreshModel` to false
- update tests that will fail after  this change

## Summary of Changes
- turn `refreshModel` to false
- use `currentRouteName` and `currentURL().includes()` instead of `currentURL() equals`

## Side Effects
none

## QA Notes
These changes shouldn't have an effect on current functionality. They will effect how query params show up on the url bar, but no changes otherwise.