### PR TITLE
[ENG-1572] Reload the model after updating subjects and institutions.

### DIFF
--- a/lib/osf-components/addon/components/subjects/manager/component.ts
+++ b/lib/osf-components/addon/components/subjects/manager/component.ts
@@ -114,6 +114,7 @@ export default class SubjectManagerComponent extends Component {
 
         try {
             yield this.model.updateM2MRelationship('subjects', selectedSubjects);
+            yield this.model.reload();
         } catch (e) {
             this.toast.error(this.intl.t('registries.registration_metadata.save_subjects_error'));
             throw e;

--- a/lib/registries/addon/drafts/draft/-components/metadata-institutions-manager/component.ts
+++ b/lib/registries/addon/drafts/draft/-components/metadata-institutions-manager/component.ts
@@ -49,6 +49,7 @@ export default class MetadataInstitutionsManagerComponent extends Component {
     save = task(function *(this: MetadataInstitutionsManagerComponent) {
         try {
             yield this.node.updateM2MRelationship('affiliatedInstitutions', this.currentAffiliatedList);
+            yield this.node.reload();
         } catch (e) {
             this.node.rollbackAttributes();
             throw e;


### PR DESCRIPTION
- Ticket: [ENG-1572]
- Feature flag: n/a

## Purpose

Currently, the autosave timestamp on the right nav does not change after successful update of subjects and institutions. Since that timestamp relies on the `draft-registration` model's `dateTimeUpdated` attribute and the `updateM2MRelationship` method does not reload the model after the update, we will manually trigger a model reload.

## Summary of Changes

Reload the model in subjects manager and institution manager.