### PR TITLE
[ENG-1572] Fix register button on draft-registration list

### DIFF
--- a/app/guid-node/drafts/register/route.ts
+++ b/app/guid-node/drafts/register/route.ts
@@ -2,6 +2,6 @@ import Route from '@ember/routing/route';
 
 export default class GuidNodeDraftsRegister extends Route {
     model() {
-        this.replaceWith('registries.drafts.draft.page', this.modelFor('guid-node.drafts'), 'review');
+        this.replaceWith('registries.drafts.draft.review', this.modelFor('guid-node.drafts'));
     }
 }


### PR DESCRIPTION
- Ticket: [ENG-1572]
- Feature flag: n/a

## Purpose

After refactoring the route, the `register` button on the draft-registration list no longer works because the `guid-node.drafts.register` route redirects us to the wrong route. This PR fixes the problem by changing it to redirect to `registries.drafts.draft.review` route instead of the `page` route.