### PR TITLE
[ENG-1572] Update metadata styling

### DIFF
--- a/lib/registries/addon/components/registries-license-picker/template.hbs
+++ b/lib/registries/addon/components/registries-license-picker/template.hbs
@@ -36,6 +36,7 @@
         
         {{#if @manager.selectedLicense}}
             <form.custom
+                local-class='AdditionalFields'
                 @changeset={{@manager.changeset}}
                 @valuePath='nodeLicense'
             >

--- a/lib/registries/addon/components/registries-license-picker/template.hbs
+++ b/lib/registries/addon/components/registries-license-picker/template.hbs
@@ -47,13 +47,13 @@
                                 {{t (concat 'app_components.license_picker.fields.' key)}}
                                 <span local-class='Required'>*</span>
                             </p>
+                            <Input
+                                data-test-required-field={{key}}
+                                @class='form-control'
+                                @value={{readonly (get @manager.changeset.nodeLicense key)}}
+                                @change={{fn @manager.updateNodeLicense key}}
+                            />
                         </label>
-                        <Input
-                            data-test-required-field={{key}}
-                            @class='form-control'
-                            @value={{readonly (get @manager.changeset.nodeLicense key)}}
-                            @change={{fn @manager.updateNodeLicense key}}
-                        />
                     </div>
                 {{/each}}
             </form.custom>

--- a/lib/registries/addon/components/registries-tags-widget/component.ts
+++ b/lib/registries/addon/components/registries-tags-widget/component.ts
@@ -37,12 +37,13 @@ export default class RegistriesTagsWidget extends Component.extend({ styles }) {
     }
 
     @action
-    removeTag(index: number) {
+    removeTag(tag: string) {
         this.analytics.trackFromElement(this.element, {
             name: 'Remove tag',
             category: 'tag',
             action: 'remove',
         });
+        const index = this.manager.tags.indexOf(tag);
         this.manager.removeTag(index);
     }
 }

--- a/lib/registries/addon/components/registries-tags-widget/styles.scss
+++ b/lib/registries/addon/components/registries-tags-widget/styles.scss
@@ -9,9 +9,9 @@
     border-radius: 0;
     color: $color-text-black;
     cursor: pointer;
-    font-size: 13px;
     max-width: 100%;
     overflow-wrap: break-word;
+    font: 14px 'Open Sans', 'Helvatica Neue', sans-serif !important;
 
     > a {
         color: $color-text-black;
@@ -21,7 +21,8 @@
         background: $color-bg-blue-dark;
         color: $color-text-gray-cool;
 
-        > a {
+        > a,
+        > button {
             color: $color-text-gray-cool;
         }
     }
@@ -32,6 +33,7 @@
 
     > input {
         width: inherit;
+        font-size: 14px;
 
         &::placeholder {
             color: $color-text-gray-light;
@@ -42,4 +44,10 @@
 
 .TagsWidget:global(.emberTagInput--readOnly) :global(.emberTagInput-new) {
     display: none;
+}
+
+.RemoveButton.RemoveButton {
+    border: 0;
+    padding: 0;
+    margin-left: 5px;
 }

--- a/lib/registries/addon/components/registries-tags-widget/template.hbs
+++ b/lib/registries/addon/components/registries-tags-widget/template.hbs
@@ -4,11 +4,11 @@
     local-class='TagsWidget'
     @tags={{if this.readOnly @manager.registration.tags @manager.tags}}
     @addTag={{action this.addTag}}
-    @removeTagAtIndex={{action this.removeTag}}
     @allowSpacesInTags={{true}}
     @placeholder={{t 'osf-components.tags-widget.add_tag'}}
     @readOnly={{this.readOnly}}
     @maxlength={{1024}}
+    @showRemoveButtons={{false}}
     as |tag|
 >
     <span
@@ -19,4 +19,15 @@
     >
         {{tag}}
     </span>
+    {{#if (not this.readOnly)}}
+        <OsfButton
+            local-class='RemoveButton'
+            data-analytics-name='Remove Tag'
+            data-analytics-extra={{tag}}
+            @type='link'
+            @onClick={{action this.removeTag tag}}
+        >
+            <FaIcon @icon='times' @fixedWidth={{true}} />
+        </OsfButton>
+    {{/if}}
 </TagInput>

--- a/lib/registries/addon/drafts/draft/-components/tags-manager/component.ts
+++ b/lib/registries/addon/drafts/draft/-components/tags-manager/component.ts
@@ -15,7 +15,7 @@ const {
     OSF: { url: baseUrl },
 } = config;
 
-export type MetadataTagsManager = Pick<TagsManager, 'addTag' | 'removeTag' | 'clickTag'>;
+export type MetadataTagsManager = Pick<TagsManager, 'addTag' | 'removeTag' | 'clickTag' | 'tags'>;
 
 @tagName('')
 @layout(template)

--- a/lib/registries/addon/drafts/draft/metadata/styles.scss
+++ b/lib/registries/addon/drafts/draft/metadata/styles.scss
@@ -3,7 +3,6 @@
         margin: 20px 0 0;
         padding: 0;
         color: $color-text-gray-blue;
-        width: 100%;
         border-bottom: 0;
         font-weight: 700;
         font-size: 14px;
@@ -17,8 +16,20 @@
         font-weight: normal;
     }
 
+    .SubjectsField label {
+        margin: 0;
+    }
+
     :global(.form-group) {
         margin: 10px 0 0;
+    }
+
+    :global(.form-control) {
+        height: 40px;
+        background-color: $color-bg-gray-blue-light;
+        color: $color-text-gray-blue;
+        border-radius: 2px;
+        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);
     }
 }
 

--- a/lib/registries/addon/drafts/draft/metadata/template.hbs
+++ b/lib/registries/addon/drafts/draft/metadata/template.hbs
@@ -120,6 +120,7 @@
                 >
                     <Subjects::Widget
                         id={{subjectsFieldId}}
+                        local-class='SubjectsField'
                         @subjectsManager={{subjectsManager}}
                     />
                     <ValidationErrors

--- a/lib/registries/addon/drafts/draft/template.hbs
+++ b/lib/registries/addon/drafts/draft/template.hbs
@@ -67,15 +67,17 @@
             <layout.main local-class='Main'>
                 {{outlet}}
             </layout.main>
-            <layout.right local-class='Right'>
-                <div local-class='RightWrapper'>
-                    <Drafts::Draft::-Components::RightNav
-                        @navManager={{navManager}}
-                        @draftManager={{draftManager}}
-                        @onSubmitRedirect={{this.onSubmitRedirect}}
-                    />
-                </div>
-            </layout.right>
+            {{#unless this.showMobileView}}
+                <layout.right local-class='Right'>
+                    <div local-class='RightWrapper'>
+                        <Drafts::Draft::-Components::RightNav
+                            @navManager={{navManager}}
+                            @draftManager={{draftManager}}
+                            @onSubmitRedirect={{this.onSubmitRedirect}}
+                        />
+                    </div>
+                </layout.right>
+            {{/unless}}
         </OsfLayout>
     {{/let}}
 {{/if}}


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-1572
- Feature flag: `N/A`

## Purpose

To update styles on the metadata page.

## Summary of Changes

- Fix searchable subjects styling
- Update tabbable focus to not jump to the hidden 'Next' button
- Update tags to look like subjects
- License field styling

## Side Effects

`N/A`

## QA Notes

Will affect the style on only the metadata page. Tabbable focus should fix the issue seen on mobile/ipad devices (hitting tab on the last input on the page will focus on the hidden 'Next' button).
