### PR TITLE
[ENG-1440][Bug] Fix search bug in power-select

### DIFF
--- a/lib/osf-components/addon/components/editable-field/license-manager/component.ts
+++ b/lib/osf-components/addon/components/editable-field/license-manager/component.ts
@@ -3,7 +3,6 @@ import Component from '@ember/component';
 import { action, computed } from '@ember/object';
 import { alias, and, not, sort } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
-import { timeout } from 'ember-concurrency';
 import { task } from 'ember-concurrency-decorators';
 import DS from 'ember-data';
 import I18N from 'ember-i18n/services/i18n';
@@ -64,22 +63,6 @@ export default class LicenseManagerComponent extends Component {
     }
 
     @task({ restartable: true, on: 'didReceiveAttrs' })
-    queryLicenses = task(function *(this: LicenseManagerComponent, name?: string) {
-        if (this.licensesAcceptable && this.licensesAcceptable.length) {
-            if (name) {
-                yield timeout(500);
-            }
-
-            const licensesAcceptable = this.licensesAcceptable
-                .filter(license => license.get('name').includes(name || ''));
-
-            this.setProperties({ licensesAcceptable });
-            return licensesAcceptable;
-        }
-        return undefined;
-    });
-
-    @task({ on: 'init' })
     getAllProviderLicenses = task(function *(this: LicenseManagerComponent) {
         const provider = yield this.node.provider;
 

--- a/lib/osf-components/addon/components/editable-field/license-manager/template.hbs
+++ b/lib/osf-components/addon/components/editable-field/license-manager/template.hbs
@@ -7,7 +7,6 @@
     inEditMode=this.inEditMode
     userCanEdit=this.userCanEdit
     shouldShowField=this.shouldShowField
-    queryLicenses=(perform this.queryLicenses)
     registration=this.node
     onSave=(action this.onSave)
     onError=(action this.onError)

--- a/lib/registries/addon/components/registries-license-picker/template.hbs
+++ b/lib/registries/addon/components/registries-license-picker/template.hbs
@@ -11,10 +11,10 @@
             data-analytics-name='Select license'
             data-test-select-license
             @valuePath='license'
-            @search={{action @manager.queryLicenses}}
             @selected={{@manager.selectedLicense}}
             @options={{@manager.licensesAcceptable}}
             @onchange={{@manager.changeLicense}}
+            @searchField={{'name'}}
             @noMatchesMessage={{t 'registries.registration_metadata.no_matches'}}
             @placeholder={{t 'registries.registration_metadata.add_license'}}
             as |license|

--- a/tests/engines/registries/acceptance/overview/overview-test.ts
+++ b/tests/engines/registries/acceptance/overview/overview-test.ts
@@ -410,6 +410,8 @@ module('Registries | Acceptance | overview.overview', hooks => {
         await click('[data-test-edit-button="license"]');
 
         assert.dom('[data-test-license-edit-form]').isVisible();
+        await selectSearch('[data-test-select-license]', 'MIT');
+        assert.dom('.ember-power-select-options').hasText('MIT License');
         await selectSearch('[data-test-select-license]', 'No');
         assert.dom('.ember-power-select-options').hasText('No license');
         await selectChoose('[data-test-select-license]', 'No license');


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-1440
- Feature flag: n/a

## Purpose

The search functionality in the power-select on the registries overview page is currently broken and should be fixed.

## Summary of Changes

- Remove query search function and replace it with native functionality on the power-select

## Side Effects

`N/A`

## QA Notes

Should only affect components that are using the `registries-license-picker`. As of this PR, this will only be the editable license field, used on the registries overview page. However it will also eventually be used in the metadata license picker, used in registries submission.