### PR TITLE
Temporarily disable handbook build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,31 +43,31 @@ jobs:
       after_success:
         - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
 
-    - stage: "deploy handbook"
-      if: |
-        branch = develop AND \
-        type != pull_request AND \
-        env(DEPLOY_KEY) IS present
-      before_install:
-        - curl -o- -L https://yarnpkg.com/install.sh | bash
-        - export PATH=$HOME/.yarn/bin:$PATH
-      install:
-        - yarn --prefer-offline --frozen-lockfile --ignore-engines
-      env:
-        - HANDBOOK_ENABLED=1
-        - MIRAGE_ENABLED=1
-        - SHOW_DEV_BANNER=1
-        - A11Y_AUDIT=0
-        - NODE_OPTIONS=--max-old-space-size=4096
-        - TARGET_BRANCH=gh-pages
-      script:
-        - export ROOT_URL="/${TRAVIS_REPO_SLUG##*\/}/"
-        - export ASSETS_PREFIX="${ROOT_URL}"
-        - ember build --environment=production
-        - cp dist/index.html dist/404.html
-      deploy:
-        provider: script
-        skip-cleanup: true
-        script: scripts/handbook_deploy.sh
-        on:
-          branch: develop
+#    - stage: "deploy handbook"
+#      if: |
+#        branch = develop AND \
+#        type != pull_request AND \
+#        env(DEPLOY_KEY) IS present
+#      before_install:
+#        - curl -o- -L https://yarnpkg.com/install.sh | bash
+#        - export PATH=$HOME/.yarn/bin:$PATH
+#      install:
+#        - yarn --prefer-offline --frozen-lockfile --ignore-engines
+#      env:
+#        - HANDBOOK_ENABLED=1
+#        - MIRAGE_ENABLED=1
+#        - SHOW_DEV_BANNER=1
+#        - A11Y_AUDIT=0
+#        - NODE_OPTIONS=--max-old-space-size=4096
+#        - TARGET_BRANCH=gh-pages
+#      script:
+#        - export ROOT_URL="/${TRAVIS_REPO_SLUG##*\/}/"
+#        - export ASSETS_PREFIX="${ROOT_URL}"
+#        - ember build --environment=production
+#        - cp dist/index.html dist/404.html
+#      deploy:
+#        provider: script
+#        skip-cleanup: true
+#        script: scripts/handbook_deploy.sh
+#        on:
+#          branch: develop


### PR DESCRIPTION
- Ticket: n/a
- Feature flag: n/a

## Purpose

Temporarily disable the handbook build since it's failing after the upgrade to Ember 3.15.

## Summary of Changes

* comment out "deploy handbook" stage in .travis.yml

## Side Effects

n/a

## QA Notes

n/a