### PR TITLE
[ENG-1525]Accessibility changes for Draft Registration Metadata content

### DIFF
--- a/lib/osf-components/addon/components/form-controls/power-select/template.hbs
+++ b/lib/osf-components/addon/components/form-controls/power-select/template.hbs
@@ -23,7 +23,10 @@
             id={{inputElementId}}
             as |option|
         >
-            <span data-test-option={{option}}>
+            <span
+                aria-label={{option}}
+                data-test-option={{option}}
+            >
                 {{yield option}}
             </span>
         </PowerSelect>

--- a/lib/osf-components/addon/components/institution-select-list/template.hbs
+++ b/lib/osf-components/addon/components/institution-select-list/template.hbs
@@ -8,21 +8,19 @@
 }}
     <list.item as |institution|>
         {{#if institution}}
-            <li data-test-institution={{institution.id}}>
-                <label local-class='label'>
-                    {{#let (contains institution @manager.affiliatedList) as |isAffiliated|}}
-                        <Input
-                            data-test-institution-button={{concat (if isAffiliated 'remove' 'add') '-' institution.id}}
-                            data-analytics-name={{if isAffiliated 'Remove' 'Add'}}
-                            @type='checkbox'
-                            @checked={{isAffiliated}}
-                            @disabled={{@manager.shouldDisable}}
-                            @change={{action @manager.toggleInstitution institution}}
-                        />
-                    {{/let}}
-                    {{institution.name}}
-                </label>
-            </li>
+            <label data-test-institution={{institution.id}} local-class='label'>
+                {{#let (contains institution @manager.affiliatedList) as |isAffiliated|}}
+                    <Input
+                        data-test-institution-button={{concat (if isAffiliated 'remove' 'add') '-' institution.id}}
+                        data-analytics-name={{if isAffiliated 'Remove' 'Add'}}
+                        @type='checkbox'
+                        @checked={{isAffiliated}}
+                        @disabled={{@manager.shouldDisable}}
+                        @change={{action @manager.toggleInstitution institution}}
+                    />
+                {{/let}}
+                {{institution.name}}
+            </label>
         {{else}}
             <ContentPlaceholders as |placeholder|>
                 {{placeholder.list items=2}}

--- a/lib/osf-components/addon/components/registries/registration-form-navigation-dropdown/template.hbs
+++ b/lib/osf-components/addon/components/registries/registration-form-navigation-dropdown/template.hbs
@@ -5,6 +5,7 @@
             data-analytics-name='Expand'
             data-test-toggle-anchor-nav-button @type='link'
             local-class='ToggleNav__button'
+            aria-label={{t 'registries.drafts.draft.review.toggle_dropdown'}}
         >
             <FaIcon @icon='bars' />
         </OsfButton>

--- a/lib/osf-components/addon/components/subjects/browse/item/template.hbs
+++ b/lib/osf-components/addon/components/subjects/browse/item/template.hbs
@@ -22,6 +22,8 @@
             <OsfButton
                 data-test-expand-children={{@singleSubjectManager.subject.id}}
                 local-class='ExpandButton'
+                role='button'
+                aria-label='{{t (if this.shouldShowChildren 'osf-components.subjects.hide_child_subjects' 'osf-components.subjects.show_child_subjects')}}'
                 @type='link'
                 @onClick={{action this.toggleChildren}}
             >

--- a/lib/osf-components/addon/components/subjects/browse/item/template.hbs
+++ b/lib/osf-components/addon/components/subjects/browse/item/template.hbs
@@ -23,7 +23,7 @@
                 data-test-expand-children={{@singleSubjectManager.subject.id}}
                 local-class='ExpandButton'
                 role='button'
-                aria-label='{{t (if this.shouldShowChildren 'osf-components.subjects.hide_child_subjects' 'osf-components.subjects.show_child_subjects')}}'
+                aria-label='{{t (if this.shouldShowChildren 'osf-components.subjects.browse.hide_child_subjects' 'osf-components.subjects.browse.show_child_subjects')}}'
                 @type='link'
                 @onClick={{action this.toggleChildren}}
             >

--- a/lib/osf-components/addon/components/subjects/display/template.hbs
+++ b/lib/osf-components/addon/components/subjects/display/template.hbs
@@ -11,6 +11,8 @@
                         local-class='RemoveButton'
                         data-analytics-name='Remove'
                         data-analytics-extra={{subject.text}}
+                        role='button'
+                        aria-label={{t 'osf-components.subjects.display.remove_subject'}}
                         @type='link'
                         @onClick={{action @removeSubject subject}}
                     >

--- a/lib/registries/addon/drafts/draft/metadata/styles.scss
+++ b/lib/registries/addon/drafts/draft/metadata/styles.scss
@@ -1,5 +1,6 @@
 .Metadata {
-    :global(label) {
+    :global(label),
+    :global(legend) {
         margin: 20px 0 0;
         padding: 0;
         color: $color-text-gray-blue;
@@ -10,6 +11,10 @@
         &:first-child {
             margin: 0;
         }
+    }
+
+    :global(fieldset) {
+        margin: 20px 0 0;
     }
 
     :global(.list-group-item label) {

--- a/lib/registries/addon/drafts/draft/metadata/template.hbs
+++ b/lib/registries/addon/drafts/draft/metadata/template.hbs
@@ -1,157 +1,153 @@
+{{title (t 'registries.drafts.draft.metadata.title')}}
+
 {{#if this.loading}}
     <LoadingIndicator @dark={{true}} />
 {{else}}
-    <h2 local-class='PageHeading'>
-        {{t 'registries.registration_metadata.metadata_page_heading'}}
-    </h2>
-    <p local-class='HeadingParagraph'>
-        {{t 'registries.registration_metadata.metadata_page_description'}}
-    </p>
-    <hr>
-    <form local-class='Metadata'>
-        <FormControls
-            @changeset={{this.draftManager.metadataChangeset}}
-            ...attributes
-            as |form|
-        >
-            {{#let (unique-id 'title') as |titleFieldId|}}
-                <label
-                    local-class='Label'
-                    for={{titleFieldId}}
-                    id='title'
-                >
-                    <p local-class='DisplayText'>
-                        {{t 'registries.registration_metadata.title'}}
-                        <span local-class='Required'>*</span>
-                    </p>
-                </label>
-                <form.text
-                    data-test-metadata-title
-                    local-class='SchemaBlockInput'
-                    id={{titleFieldId}}
-                    @valuePath='title'
-                    @onKeyUp={{perform this.draftManager.onMetadataInput}}
-                    @placeholder=' '
-                />
-            {{/let}}
-            {{#let (unique-id 'description') as |descriptionFieldId|}}
-                <label
-                    local-class='Label'
-                    for={{descriptionFieldId}}
-                    id='description'
-                >
-                    <p local-class='DisplayText'>
-                        {{t 'registries.registration_metadata.description'}}
-                        <span local-class='Required'>*</span>
-                    </p>
-                </label>
-                <form.textarea
-                    data-test-metadata-description
-                    local-class='SchemaBlockLongText'
-                    id={{descriptionFieldId}}
-                    @valuePath='description'
-                    @onKeyUp={{perform this.draftManager.onMetadataInput}}
-                    @placeholder=' '
-                />
-            {{/let}}
-            <form.select
-                data-test-metadata-category
-                local-class='SchemaBlockDropdown'
-                id='category'
-                @label={{t 'registries.registration_metadata.category'}}
-                @valuePath='category'
-                @options={{this.categoryOptions}}
-                @onchange={{perform this.draftManager.onMetadataInput}}
-                as |option|
+    <main>
+        <h2 local-class='PageHeading'>
+            {{t 'registries.registration_metadata.metadata_page_heading'}}
+        </h2>
+        <p local-class='HeadingParagraph'>
+            {{t 'registries.registration_metadata.metadata_page_description'}}
+        </p>
+        <hr>
+        <form local-class='Metadata'>
+            <FormControls
+                @changeset={{this.draftManager.metadataChangeset}}
+                ...attributes
+                as |form|
             >
-                <NodeCategory @category={{option}} />
-            </form.select>
-            {{#let (unique-id 'institutions') as |institutionsFieldId|}}
-                <label 
-                    for={{institutionsFieldId}}
-                    id='affiliated_institutions'
-                >
-                    {{t 'registries.registration_metadata.affiliated_institutions'}}
-                </label>
-                <Drafts::Draft::-Components::MetadataInstitutionsManager 
-                    @node={{this.draftManager.draftRegistration}}
-                    as |institutionsManager|
-                >
-                    <InstitutionSelectList
-                        @manager={{institutionsManager}}
-                        id={{institutionsFieldId}}
+                {{#let (unique-id 'title') as |titleFieldId|}}
+                    <label
+                        local-class='Label'
+                        for={{titleFieldId}}
+                        id='title'
+                    >
+                        <p local-class='DisplayText'>
+                            {{t 'registries.registration_metadata.title'}}
+                            <span local-class='Required'>*</span>
+                        </p>
+                    </label>
+                    <form.text
+                        data-test-metadata-title
+                        local-class='SchemaBlockInput'
+                        @valuePath='title'
+                        @onKeyUp={{perform this.draftManager.onMetadataInput}}
+                        @placeholder=' '
+                        @uniqueID={{titleFieldId}}
                     />
-                </Drafts::Draft::-Components::MetadataInstitutionsManager>
-            {{/let}}
-            <Drafts::Draft::-Components::Managers::LicensePickerManager
-                @draftManager={{this.draftManager}}
-                as |licenseManager|
-            >
-                <label
-                    for='license-select'
-                    id='license'
-                >
-                    <p local-class='DisplayText'>
-                        {{t 'registries.registration_metadata.choose_license'}}
-                        <span local-class='Required'>*</span>
-                    </p>
-                </label>
-                <RegistriesLicensePicker
+                {{/let}}
+                {{#let (unique-id 'description') as |descriptionFieldId|}}
+                    <label
+                        local-class='Label'
+                        for={{descriptionFieldId}}
+                        id='description'
+                    >
+                        <p local-class='DisplayText'>
+                            {{t 'registries.registration_metadata.description'}}
+                            <span local-class='Required'>*</span>
+                        </p>
+                    </label>
+                    <form.textarea
+                        data-test-metadata-description
+                        local-class='SchemaBlockLongText'
+                        @valuePath='description'
+                        @onKeyUp={{perform this.draftManager.onMetadataInput}}
+                        @placeholder=' '
+                        @uniqueID={{descriptionFieldId}}
+                    />
+                {{/let}}
+                <form.select
+                    data-test-metadata-category
                     local-class='SchemaBlockDropdown'
-                    @manager={{licenseManager}}
-                />
-            </Drafts::Draft::-Components::Managers::LicensePickerManager>
-            {{#let (unique-id 'subjects') as |subjectsFieldId|}}
-                <label
-                    for={{subjectsFieldId}}
-                    id='subjects'
+                    id='category'
+                    @label={{t 'registries.registration_metadata.category'}}
+                    @valuePath='category'
+                    @options={{this.categoryOptions}}
+                    @onchange={{perform this.draftManager.onMetadataInput}}
+                    as |option|
                 >
-                    <p local-class='DisplayText'>
-                        {{t 'registries.registration_metadata.subjects'}}
-                        <span local-class='Required'>*</span>
-                    </p>
-                </label>
-                <Subjects::Manager
-                    @model={{this.draftManager.draftRegistration}}
-                    @provider={{this.draftManager.draftRegistration.provider}}
-                    @doesAutosave={{true}}
-                    @metadataChangeset={{this.draftManager.metadataChangeset}}
-                    as |subjectsManager|
-                >
-                    <Subjects::Widget
-                        id={{subjectsFieldId}}
-                        local-class='SubjectsField'
-                        @subjectsManager={{subjectsManager}}
-                    />
-                    <ValidationErrors
-                        @changeset={{this.draftManager.metadataChangeset}}
-                        @key='subjects'
-                        @isValidating={{subjectsManager.isSaving}}
-                    />
-                </Subjects::Manager>
-            {{/let}}
-            {{#let (unique-id 'tags') as |tagsFieldId|}}
-                <label
-                    for={{tagsFieldId}}
-                    id='tags'
-                >
-                    {{t 'registries.registration_metadata.tags'}}
-                </label>
-                <Drafts::Draft::-Components::TagsManager
-                    @changeset={{this.draftManager.metadataChangeset}}
-                    @onMetadataInput={{perform this.draftManager.onMetadataInput}}
-                    @valuePath='tags'
-                    as |tagsManager|
-                >
-                    <div local-class='TagsContainer'>
-                        <RegistriesTagsWidget
-                            data-test-metadata-tags
-                            id={{tagsFieldId}}
-                            @manager={{tagsManager}}
+                    <NodeCategory @category={{option}} />
+                </form.select>
+                <fieldset id='affiliated_institutions'>
+                    <legend>
+                        {{t 'registries.registration_metadata.affiliated_institutions'}}
+                    </legend>
+                    <Drafts::Draft::-Components::MetadataInstitutionsManager 
+                        @node={{this.draftManager.draftRegistration}}
+                        as |institutionsManager|
+                    >
+                        <InstitutionSelectList
+                            @manager={{institutionsManager}}
                         />
-                    </div>
-                </Drafts::Draft::-Components::TagsManager>
-            {{/let}}
-        </FormControls>
-    </form>
+                    </Drafts::Draft::-Components::MetadataInstitutionsManager>
+                </fieldset>
+                <Drafts::Draft::-Components::Managers::LicensePickerManager
+                    @draftManager={{this.draftManager}}
+                    as |licenseManager|
+                >
+                    <label
+                        for='license-select'
+                        id='license'
+                    >
+                        <p local-class='DisplayText'>
+                            {{t 'registries.registration_metadata.choose_license'}}
+                            <span local-class='Required'>*</span>
+                        </p>
+                    </label>
+                    <RegistriesLicensePicker
+                        local-class='SchemaBlockDropdown'
+                        @manager={{licenseManager}}
+                    />
+                </Drafts::Draft::-Components::Managers::LicensePickerManager>
+                <fieldset id='subjects'>
+                    <legend>
+                        <p local-class='DisplayText'>
+                            {{t 'registries.registration_metadata.subjects'}}
+                            <span local-class='Required'>*</span>
+                        </p>
+                    </legend>
+                    <Subjects::Manager
+                        @model={{this.draftManager.draftRegistration}}
+                        @provider={{this.draftManager.draftRegistration.provider}}
+                        @doesAutosave={{true}}
+                        @metadataChangeset={{this.draftManager.metadataChangeset}}
+                        as |subjectsManager|
+                    >
+                        <Subjects::Widget
+                            local-class='SubjectsField'
+                            @subjectsManager={{subjectsManager}}
+                        />
+                        <ValidationErrors
+                            @changeset={{this.draftManager.metadataChangeset}}
+                            @key='subjects'
+                            @isValidating={{subjectsManager.isSaving}}
+                        />
+                    </Subjects::Manager>
+                </fieldset>
+                {{#let (unique-id 'tags') as |tagsFieldId|}}
+                    <label
+                        for={{tagsFieldId}}
+                        id='tags'
+                    >
+                        {{t 'registries.registration_metadata.tags'}}
+                    </label>
+                    <Drafts::Draft::-Components::TagsManager
+                        @changeset={{this.draftManager.metadataChangeset}}
+                        @onMetadataInput={{perform this.draftManager.onMetadataInput}}
+                        @valuePath='tags'
+                        as |tagsManager|
+                    >
+                        <div local-class='TagsContainer'>
+                            <RegistriesTagsWidget
+                                data-test-metadata-tags
+                                id={{tagsFieldId}}
+                                @manager={{tagsManager}}
+                            />
+                        </div>
+                    </Drafts::Draft::-Components::TagsManager>
+                {{/let}}
+            </FormControls>
+        </form>
+    </main>
 {{/if}}

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -986,6 +986,7 @@ registries:
                 page_label: Review
                 start_review: Review
                 invalid_warning: 'Please address invalid or missing entries to complete registration.'
+                toggle_dropdown: 'Toggle navigation dropdown'
             register: Register
             submit_error: 'Failed to create a registration. Please try again later.'
     index:
@@ -1405,12 +1406,15 @@ osf-components:
     subjects:
         browse:
             browse_all: 'Browse all subjects'
+            show_child_subjects: 'Show child subjects'
+            hide_child_subjects: 'Hide child subjects'
         search:
             search_all: 'Search subjects'
             placeholder: 'Type to search'
             no_results: 'No matching subjects found. Try a less specific search.'
         display:
             placeholder: 'Your selections will appear here'
+            remove_subject: 'Remove subject'
     registries-side-nav:
         expandSideNav: 'Expand registration form navigation'
         collapseSideNav: 'Collapse registration form navigation'


### PR DESCRIPTION
- Ticket: [ENG-1525]
- Feature flag: n/a

## Purpose
Make our new Metadata content accessible ♿️ 

## Summary of Changes
- Added aria-labels to things that did not previously have them
- Used `<fieldset>` and `<legend>` to group categories with multiple inputs (institutions, subjects)

- There were issues getting the `<TagsInput>` widget to pass the accessibility audit due to the way the `<input>` element was nested in it, and no easy way to put the appropriate `id` onto it, as well as getting an aria-label onto it

## Side Effects
- There may be some changes pertaining to components which use the `paginated-list` component as this will create an `<li>` element, but some implementations of this component would nest an additional `<li>` ( `instutional-select-list` in this case). Hopefully this does not result in any styling changes and we have good Percy coverage to catch any that do.

## QA Notes
This should not change the functionality of any existing features of the `draft_metadata` release, but should improve the quality for users using screen-readers

[ENG-1525]: https://openscience.atlassian.net/browse/ENG-1525