### PR TITLE
Add changeset for metadata and save capability

### DIFF
--- a/lib/registries/addon/drafts/draft/draft-registration-manager.ts
+++ b/lib/registries/addon/drafts/draft/draft-registration-manager.ts
@@ -41,7 +41,10 @@ export default class DraftRegistrationManager {
 
     @computed('onInput.lastComplete')
     get lastSaveFailed() {
-        return this.onPageInput.lastComplete ? this.onPageInput.lastComplete.isError : false;
+        const pageInputFailed = this.onPageInput.lastComplete ? this.onPageInput.lastComplete.isError : false;
+        const metadataInputFailed = this.onMetadataInput.lastComplete ?
+            this.onMetadataInput.lastComplete.isError : false;
+        return pageInputFailed || metadataInputFailed;
     }
 
     @task({ on: 'init' })
@@ -122,7 +125,8 @@ export default class DraftRegistrationManager {
 
     constructor(draftRegistrationAndNodeTask: TaskInstance<{draftRegistration: DraftRegistration, node: NodeModel}>) {
         set(this, 'draftRegistrationAndNodeTask', draftRegistrationAndNodeTask);
-        this.initialize();
+        this.initializePageManagers.perform();
+        this.initializeMetadataChangeset.perform();
     }
 
     @action
@@ -155,11 +159,6 @@ export default class DraftRegistrationManager {
             .forEach(pageManager => {
                 pageManager.changeset!.validate();
             });
-    }
-
-    initialize() {
-        this.initializePageManagers.perform();
-        this.initializeMetadataChangeset.perform();
     }
 
     updateMetadataChangeset() {

--- a/lib/registries/addon/drafts/draft/draft-registration-manager.ts
+++ b/lib/registries/addon/drafts/draft/draft-registration-manager.ts
@@ -47,7 +47,7 @@ export default class DraftRegistrationManager {
         return pageInputFailed || metadataInputFailed;
     }
 
-    @task({ on: 'init' })
+    @task
     initializePageManagers = task(function *(this: DraftRegistrationManager) {
         const { draftRegistration, node } = yield this.draftRegistrationAndNodeTask;
         set(this, 'draftRegistration', draftRegistration);
@@ -70,7 +70,7 @@ export default class DraftRegistrationManager {
         set(this, 'pageManagers', pageManagers);
     });
 
-    @task({ on: 'init' })
+    @task
     initializeMetadataChangeset = task(function *(this: DraftRegistrationManager) {
         const { draftRegistration } = yield this.draftRegistrationAndNodeTask;
         const metadataChangeset = buildChangeset(draftRegistration, {});

--- a/lib/registries/addon/drafts/draft/draft-registration-manager.ts
+++ b/lib/registries/addon/drafts/draft/draft-registration-manager.ts
@@ -1,6 +1,7 @@
 import { action, computed, set } from '@ember/object';
-import { alias, filterBy, not, notEmpty } from '@ember/object/computed';
+import { alias, filterBy, not, notEmpty, or } from '@ember/object/computed';
 import { isEmpty } from '@ember/utils';
+import { ChangesetDef } from 'ember-changeset/types';
 import { TaskInstance, timeout } from 'ember-concurrency';
 import { task } from 'ember-concurrency-decorators';
 
@@ -9,6 +10,8 @@ import NodeModel from 'ember-osf-web/models/node';
 import SchemaBlock from 'ember-osf-web/models/schema-block';
 
 import { getPages, PageManager, RegistrationResponse } from 'ember-osf-web/packages/registration-schema';
+import buildChangeset from 'ember-osf-web/utils/build-changeset';
+import { MetadataProperties } from './metadata/route';
 
 export default class DraftRegistrationManager {
     // Required
@@ -19,10 +22,11 @@ export default class DraftRegistrationManager {
     registrationResponses!: RegistrationResponse;
 
     pageManagers: PageManager[] = [];
+    metadataChangeset!: ChangesetDef;
 
-    @alias('onInput.isRunning') autoSaving!: boolean;
-    @alias('initializePageManagers.isRunning') initializing!: boolean;
     @alias('draftRegistration.id') draftId!: string;
+    @or('onPageInput.isRunning', 'onMetadataInput.isRunning') autoSaving!: boolean;
+    @or('initializePageManagers.isRunning', 'initializeMetadataChangeset.isRunning') initializing!: boolean;
     @not('registrationResponsesIsValid') hasInvalidResponses!: boolean;
     @filterBy('pageManagers', 'isVisited', true) visitedPages!: PageManager[];
     @notEmpty('visitedPages') hasVisitedPages!: boolean;
@@ -37,7 +41,7 @@ export default class DraftRegistrationManager {
 
     @computed('onInput.lastComplete')
     get lastSaveFailed() {
-        return this.onInput.lastComplete ? this.onInput.lastComplete.isError : false;
+        return this.onPageInput.lastComplete ? this.onPageInput.lastComplete.isError : false;
     }
 
     @task({ on: 'init' })
@@ -63,16 +67,34 @@ export default class DraftRegistrationManager {
         set(this, 'pageManagers', pageManagers);
     });
 
+    @task({ on: 'init' })
+    initializeMetadataChangeset = task(function *(this: DraftRegistrationManager) {
+        const { draftRegistration } = yield this.draftRegistrationAndNodeTask;
+        const metadataChangeset = buildChangeset(draftRegistration, {});
+        set(this, 'metadataChangeset', metadataChangeset);
+    });
+
     @task({ restartable: true })
-    onInput = task(function *(this: DraftRegistrationManager, currentPageManager: PageManager) {
+    onMetadataInput = task(function *(this: DraftRegistrationManager) {
         yield timeout(5000); // debounce
+        this.updateMetadataChangeset();
+        try {
+            yield this.draftRegistration.save();
+        } catch (error) {
+            throw error;
+        }
+    });
+
+    @task({ restartable: true })
+    onPageInput = task(function *(this: DraftRegistrationManager, currentPageManager: PageManager) {
+        yield timeout(5000); // debounce
+
         if (currentPageManager && currentPageManager.schemaBlockGroups) {
             this.updateRegistrationResponses(currentPageManager);
 
             this.draftRegistration.setProperties({
                 registrationResponses: this.registrationResponses,
             });
-
             try {
                 yield this.draftRegistration.save();
             } catch (error) {
@@ -100,7 +122,7 @@ export default class DraftRegistrationManager {
 
     constructor(draftRegistrationAndNodeTask: TaskInstance<{draftRegistration: DraftRegistration, node: NodeModel}>) {
         set(this, 'draftRegistrationAndNodeTask', draftRegistrationAndNodeTask);
-        this.initializePageManagers.perform();
+        this.initialize();
     }
 
     @action
@@ -133,6 +155,22 @@ export default class DraftRegistrationManager {
             .forEach(pageManager => {
                 pageManager.changeset!.validate();
             });
+    }
+
+    initialize() {
+        this.initializePageManagers.perform();
+        this.initializeMetadataChangeset.perform();
+    }
+
+    updateMetadataChangeset() {
+        const { metadataChangeset, draftRegistration } = this;
+        Object.values(MetadataProperties).forEach(metadataKey => {
+            set(
+                draftRegistration,
+                metadataKey,
+                metadataChangeset!.get(metadataKey),
+            );
+        });
     }
 
     updateRegistrationResponses(pageManager: PageManager) {

--- a/lib/registries/addon/drafts/draft/metadata/controller.ts
+++ b/lib/registries/addon/drafts/draft/metadata/controller.ts
@@ -7,6 +7,7 @@ import DraftRegistration from 'ember-osf-web/models/draft-registration';
 import Media from 'ember-responsive';
 
 import NodeModel, { NodeCategory } from 'ember-osf-web/models/node';
+import DraftRegistrationManager from 'registries/drafts/draft/draft-registration-manager';
 import { DraftRouteModel } from '../route';
 
 export default class RegistriesDraftMetadata extends Controller {
@@ -16,9 +17,10 @@ export default class RegistriesDraftMetadata extends Controller {
     model!: DraftRouteModel;
     categoryOptions = Object.keys(NodeCategory);
 
+    @alias('model.draftRegistrationManager') draftManager!: DraftRegistrationManager;
     @alias('model.draftRegistrationManager.draftRegistration') draftRegistration?: DraftRegistration;
     @alias('model.draftRegistrationManager.node') node?: NodeModel;
+    @alias('model.draftRegistrationManager.initializing') loading!: boolean;
 
-    @not('draftRegistration') loading!: boolean;
     @not('media.isDesktop') showMobileView!: boolean;
 }

--- a/lib/registries/addon/drafts/draft/metadata/controller.ts
+++ b/lib/registries/addon/drafts/draft/metadata/controller.ts
@@ -3,10 +3,9 @@ import { alias, not } from '@ember/object/computed';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 
-import DraftRegistration from 'ember-osf-web/models/draft-registration';
 import Media from 'ember-responsive';
 
-import NodeModel, { NodeCategory } from 'ember-osf-web/models/node';
+import { NodeCategory } from 'ember-osf-web/models/node';
 import DraftRegistrationManager from 'registries/drafts/draft/draft-registration-manager';
 import { DraftRouteModel } from '../route';
 
@@ -18,8 +17,6 @@ export default class RegistriesDraftMetadata extends Controller {
     categoryOptions = Object.keys(NodeCategory);
 
     @alias('model.draftRegistrationManager') draftManager!: DraftRegistrationManager;
-    @alias('model.draftRegistrationManager.draftRegistration') draftRegistration?: DraftRegistration;
-    @alias('model.draftRegistrationManager.node') node?: NodeModel;
     @alias('model.draftRegistrationManager.initializing') loading!: boolean;
 
     @not('media.isDesktop') showMobileView!: boolean;

--- a/lib/registries/addon/drafts/draft/metadata/route.ts
+++ b/lib/registries/addon/drafts/draft/metadata/route.ts
@@ -9,6 +9,14 @@ import Analytics from 'ember-osf-web/services/analytics';
 import { DraftRoute } from 'registries/drafts/draft/navigation-manager';
 import { DraftRouteModel } from '../route';
 
+export enum MetadataProperties {
+    Title = 'title',
+    Description = 'description',
+    Tags = 'tags',
+    Category = 'category',
+    NodeLicense = 'nodeLicense',
+}
+
 export default class DraftRegistrationMetadataRoute extends Route {
     @service analytics!: Analytics;
     @service store!: DS.Store;
@@ -19,7 +27,7 @@ export default class DraftRegistrationMetadataRoute extends Route {
         const { navigationManager } = draftRouteModel;
 
         navigationManager.setPageAndRoute(DraftRoute.Metadata);
-        return this.modelFor('drafts.draft') as DraftRouteModel;
+        return draftRouteModel;
     }
 
     @action

--- a/lib/registries/addon/drafts/draft/metadata/template.hbs
+++ b/lib/registries/addon/drafts/draft/metadata/template.hbs
@@ -3,7 +3,7 @@
 {{else}}
     <form>
         <FormControls
-            @changeset={{changeset this.draftManager.metadataChangeset}}
+            @changeset={{this.draftManager.metadataChangeset}}
             ...attributes as |form|
         >
             <form.text

--- a/lib/registries/addon/drafts/draft/metadata/template.hbs
+++ b/lib/registries/addon/drafts/draft/metadata/template.hbs
@@ -3,24 +3,27 @@
 {{else}}
     <form>
         <FormControls
-            @changeset={{changeset this.draftRegistration}}
+            @changeset={{changeset this.draftManager.metadataChangeset}}
             ...attributes as |form|
         >
             <form.text
                 data-test-metadata-title
                 @label={{t 'registries.registration_metadata.title'}}
                 @valuePath='title'
+                @onKeyUp={{perform this.draftManager.onMetadataInput}}
             />
             <form.textarea
                 data-test-metadata-description
                 @label={{t 'registries.registration_metadata.description'}}
                 @valuePath='description'
+                @onKeyUp={{perform this.draftManager.onMetadataInput}}
             />
             <form.select
                 data-test-metadata-category
                 @label={{t 'registries.registration_metadata.category'}}
                 @valuePath='category'
                 @options={{this.categoryOptions}}
+                @onchange={{perform this.draftManager.onMetadataInput}}
             />
         </FormControls>
     </form>

--- a/lib/registries/addon/drafts/draft/page/template.hbs
+++ b/lib/registries/addon/drafts/draft/page/template.hbs
@@ -15,7 +15,7 @@
             {{#if navManager.currentPageManager}}
                 <Registries::PageRenderer
                     @pageManager={{navManager.currentPageManager}}
-                    @onInput={{perform draftManager.onInput navManager.currentPageManager}}
+                    @onInput={{perform draftManager.onPageInput navManager.currentPageManager}}
                     @node={{this.node}}
                 />
             {{/if}}


### PR DESCRIPTION
- Ticket: []
- Feature flag: n/a

## Purpose
- Add changeset for metadata page to support save capability

## Summary of Changes
- Added a new `enum` in metadata route called `MetadataProperties`
- Add new task to create changeset for draftMetadata
- Add new task to save metadata
- Apply save task (`onMetadataInput`) to metadata template
- Update name of `onInput` to `onPageInput`

## Side Effects
- There should be none, but let's just double check to see if changes to the draft pages are not effected 😅 

## QA Notes
- This will be tested with the draft_metadata release
