### PR TITLE
[ENG-1629] Change `field` to `field(s)` and add validation for year.

### DIFF
--- a/app/packages/registration-schema/validations.ts
+++ b/app/packages/registration-schema/validations.ts
@@ -96,9 +96,31 @@ export function validateNodeLicense() {
                 type: 'node_license_missing_fields',
                 translationArgs: {
                     missingFields,
+                    numOfFields: missingFieldsList.length,
                 },
             },
         };
+    };
+}
+
+export function validateNodeLicenseYear() {
+    return (_: unknown, __: unknown, ___: unknown, changes: any, content: DraftRegistration) => {
+        let validateYearTarget: string = '';
+        if (content.nodeLicense && content.nodeLicense.year) {
+            validateYearTarget = content.nodeLicense.year;
+        }
+        if (changes.nodeLicense && changes.nodeLicense.year) {
+            validateYearTarget = changes.nodeLicense.year;
+        }
+        const regex = /^((?!(0))[0-9]{4})$/;
+        if (validateYearTarget && !validateYearTarget.match(regex)) {
+            return {
+                context: {
+                    type: 'year_format',
+                },
+            };
+        }
+        return true;
     };
 }
 
@@ -129,6 +151,6 @@ export function buildMetadataValidations() {
     set(validationObj, DraftMetadataProperties.Description, notBlank);
     set(validationObj, DraftMetadataProperties.License, notBlank);
     set(validationObj, DraftMetadataProperties.Subjects, validateSubjects());
-    set(validationObj, DraftMetadataProperties.NodeLicenseProperty, validateNodeLicense());
+    set(validationObj, DraftMetadataProperties.NodeLicenseProperty, [validateNodeLicense(), validateNodeLicenseYear()]);
     return validationObj;
 }

--- a/app/validators/node-license.ts
+++ b/app/validators/node-license.ts
@@ -34,14 +34,14 @@ export default class NodeLicenseValidator extends BaseValidator {
             return this.createErrorMessage('node_license_invalid', value, options);
         }
 
-        const missingFields = license.requiredFields
+        const missingFieldsList = license.requiredFields
             .filter(field => !value[field])
             .sort()
