### PR TITLE
[ENG-1614] Add placeholder routes for branded registries

### DIFF
--- a/app/adapters/registration-provider.ts
+++ b/app/adapters/registration-provider.ts
@@ -2,7 +2,7 @@ import OsfAdapter from './osf-adapter';
 
 export default class RegistrationProviderAdapter extends OsfAdapter {
     pathForType(_: string): string {
-        return 'providers/registries';
+        return 'providers/registrations';
     }
 }
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -232,6 +232,8 @@ module.exports = function(environment) {
         },
         featureFlagNames: {
             routes: {
+                'branded': 'ember_registries_detail_page', //TODO Replace with another flag
+                'branded.discover': 'ember_registries_detail_page', //TODO Replace with another flag
                 'guid-node.index': 'ember_project_detail_page',
                 'guid-node.drafts.index': 'ember_edit_draft_registration_page',
                 'guid-node.drafts.register': 'ember_edit_draft_registration_page',

--- a/config/environment.js
+++ b/config/environment.js
@@ -232,8 +232,8 @@ module.exports = function(environment) {
         },
         featureFlagNames: {
             routes: {
-                'branded': 'ember_registries_detail_page', //TODO Replace with another flag
-                'branded.discover': 'ember_registries_detail_page', //TODO Replace with another flag
+                'registries.branded': 'branded_registries',
+                'registries.branded.discover': 'branded_registries',
                 'guid-node.index': 'ember_project_detail_page',
                 'guid-node.drafts.index': 'ember_edit_draft_registration_page',
                 'guid-node.drafts.register': 'ember_edit_draft_registration_page',

--- a/lib/registries/addon/branded/discover/route.ts
+++ b/lib/registries/addon/branded/discover/route.ts
@@ -1,0 +1,14 @@
+import { action } from '@ember/object';
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+import Analytics from 'ember-osf-web/services/analytics';
+
+export default class BrandedRegistriesDiscoverRoute extends Route {
+    @service analytics!: Analytics;
+
+    @action
+    didTransition() {
+        this.analytics.trackPage();
+    }
+}

--- a/lib/registries/addon/branded/discover/template.hbs
+++ b/lib/registries/addon/branded/discover/template.hbs
@@ -1,1 +1,0 @@
-<p>Branded Discover</p>

--- a/lib/registries/addon/branded/discover/template.hbs
+++ b/lib/registries/addon/branded/discover/template.hbs
@@ -1,0 +1,1 @@
+<p>Branded Discover</p>

--- a/lib/registries/addon/branded/route.ts
+++ b/lib/registries/addon/branded/route.ts
@@ -1,0 +1,20 @@
+import { action } from '@ember/object';
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import DS from 'ember-data';
+
+import Analytics from 'ember-osf-web/services/analytics';
+
+export default class BrandedRegistriesRoute extends Route {
+    @service analytics!: Analytics;
+    @service store!: DS.Store;
+
+    model(params: Record<string, string>) {
+        return this.store.findRecord('registration-provider', params.provider_id);
+    }
+
+    @action
+    didTransition() {
+        this.analytics.trackPage();
+    }
+}

--- a/lib/registries/addon/branded/route.ts
+++ b/lib/registries/addon/branded/route.ts
@@ -9,8 +9,8 @@ export default class BrandedRegistriesRoute extends Route {
     @service analytics!: Analytics;
     @service store!: DS.Store;
 
-    model(params: Record<string, string>) {
-        return this.store.findRecord('registration-provider', params.provider_id);
+    model(params: { providerId: string }) {
+        return this.store.findRecord('registration-provider', params.providerId);
     }
 
     @action

--- a/lib/registries/addon/branded/template.hbs
+++ b/lib/registries/addon/branded/template.hbs
@@ -1,0 +1,1 @@
+<p>Branded Landing Page</p>

--- a/lib/registries/addon/branded/template.hbs
+++ b/lib/registries/addon/branded/template.hbs
@@ -1,1 +1,1 @@
-<p>Branded Landing Page</p>
+{{outlet}}

--- a/lib/registries/addon/routes.ts
+++ b/lib/registries/addon/routes.ts
@@ -3,6 +3,9 @@ import buildRoutes from 'ember-engines/routes';
 export default buildRoutes(function() {
     this.route('index', { path: '/registries' });
     this.route('discover', { path: '/registries/discover' });
+    this.route('branded', { path: '/registries/:provider_id' } as any, function() {
+        this.route('discover', { path: '/discover' });
+    });
 
     this.route('start', { path: '/registries/start' });
 

--- a/lib/registries/addon/routes.ts
+++ b/lib/registries/addon/routes.ts
@@ -3,7 +3,7 @@ import buildRoutes from 'ember-engines/routes';
 export default buildRoutes(function() {
     this.route('index', { path: '/registries' });
     this.route('discover', { path: '/registries/discover' });
-    this.route('branded', { path: '/registries/:providerId' } as any, function() {
+    this.route('branded', { path: '/registries/:providerId' }, function() {
         this.route('discover', { path: '/discover' });
     });
 

--- a/lib/registries/addon/routes.ts
+++ b/lib/registries/addon/routes.ts
@@ -3,7 +3,7 @@ import buildRoutes from 'ember-engines/routes';
 export default buildRoutes(function() {
     this.route('index', { path: '/registries' });
     this.route('discover', { path: '/registries/discover' });
-    this.route('branded', { path: '/registries/:provider_id' } as any, function() {
+    this.route('branded', { path: '/registries/:providerId' } as any, function() {
         this.route('discover', { path: '/discover' });
     });
 


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-1614]
- Feature flag: n/a

## Purpose

Add two routes `registries/:provider_id` and `registries/:provider_id/discover`

## Summary of Changes

These routes are placeholders for branded components to be built in

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->



[ENG-1614]: https://openscience.atlassian.net/browse/ENG-1614