### PR TITLE
[ENG-1451] Fix editable field.

### DIFF
--- a/lib/osf-components/addon/components/editable-field/license-manager/component.ts
+++ b/lib/osf-components/addon/components/editable-field/license-manager/component.ts
@@ -89,6 +89,7 @@ export default class LicenseManagerComponent extends Component {
 
     @action
     cancel() {
+        this.reset();
         this.set('requestedEditMode', false);
     }
 
@@ -118,11 +119,5 @@ export default class LicenseManagerComponent extends Component {
     @action
     onError() {
         this.toast.error(this.intl.t('registries.registration_metadata.edit_license.error'));
-    }
-
-    @action
-    onCancel() {
-        this.reset();
-        this.set('requestedEditMode', false);
     }
 }

--- a/lib/osf-components/addon/components/editable-field/license-manager/component.ts
+++ b/lib/osf-components/addon/components/editable-field/license-manager/component.ts
@@ -48,10 +48,10 @@ export default class LicenseManagerComponent extends Component {
     helpLink: string = 'https://help.osf.io/hc/en-us/articles/360019739014-Licensing';
     currentLicense!: License;
     currentNodeLicense!: NodeLicense;
+    selectedLicense!: License;
 
     @alias('node.userHasAdminPermission') userCanEdit!: boolean;
     @and('userCanEdit', 'requestedEditMode') inEditMode!: boolean;
-    @alias('node.license') selectedLicense!: License;
     @not('currentLicense') fieldIsEmpty!: License;
 
     @sort('selectedLicense.requiredFields', (a: string, b: string) => +(a > b))

--- a/lib/osf-components/addon/components/editable-field/license-manager/template.hbs
+++ b/lib/osf-components/addon/components/editable-field/license-manager/template.hbs
@@ -10,7 +10,6 @@
     registration=this.node
     onSave=(action this.onSave)
     onError=(action this.onError)
-    onCancel=(action this.onCancel)
     changeLicense=(action this.changeLicense)
     requiredFields=this.requiredFields
     selectedLicense=this.selectedLicense

--- a/lib/registries/addon/components/registries-license-picker/template.hbs
+++ b/lib/registries/addon/components/registries-license-picker/template.hbs
@@ -69,7 +69,7 @@
                 <OsfButton
                     @type='default'
                     @disabled={{form.disabled}}
-                    @onClick={{action @manager.onCancel}}
+                    @onClick={{action @manager.cancel}}
                 >
                     {{t 'general.cancel'}}
                 </OsfButton>


### PR DESCRIPTION
- Ticket: [ENG-1451]
- Feature flag: n/a

## Purpose

Fix overview page editable field weirdness.

## Summary of Changes

Somehow `selectedLicense` is an alias to `node.license`. Remove that alias.

## Side Effects

None.

## QA Notes

First go to overview page of a registration. Change the license and save. Then change the license again but instead of clicking `Save`, click `Cancel`. The change should not be persisted and the license field shows the correct license.

[ENG-1451]: https://openscience.atlassian.net/browse/ENG-1451