### PR TITLE
[No Ticket] [Bug] Fix metadata button border

### DIFF
--- a/lib/registries/addon/drafts/draft/-components/top-nav/styles.scss
+++ b/lib/registries/addon/drafts/draft/-components/top-nav/styles.scss
@@ -4,3 +4,7 @@
     z-index: 1;
     border-bottom: 1px solid $color-border-white;
 }
+
+.MetadataButton {
+    padding: 15px;
+}

--- a/lib/registries/addon/drafts/draft/-components/top-nav/template.hbs
+++ b/lib/registries/addon/drafts/draft/-components/top-nav/template.hbs
@@ -31,6 +31,7 @@
                     data-test-goto-metadata
                     data-analytics-name='Sidenav back to metadata'
                     aria-label={{t 'osf-components.registries-top-nav.metadata'}}
+                    local-class='MetadataButton'
                     @route='registries.drafts.draft.metadata'
                     @models={{array @draftManager.draftId }}
                 >


### PR DESCRIPTION
- Ticket: `n/a`
- Feature flag: `n/a`

## Purpose

The metadata button on the mobile navbar on registries submission currently has a border that goes outside of its container.

## Summary of Changes

- Change padding of the metadata button from `16px` to `15px`

## Side Effects

`n/a`

## QA Notes

This should only affect the metadata button on the mobile navbar on registries submission. It should only remove the overflowing border on the right side of the button. There shouldn't be any other notable effects from this.
