### PR TITLE
[No Ticket] [Bug] Update metadata test

### DIFF
--- a/lib/registries/addon/drafts/draft/-components/top-nav/template.hbs
+++ b/lib/registries/addon/drafts/draft/-components/top-nav/template.hbs
@@ -16,8 +16,10 @@
         </nav.bordered-section>
         <nav.bordered-section local-class='MobileNavPageLabelSection'>
             <div local-class='MobileNavPageLabel' data-test-page-label>
-                {{#if @inReview}}
+                {{#if @navManager.inReview}}
                     {{t 'registries.drafts.draft.review.page_label'}}
+                {{else if @navManager.inMetadata}}
+                    {{t 'registries.drafts.draft.metadata.page_label'}}
                 {{else}}
                     {{@navManager.currentPageManager.pageHeadingText}}
                 {{/if}}

--- a/lib/registries/addon/drafts/draft/review/styles.scss
+++ b/lib/registries/addon/drafts/draft/review/styles.scss
@@ -1,0 +1,4 @@
+.WarningMessage {
+    text-align: center;
+    padding-top: 10px;
+}

--- a/lib/registries/addon/drafts/draft/styles.scss
+++ b/lib/registries/addon/drafts/draft/styles.scss
@@ -112,11 +112,6 @@
     width: 100%;
 }
 
-.WarningMessage {
-    text-align: center;
-    padding-top: 10px;
-}
-
 .MobileNavPageLabelSection {
     min-width: 0;
     width: 100%;

--- a/tests/engines/registries/acceptance/draft/draft-test.ts
+++ b/tests/engines/registries/acceptance/draft/draft-test.ts
@@ -209,14 +209,23 @@ module('Registries | Acceptance | draft form', hooks => {
         await visit(`/registries/drafts/${registration.id}/`);
         setBreakpoint('mobile');
 
-        assert.ok(currentURL().includes(`/registries/drafts/${registration.id}/1-`), 'At first schema page');
+        assert.ok(currentURL().includes(`/registries/drafts/${registration.id}/metadata`), 'At metadata page');
+
+        // Check header
+        assert.dom('[data-test-page-label]').containsText('Metadata');
+
+        // Check next page arrow
+        assert.dom('[data-test-goto-previous-page]').isNotVisible();
+        assert.dom('[data-test-goto-next-page]').isVisible();
+        await click('[data-test-goto-next-page]');
 
         // Check header
         assert.dom('[data-test-page-label]').containsText('First page of Test Schema');
 
         // Check next page arrow
-        assert.dom('[data-test-goto-previous-page]').isNotVisible();
-        assert.dom('[data-test-goto-next-page]').isVisible();
+        assert.dom('[data-test-goto-metadata]').isVisible();
+
+        // Next page
         await click('[data-test-goto-next-page]');
 
         // Check that the header is expected
@@ -224,6 +233,7 @@ module('Registries | Acceptance | draft form', hooks => {
 
         // Check that left arrow exists
         assert.dom('[data-test-goto-previous-page]').isVisible();
+        assert.dom('[data-test-goto-metadata]').isNotVisible();
 
         // Check navigation to review page
         await click('[data-test-goto-review]');


### PR DESCRIPTION
- Ticket: `n/a`
- Feature flag: `n/a`

## Purpose

To fix tests on the draft_manager branch. Currently failing because it isn't expecting the new metadata page.

This will also fix the headings for the metadata and review pages on the mobile navbar.

## Summary of Changes

- Update test to anticipate being at the metadata page when first going to the registries' submission page
- Fix the mobile navbar headers

## Side Effects

`n/a`

## QA Notes

This will affect tests (which shouldn't have any side effects), and the header on the mobile navbar on registries submission. It shouldn't affect anything else.
