### PR TITLE
[Fix] Update config to use isTruthy

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -307,7 +307,7 @@ module.exports = function(environment) {
             shouldIncludeStyleguide: false,
         },
         'ember-cli-mirage': {
-            enabled: Boolean(MIRAGE_ENABLED),
+            enabled: isTruthy(MIRAGE_ENABLED),
         },
         'changeset-validations': {
             rawOutput: true,


### PR DESCRIPTION
- Ticket: `n/a`
- Feature flag: `n/a`

## Purpose

We're currently using `Boolean()` instead of `isTruthy()` for the `ember-cli-mirage` check in the config file. This should be updated to use `isTruthy`.

## Summary of Changes

- Update `Boolean` to be `isTruthy`

## Side Effects

`n/a`

## QA Notes

This shouldn't need QA and should only affect dev environments using mirage.
