### PR TITLE
[ENG-1523] [Feature] Add metadata styling

### DIFF
--- a/lib/osf-components/addon/components/form-controls/power-select/template.hbs
+++ b/lib/osf-components/addon/components/form-controls/power-select/template.hbs
@@ -11,6 +11,7 @@
     <div
         data-test-power-select-dropdown
         id={{inputElementId}}
+        ...attributes
     >
         <PowerSelect
             @options={{this.options}}

--- a/lib/registries/addon/components/registries-license-picker/template.hbs
+++ b/lib/registries/addon/components/registries-license-picker/template.hbs
@@ -16,6 +16,7 @@
                 @searchField={{'name'}}
                 @noMatchesMessage={{t 'registries.registration_metadata.no_matches'}}
                 @placeholder={{t 'registries.registration_metadata.add_license'}}
+                ...attributes
                 as |license|
             >
                 {{license.name}}

--- a/lib/registries/addon/drafts/draft/metadata/styles.scss
+++ b/lib/registries/addon/drafts/draft/metadata/styles.scss
@@ -1,0 +1,93 @@
+.Metadata {
+    :global(label) {
+        margin: 20px 0 0;
+        padding: 0;
+        color: $color-text-gray-blue;
+        width: 100%;
+        border-bottom: 0;
+        font-weight: 700;
+        font-size: 14px;
+    
+        &:first-child {
+            margin: 0;
+        }
+    }
+
+    :global(.list-group-item label) {
+        font-weight: normal;
+    }
+
+    :global(.form-group) {
+        margin: 10px 0 0;
+    }
+}
+
+.PageHeading {
+    color: $color-text-gray-blue;
+    margin: 20px 0 0;
+    padding: 0;
+
+    &:first-child {
+        margin: 0;
+    }
+}
+
+.HeadingParagraph {
+    margin: 10px 0;
+}
+
+
+.SchemaBlockInput {
+    :global(input) {
+        height: 40px;
+        background-color: $color-bg-gray-blue-light;
+        color: $color-text-gray-blue;
+        border-radius: 2px;
+        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);
+    }
+}
+
+.SchemaBlockLongText {
+    :global(.form-control) {
+        min-height: 100px;
+        color: $color-text-gray-blue;
+        background-color: $color-bg-gray-blue-light;
+        border: 1px solid $color-border-gray;
+        border-radius: 2px;
+        font-size: 14px;
+        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);
+    }
+
+    textarea {
+        resize: vertical;
+    }
+}
+
+.SchemaBlockDropdown {
+    margin: 10px 0 0;
+
+    :global(.ember-power-select-trigger) {
+        line-height: 40px;
+        color: $color-text-gray-blue;
+        background-color: $color-bg-gray-blue-light;
+        border: 1px solid $color-border-gray;
+        border-radius: 2px;
+        font-size: 14px;
+        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);
+    }
+}
+
+.DisplayText {
+    display: inline-block;
+    margin: 0;
+}
+
+.Required {
+    color: $brand-danger;
+}
+
+.TagsContainer {
+    margin-top: 10px;
+    padding: 5px 5px 0;
+    border: 1px dotted #d9d9d9;
+}

