### PR TITLE
[ENG-1400] Use sparse node for dashboard project list

### DIFF
--- a/app/adapters/sparse-node.ts
+++ b/app/adapters/sparse-node.ts
@@ -1,0 +1,13 @@
+import OsfAdapter from './osf-adapter';
+
+export default class SparseNodeAdapter extends OsfAdapter {
+    pathForType(_: string) {
+        return 'sparse/nodes';
+    }
+}
+
+declare module 'ember-data/types/registries/adapter' {
+    export default interface AdapterRegistry {
+        'sparse-node': SparseNodeAdapter;
+    } // eslint-disable-line semi
+}

--- a/app/dashboard/controller.ts
+++ b/app/dashboard/controller.ts
@@ -78,7 +78,7 @@ export default class Dashboard extends Controller {
 
         const user: User = yield this.currentUser.user;
 
-        const nodes: QueryHasManyResult<Node> = yield user.queryHasMany('nodes', {
+        const nodes: QueryHasManyResult<Node> = yield user.queryHasMany('sparseNodes', {
             embed: ['bibliographic_contributors', 'parent', 'root'],
             // eslint-disable-next-line ember/no-global-jquery
             filter: this.filter ? { title: $('<div>').text(this.filter).html() } : undefined,

--- a/app/models/sparse-node.ts
+++ b/app/models/sparse-node.ts
@@ -1,0 +1,53 @@
+import DS from 'ember-data';
+
+import { computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
+import ContributorModel from 'ember-osf-web/models/contributor';
+import NodeModel, { NodeCategory } from 'ember-osf-web/models/node';
+import OsfModel, { Permission } from './osf-model';
+
+const { attr, belongsTo, hasMany } = DS;
+
+export default class SparseNodeModel extends OsfModel {
+    @attr('fixstring') title!: string;
+    @attr('fixstring') description!: string;
+    @attr('node-category') category!: NodeCategory;
+    @attr('date') dateCreated!: Date;
+    @attr('date') dateModified!: Date;
+    @attr('boolean') fork!: boolean;
+    @alias('fork') isFork!: boolean;
+    @attr('fixstringarray') tags!: string[];
+    @attr('array') currentUserPermissions!: Permission[];
+    @attr('boolean') currentUserIsContributor!: boolean;
+    @attr('boolean') public!: boolean;
+
+    @hasMany('node', { inverse: 'parent' })
+    children!: DS.PromiseManyArray<NodeModel>;
+
+    @hasMany('contributor', { inverse: 'node' })
+    contributors!: DS.PromiseManyArray<ContributorModel>;
+
+    @hasMany('contributor', { inverse: null })
+    bibliographicContributors!: DS.PromiseManyArray<ContributorModel>;
+
+    @belongsTo('node', { inverse: 'children' })
+    parent!: DS.PromiseObject<NodeModel> & NodeModel;
+
+    @belongsTo('node', { inverse: null })
+    root!: DS.PromiseObject<NodeModel> & NodeModel;
+
+    @belongsTo('node', { inverse: null })
+    detail!: DS.PromiseObject<NodeModel> & NodeModel;
+
+    @computed('root')
+    get isRoot() {
+        const rootId = (this as SparseNodeModel).belongsTo('root').id();
+        return !rootId || rootId === this.id;
+    }
+}
+
+declare module 'ember-data/types/registries/model' {
+    export default interface ModelRegistry {
+        'sparse-node': SparseNodeModel;
+    } // eslint-disable-line semi
+}

--- a/app/models/user.ts
+++ b/app/models/user.ts
@@ -3,6 +3,7 @@ import { buildValidations, validator } from 'ember-cp-validations';
 import DS from 'ember-data';
 import { Link } from 'jsonapi-typescript';
 
+import SparseNodeModel from 'ember-osf-web/models/sparse-node';
 import ContributorModel from './contributor';
 import FileModel from './file';
 import InstitutionModel from './institution';
@@ -92,6 +93,9 @@ export default class UserModel extends OsfModel.extend(Validations) {
 
     @hasMany('user-email', { inverse: 'user' })
     emails!: DS.PromiseManyArray<UserEmailModel>;
+
+    @hasMany('sparse-node', { inverse: null })
+    sparseNodes!: DS.PromiseArray<SparseNodeModel>;
 
     // Calculated fields
     @alias('links.html') profileURL!: string;

--- a/app/serializers/sparse-node.ts
+++ b/app/serializers/sparse-node.ts
@@ -1,0 +1,10 @@
+import OsfSerializer from './osf-serializer';
+
+export default class SparseNodeSerializer extends OsfSerializer {
+}
+
+declare module 'ember-data/types/registries/serializer' {
+    export default interface SerializerRegistry {
+        'sparse-node': SparseNodeSerializer;
+    } // eslint-disable-line semi
+}

--- a/app/serializers/user.ts
+++ b/app/serializers/user.ts
@@ -1,6 +1,14 @@
 import DS from 'ember-data';
+import config from 'ember-get-config';
 import { Resource } from 'osf-api';
 import OsfSerializer from './osf-serializer';
+
+const {
+    OSF: {
+        apiUrl,
+        apiNamespace,
+    },
+} = config;
 
 export default class UserSerializer extends OsfSerializer {
     normalize(modelClass: DS.Model, resourceHash: Resource) {
@@ -9,7 +17,7 @@ export default class UserSerializer extends OsfSerializer {
         result.data.relationships!.sparseNodes = {
             links: {
                 related: {
-                    href: `http://localhost:8000/v2/sparse/users/${resourceHash.id}/nodes`,
+                    href: `${apiUrl}/${apiNamespace}/sparse/users/${resourceHash.id}/nodes`,
                 },
             },
         };

--- a/app/serializers/user.ts
+++ b/app/serializers/user.ts
@@ -1,6 +1,20 @@
+import DS from 'ember-data';
+import { Resource } from 'osf-api';
 import OsfSerializer from './osf-serializer';
 
 export default class UserSerializer extends OsfSerializer {
+    normalize(modelClass: DS.Model, resourceHash: Resource) {
+        const result = super.normalize(modelClass, resourceHash);
+        // Manually insert a `sparseNodes` relationship to the model because the API doesn't serialize this relationship
+        result.data.relationships!.sparseNodes = {
+            links: {
+                related: {
+                    href: `http://localhost:8000/v2/sparse/users/${resourceHash.id}/nodes`,
+                },
+            },
+        };
+        return result;
+    }
 }
 
 declare module 'ember-data/types/registries/serializer' {

--- a/app/serializers/user.ts
+++ b/app/serializers/user.ts
@@ -13,14 +13,17 @@ const {
 export default class UserSerializer extends OsfSerializer {
     normalize(modelClass: DS.Model, resourceHash: Resource) {
         const result = super.normalize(modelClass, resourceHash);
+        // TODO: ENG-1486
         // Manually insert a `sparseNodes` relationship to the model because the API doesn't serialize this relationship
-        result.data.relationships!.sparseNodes = {
-            links: {
-                related: {
-                    href: `${apiUrl}/${apiNamespace}/sparse/users/${resourceHash.id}/nodes`,
+        if (result.data.relationships!.sparseNodes === undefined) {
+            result.data.relationships!.sparseNodes = {
+                links: {
+                    related: {
+                        href: `${apiUrl}/${apiNamespace}/sparse/users/${resourceHash.id}/nodes`,
+                    },
                 },
-            },
-        };
+            };
+        }
         return result;
     }
 }

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -178,6 +178,8 @@ export default function(this: Server) {
     });
 
     this.get('/users/:id/nodes', userNodeList);
+    this.get('/sparse/users/:id/nodes', userNodeList);
+
     osfNestedResource(this, 'user', 'quickfiles', { only: ['index', 'show'] });
 
     osfResource(this, 'preprint-provider', { path: '/providers/preprints' });


### PR DESCRIPTION
- Ticket: [ENG-1400]
- Feature flag: n/a

## Purpose

Change dashboard project list to use sparse node endpoint.

## Summary of Changes

Add `SparseNode` model. Fake the `sparseNodes` relationship on user.

## Side Effects

There shouldn't be any.

## QA Notes

Make sure the dashboard page project list works exactly the same as before.

[ENG-1400]: https://openscience.atlassian.net/browse/ENG-1400