### PR TITLE
[ENG-1546] Render status messages as htmlSafe

### DIFF
--- a/lib/osf-components/addon/components/status-banner/template.hbs
+++ b/lib/osf-components/addon/components/status-banner/template.hbs
@@ -5,7 +5,7 @@
         @classNames={{if stat.jumbo (local-class 'StatusBanner__jumbo')}}
     >
         <div class='{{if stat.jumbo 'jumbotron'}}'>
-            <p>{{t stat.id extra=stat.extra}}</p>
+            <p data-test-status-message={{stat.id}}>{{t stat.id extra=stat.extra htmlSafe=true}}</p>
         </div>
     </BsAlert>
 {{/each}}

--- a/tests/acceptance/status-banner-test.ts
+++ b/tests/acceptance/status-banner-test.ts
@@ -1,0 +1,35 @@
+import { visit } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import config from 'ember-get-config';
+import { t } from 'ember-intl/test-support';
+import { percySnapshot } from 'ember-percy';
+import { module, test } from 'qunit';
+
+import { setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
+import stripHtmlTags from 'ember-osf-web/tests/helpers/strip-html-tags';
+
+const {
+    OSF: {
+        cookies: {
+            status: statusCookie,
+        },
+    },
+} = config;
+
+module('Acceptance | Status Banner', hooks => {
+    setupOSFApplicationTest(hooks);
+    setupMirage(hooks);
+
+    test('welcome message shows correctly', async assert => {
+        server.create('user', 'loggedIn');
+
+        /* eslint-disable-next-line max-len */
+        document.cookie = `${statusCookie}=[{"id": "welcome_message", "class": "default", "jumbo": true, "dismiss": true, "extra": {}}]; path=/;`;
+        await visit('/');
+
+        assert.dom('[data-test-status-message="status.welcome_message"]')
+            .hasText(stripHtmlTags(t('status.welcome_message').toString()));
+
+        await percySnapshot(assert);
+    });
+});


### PR DESCRIPTION
## Purpose

Render status messages as htmlSafe

## Summary of Changes

- Add `htmlSafe=true` to status message translations.
- Add acceptance test and Percy snapshot.

## Side Effects

## QA Notes

Please make sure the welcome message has no html markup in it. Other status messages should also show correctly if we do get them on the emberized frontend.
