### PR TITLE
[Bug] [ENG-1034] Fix Analytics page breaking on 'View Links' button click

### DIFF
--- a/lib/analytics-page/package.json
+++ b/lib/analytics-page/package.json
@@ -8,6 +8,7 @@
     "ember-bootstrap": "*",
     "ember-truth-helpers": "*",
     "ember-component-attributes": "*",
+    "ember-composable-helpers": "*",
     "ember-content-placeholders": "*",
     "ember-cli-babel": "*",
     "ember-cli-htmlbars": "*",


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-1034
- Feature flag: n/a

## Purpose

Currently the analytics page is breaking when users click to 'View Links'. This is because it needs `ember-composable-helpers` to be included in order to use the range helper.

## Summary of Changes

- Add `ember-composable-helpers` to the analytics engine

## Side Effects

`N/A`

## QA Notes

Because this was only adding a dependency to the analytics page, there shouldn't be any outward effects besides getting rid of the current issue. The modal should now display and will not break the page anymore on click.
