### PR TITLE
[ENG-1572] Validate metadataChangeset when navigate away from metadata page.

### DIFF
--- a/app/packages/registration-schema/validations.ts
+++ b/app/packages/registration-schema/validations.ts
@@ -99,6 +99,23 @@ export function validateNodeLicense() {
     };
 }
 
+export function validateSubjects() {
+    return async (_: unknown, __: unknown, ___: unknown, ____: unknown, content: DraftRegistration) => {
+        const subjects = await content.subjects;
+        if (subjects.length === 0) {
+            return {
+                context: {
+                    type: 'min_subjects',
+                    translationArgs: {
+                        minLength: 1,
+                    },
+                },
+            };
+        }
+        return true;
+    };
+}
+
 export function buildMetadataValidations() {
     const validationObj: ValidationObject<DraftRegistration> = {};
     const notBlank: ValidatorFunction[] = [validatePresence({
@@ -111,6 +128,7 @@ export function buildMetadataValidations() {
     set(validationObj, DraftMetadataProperties.Title, notBlank);
     set(validationObj, DraftMetadataProperties.Description, notBlank);
     set(validationObj, DraftMetadataProperties.License, notBlank);
+    set(validationObj, DraftMetadataProperties.Subjects, validateSubjects());
     set(validationObj, DraftMetadataProperties.NodeLicenseProperty, validateNodeLicense());
     return validationObj;
 }

--- a/app/packages/registration-schema/validations.ts
+++ b/app/packages/registration-schema/validations.ts
@@ -102,7 +102,7 @@ export function validateNodeLicense() {
 export function validateSubjects() {
     return async (_: unknown, __: unknown, ___: unknown, ____: unknown, content: DraftRegistration) => {
         const subjects = await content.subjects;
-        if (subjects.length === 0) {
+        if (!subjects || subjects.length === 0) {
             return {
                 context: {
                     type: 'min_subjects',

--- a/lib/osf-components/addon/components/subjects/manager/component.ts
+++ b/lib/osf-components/addon/components/subjects/manager/component.ts
@@ -14,6 +14,7 @@ import OsfModel from 'ember-osf-web/models/osf-model';
 import ProviderModel from 'ember-osf-web/models/provider';
 import SubjectModel from 'ember-osf-web/models/subject';
 
+import { ChangesetDef } from 'ember-changeset/types';
 import template from './template';
 
 interface ModelWithSubjects extends OsfModel {
@@ -48,6 +49,9 @@ export default class SubjectManagerComponent extends Component {
     model!: ModelWithSubjects;
     provider!: ProviderModel;
     doesAutosave!: boolean;
+
+    // optional
+    metadataChangeset?: ChangesetDef;
 
     // private
     @service intl!: Intl;
@@ -115,6 +119,9 @@ export default class SubjectManagerComponent extends Component {
         try {
             yield this.model.updateM2MRelationship('subjects', selectedSubjects);
             yield this.model.reload();
+            if (this.metadataChangeset) {
+                this.metadataChangeset.validate('subjects');
+            }
         } catch (e) {
             this.toast.error(this.intl.t('registries.registration_metadata.save_subjects_error'));
             throw e;

--- a/lib/osf-components/addon/components/subjects/manager/component.ts
+++ b/lib/osf-components/addon/components/subjects/manager/component.ts
@@ -112,7 +112,7 @@ export default class SubjectManagerComponent extends Component {
         this.incrementProperty('savedSubjectsChanges');
     });
 
-    @task({ drop: true })
+    @task({ restartable: true })
     saveChanges = task(function *(this: SubjectManagerComponent) {
         const { selectedSubjects } = this;
 

--- a/lib/osf-components/addon/components/subjects/manager/component.ts
+++ b/lib/osf-components/addon/components/subjects/manager/component.ts
@@ -118,7 +118,7 @@ export default class SubjectManagerComponent extends Component {
 
         try {
             yield this.model.updateM2MRelationship('subjects', selectedSubjects);
-            yield this.model.reload();
+            yield this.model.hasMany('subjects').reload();
             if (this.metadataChangeset) {
                 this.metadataChangeset.validate('subjects');
             }

--- a/lib/osf-components/addon/components/subjects/manager/template.hbs
+++ b/lib/osf-components/addon/components/subjects/manager/template.hbs
@@ -8,6 +8,7 @@
     selectSubject=(action this.selectSubject)
     unselectSubject=(action this.unselectSubject)
     saveChanges=(perform this.saveChanges)
+    isSaving=this.saveChanges.isRunning
     discardChanges=(action this.discardChanges)
 
     subjectIsSelected=(action this.subjectIsSelected)

--- a/lib/registries/addon/components/page-link/component.ts
+++ b/lib/registries/addon/components/page-link/component.ts
@@ -44,7 +44,7 @@ export default class PageLinkComponent extends Component {
             undefined;
     }
 
-    @computed('pageManager', 'pageManager.{isVisited,pageIsValid}', 'pageIsActive')
+    @computed('pageManager', 'pageManager.{isVisited,pageIsValid}', 'pageIsActive', 'metadataIsValid')
     get pageState(): PageState {
         if (this.pageIsActive) {
             return PageState.Active;

--- a/lib/registries/addon/components/registries-license-picker/styles.scss
+++ b/lib/registries/addon/components/registries-license-picker/styles.scss
@@ -16,3 +16,8 @@
 .small {
     font-size: 85%;
 }
+
+
+.Required {
+    color: $brand-danger;
+}

--- a/lib/registries/addon/components/registries-license-picker/template.hbs
+++ b/lib/registries/addon/components/registries-license-picker/template.hbs
@@ -35,9 +35,6 @@
         </div>
         
         {{#if @manager.selectedLicense}}
-            {{#if @manager.requiredFields}}
-                <br>
-            {{/if}}
             <form.custom
                 @changeset={{@manager.changeset}}
                 @valuePath='nodeLicense'
@@ -45,15 +42,17 @@
                 {{#each @manager.requiredFields as |key|}}
                     <div class='form-group'>
                         <label>
-                            {{t (concat 'app_components.license_picker.fields.' key)}}
-                            <Input
-                                data-test-required-field={{key}}
-                                @class='form-control'
-                                @value={{readonly (get @manager.changeset.nodeLicense key)}}
-                                @placeholder={{t 'general.required'}}
-                                @change={{fn @manager.updateNodeLicense key}}
-                            />
+                            <p>
+                                {{t (concat 'app_components.license_picker.fields.' key)}}
+                                <span local-class='Required'>*</span>
+                            </p>
                         </label>
+                        <Input
+                            data-test-required-field={{key}}
+                            @class='form-control'
+                            @value={{readonly (get @manager.changeset.nodeLicense key)}}
+                            @change={{fn @manager.updateNodeLicense key}}
+                        />
                     </div>
                 {{/each}}
             </form.custom>

--- a/lib/registries/addon/drafts/draft/draft-registration-manager.ts
+++ b/lib/registries/addon/drafts/draft/draft-registration-manager.ts
@@ -167,6 +167,7 @@ export default class DraftRegistrationManager {
 
     @action
     validateAllVisitedPages() {
+        this.metadataChangeset.validate();
         this.visitedPages
             .forEach(pageManager => {
                 pageManager.changeset!.validate();

--- a/lib/registries/addon/drafts/draft/metadata/template.hbs
+++ b/lib/registries/addon/drafts/draft/metadata/template.hbs
@@ -103,12 +103,16 @@
                     for={{subjectsFieldId}}
                     id='subjects'
                 >
-                    {{t 'registries.registration_metadata.subjects'}}
+                    <p local-class='DisplayText'>
+                        {{t 'registries.registration_metadata.subjects'}}
+                        <span local-class='Required'>*</span>
+                    </p>
                 </label>
                 <Subjects::Manager
                     @model={{this.draftManager.draftRegistration}}
                     @provider={{this.draftManager.draftRegistration.provider}}
                     @doesAutosave={{true}}
+                    @metadataChangeset={{this.draftManager.metadataChangeset}}
                     as |subjectsManager|
                 >
                     <Subjects::Widget
@@ -116,6 +120,7 @@
                         @subjectsManager={{subjectsManager}}
                     />
                 </Subjects::Manager>
+                <ValidationErrors @changeset={{this.draftManager.metadataChangeset}} @key={{'subjects'}} />
             {{/let}}
             {{#let (unique-id 'tags') as |tagsFieldId|}}
                 <label

--- a/lib/registries/addon/drafts/draft/metadata/template.hbs
+++ b/lib/registries/addon/drafts/draft/metadata/template.hbs
@@ -123,7 +123,11 @@
                         @subjectsManager={{subjectsManager}}
                     />
                 </Subjects::Manager>
-                <ValidationErrors @changeset={{this.draftManager.metadataChangeset}} @key={{'subjects'}} />
+                <ValidationErrors
+                    @changeset={{this.draftManager.metadataChangeset}}
+                    @key='subjects'
+                    @isValidating={{this.draftManager.metadataChangeset.isValidating}}
+                />
             {{/let}}
             {{#let (unique-id 'tags') as |tagsFieldId|}}
                 <label

--- a/lib/registries/addon/drafts/draft/metadata/template.hbs
+++ b/lib/registries/addon/drafts/draft/metadata/template.hbs
@@ -91,7 +91,10 @@
                     for='license-select'
                     id='license'
                 >
-                    {{t 'registries.registration_metadata.choose_license'}}
+                    <p local-class='DisplayText'>
+                        {{t 'registries.registration_metadata.choose_license'}}
+                        <span local-class='Required'>*</span>
+                    </p>
                 </label>
                 <RegistriesLicensePicker
                     local-class='SchemaBlockDropdown'

--- a/lib/registries/addon/drafts/draft/metadata/template.hbs
+++ b/lib/registries/addon/drafts/draft/metadata/template.hbs
@@ -122,12 +122,12 @@
                         id={{subjectsFieldId}}
                         @subjectsManager={{subjectsManager}}
                     />
+                    <ValidationErrors
+                        @changeset={{this.draftManager.metadataChangeset}}
+                        @key='subjects'
+                        @isValidating={{subjectsManager.isSaving}}
+                    />
                 </Subjects::Manager>
-                <ValidationErrors
-                    @changeset={{this.draftManager.metadataChangeset}}
-                    @key='subjects'
-                    @isValidating={{this.draftManager.metadataChangeset.isValidating}}
-                />
             {{/let}}
             {{#let (unique-id 'tags') as |tagsFieldId|}}
                 <label

--- a/lib/registries/addon/drafts/draft/page/controller.ts
+++ b/lib/registries/addon/drafts/draft/page/controller.ts
@@ -31,6 +31,7 @@ export default class RegistriesDraftPage extends Controller {
             this.replaceRoute('drafts.draft.page', draftId, pageSlug);
         }
         this.draftRegistrationManager.onPageChange(pageIndex);
+        this.draftRegistrationManager.metadataChangeset.validate();
     }
 
     @action

--- a/tests/engines/registries/acceptance/draft/draft-test.ts
+++ b/tests/engines/registries/acceptance/draft/draft-test.ts
@@ -96,7 +96,7 @@ module('Registries | Acceptance | draft form', hooks => {
         await click('[data-test-link="2-this-is-the-second-page"]');
         assert.equal(currentRouteName(), 'registries.drafts.draft.page', 'Goes to page route');
         assert.dom('[data-test-link="metadata"] > [data-test-icon]')
-            .hasClass('fa-check-circle-o', 'metadata is marked visited, valid');
+            .hasClass('fa-exclamation-circle', 'metadata is marked visited, invalid');
         assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')
             .hasClass('fa-circle', 'page 1 is marked unvisited');
         assert.dom('[data-test-link="2-this-is-the-second-page"] > [data-test-icon]')
@@ -112,7 +112,7 @@ module('Registries | Acceptance | draft form', hooks => {
         // Navigate to first page
         await click('[data-test-link="1-first-page-of-test-schema"]');
         assert.dom('[data-test-link="metadata"] > [data-test-icon]')
-            .hasClass('fa-check-circle-o', 'metadata is marked visited, valid');
+            .hasClass('fa-exclamation-circle', 'metadata is marked visited, invalid');
         assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')
             .hasClass('fa-circle-o', 'page 1 is marked current page');
         assert.dom('[data-test-link="2-this-is-the-second-page"] > [data-test-icon]')
@@ -143,7 +143,7 @@ module('Registries | Acceptance | draft form', hooks => {
         await click('[data-test-link="review"]');
         assert.equal(currentRouteName(), 'registries.drafts.draft.review', 'Goes to review route');
         assert.dom('[data-test-link="metadata"] > [data-test-icon]')
-            .hasClass('fa-check-circle-o', 'metadata is marked visited, valid');
+            .hasClass('fa-exclamation-circle', 'metadata is marked visited, invalid');
         assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')
             .hasClass('fa-exclamation-circle', 'page 1 is marked visited, invalid');
         assert.dom('[data-test-link="2-this-is-the-second-page"] > [data-test-icon]')
@@ -503,6 +503,6 @@ module('Registries | Acceptance | draft form', hooks => {
         await fillIn('input[name="title"]', 'A non-empty, but still vague title');
         await click('[data-test-goto-next-page]');
         assert.dom('[data-test-link="metadata"] > [data-test-icon]')
-            .hasClass('fa-check-circle-o', 'metadata page is now valid');
+            .hasClass('fa-exclamation-circle', 'metadata page is now invalid');
     });
 });

--- a/tests/engines/registries/acceptance/draft/draft-test.ts
+++ b/tests/engines/registries/acceptance/draft/draft-test.ts
@@ -371,8 +371,11 @@ module('Registries | Acceptance | draft form', hooks => {
                 initiator,
                 registrationResponses,
                 branchedFrom: rootNode,
+                license: server.schema.licenses.first(),
             },
         );
+        const subjects = [server.create('subject')];
+        registration.update({ subjects });
         await visit(`/registries/drafts/${registration.id}/review`);
         assert.ok(currentURL().includes(`/registries/drafts/${registration.id}/review`), 'At review page');
         assert.dom('[data-test-goto-register]').isNotDisabled();


### PR DESCRIPTION
- Ticket: [ENG-1572]
- Feature flag: n/a

## Purpose

This PR fix three things:
- Metadata page doesn't validate when navigating away
- Subjects field doesn't have validation error message
- Some of the required fields doesn't have a red * next to the label.

## Summary of Changes

- In `updateRoute()` hook of the `drafts/draft/page` controller, we validate `metadataChangeset` so what the validation will run on the metadata page upon navigating away.
  - In `page-link` component, make the `pageState` watch for changes in `metadataIsValid` so that it can recompute on validation status change.
- Added `validateSubjects` validator function and use that to build validation object for `metadataChangeset`.
  - In `subjects/manager` component, we pass the `metadataChangeset` to it and validate the `subjects` property on save.
  - Added `ValidationError` component invocation to the metadata template to show validation error messages for subjects field.

[ENG-1572]: https://openscience.atlassian.net/browse/ENG-1572