### PR TITLE
[ENG-1572] Fix tags widget not update issue on metadata page

### DIFF
--- a/lib/osf-components/addon/components/registries/review-metadata-renderer/template.hbs
+++ b/lib/osf-components/addon/components/registries/review-metadata-renderer/template.hbs
@@ -85,11 +85,12 @@
             @registration={{@draftRegistration}}
             @valuePath='tags'
             @tags={{@draftRegistration.tags}}
+            @readOnly={{true}}
             as |tagsManager|
         >
             <RegistriesTagsWidget
                 @manager={{tagsManager}}
-                @readOnly={{true}}
+                @readOnly={{tagsManager.readOnly}}
             />
         </Drafts::Draft::-Components::TagsManager>
     {{else}}

--- a/lib/registries/addon/drafts/draft/-components/tags-manager/component.ts
+++ b/lib/registries/addon/drafts/draft/-components/tags-manager/component.ts
@@ -1,6 +1,6 @@
 import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
-import { action } from '@ember/object';
+import { action, set } from '@ember/object';
 import { ChangesetDef } from 'ember-changeset/types';
 import config from 'ember-get-config';
 
@@ -23,6 +23,7 @@ export default class MetadataTagsManagerComponent extends Component {
     // required
     changeset!: ChangesetDef;
     valuePath!: string;
+    readOnly: boolean = false;
 
     // optional
     registration?: DraftRegistrationModel;
@@ -31,10 +32,16 @@ export default class MetadataTagsManagerComponent extends Component {
     // properties
     tags: string[] = [];
 
+    didReceiveAttrs() {
+        if (this.changeset && !this.readOnly) {
+            set(this, 'tags', this.changeset.get(this.valuePath).slice());
+        }
+    }
+
     @action
     addTag(tag: string) {
-        this.set('tags', [...this.tags, tag].sort());
-        this.changeset.set(this.valuePath, this.tags);
+        set(this, 'tags', [...this.tags, tag].sort());
+        set(this.changeset, this.valuePath, this.tags);
         if (this.onMetadataInput) {
             this.onMetadataInput();
         }
@@ -42,8 +49,8 @@ export default class MetadataTagsManagerComponent extends Component {
 
     @action
     removeTag(index: number) {
-        this.set('tags', this.tags.slice().removeAt(index));
-        this.changeset.set(this.valuePath, this.tags);
+        set(this, 'tags', this.tags.slice().removeAt(index));
+        set(this.changeset, this.valuePath, this.tags);
         if (this.onMetadataInput) {
             this.onMetadataInput();
         }

--- a/lib/registries/addon/drafts/draft/-components/tags-manager/template.hbs
+++ b/lib/registries/addon/drafts/draft/-components/tags-manager/template.hbs
@@ -5,5 +5,6 @@
         clickTag=this.clickTag
         tags=this.tags
         registration=this.registration
+        readOnly=this.readOnly
     )
 }}


### PR DESCRIPTION
- Ticket: [ENG-1572]
- Feature flag: n/a

## Purpose

Currently, draft metadata page's tags widget would not show updated tags if you go to review page and come back. This PR fix the problem.

## Summary of Changes

Because the tags widget relies on `tagsManager.tags` to render the list of existing tags, changes are made to initialize the `tags` array with existing tags on the model in `didReceiveAttrs()`.

[ENG-1572]: https://openscience.atlassian.net/browse/ENG-1572