### PR TITLE
[Improvement] Add test for registries mobile navbar

### DIFF
--- a/lib/registries/addon/drafts/draft/-components/top-nav/template.hbs
+++ b/lib/registries/addon/drafts/draft/-components/top-nav/template.hbs
@@ -10,7 +10,7 @@
             </nav.buttons.default>
         </nav.bordered-section>
         <nav.bordered-section local-class='MobileNavPageLabelSection'>
-            <div local-class='MobileNavPageLabel'>
+            <div local-class='MobileNavPageLabel' data-test-page-label>
                 {{#if @inReview}}
                     {{t 'registries.drafts.draft.review.page_label'}}
                 {{else}}

--- a/tests/engines/registries/acceptance/draft/draft-test.ts
+++ b/tests/engines/registries/acceptance/draft/draft-test.ts
@@ -123,24 +123,28 @@ module('Registries | Acceptance | draft form', hooks => {
         assert.dom('[data-test-page-label]').containsText('First page of Test Schema');
 
         // Check next page arrow
-        assert.dom('[data-analytics-name="Sidenav back"]').isNotVisible();
-        assert.dom('[data-analytics-name="Sidenav next"]').isVisible();
-        await click('[data-analytics-name="Sidenav next"]');
+        assert.dom('[data-test-goto-previous-page]').isNotVisible();
+        assert.dom('[data-test-goto-next-page]').isVisible();
+        await click('[data-test-goto-next-page]');
 
         // Check that the header is expected
         assert.dom('[data-test-page-label]').containsText('This is the second page');
 
         // Check that left arrow exists
-        assert.dom('[data-analytics-name="Sidenav back"]').isVisible();
+        assert.dom('[data-test-goto-previous-page]').isVisible();
 
         // Check navigation to review page
         await click('[data-test-goto-review]');
         assert.dom('[data-test-page-label]').containsText('Review');
-        assert.dom('[data-test-analytics-name="Sidenav Next"]').isNotVisible();
+        assert.dom('[data-test-goto-next-page]').isNotVisible();
         assert.dom('[data-test-goto-register]').isVisible();
 
+        // check that register button is disabled
+        assert.dom('[data-test-goto-register]').isDisabled();
+        assert.dom('[data-test-invalid-responses-text]').isVisible();
+
         // Check that back button works
-        await click('[data-analytics-name="Sidenav back"]');
+        await click('[data-test-goto-previous-page]');
         assert.dom('[data-test-page-label]').containsText('This is the second page');
     });
 


### PR DESCRIPTION
- Ticket: []
- Feature flag: n/a

## Purpose

To add a test for the registries mobile navbar.

## Summary of Changes

- Add acceptance test for the mobile navbar

## Side Effects

`N/A`

## QA Notes

This is only adding a test and won't have any outward facing changes.
