### PR TITLE
fix(types): don't clobber Record in ember-cli-mirage types

### DIFF
--- a/mirage/views/user-password.ts
+++ b/mirage/views/user-password.ts
@@ -6,7 +6,7 @@ export function updatePassword(this: HandlerContext) {
 
     if (attrs.existingPassword !== undefined) {
         if (attrs.existingPassword === existingPassword) {
-            return new Response(204, undefined, undefined);
+            return new Response(204);
         }
         return new Response(409, { 'Content-Type': 'application/vnd.api+json' }, {
             errors: [{

--- a/types/ember-cli-mirage/index.d.ts
+++ b/types/ember-cli-mirage/index.d.ts
@@ -16,17 +16,17 @@ interface AnyAttrs {
     [key: string]: any;
 }
 
-type Record < T > = T & { id: ID };
+type DatabaseRecord < T > = T & { id: ID };
 
 export interface DatabaseCollection<T = AnyAttrs> {
-    insert<S extends T | T[]>(data: S): S extends T ? Record<T> : Array<Record<T>>;
-    find<S extends ID | ID[]>(ids: S): S extends ID ? Record<T> : Array<Record<T>>;
-    findBy(query: T): Record<T>;
-    where(query: T | ((r: Record<T>) => boolean)): Array<Record<T>>;
-    update(attrs: T): Array<Record<T>>;
-    update(target: ID | T, attrs: T): Array<Record<T>>;
+    insert<S extends T | T[]>(data: S): S extends T ? DatabaseRecord<T> : Array<DatabaseRecord<T>>;
+    find<S extends ID | ID[]>(ids: S): S extends ID ? DatabaseRecord<T> : Array<DatabaseRecord<T>>;
+    findBy(query: T): DatabaseRecord<T>;
+    where(query: T | ((r: DatabaseRecord<T>) => boolean)): Array<DatabaseRecord<T>>;
+    update(attrs: T): Array<DatabaseRecord<T>>;
+    update(target: ID | T, attrs: T): Array<DatabaseRecord<T>>;
     remove(target?: ID | T): void;
-    firstOrCreate(query: T, attributesForCreate?: T): Record<T>;
+    firstOrCreate(query: T, attributesForCreate?: T): DatabaseRecord<T>;
 }
 
 export interface Database {
@@ -95,7 +95,7 @@ export type Schema = {
 };
 
 export declare class Response {
-    constructor(code: number, headers: Record<string, string>, body: any);
+    constructor(code: number, headers?: Record<string, string>, body?: {});
 }
 
 export interface Request {


### PR DESCRIPTION
- Ticket: n/a
- Feature flag: n/a

## Purpose

Our ember-cli-mirage types redefine the built-in `Record` utility type, which we attempt use elsewhere in the ember-cli-mirage type declaration file (for Response headers). This results in the `Response` constructor expecting args of incorrect type.

## Summary of Changes

* don't clobber the `Record` type
* update `Response` constructor with better types
* update usage of `Response` to no unnecessarily pass `undefined`

## Side Effects

None expected.

## QA Notes

No QA needed as this does not affect runtime or production code.