-            .map(field => this.intl.t(`app_components.license_picker.fields.${field}`))
-            .join(', ');
-
-        if (missingFields.length) {
-            return this.createErrorMessage('node_license_missing_fields', value, { missingFields });
+            .map(field => this.intl.t(`app_components.license_picker.fields.${field}`));
+        const missingFields = missingFieldsList.join(', ');
+        if (missingFieldsList.length) {
+            return this.createErrorMessage('node_license_missing_fields',
+                value, { missingFields, numOfFields: missingFieldsList.length });
         }
 
         return true;

--- a/lib/osf-components/addon/components/license-picker/component.ts
+++ b/lib/osf-components/addon/components/license-picker/component.ts
@@ -15,6 +15,7 @@ import Provider from 'ember-osf-web/models/provider';
 import Analytics from 'ember-osf-web/services/analytics';
 import Theme from 'ember-osf-web/services/theme';
 
+import ValidatedModelForm from 'osf-components/components/validated-model-form/component';
 import styles from './styles';
 import template from './template';
 
@@ -25,6 +26,7 @@ export default class LicensePicker extends Component {
     @service theme!: Theme;
     @service intl!: Intl;
 
+    form?: ValidatedModelForm<'node'>;
     showText: boolean = false;
     node: Node = this.node;
     licensesAcceptable!: QueryHasManyResult<License>;
@@ -63,13 +65,14 @@ export default class LicensePicker extends Component {
         this.node.setNodeLicenseDefaults(selected.requiredFields);
     }
 
-    /**
-     * Calling notifyPropertyChange doesn't trigger dirty attributes
-     */
     @action
-    notify() {
-        // TODO: find a better way to set propertyDidChange
-        this.node.set('nodeLicense', { ...this.node.nodeLicense });
+    updateNodeLicense(key: string, event: Event) {
+        if (this.form) {
+            const target = event.target as HTMLInputElement;
+            const newNodeLicense = { ...this.form.changeset.get('nodeLicense') } as { [key: string]: string };
+            newNodeLicense[key] = target.value;
+            this.form.changeset.set('nodeLicense', newNodeLicense);
+        }
     }
 
     didReceiveAttrs(...args: any[]) {

--- a/lib/osf-components/addon/components/license-picker/template.hbs
+++ b/lib/osf-components/addon/components/license-picker/template.hbs
@@ -37,8 +37,8 @@
             <Input
                 @class='form-control'
                 @id={{concat 'nodeLicense-' key}}
-                @value={{mut (get this.node.nodeLicense key)}}
-                @input={{action 'notify'}}
+                @value={{readonly (get this.node.nodeLicense key)}}
+                @change={{fn this.updateNodeLicense key}}
                 @placeholder={{t 'general.required'}}
             />
         {{/each}}

--- a/tests/engines/registries/acceptance/draft/draft-test.ts
+++ b/tests/engines/registries/acceptance/draft/draft-test.ts
@@ -564,14 +564,16 @@ module('Registries | Acceptance | draft form', hooks => {
         assert.dom('[data-test-required-field="copyrightHolders"]')
             .hasText('', 'License: CopyrightHolders does not autofill');
         let missingFields = 'Copyright Holders';
-        let validationErrorMsg = t('validationErrors.node_license_missing_fields', { missingFields }).toString();
+        let validationErrorMsg = t('validationErrors.node_license_missing_fields',
+            { missingFields, numOfFields: 1 }).toString();
         assert.dom('[data-test-validation-errors="nodeLicense"]')
             .containsText(validationErrorMsg, 'NodeLicense validation error when copyright holder is empty');
 
         // Input invalid Nodelicense fields
         await fillIn('[data-test-required-field="year"]', '');
         missingFields = 'Year, Copyright Holders';
-        validationErrorMsg = t('validationErrors.node_license_missing_fields', { missingFields }).toString();
+        validationErrorMsg = t('validationErrors.node_license_missing_fields',
+            { missingFields, numOfFields: 2 }).toString();
         assert.dom('[data-test-validation-errors="nodeLicense"]')
             .containsText(validationErrorMsg, 'NodeLicense validation error when year and copyrightholder are empty');
         await percySnapshot('Registries | Acceptance | draft form | metadata editing | metadata: invalid nodelicense');

--- a/tests/engines/registries/acceptance/overview/overview-test.ts
+++ b/tests/engines/registries/acceptance/overview/overview-test.ts
@@ -420,7 +420,8 @@ module('Registries | Acceptance | overview.overview', hooks => {
         await click('[data-test-save-license]');
 
         const missingFields = 'Copyright Holders';
-        const validationErrorMsg = t('validationErrors.node_license_missing_fields', { missingFields }).toString();
+        const validationErrorMsg = t('validationErrors.node_license_missing_fields',
+            { missingFields, numOfFields: 1 }).toString();
         assert.dom('.help-block').hasText(validationErrorMsg, 'validation works');
 
         await fillIn('[data-test-required-field="copyrightHolders"]', 'Jane Doe, John Doe');

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -514,13 +514,14 @@ validationErrors:
     affirm_terms: 'You must read and agree to the Terms of Use and Privacy Policy.'
     min_subjects: 'You must select at least one subject.'
     node_license_invalid: 'Invalid required fields for the license'
-    node_license_missing_fields: 'The following required fields are missing: {missingFields}'
+    node_license_missing_fields: 'The following required {numOfFields, plural, =1 {field is} other {fields are}} missing: {missingFields}'
     invalid_doi: 'Please use a valid DOI format (10.xxxx/xxxxx)'
     mustSelect: 'You must select a value for this field.'
     mustSelectMinOne: 'You must select at least one value for this field.'
     mustSelectFileMinOne: 'You must select at least one file for this field.'
     onlyProjectOrComponentFiles: 'The {numOfFiles, plural, =1 {file} other {files}} "{missingFilesList}" cannot be found on this {projectOrComponent}.'
     new_folder_name: 'Folder name must not be blank.'
+    year_format: 'Please specify a valid year.'
 validated_input_form:
     discard_changes: 'Discard changes'
 node_navbar:


### PR DESCRIPTION
- Ticket: [ENG-1629]
- Feature flag: n/a

## Purpose

For validation message for subjects, change `field` to `field(s)`
Add validation error message from year.



[ENG-1629]: https://openscience.atlassian.net/browse/ENG-1629