### PR TITLE
[No Ticket] [Bug] Update placeholder to accept a param

### DIFF
--- a/lib/app-components/addon/components/project-metadata/template.hbs
+++ b/lib/app-components/addon/components/project-metadata/template.hbs
@@ -23,6 +23,7 @@
             data-test-project-metadata-license-picker
             @node={{this.node}}
             @form={{form}}
+            @placeholder={{t 'general.required'}}
         >
             {{t 'app_components.project_metadata.field_license_label'}}
         </LicensePicker>

--- a/lib/osf-components/addon/components/license-picker/component.ts
+++ b/lib/osf-components/addon/components/license-picker/component.ts
@@ -27,6 +27,7 @@ export default class LicensePicker extends Component {
     node: Node = this.node;
     licensesAcceptable!: QueryHasManyResult<License>;
     helpLink: string = 'https://openscience.zendesk.com/hc/en-us/articles/360019739014';
+    placeholder: string = this.i18n.t('registries.registration_metadata.select_license');
 
     @alias('theme.provider') provider!: Provider;
     @alias('node.license') selected!: License;

--- a/lib/osf-components/addon/components/license-picker/component.ts
+++ b/lib/osf-components/addon/components/license-picker/component.ts
@@ -5,6 +5,7 @@ import { inject as service } from '@ember/service';
 import { timeout } from 'ember-concurrency';
 import { task } from 'ember-concurrency-decorators';
 import DS from 'ember-data';
+import Intl from 'ember-intl/services/intl';
 
 import { layout } from 'ember-osf-web/decorators/component';
 import License from 'ember-osf-web/models/license';
@@ -22,12 +23,13 @@ export default class LicensePicker extends Component {
     @service analytics!: Analytics;
     @service store!: DS.Store;
     @service theme!: Theme;
+    @service intl!: Intl;
 
     showText: boolean = false;
     node: Node = this.node;
     licensesAcceptable!: QueryHasManyResult<License>;
     helpLink: string = 'https://openscience.zendesk.com/hc/en-us/articles/360019739014';
-    placeholder: string = this.i18n.t('registries.registration_metadata.select_license');
+    placeholder: string = this.intl.t('registries.registration_metadata.select_license');
 
     @alias('theme.provider') provider!: Provider;
     @alias('node.license') selected!: License;

--- a/lib/osf-components/addon/components/license-picker/template.hbs
+++ b/lib/osf-components/addon/components/license-picker/template.hbs
@@ -8,7 +8,7 @@
     @options={{this.licensesAcceptable}}
     @onchange={{action this.changeLicense}}
     @noMatchesMessage={{t 'new_project.no_matches'}}
-    @placeholder={{t 'registries.registration_metadata.select_license'}}
+    @placeholder={{this.placeholder}}
     as |license|
 >
     {{license.name}}


### PR DESCRIPTION
- Ticket: `n/a`
- Feature flag: `n/a`

## Purpose

With the draft-metadata license picker changes also came a change to the placeholder from `Required` to `Select license`. This change causes an issue with collections though since it needs the required placeholder there. This will add a new placeholder param that can be passed into the `license-picker` to help it be more dynamic.

## Summary of Changes

- Add `placeholder` param with default value of `Select license`
- Update the collections instance of the `license-picker` to also pass in a value of `Required` to the placeholder

## Side Effects

This shouldn't have any side effects.

## QA Notes

This will affect the `license-picker` component, which is used in three places: the editable metadata field on the registries overview page, the draft-metadata section in registries submission, and on the collections submission/edit page. This will only affect the value of the placeholder in the drop-down list. It should show `Select license` as a default value, but should change to `Required` on collections.
