### PR TITLE
[ENG-1572] Add nodelicense fields to the review page

### DIFF
--- a/lib/osf-components/addon/components/registries/review-metadata-renderer/label-display/template.hbs
+++ b/lib/osf-components/addon/components/registries/review-metadata-renderer/label-display/template.hbs
@@ -15,8 +15,10 @@
 <p local-class='ResponseValue' ...attributes>
     {{~yield~}}
 </p>
-<ValidationErrors
-    local-class='ValidationErrors'
-    @changeset={{@changeset}}
-    @key={{@field}}
-/>
+{{#unless @hideError}}
+    <ValidationErrors
+        local-class='ValidationErrors'
+        @changeset={{@changeset}}
+        @key={{@field}}
+    />
+{{/unless}}

--- a/lib/osf-components/addon/components/registries/review-metadata-renderer/styles.scss
+++ b/lib/osf-components/addon/components/registries/review-metadata-renderer/styles.scss
@@ -5,3 +5,11 @@
 .TextResponse {
     white-space: pre-wrap;
 }
+
+.NestedProperty {
+    margin: 0 0 0 20px;
+}
+
+.ValidationErrors {
+    composes: Element from '../schema-block-renderer/styles.scss';
+}

--- a/lib/osf-components/addon/components/registries/review-metadata-renderer/template.hbs
+++ b/lib/osf-components/addon/components/registries/review-metadata-renderer/template.hbs
@@ -63,16 +63,17 @@
     {{#if fields}}
         <div local-class='NestedProperty'>
             {{#each fields as |field|}}
+          {{#let (get @draftRegistration.nodeLicense field) as |nodeLicenseField|}}
                 <Registries::ReviewMetadataRenderer::LabelDisplay 
                     @draftRegistration={{@draftRegistration}}
                     @changeset={{@metadataChangeset}}
                     @field='nodeLicense.{{field}}'
                     @hideError={{true}}
-                    local-class='{{if (not (get @draftRegistration.nodeLicense field)) 'NoResponse'}}'
+                    local-class='{{unless nodeLicenseField 'NoResponse'}}'
                 >
-                    {{~if (get @draftRegistration.nodeLicense field) (get @draftRegistration.nodeLicense field)
-                        (t (concat 'registries.registration_metadata.no_' field))~}}
+                    {{~or nodeLicenseField (t (concat 'registries.registration_metadata.no_' field))~}}
                 </Registries::ReviewMetadataRenderer::LabelDisplay>
+          {{/let}}
             {{/each}}
             <ValidationErrors
                 local-class='ValidationErrors'

--- a/lib/osf-components/addon/components/registries/review-metadata-renderer/template.hbs
+++ b/lib/osf-components/addon/components/registries/review-metadata-renderer/template.hbs
@@ -63,17 +63,17 @@
     {{#if fields}}
         <div local-class='NestedProperty'>
             {{#each fields as |field|}}
-          {{#let (get @draftRegistration.nodeLicense field) as |nodeLicenseField|}}
-                <Registries::ReviewMetadataRenderer::LabelDisplay 
-                    @draftRegistration={{@draftRegistration}}
-                    @changeset={{@metadataChangeset}}
-                    @field='nodeLicense.{{field}}'
-                    @hideError={{true}}
-                    local-class='{{unless nodeLicenseField 'NoResponse'}}'
-                >
-                    {{~or nodeLicenseField (t (concat 'registries.registration_metadata.no_' field))~}}
-                </Registries::ReviewMetadataRenderer::LabelDisplay>
-          {{/let}}
+                {{#let (get @draftRegistration.nodeLicense field) as |nodeLicenseField|}}
+                    <Registries::ReviewMetadataRenderer::LabelDisplay 
+                        @draftRegistration={{@draftRegistration}}
+                        @changeset={{@metadataChangeset}}
+                        @field='nodeLicense.{{field}}'
+                        @hideError={{true}}
+                        local-class='{{unless nodeLicenseField 'NoResponse'}}'
+                    >
+                        {{~or nodeLicenseField (t (concat 'registries.registration_metadata.no_' field))~}}
+                    </Registries::ReviewMetadataRenderer::LabelDisplay>
+                {{/let}}
             {{/each}}
             <ValidationErrors
                 local-class='ValidationErrors'

--- a/lib/osf-components/addon/components/registries/review-metadata-renderer/template.hbs
+++ b/lib/osf-components/addon/components/registries/review-metadata-renderer/template.hbs
@@ -59,6 +59,30 @@
     {{/if}}
 </Registries::ReviewMetadataRenderer::LabelDisplay>
 
+{{#let @draftRegistration.license.requiredFields as |fields|}}
+    {{#if fields}}
+        <div local-class='NestedProperty'>
+            {{#each fields as |field|}}
+                <Registries::ReviewMetadataRenderer::LabelDisplay 
+                    @draftRegistration={{@draftRegistration}}
+                    @changeset={{@metadataChangeset}}
+                    @field='nodeLicense.{{field}}'
+                    @hideError={{true}}
+                    local-class='{{if (not (get @draftRegistration.nodeLicense field)) 'NoResponse'}}'
+                >
+                    {{~if (get @draftRegistration.nodeLicense field) (get @draftRegistration.nodeLicense field)
+                        (t (concat 'registries.registration_metadata.no_' field))~}}
+                </Registries::ReviewMetadataRenderer::LabelDisplay>
+            {{/each}}
+            <ValidationErrors
+                local-class='ValidationErrors'
+                @changeset={{@metadataChangeset}}
+                @key='nodeLicense'
+            />
+        </div>
+    {{/if}}
+{{/let}}
+
 <Registries::ReviewMetadataRenderer::LabelDisplay 
     @draftRegistration={{@draftRegistration}}
     @changeset={{@metadataChangeset}}

--- a/lib/registries/addon/components/registries-license-picker/template.hbs
+++ b/lib/registries/addon/components/registries-license-picker/template.hbs
@@ -43,7 +43,7 @@
                 {{#each @manager.requiredFields as |key|}}
                     <div class='form-group'>
                         <label>
-                            <p>
+                            <p id='nodeLicense.{{key}}'>
                                 {{t (concat 'app_components.license_picker.fields.' key)}}
                                 <span local-class='Required'>*</span>
                             </p>

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1029,7 +1029,7 @@ registries:
         metadata_page_heading: 'Registration Metadata'
         metadata_page_description: 'This metadata applies only to the registration you are creating, and will not be applied to your project.'
         no_affiliated_institutions: 'No affiliated institutions'
-        no_copyrightHolders: 'No copyright holder'
+        no_copyrightHolders: 'No copyright holders'
         no_description: 'No description'
         no_doi: 'No DOI assigned'
         no_license: 'No license'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1029,6 +1029,7 @@ registries:
         metadata_page_heading: 'Registration Metadata'
         metadata_page_description: 'This metadata applies only to the registration you are creating, and will not be applied to your project.'
         no_affiliated_institutions: 'No affiliated institutions'
+        no_copyrightHolders: 'No copyright holder'
         no_description: 'No description'
         no_doi: 'No DOI assigned'
         no_license: 'No license'
@@ -1036,6 +1037,7 @@ registries:
         no_publication_doi: 'No publication DOI'
         no_subjects: 'No subjects'
         no_title: 'No title'
+        no_year: 'No year'
         publication_doi: 'Publication DOI'
         registered_from: 'Registered from'
         registration_doi: 'Registration DOI'
@@ -1069,6 +1071,9 @@ registries:
         edit_tags:
             success: 'Tags successfully updated.'
             error: 'Unable to save tags.'
+        nodeLicense:
+            year: 'Year'
+            copyrightHolders: 'Copyright Holder'
         save_subjects_error: 'Unable to save subjects'
     form_view:
         none_selected: 'None selected'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1073,7 +1073,7 @@ registries:
             error: 'Unable to save tags.'
         nodeLicense:
             year: 'Year'
-            copyrightHolders: 'Copyright Holder'
+            copyrightHolders: 'Copyright Holders'
         save_subjects_error: 'Unable to save subjects'
     form_view:
         none_selected: 'None selected'


### PR DESCRIPTION
- Ticket: [ENG-1572]
- Feature flag: n/a

## Purpose
- Add the node license fields to the review page and add validation status to it

## Summary of Changes
- Added flag to hide validation option for fields (needed to combine the nodelicense validations together)
- styling changes for nested properties
- node license required fields to `review-metadata-renderer`
- added anchor id's to the `registries license picker`
## Side Effects
`NA`

## QA Notes
- this is part of the metadata feature stuff, so if there is any weirdness associated with the license picker and required fields validation, these should be addressing them!

[ENG-1572]: https://openscience.atlassian.net/browse/ENG-1572