### PR TITLE
[ENG-1420] Add validations to metadata page

### DIFF
--- a/app/models/draft-registration.ts
+++ b/app/models/draft-registration.ts
@@ -13,6 +13,15 @@ import UserModel from './user';
 
 const { attr, belongsTo, hasMany } = DS;
 
+export enum DraftMetadataProperties {
+    Title = 'title',
+    Description = 'description',
+    Tags = 'tags',
+    Category = 'category',
+    License = 'license',
+    Subjects = 'subjects',
+}
+
 export default class DraftRegistrationModel extends OsfModel {
     @attr('fixstring') registrationSupplement!: string;
     @attr('object') registrationMetadata!: RegistrationMetadata;

--- a/app/models/draft-registration.ts
+++ b/app/models/draft-registration.ts
@@ -19,6 +19,7 @@ export enum DraftMetadataProperties {
     Tags = 'tags',
     Category = 'category',
     License = 'license',
+    NodeLicenseProperty = 'nodeLicense',
     Subjects = 'subjects',
 }
 

--- a/app/packages/registration-schema/index.ts
+++ b/app/packages/registration-schema/index.ts
@@ -2,7 +2,7 @@ export { getPages } from './get-pages';
 export { getSchemaBlockGroups } from './get-schema-block-group';
 export { SchemaBlock, SchemaBlockType } from './schema-block';
 export { SchemaBlockGroup } from './schema-block-group';
-export { buildValidation } from './validations';
+export { buildValidation, buildMetadataValidations } from './validations';
 export {
     FileReference,
     RegistrationResponse,

--- a/app/packages/registration-schema/validations.ts
+++ b/app/packages/registration-schema/validations.ts
@@ -4,13 +4,11 @@ import { ValidationObject, ValidatorFunction } from 'ember-changeset-validations
 import { validateLength, validatePresence } from 'ember-changeset-validations/validators';
 
 import translations from 'ember-osf-web/locales/en/translations';
-import DraftRegistration from 'ember-osf-web/models/draft-registration';
+import DraftRegistration, { DraftMetadataProperties } from 'ember-osf-web/models/draft-registration';
 import NodeModel from 'ember-osf-web/models/node';
 import { RegistrationResponse } from 'ember-osf-web/packages/registration-schema';
 import { SchemaBlockGroup } from 'ember-osf-web/packages/registration-schema/schema-block-group';
 import { validateFileList } from 'ember-osf-web/validators/validate-response-format';
-
-import { MetadataProperties } from 'registries/drafts/draft/metadata/route';
 
 // TODO: find a way to use i18n to translate error messages
 
@@ -72,21 +70,21 @@ export function buildValidation(groups: SchemaBlockGroup[], node?: NodeModel) {
 
 export function buildMetadataValidations() {
     const validationObj: ValidationObject<DraftRegistration> = {};
-    const validationFuncs: ValidatorFunction[] = [validatePresence({
+    const notBlank: ValidatorFunction[] = [validatePresence({
         presence: true,
         ignoreBlank: true,
         allowBlank: false,
         allowNone: false,
         message: translations.validationErrors.blank,
     })];
-    set(validationObj, MetadataProperties.Title, validationFuncs);
-    set(validationObj, MetadataProperties.Description, validationFuncs);
-    set(validationObj, MetadataProperties.NodeLicense, validationFuncs);
+    set(validationObj, DraftMetadataProperties.Title, notBlank);
+    set(validationObj, DraftMetadataProperties.Description, notBlank);
+    set(validationObj, DraftMetadataProperties.License, notBlank);
 
-    validationFuncs.push(validateLength({
+    const pickOne: ValidatorFunction[] = [validateLength({
         min: 1,
         message: translations.validationErrors.mustSelectMinOne,
-    }));
-    set(validationObj, MetadataProperties.Subjects, validationFuncs);
+    })];
+    set(validationObj, DraftMetadataProperties.Subjects, pickOne);
     return validationObj;
 }

--- a/app/packages/registration-schema/validations.ts
+++ b/app/packages/registration-schema/validations.ts
@@ -1,7 +1,7 @@
 import { assert } from '@ember/debug';
 import { set } from '@ember/object';
 import { ValidationObject, ValidatorFunction } from 'ember-changeset-validations';
-import { validateLength, validatePresence } from 'ember-changeset-validations/validators';
+import { validatePresence } from 'ember-changeset-validations/validators';
 
 import translations from 'ember-osf-web/locales/en/translations';
 import DraftRegistration, { DraftMetadataProperties } from 'ember-osf-web/models/draft-registration';
@@ -80,11 +80,5 @@ export function buildMetadataValidations() {
     set(validationObj, DraftMetadataProperties.Title, notBlank);
     set(validationObj, DraftMetadataProperties.Description, notBlank);
     set(validationObj, DraftMetadataProperties.License, notBlank);
-
-    const pickOne: ValidatorFunction[] = [validateLength({
-        min: 1,
-        message: translations.validationErrors.mustSelectMinOne,
-    })];
-    set(validationObj, DraftMetadataProperties.Subjects, pickOne);
     return validationObj;
 }

--- a/lib/registries/addon/components/page-link/component.ts
+++ b/lib/registries/addon/components/page-link/component.ts
@@ -32,6 +32,7 @@ export default class PageLinkComponent extends Component {
     currentPageName?: string;
     label?: string;
     navMode?: string;
+    metadataIsValid?: boolean;
 
     @computed('pageName', 'pageIndex', 'pageManager', 'pageManager.pageHeadingText')
     get page(): string | undefined {
@@ -50,6 +51,12 @@ export default class PageLinkComponent extends Component {
         }
         if (this.pageManager && this.pageManager.isVisited) {
             if (this.pageManager.pageIsValid) {
+                return PageState.Valid;
+            }
+            return PageState.Invalid;
+        }
+        if (this.pageName === 'metadata') {
+            if (this.metadataIsValid) {
                 return PageState.Valid;
             }
             return PageState.Invalid;

--- a/lib/registries/addon/drafts/draft/draft-registration-manager.ts
+++ b/lib/registries/addon/drafts/draft/draft-registration-manager.ts
@@ -9,7 +9,12 @@ import DraftRegistration from 'ember-osf-web/models/draft-registration';
 import NodeModel from 'ember-osf-web/models/node';
 import SchemaBlock from 'ember-osf-web/models/schema-block';
 
-import { getPages, PageManager, RegistrationResponse } from 'ember-osf-web/packages/registration-schema';
+import {
+    buildMetadataValidations,
+    getPages,
+    PageManager,
+    RegistrationResponse,
+} from 'ember-osf-web/packages/registration-schema';
 import buildChangeset from 'ember-osf-web/utils/build-changeset';
 import { MetadataProperties } from './metadata/route';
 
@@ -73,7 +78,8 @@ export default class DraftRegistrationManager {
     @task
     initializeMetadataChangeset = task(function *(this: DraftRegistrationManager) {
         const { draftRegistration } = yield this.draftRegistrationAndNodeTask;
-        const metadataChangeset = buildChangeset(draftRegistration, {});
+        const metadataValidations = buildMetadataValidations();
+        const metadataChangeset = buildChangeset(draftRegistration, metadataValidations);
         set(this, 'metadataChangeset', metadataChangeset);
     });
 

--- a/lib/registries/addon/drafts/draft/draft-registration-manager.ts
+++ b/lib/registries/addon/drafts/draft/draft-registration-manager.ts
@@ -5,7 +5,7 @@ import { ChangesetDef } from 'ember-changeset/types';
 import { TaskInstance, timeout } from 'ember-concurrency';
 import { task } from 'ember-concurrency-decorators';
 
-import DraftRegistration from 'ember-osf-web/models/draft-registration';
+import DraftRegistration, { DraftMetadataProperties } from 'ember-osf-web/models/draft-registration';
 import NodeModel from 'ember-osf-web/models/node';
 import SchemaBlock from 'ember-osf-web/models/schema-block';
 
@@ -16,7 +16,6 @@ import {
     RegistrationResponse,
 } from 'ember-osf-web/packages/registration-schema';
 import buildChangeset from 'ember-osf-web/utils/build-changeset';
-import { MetadataProperties } from './metadata/route';
 
 export default class DraftRegistrationManager {
     // Required
@@ -41,7 +40,12 @@ export default class DraftRegistrationManager {
 
     @computed('pageManagers.{[],@each.pageIsValid}')
     get registrationResponsesIsValid() {
-        return this.pageManagers.every(pageManager => pageManager.pageIsValid);
+        return this.pageManagers.every(pageManager => pageManager.pageIsValid) && this.metadataIsValid;
+    }
+
+    @computed('metadataChangeset.isValid')
+    get metadataIsValid() {
+        return this.metadataChangeset.get('isValid');
     }
 
     @computed('onInput.lastComplete')
@@ -169,7 +173,7 @@ export default class DraftRegistrationManager {
 
     updateMetadataChangeset() {
         const { metadataChangeset, draftRegistration } = this;
-        Object.values(MetadataProperties).forEach(metadataKey => {
+        Object.values(DraftMetadataProperties).forEach(metadataKey => {
             set(
                 draftRegistration,
                 metadataKey,

--- a/lib/registries/addon/drafts/draft/metadata/route.ts
+++ b/lib/registries/addon/drafts/draft/metadata/route.ts
@@ -16,6 +16,7 @@ export enum MetadataProperties {
     Category = 'category',
     License = 'license',
     NodeLicense = 'nodeLicense',
+    Subjects = 'subjects',
 }
 
 export default class DraftRegistrationMetadataRoute extends Route {

--- a/lib/registries/addon/drafts/draft/metadata/route.ts
+++ b/lib/registries/addon/drafts/draft/metadata/route.ts
@@ -9,16 +9,6 @@ import Analytics from 'ember-osf-web/services/analytics';
 import { DraftRoute } from 'registries/drafts/draft/navigation-manager';
 import { DraftRouteModel } from '../route';
 
-export enum MetadataProperties {
-    Title = 'title',
-    Description = 'description',
-    Tags = 'tags',
-    Category = 'category',
-    License = 'license',
-    NodeLicense = 'nodeLicense',
-    Subjects = 'subjects',
-}
-
 export default class DraftRegistrationMetadataRoute extends Route {
     @service analytics!: Analytics;
     @service store!: DS.Store;

--- a/lib/registries/addon/drafts/draft/template.hbs
+++ b/lib/registries/addon/drafts/draft/template.hbs
@@ -41,6 +41,7 @@
                     @currentPageName={{navManager.currentRoute}}
                     @label='{{t 'registries.drafts.draft.metadata.page_label'}}'
                     @navMode={{leftNav.leftGutterMode}}
+                    @metadataIsValid={{draftManager.metadataIsValid}}
                 />
                 {{#each draftManager.pageManagers as |pageManager index|}}
                     <PageLink

--- a/tests/engines/registries/acceptance/draft/draft-test.ts
+++ b/tests/engines/registries/acceptance/draft/draft-test.ts
@@ -75,7 +75,6 @@ module('Registries | Acceptance | draft form', hooks => {
 
         await visit(`/registries/drafts/${registration.id}/`);
 
-        // TODO: Add necessary assertions to make sure metadata page undergoes validations
         // Metadata page
         assert.equal(currentRouteName(), 'registries.drafts.draft.metadata', 'Starts at metadata route');
         assert.dom('[data-test-link="metadata"] > [data-test-icon]')
@@ -91,7 +90,7 @@ module('Registries | Acceptance | draft form', hooks => {
         await click('[data-test-link="2-this-is-the-second-page"]');
         assert.equal(currentRouteName(), 'registries.drafts.draft.page', 'Goes to page route');
         assert.dom('[data-test-link="metadata"] > [data-test-icon]')
-            .hasClass('fa-circle', 'metadata is marked unvisited');
+            .hasClass('fa-check-circle-o', 'metadata is marked visited, valid');
         assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')
             .hasClass('fa-circle', 'page 1 is marked unvisited');
         assert.dom('[data-test-link="2-this-is-the-second-page"] > [data-test-icon]')
@@ -102,7 +101,7 @@ module('Registries | Acceptance | draft form', hooks => {
         // Navigate to first page
         await click('[data-test-link="1-first-page-of-test-schema"]');
         assert.dom('[data-test-link="metadata"] > [data-test-icon]')
-            .hasClass('fa-circle', 'metadata is marked unvisited');
+            .hasClass('fa-check-circle-o', 'metadata is marked visited, valid');
         assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')
             .hasClass('fa-circle-o', 'page 1 is marked current page');
         assert.dom('[data-test-link="2-this-is-the-second-page"] > [data-test-icon]')
@@ -114,9 +113,6 @@ module('Registries | Acceptance | draft form', hooks => {
         await click('[data-test-link="metadata"]');
         assert.dom('[data-test-link="metadata"] > [data-test-icon]')
             .hasClass('fa-circle-o', 'metadata is marked current again');
-        // TODO: Metadata route does not validate upon load. Please add this logic in later
-        // assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')
-        //     .hasClass('fa-exclamation-circle', 'page 1 is marked visited, invalid');
         assert.dom('[data-test-link="2-this-is-the-second-page"] > [data-test-icon]')
             .hasClass('fa-check-circle-o', 'page 2 is marked visited, valid');
         assert.dom('[data-test-link="review"] > [data-test-icon]')
@@ -126,7 +122,7 @@ module('Registries | Acceptance | draft form', hooks => {
         await click('[data-test-link="review"]');
         assert.equal(currentRouteName(), 'registries.drafts.draft.review', 'Goes to review route');
         assert.dom('[data-test-link="metadata"] > [data-test-icon]')
-            .hasClass('fa-circle', 'metadata is marked unvisited');
+            .hasClass('fa-check-circle-o', 'metadata is marked visited, valid');
         assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')
             .hasClass('fa-exclamation-circle', 'page 1 is marked visited, invalid');
         assert.dom('[data-test-link="2-this-is-the-second-page"] > [data-test-icon]')
@@ -400,9 +396,18 @@ module('Registries | Acceptance | draft form', hooks => {
             },
         );
 
-        await visit(`/registries/drafts/${registration.id}/1`);
+        await visit(`/registries/drafts/${registration.id}/`);
+        assert.dom('[data-test-link="metadata"] > [data-test-icon]')
+            .hasClass('fa-circle-o', 'on metadata page');
+        await fillIn('input[name="title"]', '');
+        assert.dom('input[name="title"] + div')
+            .hasClass('help-block', 'Metadata title has validation errors');
+
+        await click('[data-test-goto-next-page]');
         assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')
             .hasClass('fa-circle-o', 'on page 1');
+        assert.dom('[data-test-link="metadata"] > [data-test-icon]')
+            .hasClass('fa-exclamation-circle', 'Metadata has validation error');
 
         await click('[data-test-goto-next-page]');
         assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')
@@ -415,8 +420,12 @@ module('Registries | Acceptance | draft form', hooks => {
             .hasClass('help-block', 'page-one_short-text has validation errors');
         await fillIn(`input[name="${shortTextKey}"]`, 'ditto');
 
-        await click('[data-test-goto-next-page]');
+        await click('[data-test-goto-metadata]');
         assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')
             .hasClass('fa-check-circle-o', 'page 1 is now valid');
+        await fillIn('input[name="title"]', 'A non-empty, but still vague title');
+        await click('[data-test-goto-next-page]');
+        assert.dom('[data-test-link="metadata"] > [data-test-icon]')
+            .hasClass('fa-check-circle-o', 'metadata page is now valid');
     });
 });


### PR DESCRIPTION
- Ticket: [ENG-1420]
- Feature flag: n/a

## Purpose
- Add validations to the required inputs of the Draft Metadata page

## Summary of Changes
- Add `metadataIsValid` property to `DraftRegistrationModel` class
- Add new function to `app/registration-schema/validation.ts` to build the Metadata validations object
- refactored the existing validation building function for readability
- Moved + renamed `MetadataProperties` to `DraftMetadataProperties` under `draft-registration` model
- Add Subjects to the `DraftMetadataProperties` enum
- *Contributors will not be validated at this stage*
- Update `draft form` test to check metadata validations

## Side Effects
- All functionality should be maintained in the draft registration process

## QA Notes
This PR is responsible for adding error messages to the draft Metadata page. As functionality on that page is added, please check to make sure that required fields (title, description, license, and subjects) give an error message when they are in an invalid state (ie: blank or empty).


[ENG-1420]: https://openscience.atlassian.net/browse/ENG-1420