--- a/lib/registries/addon/drafts/draft/metadata/template.hbs
+++ b/lib/registries/addon/drafts/draft/metadata/template.hbs
@@ -1,25 +1,54 @@
 {{#if this.loading}}
     <LoadingIndicator @dark={{true}} />
 {{else}}
-    <form>
+    <h2 local-class='PageHeading'>
+        {{t 'registries.registration_metadata.metadata_page_heading'}}
+    </h2>
+    <p local-class='HeadingParagraph'>
+        {{t 'registries.registration_metadata.metadata_page_description'}}
+    </p>
+    <hr>
+    <form local-class='Metadata'>
         <FormControls
             @changeset={{this.draftManager.metadataChangeset}}
-            ...attributes as |form|
+            ...attributes
+            as |form|
         >
-            <form.text
-                data-test-metadata-title
-                @label={{t 'registries.registration_metadata.title'}}
-                @valuePath='title'
-                @onKeyUp={{perform this.draftManager.onMetadataInput}}
-            />
-            <form.textarea
-                data-test-metadata-description
-                @label={{t 'registries.registration_metadata.description'}}
-                @valuePath='description'
-                @onKeyUp={{perform this.draftManager.onMetadataInput}}
-            />
+            {{#let (unique-id 'title') as |titleFieldId|}}
+                <label local-class='Label' for={{titleFieldId}}>
+                    <p local-class='DisplayText'>
+                        {{t 'registries.registration_metadata.title'}}
+                        <span local-class='Required'>*</span>
+                    </p>
+                </label>
+                <form.text
+                    data-test-metadata-title
+                    local-class='SchemaBlockInput'
+                    id={{titleFieldId}}
+                    @valuePath='title'
+                    @onKeyUp={{perform this.draftManager.onMetadataInput}}
+                    @placeholder=' '
+                />
+            {{/let}}
+            {{#let (unique-id 'description') as |descriptionFieldId|}}
+                <label local-class='Label' for={{descriptionFieldId}}>
+                    <p local-class='DisplayText'>
+                        {{t 'registries.registration_metadata.description'}}
+                        <span local-class='Required'>*</span>
+                    </p>
+                </label>
+                <form.textarea
+                    data-test-metadata-description
+                    local-class='SchemaBlockLongText'
+                    id={{descriptionFieldId}}
+                    @valuePath='description'
+                    @onKeyUp={{perform this.draftManager.onMetadataInput}}
+                    @placeholder=' '
+                />
+            {{/let}}
             <form.select
                 data-test-metadata-category
+                local-class='SchemaBlockDropdown'
                 @label={{t 'registries.registration_metadata.category'}}
                 @valuePath='category'
                 @options={{this.categoryOptions}}
@@ -29,7 +58,9 @@
                 <NodeCategory @category={{option}} />
             </form.select>
             {{#let (unique-id 'institutions') as |institutionsFieldId|}}
-                <label for={{institutionsFieldId}}>{{t 'registries.registration_metadata.affiliated_institutions'}}</label>
+                <label for={{institutionsFieldId}}>
+                    {{t 'registries.registration_metadata.affiliated_institutions'}}
+                </label>
                 <Drafts::Draft::-Components::MetadataInstitutionsManager 
                     @node={{this.draftManager.draftRegistration}}
                     as |institutionsManager|
@@ -44,11 +75,18 @@
                 @draftManager={{this.draftManager}}
                 as |licenseManager|
             >
-                <label for='license-select'>{{t 'registries.registration_metadata.choose_license'}}</label>
-                <RegistriesLicensePicker @manager={{licenseManager}} />
+                <label for='license-select'>
+                    {{t 'registries.registration_metadata.choose_license'}}
+                </label>
+                <RegistriesLicensePicker
+                    local-class='SchemaBlockDropdown'
+                    @manager={{licenseManager}}
+                />
             </Drafts::Draft::-Components::Managers::LicensePickerManager>
             {{#let (unique-id 'subjects') as |subjectsFieldId|}}
-                <label for={{subjectsFieldId}}>{{t 'registries.registration_metadata.subjects'}}</label>
+                <label for={{subjectsFieldId}}>
+                    {{t 'registries.registration_metadata.subjects'}}
+                </label>
                 <Subjects::Manager
                     @model={{this.draftManager.draftRegistration}}
                     @provider={{this.draftManager.draftRegistration.provider}}
@@ -62,18 +100,22 @@
                 </Subjects::Manager>
             {{/let}}
             {{#let (unique-id 'tags') as |tagsFieldId|}}
-                <label for={{tagsFieldId}}>{{t 'registries.registration_metadata.tags'}}</label>
+                <label for={{tagsFieldId}}>
+                    {{t 'registries.registration_metadata.tags'}}
+                </label>
                 <Drafts::Draft::-Components::TagsManager
                     @changeset={{this.draftManager.metadataChangeset}}
                     @onMetadataInput={{perform this.draftManager.onMetadataInput}}
                     @valuePath='tags'
                     as |tagsManager|
                 >
-                    <RegistriesTagsWidget
-                        data-test-metadata-tags
-                        id={{tagsFieldId}}
-                        @manager={{tagsManager}}
-                    />
+                    <div local-class='TagsContainer'>
+                        <RegistriesTagsWidget
+                            data-test-metadata-tags
+                            id={{tagsFieldId}}
+                            @manager={{tagsManager}}
+                        />
+                    </div>
                 </Drafts::Draft::-Components::TagsManager>
             {{/let}}
         </FormControls>

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1025,6 +1025,8 @@ registries:
         disciplines: Disciplines
         edit_field: 'Edit {field}'
         license: License
+        metadata_page_heading: 'Registration Metadata'
+        metadata_page_description: 'This metadata will be applied to your registration and the project associated with it, once the registration is complete.'
         no_affiliated_institutions: 'No affiliated institutions'
         no_description: 'No description'
         no_doi: 'No DOI assigned'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1026,7 +1026,7 @@ registries:
         edit_field: 'Edit {field}'
         license: License
         metadata_page_heading: 'Registration Metadata'
-        metadata_page_description: 'This metadata will be applied to your registration and the project associated with it, once the registration is complete.'
+        metadata_page_description: 'This metadata applies only to the registration you are creating, and will not be applied to your project.'
         no_affiliated_institutions: 'No affiliated institutions'
         no_description: 'No description'
         no_doi: 'No DOI assigned'


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-1523
- Feature flag: `N/A`

## Purpose

To add styling to the metadata page on registries submission.

## Summary of Changes

- Add styling
- Update some components to allow `...attributes`
- Add translations for heading and description text

<img width="1031" alt="Screen Shot 2020-02-25 at 1 38 40 PM" src="https://user-images.githubusercontent.com/19379783/75276722-b2a40b80-57d4-11ea-944f-822a325acef7.png">


## Side Effects

`N/A`

## QA Notes

This should only affect styling on the metadata page. Only adds styles to the page and doesn't change anything pre-existing.
