### PR TITLE
[ENG-1452] Lookup file detail using file long id not guid

### DIFF
--- a/app/guid-file/route.ts
+++ b/app/guid-file/route.ts
@@ -42,8 +42,12 @@ export default class GuidFile extends Route {
     });
 
     async model(params: { guid: string }) {
+        const { guid } = params;
         try {
-            const file = await this.store.findRecord('file', params.guid);
+            let file = this.store.peekAll('file').findBy('guid', guid);
+            if (!file) {
+                file = await this.store.findRecord('file', guid);
+            }
             const fileId = file.get('id');
             const fileUser: User = await file.get('user');
             const user: User = await fileUser.reload();
@@ -59,7 +63,7 @@ export default class GuidFile extends Route {
                 files,
             };
         } catch (error) {
-            this.transitionTo('not-found', params.guid);
+            this.transitionTo('not-found', guid);
             throw error;
         }
     }

--- a/tests/acceptance/guid-user/quickfiles-test.ts
+++ b/tests/acceptance/guid-user/quickfiles-test.ts
@@ -1,5 +1,6 @@
 import {
     click as untrackedClick,
+    currentRouteName,
     currentURL,
     fillIn,
     settled,
@@ -512,10 +513,12 @@ module('Acceptance | Guid User Quickfiles', hooks => {
             await untrackedClick(`[data-test-file-icon-and-name="${file.name}"]`);
             assert.dom('[data-test-view-button]').exists();
             await click('[data-test-view-button]');
-            assert.equal(currentURL(), '/xyzzy');
+            assert.equal(currentRouteName(), 'guid-file');
+            assert.ok(currentURL().startsWith('/--file/xyzzy'));
             await visit(`/--user/${currentUser.id}/quickfiles`);
             await click('[data-test-file-item-link]');
-            assert.equal(currentURL(), '/xyzzy');
+            assert.equal(currentRouteName(), 'guid-file');
+            assert.ok(currentURL().startsWith('/--file/xyzzy'));
         });
 
         test('can filter files', async assert => {


### PR DESCRIPTION
- Ticket: [ENG-1452]
- Feature flag: n/a

## Purpose

Due to recent upgrades ember-data, the frontend errors when
we lookup file detail using the guid `/v2/files/wsfvj` and return id as the long _id.
If the file record is present in the store with identifier (ember-data) `file:file_long_id` (say you've loaded the list of quickfiles before the detail view),  ember-data IdentifierCache triesto make a new identifier (`file:guid`) but realize that record already exists and fails to merge both identifiers. 

<details>
  <summary>console errors</summary>
  
"Error: Failed to update the 'id' for the RecordIdentifier 'file:wsfvj (@ember-data:lid-file-wsfvj)' to '5df166775ba94a0009c70765', because that id is already in use by 'file:5df166775ba94a0009c70765 (@ember-data:lid-file-5df166775ba94a0009c70765)'
    at IdentifierCache._merge
    at IdentifierCache._mergeRecordIdentifiers
    at IdentifierCache.updateRecordIdentifier
</details>

## Summary of Changes

To avoid recordIdentifier merge conflicts, first check the store for the file record (using the guid).
If the record is present, use it. Otherwise, query the api using the guid.

## QA Notes

Verify that both the following cases work.

1)  Go to user's quickfiles yours or any other user. Click to view one of the files.
(this currently 404s)
2)  Go straight to view a user quickfile. 


[ENG-1452]: https://openscience.atlassian.net/browse/ENG-1452