### PR TITLE
upgrade all things bugs fixes

### DIFF
--- a/app/packages/registration-schema/page-manager.ts
+++ b/app/packages/registration-schema/page-manager.ts
@@ -22,7 +22,6 @@ export class PageManager {
         this.schemaBlockGroups = getSchemaBlockGroups(pageSchemaBlocks);
         if (this.schemaBlockGroups) {
             this.pageHeadingText = this.schemaBlockGroups[0].labelBlock!.displayText!;
-            this.isVisited = false;
 
             this.isVisited = this.schemaBlockGroups.some(
                 ({ registrationResponseKey: key }) => Boolean(key && (key in registrationResponses)),
@@ -35,7 +34,7 @@ export class PageManager {
                 validations,
             ) as ChangesetDef;
 
-            if (Object.values(registrationResponses).length) {
+            if (this.isVisited) {
                 this.changeset.validate();
             }
         } else {

--- a/app/packages/registration-schema/page-manager.ts
+++ b/app/packages/registration-schema/page-manager.ts
@@ -34,10 +34,6 @@ export class PageManager {
                 lookupValidator(validations),
                 validations,
             ) as ChangesetDef;
-
-            if (Object.values(registrationResponses).length) {
-                this.changeset.validate();
-            }
         } else {
             assert('PageManager: schemaBlockGroups is not defined.');
         }

--- a/app/packages/registration-schema/page-manager.ts
+++ b/app/packages/registration-schema/page-manager.ts
@@ -34,6 +34,9 @@ export class PageManager {
                 lookupValidator(validations),
                 validations,
             ) as ChangesetDef;
+            if (Object.values(registrationResponses).length) {
+                this.changeset.validate();
+            }
         } else {
             assert('PageManager: schemaBlockGroups is not defined.');
         }

--- a/app/packages/registration-schema/page-manager.ts
+++ b/app/packages/registration-schema/page-manager.ts
@@ -34,6 +34,7 @@ export class PageManager {
                 lookupValidator(validations),
                 validations,
             ) as ChangesetDef;
+
             if (Object.values(registrationResponses).length) {
                 this.changeset.validate();
             }

--- a/app/serializers/draft-registration.ts
+++ b/app/serializers/draft-registration.ts
@@ -9,7 +9,7 @@ import {
     ResponseValue,
 } from 'ember-osf-web/packages/registration-schema';
 import { mapKeysAndValues } from 'ember-osf-web/utils/map-keys';
-import { SingleResourceDocument } from 'osf-api';
+import { Resource } from 'osf-api';
 import OsfSerializer from './osf-serializer';
 
 interface JsonPayload {
@@ -67,24 +67,18 @@ function serializeRegistrationResponses(value: NormalizedResponseValue) {
 }
 
 export default class DraftRegistrationSerializer extends OsfSerializer {
-    normalizeResponse(
-        store: DS.Store,
-        primaryModelClass: any,
-        payload: SingleResourceDocument,
-        id: string,
-        requestType: string,
-    ) {
-        if (payload.data.attributes) {
-            const registrationResponses = payload.data.attributes.registration_responses as RegistrationResponse;
+    normalize(modelClass: DS.Model, resourceHash: Resource) {
+        if (resourceHash.attributes) {
+            const registrationResponses = resourceHash.attributes.registration_responses as RegistrationResponse;
             // @ts-ignore
             // eslint-disable-next-line no-param-reassign
-            payload.data.attributes.registration_responses = mapKeysAndValues(
+            resourceHash.attributes.registration_responses = mapKeysAndValues(
                 registrationResponses || {},
                 key => key,
-                value => normalizeRegistrationResponses(value, store),
+                value => normalizeRegistrationResponses(value, this.store),
             ) as NormalizedRegistrationResponse;
         }
-        return super.normalizeResponse(store, primaryModelClass, payload, id, requestType);
+        return super.normalize(modelClass, resourceHash) as { data: Resource };
     }
 
     serializeAttribute(snapshot: DS.Snapshot, json: JsonPayload, key: string, attribute: object): void {

--- a/app/validators/validate-response-format.ts
+++ b/app/validators/validate-response-format.ts
@@ -10,7 +10,7 @@ export function validateFileList(responseKey: string, node?: NodeModel): Validat
         if (newValue && node) {
             const fileReloads: Array<() => Promise<File>> = [];
             newValue.forEach(file => {
-                if (file && !file.isError && typeof file.reload === 'function') {
+                if (file && !file.isError) {
                     fileReloads.push(file.reload());
                 }
             });

--- a/app/validators/validate-response-format.ts
+++ b/app/validators/validate-response-format.ts
@@ -8,7 +8,13 @@ import { allSettled } from 'rsvp';
 export function validateFileList(responseKey: string, node?: NodeModel): ValidatorFunction {
     return async (_: string, newValue: File[]) => {
         if (newValue && node) {
-            await allSettled(newValue.map(file => file.reload()));
+            const fileReloads: Array<() => Promise<File>> = [];
+            newValue.forEach(file => {
+                if (file && !file.isError) {
+                    fileReloads.push(file.reload());
+                }
+            });
+            await allSettled(fileReloads);
 
             const detachedFiles = [];
 

--- a/app/validators/validate-response-format.ts
+++ b/app/validators/validate-response-format.ts
@@ -10,7 +10,7 @@ export function validateFileList(responseKey: string, node?: NodeModel): Validat
         if (newValue && node) {
             const fileReloads: Array<() => Promise<File>> = [];
             newValue.forEach(file => {
-                if (file && !file.isError) {
+                if (file && !file.isError && typeof file.reload === 'function') {
                     fileReloads.push(file.reload());
                 }
             });

--- a/lib/osf-components/addon/components/registries/draft-registration-manager/component.ts
+++ b/lib/osf-components/addon/components/registries/draft-registration-manager/component.ts
@@ -198,15 +198,19 @@ export default class DraftRegistrationManagerComponent extends Component {
     });
 
     @action
-    onPageChange(_: HTMLElement, [currentPage, inReview]: [number, boolean]) {
+    onPageChange(_: HTMLElement, [currentPage, inReview, onLoad]: [number, boolean, boolean]) {
         if (inReview) {
             this.markAllPagesVisited();
             this.saveAllVisitedPages.perform();
-            this.validateAllVisitedPages();
+            if (!onLoad) {
+                this.validateAllVisitedPages();
+            }
         } else {
             if (this.hasVisitedPages) {
                 this.saveAllVisitedPages.perform();
-                this.validateAllVisitedPages();
+                if (!onLoad) {
+                    this.validateAllVisitedPages();
+                }
             }
             this.markCurrentPageVisited(currentPage);
         }

--- a/lib/osf-components/addon/components/registries/draft-registration-manager/component.ts
+++ b/lib/osf-components/addon/components/registries/draft-registration-manager/component.ts
@@ -201,14 +201,14 @@ export default class DraftRegistrationManagerComponent extends Component {
     onPageChange(_: HTMLElement, [currentPage, inReview, onLoad]: [number, boolean, boolean]) {
         if (inReview) {
             this.markAllPagesVisited();
-            this.saveAllVisitedPages.perform();
             if (!onLoad) {
+                this.saveAllVisitedPages.perform();
                 this.validateAllVisitedPages();
             }
         } else {
             if (this.hasVisitedPages) {
-                this.saveAllVisitedPages.perform();
                 if (!onLoad) {
+                    this.saveAllVisitedPages.perform();
                     this.validateAllVisitedPages();
                 }
             }

--- a/lib/osf-components/addon/components/registries/draft-registration-manager/component.ts
+++ b/lib/osf-components/addon/components/registries/draft-registration-manager/component.ts
@@ -201,12 +201,12 @@ export default class DraftRegistrationManagerComponent extends Component {
     onPageChange(_: HTMLElement, [currentPage, inReview]: [number, boolean]) {
         if (inReview) {
             this.markAllPagesVisited();
-            this.validateAllVisitedPages();
             this.saveAllVisitedPages.perform();
+            this.validateAllVisitedPages();
         } else {
             if (this.hasVisitedPages) {
-                this.validateAllVisitedPages();
                 this.saveAllVisitedPages.perform();
+                this.validateAllVisitedPages();
             }
             this.markCurrentPageVisited(currentPage);
         }

--- a/lib/osf-components/addon/components/registries/draft-registration-manager/component.ts
+++ b/lib/osf-components/addon/components/registries/draft-registration-manager/component.ts
@@ -35,6 +35,7 @@ export interface DraftRegistrationManager {
 
     onInput(): void;
     onPageChange(): void;
+    onPageLoad(): void;
 }
 
 @tagName('')
@@ -198,20 +199,25 @@ export default class DraftRegistrationManagerComponent extends Component {
     });
 
     @action
-    onPageChange(_: HTMLElement, [currentPage, inReview, onLoad]: [number, boolean, boolean]) {
+    onPageChange(_: HTMLElement, [currentPage, inReview]: [number, boolean]) {
         if (inReview) {
             this.markAllPagesVisited();
-            if (!onLoad) {
+            this.saveAllVisitedPages.perform();
+            this.validateAllVisitedPages();
+        } else {
+            if (this.hasVisitedPages) {
                 this.saveAllVisitedPages.perform();
                 this.validateAllVisitedPages();
             }
+            this.markCurrentPageVisited(currentPage);
+        }
+    }
+
+    @action
+    onPageLoad(_: HTMLElement, [currentPage, inReview]: [number, boolean]) {
+        if (inReview) {
+            this.markAllPagesVisited();
         } else {
-            if (this.hasVisitedPages) {
-                if (!onLoad) {
-                    this.saveAllVisitedPages.perform();
-                    this.validateAllVisitedPages();
-                }
-            }
             this.markCurrentPageVisited(currentPage);
         }
     }

--- a/lib/osf-components/addon/components/registries/draft-registration-manager/component.ts
+++ b/lib/osf-components/addon/components/registries/draft-registration-manager/component.ts
@@ -21,7 +21,7 @@ import template from './template';
 export interface DraftRegistrationManager {
     registrationResponsesIsValid: boolean;
     hasInvalidResponses: boolean;
-    registrationResponses: RegistrationResponse;
+    draftRegistration: DraftRegistration;
     schemaBlocks: SchemaBlock[];
     currentPageManager: PageManager;
     pageManagers: PageManager[];

--- a/lib/osf-components/addon/components/registries/draft-registration-manager/template.hbs
+++ b/lib/osf-components/addon/components/registries/draft-registration-manager/template.hbs
@@ -14,6 +14,7 @@
     lastSaveFailed=this.lastSaveFailed
     schemaBlocks=this.schemaBlocks
 
-    onPageChange=(action this.onPageChange)
+    onPageChange=this.onPageChange
+    onPageLoad=this.onPageLoad
     onInput=(perform this.onInput)
 )}}

--- a/lib/osf-components/addon/components/registries/draft-registration-manager/template.hbs
+++ b/lib/osf-components/addon/components/registries/draft-registration-manager/template.hbs
@@ -4,7 +4,7 @@
     currentPage=this.currentPage
     registrationResponsesIsValid=this.registrationResponsesIsValid
     hasInvalidResponses=this.hasInvalidResponses
-    registrationResponses=this.registrationResponses
+    draftRegistration=this.draftRegistration
     nextPageParam=this.nextPageParam
     prevPageParam=this.prevPageParam
     pageManagers=this.pageManagers

--- a/lib/osf-components/addon/components/registries/review-form-renderer/template.hbs
+++ b/lib/osf-components/addon/components/registries/review-form-renderer/template.hbs
@@ -10,7 +10,7 @@
             @renderStrategy={{
                 component
                 'registries/schema-block-renderer/read-only/mapper'
-                registrationResponses=@draftManager.registrationResponses
+                registrationResponses=@draftManager.draftRegistration.registrationResponses
                 node=@node
                 changeset=pageManager.changeset
                 draftManager=@draftManager

--- a/lib/registries/addon/drafts/draft/page/template.hbs
+++ b/lib/registries/addon/drafts/draft/page/template.hbs
@@ -72,7 +72,7 @@
                 </layout.leftNav>
                 <layout.main local-class='Main'>
                     <main
-                        {{did-insert draftManager.onPageChange this.pageIndex this.inReview}}
+                        {{did-insert draftManager.onPageChange this.pageIndex this.inReview true}}
                         {{did-update draftManager.onPageChange this.pageIndex this.inReview}}
                     >
                         {{#if this.inReview}}

--- a/lib/registries/addon/drafts/draft/page/template.hbs
+++ b/lib/registries/addon/drafts/draft/page/template.hbs
@@ -72,7 +72,7 @@
                 </layout.leftNav>
                 <layout.main local-class='Main'>
                     <main
-                        {{did-insert draftManager.onPageChange this.pageIndex this.inReview true}}
+                        {{did-insert draftManager.onPageLoad this.pageIndex this.inReview}}
                         {{did-update draftManager.onPageChange this.pageIndex this.inReview}}
                     >
                         {{#if this.inReview}}

--- a/tests/engines/registries/acceptance/draft/draft-test.ts
+++ b/tests/engines/registries/acceptance/draft/draft-test.ts
@@ -295,7 +295,7 @@ module('Registries | Acceptance | draft form', hooks => {
         assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')
             .hasClass('fa-circle-o', 'page 1 is current page');
 
-        await visit(`/registries/drafts/${registration.id}/2`);
+        await click('[data-test-goto-next-page]');
         assert.dom('[data-test-link="2-this-is-the-second-page"] > [data-test-icon]')
             .hasClass('fa-circle-o', 'page 2 is current page');
         assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')

--- a/tests/engines/registries/acceptance/draft/draft-test.ts
+++ b/tests/engines/registries/acceptance/draft/draft-test.ts
@@ -199,7 +199,7 @@ module('Registries | Acceptance | draft form', hooks => {
 
         await visit(`/registries/drafts/${registration.id}/`);
 
-        await visit(`/registries/drafts/${registration.id}/review`);
+        await click('[data-test-link="review"]');
 
         assert.dom('[data-test-goto-register]').isDisabled();
         assert.dom('[data-test-invalid-responses-text]').isVisible();
@@ -276,7 +276,7 @@ module('Registries | Acceptance | draft form', hooks => {
         assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')
             .hasClass('fa-circle', 'page 1 is unvisited, not validated');
 
-        await visit(`/registries/drafts/${registration.id}/review`);
+        await click('[data-test-goto-review]');
 
         assert.dom('[data-test-link="2-this-is-the-second-page"] > [data-test-icon]')
             .hasClass('fa-check-circle-o', 'page 2 is marked visited, valid');
@@ -313,18 +313,20 @@ module('Registries | Acceptance | draft form', hooks => {
         assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')
             .hasClass('fa-circle-o', 'on page 1');
 
-        await visit(`/registries/drafts/${registration.id}/2`);
+        await click('[data-test-goto-next-page]');
         assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')
             .hasClass('fa-exclamation-circle', 'page 1 is invalid');
 
-        await visit(`/registries/drafts/${registration.id}/1`);
+        await click('[data-test-goto-previous-page]');
 
         const shortTextKey = deserializeResponseKey('page-one_short-text');
         assert.dom(`input[name="${shortTextKey}"] + div`)
             .hasClass('help-block', 'page-one_short-text has validation errors');
         await fillIn(`input[name="${shortTextKey}"]`, 'ditto');
 
-        await visit(`/registries/drafts/${registration.id}/2`);
+        await click('[data-test-link="review"]');
+
+        assert.dom(`[data-test-read-only-response="${shortTextKey}"]`).hasText('ditto');
         assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')
             .hasClass('fa-check-circle-o', 'page 1 is now valid');
     });


### PR DESCRIPTION
## Purpose

- Fix out-of-sync registrationResponses when user switches to review right after modifying
an input field.
- Avoid reloading known deleted files
- Don't save or validate visited page on page load, because there aren't changes and each visited page's changeset is validated when its page manager is instantiated.

## Summary of Changes

- use `registration.registrationResponses` instead of `draftManager.registrationResponses` 
- Avoid reloading known deleted files. They won't come back.
- Add tests; Update tests to use navigation controls instead of reloading the whole app with `visit`; this will help catch more bugs.
- Fix file validations TypeError; [sentry error logs](https://staging-sentry.cos.io/cos/ember-osf-web-27/issues/7864/) We were not normalizing array data (list of draft-registration), so when you transition from draft-registration list to a particular draft, `registrationResponses` still have file references instead of file models array.
- Avoid double validations on load: we were validating at page instantiation (if the page has got responses) and running `saveAllVisitedPages` in the `onPageChange` that runs on every page. This would be fine if we do not have async validations (file). 
- Validate pages (async) after saving changes. Granted it's possible to leave a page before onInput terminates, we should save the responses on the changeset of the previous page upon
entering new page first thing. Validation (also async) can follow.

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- Go to any draft registration schema page, modify an input field say title or description, quickly switch to review page, does the modified response show? It should.