### PR TITLE
[ENG-1527] Fix rightnav issues

### DIFF
--- a/lib/registries/addon/drafts/draft/navigation-manager.ts
+++ b/lib/registries/addon/drafts/draft/navigation-manager.ts
@@ -52,7 +52,7 @@ export default class NavigationManager {
         return pageManagers.length - 1;
     }
 
-    @computed('currentPage', 'pageManagers.[]', 'currentRoute')
+    @computed('currentPage', 'pageManagers.[]', 'inMetadata', 'lastPage')
     get nextPageParam() {
         const {
             pageManagers,
@@ -77,7 +77,7 @@ export default class NavigationManager {
         return '';
     }
 
-    @computed('currentPage', 'pageManagers.[]', 'currentRoute')
+    @computed('currentPage', 'pageManagers.[]', 'inReview', 'lastPage')
     get prevPageParam() {
         const {
             pageManagers,

--- a/lib/registries/addon/drafts/draft/navigation-manager.ts
+++ b/lib/registries/addon/drafts/draft/navigation-manager.ts
@@ -52,7 +52,7 @@ export default class NavigationManager {
         return pageManagers.length - 1;
     }
 
-    @computed('currentPage', 'pageManagers.[]')
+    @computed('currentPage', 'pageManagers.[]', 'currentRoute')
     get nextPageParam() {
         const {
             pageManagers,
@@ -77,7 +77,7 @@ export default class NavigationManager {
         return '';
     }
 
-    @computed('currentPage', 'pageManagers.[]')
+    @computed('currentPage', 'pageManagers.[]', 'currentRoute')
     get prevPageParam() {
         const {
             pageManagers,

--- a/tests/engines/registries/acceptance/draft/draft-test.ts
+++ b/tests/engines/registries/acceptance/draft/draft-test.ts
@@ -86,6 +86,11 @@ module('Registries | Acceptance | draft form', hooks => {
             .hasClass('fa-circle', 'page 2 is marked unvisited');
         assert.dom('[data-test-link="review"] > [data-test-icon]')
             .hasClass('fa-circle', 'review is marked unvisited');
+        assert.dom('[data-test-goto-metadata]').doesNotExist();
+        assert.dom('[data-test-goto-previous-page]').doesNotExist();
+        assert.dom('[data-test-goto-next-page]').isVisible();
+        assert.dom('[data-test-goto-review]').doesNotExist();
+        assert.dom('[data-test-goto-register]').doesNotExist();
 
         // Navigate to second page
         await click('[data-test-link="2-this-is-the-second-page"]');
@@ -98,6 +103,11 @@ module('Registries | Acceptance | draft form', hooks => {
             .hasClass('fa-circle-o', 'page 2 is marked as current page');
         assert.dom('[data-test-link="review"] > [data-test-icon]')
             .hasClass('fa-circle', 'review is marked unvisited');
+        assert.dom('[data-test-goto-metadata]').doesNotExist();
+        assert.dom('[data-test-goto-previous-page]').isVisible();
+        assert.dom('[data-test-goto-next-page]').doesNotExist();
+        assert.dom('[data-test-goto-review]').isVisible();
+        assert.dom('[data-test-goto-register]').doesNotExist();
 
         // Navigate to first page
         await click('[data-test-link="1-first-page-of-test-schema"]');
@@ -109,6 +119,11 @@ module('Registries | Acceptance | draft form', hooks => {
             .hasClass('fa-check-circle-o', 'page 2 is marked visited, valid');
         assert.dom('[data-test-link="review"] > [data-test-icon]')
             .hasClass('fa-circle', 'review is marked unvisited');
+        assert.dom('[data-test-goto-metadata]').isVisible();
+        assert.dom('[data-test-goto-previous-page]').doesNotExist();
+        assert.dom('[data-test-goto-next-page]').isVisible();
+        assert.dom('[data-test-goto-review]').doesNotExist();
+        assert.dom('[data-test-goto-register]').doesNotExist();
 
         // Navigate back to metadata
         await click('[data-test-link="metadata"]');
@@ -118,6 +133,11 @@ module('Registries | Acceptance | draft form', hooks => {
             .hasClass('fa-check-circle-o', 'page 2 is marked visited, valid');
         assert.dom('[data-test-link="review"] > [data-test-icon]')
             .hasClass('fa-circle', 'review is marked unvisited');
+        assert.dom('[data-test-goto-metadata]').doesNotExist();
+        assert.dom('[data-test-goto-previous-page]').doesNotExist();
+        assert.dom('[data-test-goto-next-page]').isVisible();
+        assert.dom('[data-test-goto-review]').doesNotExist();
+        assert.dom('[data-test-goto-register]').doesNotExist();
 
         // Navigate to review
         await click('[data-test-link="review"]');
@@ -130,6 +150,11 @@ module('Registries | Acceptance | draft form', hooks => {
             .hasClass('fa-check-circle-o', 'page 2 is marked visited, valid');
         assert.dom('[data-test-link="review"] > [data-test-icon]')
             .hasClass('fa-circle-o', 'review is marked current');
+        assert.dom('[data-test-goto-metadata]').doesNotExist();
+        assert.dom('[data-test-goto-previous-page]').isVisible();
+        assert.dom('[data-test-goto-next-page]').doesNotExist();
+        assert.dom('[data-test-goto-review]').doesNotExist();
+        assert.dom('[data-test-goto-register]').isVisible();
     });
 
     test('right sidenav controls', async assert => {


### PR DESCRIPTION


- Ticket: [ENG-1527]
- Feature flag: n/a

## Purpose
The right navigation buttons could end up in a state where it would display the `Next ->` button on the review page, or `<- Back` on the metadata page. This PR fixes this issue.

## Summary of Changes
- Add `currentRoute` to the dependent keys of `nextPageParam` and `prevPageParam` in `NavigationManager`
- Added tests to assert which icons should be shown in the LeftNav test of the `draft form` acceptance test

## Side Effects
- No side effects should be present

## QA Notes
- This PR should fix the aforementioned issue and also tighten up the test coverage in these scenarios. This should fix any mismatch between the actual state of the draft registration and what is shown in the left or right navigation columns

[ENG-1527]: https://openscience.atlassian.net/browse/ENG-1527