### PR TITLE
[ENG-1574] Temp fix for nav dropdown

### DIFF
--- a/lib/registries/addon/components/registries-navbar/styles.scss
+++ b/lib/registries/addon/components/registries-navbar/styles.scss
@@ -119,6 +119,8 @@
 
 .AuthDropdownMenu {
     font-size: 16px;
+    right: 0;
+    left: auto;
 
     // Logout and sign in buttons
     & > li > :global(.btn.btn-link) {


### PR DESCRIPTION
Temp fix to unblock release.
In our production build, the `dropdown-menu-right` class does not contain `left:auto` while our non-production build contains `left:auto, right:0`. This is likely a build issue regard how production and non-production build import css assets differently.
 
Fixed:
![Screen Shot 2020-02-27 at 2 48 02 PM](https://user-images.githubusercontent.com/1566880/75480978-45c57880-5970-11ea-84bb-ee2c9af7c190.png)

Broken:
![Screen Shot 2020-02-27 at 2 59 08 PM](https://user-images.githubusercontent.com/51409893/75481877-be790480-5971-11ea-91bd-341ba4960d17.png)
