### PR TITLE
[ENG-1288] fix special char encoding for citation widget

### DIFF
--- a/lib/osf-components/addon/components/citation-viewer/component.ts
+++ b/lib/osf-components/addon/components/citation-viewer/component.ts
@@ -85,6 +85,6 @@ export default class CitationViewer extends Component {
             url: citationUrl(this.citable, citationStyle.id),
         });
         const citationString = response.data.attributes!.citation;
-        return typeof citationString = 'string' ? fixSpecialChars(citationString) : citationString;
+        return typeof citationString === 'string' ? fixSpecialChars(citationString) : citationString;
     });
 }

--- a/lib/osf-components/addon/components/citation-viewer/component.ts
+++ b/lib/osf-components/addon/components/citation-viewer/component.ts
@@ -9,6 +9,7 @@ import CitationStyle from 'ember-osf-web/models/citation-style';
 import Node from 'ember-osf-web/models/node';
 import Preprint from 'ember-osf-web/models/preprint';
 import CurrentUser from 'ember-osf-web/services/current-user';
+import fixSpecialChars from 'ember-osf-web/utils/fix-special-char';
 import getRelatedHref from 'ember-osf-web/utils/get-related-href';
 import { addPathSegment } from 'ember-osf-web/utils/url-parts';
 import { SingleResourceDocument } from 'osf-api';
@@ -60,7 +61,7 @@ export default class CitationViewer extends Component {
         );
         return responses.map((r, i) => ({
             ...defaultCitations[i],
-            citation: r.data.attributes!.citation,
+            citation: fixSpecialChars(r.data.attributes!.citation as string),
         }));
     });
 
@@ -81,6 +82,7 @@ export default class CitationViewer extends Component {
         const response: SingleResourceDocument = yield this.currentUser.authenticatedAJAX({
             url: citationUrl(this.citable, citationStyle.id),
         });
-        return response.data.attributes!.citation;
+        const citationString = response.data.attributes!.citation;
+        return fixSpecialChars(citationString as string);
     });
 }

--- a/lib/osf-components/addon/components/citation-viewer/component.ts
+++ b/lib/osf-components/addon/components/citation-viewer/component.ts
@@ -61,7 +61,9 @@ export default class CitationViewer extends Component {
         );
         return responses.map((r, i) => ({
             ...defaultCitations[i],
-            citation: fixSpecialChars(r.data.attributes!.citation as string),
+            citation: typeof r.data.attributes!.citation === 'string' ?
+                fixSpecialChars(r.data.attributes!.citation) :
+                r.data.attributes!.citation,
         }));
     });
 
@@ -83,6 +85,6 @@ export default class CitationViewer extends Component {
             url: citationUrl(this.citable, citationStyle.id),
         });
         const citationString = response.data.attributes!.citation;
-        return fixSpecialChars(citationString as string);
+        return typeof citationString = 'string' ? fixSpecialChars(citationString) : citationString;
     });
 }


### PR DESCRIPTION
- Ticket: [ENG-1288]
- Feature flag: n/a

## Purpose

Fix special character encoding for `citation-viewer` component.

## Summary of Changes

Use `fixSpecialChars` for the citation endpoint response. It would be nicer if we use ember-data to fetch these citations though...

## QA Notes

Citation on registration overview page should render special characters without escaping.

[ENG-1288]: https://openscience.atlassian.net/browse/ENG-1288