### PR TITLE
[No ticket] Use reload:true for findAll()

### DIFF
--- a/app/guid-node/registrations/controller.ts
+++ b/app/guid-node/registrations/controller.ts
@@ -44,6 +44,7 @@ export default class GuidNodeRegistrations extends Controller {
                         'filter[active]': true,
                     },
                 },
+                reload: true,
             });
         schemas = schemas.toArray();
         schemas.sort((a: RegistrationSchema, b: RegistrationSchema) => a.name.length - b.name.length);


### PR DESCRIPTION
Use `reload: true` so that we will always fetch from API the list of active schemas instead of getting that list from the cached store, which may contain multiple versions of the same schema because of existing drafts with old version schemas.
