### PR TITLE
[ENG-1535] Fix file links issue on overview page

### DIFF
--- a/app/serializers/registration.ts
+++ b/app/serializers/registration.ts
@@ -6,28 +6,22 @@ import {
 } from 'ember-osf-web/packages/registration-schema';
 import { normalizeRegistrationResponses } from 'ember-osf-web/serializers/draft-registration';
 import { mapKeysAndValues } from 'ember-osf-web/utils/map-keys';
-import { SingleResourceDocument } from 'osf-api';
+import { Resource } from 'osf-api';
 import OsfSerializer from './osf-serializer';
 
 export default class RegistrationSerializer extends OsfSerializer {
-    normalizeResponse(
-        store: DS.Store,
-        primaryModelClass: any,
-        payload: SingleResourceDocument,
-        id: string,
-        requestType: string,
-    ) {
-        if (payload.data.attributes) {
-            const registrationResponses = payload.data.attributes.registration_responses as RegistrationResponse;
+    normalize(modelClass: DS.Model, resourceHash: Resource) {
+        if (resourceHash.attributes) {
+            const registrationResponses = resourceHash.attributes.registration_responses as RegistrationResponse;
             // @ts-ignore
             // eslint-disable-next-line no-param-reassign
-            payload.data.attributes.registration_responses = mapKeysAndValues(
+            resourceHash.attributes.registration_responses = mapKeysAndValues(
                 registrationResponses || {},
                 key => key,
-                value => normalizeRegistrationResponses(value, store),
+                value => normalizeRegistrationResponses(value, this.store),
             ) as NormalizedRegistrationResponse;
         }
-        return super.normalizeResponse(store, primaryModelClass, payload, id, requestType);
+        return super.normalize(modelClass, resourceHash) as { data: Resource };
     }
 }
 

--- a/lib/osf-components/addon/components/node-card/template.hbs
+++ b/lib/osf-components/addon/components/node-card/template.hbs
@@ -30,6 +30,7 @@
                 {{node-card/node-icon category=@node.category}}
                 <OsfLink
                     data-analytics-name='Title'
+                    data-test-node-title='{{@node.id}}'
                     @route='resolve-guid'
                     @models={{array @node.id}}
                 >

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/component.ts
@@ -31,7 +31,7 @@ export default class ReadOnlyFiles extends Component {
         );
     }
 
-    @computed('schemaBlock')
+    @computed('schemaBlock', 'registrationResponses')
     get responses() {
         const {
             schemaBlock: { registrationResponseKey },

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/template.hbs
@@ -10,6 +10,7 @@
                     {{~file.name~}}
                 {{else}}
                     <OsfLink
+                        data-test-file-link='{{file.id}}'
                         @href={{file.links.html}}
                         @target='_blank'
                     >

--- a/mirage/factories/file.ts
+++ b/mirage/factories/file.ts
@@ -1,5 +1,6 @@
 import { association, Factory, faker, trait, Trait } from 'ember-cli-mirage';
 import File from 'ember-osf-web/models/file';
+import { FileReference } from 'ember-osf-web/packages/registration-schema';
 
 import { guid, guidAfterCreate } from './utils';
 
@@ -7,7 +8,11 @@ export interface FileTraits {
     asFolder: Trait;
 }
 
-export default Factory.extend<File & FileTraits>({
+export interface MirageFile extends File {
+    fileReference: FileReference;
+}
+
+export default Factory.extend<MirageFile & FileTraits>({
     id: guid('file'),
     guid: guid('file'),
     afterCreate: guidAfterCreate,
@@ -22,8 +27,6 @@ export default Factory.extend<File & FileTraits>({
         },
         downloads: faker.random.number(1000),
     },
-    // kind: 'file',
-    // currentUserCanComment: true,
     lastTouched() {
         return faker.date.past(2, new Date(2018, 0, 0));
     },
@@ -65,7 +68,26 @@ export default Factory.extend<File & FileTraits>({
             });
         },
     }),
+    fileReference() {
+        return {
+            file_id: this.id as string,
+            file_name: this.name as string,
+            file_urls: {
+                html: `fakedomain/${this.id}`,
+                download: `fakedomain/${this.id}/download`,
+            },
+            file_hashes: {
+                sha256: this.extra.hashes.sha256,
+            },
+        };
+    },
 });
+
+declare module 'ember-cli-mirage/types/registries/model' {
+    export default interface MirageModelRegistry {
+        file: MirageFile;
+    } // eslint-disable-line semi
+}
 
 declare module 'ember-cli-mirage/types/registries/schema' {
     export default interface MirageSchemaRegistry {

--- a/mirage/fixture-data/schema-blocks/open-ended-registration.ts
+++ b/mirage/fixture-data/schema-blocks/open-ended-registration.ts
@@ -37,6 +37,17 @@ const schemaBlocks: Array<Partial<SchemaBlock>> = [
         schemaBlockGroupKey: '5da4cf5ff04bcd000155f331',
         id: '5da4cf5ff04bcd000155f333',
     },
+    {
+        displayText: '',
+        exampleText: '',
+        blockType: 'file-input',
+        registrationResponseKey: 'uploader',
+        index: 3,
+        required: false,
+        helpText: '',
+        schemaBlockGroupKey: '5e72398a31655a0001ea8ef8',
+        id: '5e72398a31655a0001ea8efa',
+    },
 ];
 
 export const schemaBlockIds = schemaBlocks.map(block => block.id);

--- a/tests/acceptance/guid-file/file-detail-test.ts
+++ b/tests/acceptance/guid-file/file-detail-test.ts
@@ -353,6 +353,7 @@ module('Acceptance | guid file', hooks => {
                 'file',
                 {
                     user: currentUser,
+                    currentVersion: 3,
                 },
             );
             await visit(`--file/${file.guid}`);

--- a/tests/acceptance/guid-user/quickfiles-test.ts
+++ b/tests/acceptance/guid-user/quickfiles-test.ts
@@ -305,9 +305,6 @@ module('Acceptance | Guid User Quickfiles', hooks => {
                 dateModified: '2016-08-07T16:43:18.319Z',
                 guid: 'xyzzy',
                 currentVersion: 7,
-                extra: {
-                    downloads: 42,
-                },
                 user: currentUser,
             });
             const date = moment('2016-08-07T16:43:18.319Z').format('YYYY-MM-DD h:mm A');
@@ -323,7 +320,7 @@ module('Acceptance | Guid User Quickfiles', hooks => {
             assert.dom('[data-test-version-link]')
                 .containsText('7');
             assert.dom('[data-test-download-count]')
-                .containsText('42');
+                .containsText(file.extra.downloads);
             assert.dom('[data-test-date-modified]')
                 .hasText(date);
         });

--- a/tests/engines/registries/acceptance/overview/overview-test.ts
+++ b/tests/engines/registries/acceptance/overview/overview-test.ts
@@ -433,4 +433,60 @@ module('Registries | Acceptance | overview.overview', hooks => {
         // @ts-ignore
         assert.deepEqual(reg.nodeLicense!.copyright_holders, ['Jane Doe', 'John Doe']);
     });
+
+    test('File links show on registration detail', async assert => {
+        const openEndedReg = server.schema.registrationSchemas.find('open_ended_registration');
+        const registeredFrom = server.create('node', 'currentUserAdmin');
+        const fileOne = server.create('file', { target: registeredFrom });
+        const fileTwo = server.create('file', { target: registeredFrom });
+        const registrationResponses = {
+            summary: 'Test file links',
+            uploader: [fileOne.fileReference, fileTwo.fileReference],
+        };
+
+        const reg = server.create('registration', {
+            registrationSchema: openEndedReg,
+            currentUserPermissions: Object.values(Permission),
+            registrationResponses,
+            registeredFrom,
+        });
+
+        await visit(`/${reg.id}/`);
+
+        assert.dom('[data-test-read-only-file-widget]').isVisible();
+        assert.dom(`[data-test-file-link="${fileOne.id}"]`).hasText(fileOne.name);
+        assert.dom(`[data-test-file-link="${fileOne.id}"]`).hasAttribute('href', `fakedomain/${fileOne.id}`);
+        assert.dom(`[data-test-file-link="${fileTwo.id}"]`).hasText(fileTwo.name);
+        assert.dom(`[data-test-file-link="${fileTwo.id}"]`).hasAttribute('href', `fakedomain/${fileTwo.id}`);
+    });
+
+    test('File links show on registration detail from registrations list', async assert => {
+        const openEndedReg = server.schema.registrationSchemas.find('open_ended_registration');
+        const registeredFrom = server.create('node', 'currentUserAdmin');
+        const fileOne = server.create('file', { target: registeredFrom });
+        const fileTwo = server.create('file', { target: registeredFrom });
+        const registrationResponses = {
+            summary: 'Test file links',
+            uploader: [fileOne.fileReference, fileTwo.fileReference],
+        };
+
+        const reg = server.create('registration', {
+            registrationSchema: openEndedReg,
+            currentUserPermissions: Object.values(Permission),
+            registrationResponses,
+            registeredFrom,
+        });
+
+        await visit(`/--node/${registeredFrom.id}/registrations`);
+
+        assert.dom('[data-test-node-card]').exists({ count: 1 });
+
+        await click(`[data-test-node-title="${reg.id}"]`);
+
+        assert.dom('[data-test-read-only-file-widget]').isVisible();
+        assert.dom(`[data-test-file-link="${fileOne.id}"]`).hasText(fileOne.name);
+        assert.dom(`[data-test-file-link="${fileOne.id}"]`).hasAttribute('href', `fakedomain/${fileOne.id}`);
+        assert.dom(`[data-test-file-link="${fileTwo.id}"]`).hasText(fileTwo.name);
+        assert.dom(`[data-test-file-link="${fileTwo.id}"]`).hasAttribute('href', `fakedomain/${fileTwo.id}`);
+    });
 });


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: []
- Feature flag: n/a

## Purpose

Transitioning from a project's registration list to a registration overview page, the file links do not show.

## Summary of Changes
- Use `Normalize` instead of `NormalizeResponse` to normalize both registration list and detail.
- Add test
- Adds `fileReference` to mirage file model

## Side Effects

## QA Notes
Please make sure files link are shown on the overview page in both these cases:
- From a project's registration list tab to a particular registration.
- Go directly to a registration overview page.
