### PR TITLE
[ENG-613] Update component to remove progress-bar

### DIFF
--- a/lib/osf-components/addon/components/draft-registration-card/component.ts
+++ b/lib/osf-components/addon/components/draft-registration-card/component.ts
@@ -1,7 +1,6 @@
 import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import { action } from '@ember/object';
-import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 
 import { layout } from 'ember-osf-web/decorators/component';
@@ -15,7 +14,6 @@ import template from './template';
 @tagName('')
 export default class DraftRegistrationCard extends Component {
     @service analytics!: Analytics;
-    @service router!: RouterService;
 
     // Required arguments
     draftRegistration!: DraftRegistration;

--- a/lib/osf-components/addon/components/draft-registration-card/component.ts
+++ b/lib/osf-components/addon/components/draft-registration-card/component.ts
@@ -1,13 +1,11 @@
 import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
-import { action, computed } from '@ember/object';
+import { action } from '@ember/object';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
-import { htmlSafe } from '@ember/string';
 
 import { layout } from 'ember-osf-web/decorators/component';
 import DraftRegistration from 'ember-osf-web/models/draft-registration';
-import { RegistrationMetadata } from 'ember-osf-web/models/registration-schema';
 import Analytics from 'ember-osf-web/services/analytics';
 
 import styles from './styles';
@@ -24,87 +22,9 @@ export default class DraftRegistrationCard extends Component {
 
     // Optional arguments
     onDelete?: (draftRegistration?: DraftRegistration) => void;
-    decrementCount?: () => void;
 
     // Private properties
     deleteModalOpen = false;
-
-    @computed('draftRegistration.{registrationSchema,registrationMetadata}')
-    get percentComplete() {
-        let requiredQuestions = 0;
-        let answeredRequiredQuestions = 0;
-        const schema = this.draftRegistration.registrationSchema.get('schema');
-        if (!schema) {
-            return -1;
-        }
-        const metadata = this.draftRegistration.registrationMetadata;
-        if (!metadata) {
-            return 0;
-        }
-        schema.pages.forEach(page =>
-            page.questions.forEach(question => {
-                if (question.type === 'object' && question.properties) {
-                    question.properties.forEach(property => {
-                        if (!property.required) {
-                            return;
-                        }
-
-                        requiredQuestions++;
-
-                        if (!(question.qid in metadata)) {
-                            return;
-                        }
-
-                        const answers = metadata[question.qid];
-                        if ('value' in answers) {
-                            const value = answers.value as RegistrationMetadata;
-                            if (value && property.id in value) {
-                                const propertyValue = value[property.id].value;
-                                if (Array.isArray(propertyValue) ? propertyValue.length : propertyValue) {
-                                    answeredRequiredQuestions++;
-                                }
-                            }
-                        }
-                    });
-                } else if (question.required) {
-                    requiredQuestions++;
-                    if (question.qid in metadata && 'value' in metadata[question.qid]) {
-                        const { value } = metadata[question.qid];
-                        if (Array.isArray(value) ? value.length : value) {
-                            answeredRequiredQuestions++;
-                        }
-                    }
-                }
-            }));
-        return requiredQuestions ? (answeredRequiredQuestions / requiredQuestions) * 100 : -1;
-    }
-
-    @computed('percentComplete')
-    get showProgress() {
-        return this.percentComplete >= 0;
-    }
-
-    @computed('percentComplete')
-    get progressStyle() {
-        return htmlSafe(`width: ${this.percentComplete}%`);
-    }
-
-    @computed('draftRegistration', 'showProgress', 'percentComplete')
-    get enableRegister() {
-        if (this.draftRegistration) {
-            return this.showProgress ? this.percentComplete === 100 : true;
-        }
-        return false;
-    }
-
-    @action
-    edit() {
-        this.router.transitionTo(
-            'guid-node.drafts',
-            this.draftRegistration.branchedFrom.get('id'),
-            this.draftRegistration.id,
-        );
-    }
 
     @action
     delete() {
@@ -123,14 +43,5 @@ export default class DraftRegistrationCard extends Component {
         if (this.onDelete) {
             this.onDelete(this.draftRegistration);
         }
-    }
-
-    @action
-    register() {
-        this.router.transitionTo(
-            'guid-node.drafts.register',
-            this.draftRegistration.branchedFrom.get('id'),
-            this.draftRegistration.id,
-        );
     }
 }

--- a/lib/osf-components/addon/components/draft-registration-card/styles.scss
+++ b/lib/osf-components/addon/components/draft-registration-card/styles.scss
@@ -18,11 +18,19 @@
     }
 }
 
-.DraftRegistratrionCard__body {
+.DraftRegistrationCard__body {
+    font-size: 18px;
+    font-weight: 400;
+    line-height: 1;
+    color: $color-text-gray-light;
+
+    small {
+        font-size: 75%;
+    }
+
     :global(.ember-content-placeholders-text) {
         width: 33%;
     }
-
 }
 
 :global(.delete_draft_registration) {

--- a/lib/osf-components/addon/components/draft-registration-card/template.hbs
+++ b/lib/osf-components/addon/components/draft-registration-card/template.hbs
@@ -5,21 +5,22 @@
 >
     <h4 local-class='DraftRegistratrionCard__title' data-test-draft-registration-card-title>
         {{#if this.draftRegistration}}
-            {{this.draftRegistration.registrationSchema.name}}
+            <OsfLink
+                data-analytics-name='view_registration'
+                @route='registries.drafts.draft'
+                @models={{array this.draftRegistration.id}}
+            >
+                {{this.draftRegistration.registrationSchema.name}}
+            </OsfLink>
         {{else}}
             <ContentPlaceholders as |placeholder|>
                 <placeholder.text @lines={{1}} />
             </ContentPlaceholders>
         {{/if}}
     </h4>
-    <h4 local-class='DraftRegistratrionCard__body' data-test-draft-registration-card-body>
-        <small>
-            {{#if this.draftRegistration}}
-                {{#if this.showProgress}}
-                    <div class='progress progress-bar-md' data-test-draft-registration-card-progress-bar>
-                        <div class='progress-bar' style={{this.progressStyle}}></div>
-                    </div>
-                {{/if}}
+    <section local-class='DraftRegistrationCard__body' data-test-draft-registration-card-body>
+        {{#if this.draftRegistration}}
+            <small>
                 <p>
                     {{t 'osf-components.draft-registration-card.initiated_by'}}
                     {{this.draftRegistration.initiator.fullName}}
@@ -32,69 +33,70 @@
                     {{t 'osf-components.draft-registration-card.last_updated'}}
                     {{moment this.draftRegistration.datetimeUpdated}}
                 </p>
-            {{else}}
-                <ContentPlaceholders as |placeholder|>
-                    <placeholder.text @lines={{3}} />
-                </ContentPlaceholders>
-            {{/if}}
-        </small>
-        <div class='row'>
-            <div class='col-md-10'>
-                <OsfButton
-                    data-analytics-name='Edit'
-                    @type='default' 
-                    @onClick={{action this.edit}}
-                    @disabled={{not this.draftRegistration}}
-                >
-                    {{fa-icon 'pencil'}} {{t 'general.edit'}}
-                </OsfButton><OsfButton {{! template-lint-disable }}
-                    data-analytics-name='Delete'
-                    @type='default' 
-                    @onClick={{action this.delete}}
-                    disabled={{not this.draftRegistration}}
-                >
-                    {{fa-icon 'times'}} {{t 'general.delete'}}
-                </OsfButton>
-                <BsModal
-                    @open={{this.deleteModalOpen}}
-                    @onHidden={{action this.cancelDelete}}
-                    class='delete_draft_registration' 
-                    as |modal|
-                >
-                    <modal.header>
-                        <h4>{{t 'general.please_confirm'}}</h4>
-                    </modal.header>
-                    <modal.body>
-                        {{t 'osf-components.draft-registration-card.delete_draft_confirm'}}
-                    </modal.body>
-                    <modal.footer data-analytics-scope='Draft registrations delete modal'>
-                        <OsfButton
-                            data-analytics-name='Cancel delete'
-                            @onClick={{action modal.close}}
-                            @type='default'
-                        >
-                            {{t 'general.cancel'}}
-                        </OsfButton>
-                        <OsfButton
-                            data-analytics-name='Confirm delete'
-                            @onClick={{action this.confirmDelete}}
-                            @type='danger'
-                        >
-                            {{t 'general.delete'}}
-                        </OsfButton>
-                    </modal.footer>
-                </BsModal>
+            </small>
+            <div class='row'>
+                <div class='col-md-10'>
+                    <OsfLink
+                        data-analytics-name='Edit'
+                        class='btn btn-default'
+                        @route='registries.drafts.draft'
+                        @models={{array @draftRegistration.id}}
+                    >
+                        {{fa-icon 'pencil'}} {{t 'general.edit'}}
+                    </OsfLink>
+                    <OsfButton
+                        data-analytics-name='Delete'
+                        @type='default' 
+                        @onClick={{action this.delete}}
+                        disabled={{not this.draftRegistration}}
+                    >
+                        {{fa-icon 'times'}} {{t 'general.delete'}}
+                    </OsfButton>
+                    <BsModal
+                        @open={{this.deleteModalOpen}}
+                        @onHidden={{action this.cancelDelete}}
+                        class='delete_draft_registration' 
+                        as |modal|
+                    >
+                        <modal.header>
+                            <h4>{{t 'general.please_confirm'}}</h4>
+                        </modal.header>
+                        <modal.body>
+                            {{t 'osf-components.draft-registration-card.delete_draft_confirm'}}
+                        </modal.body>
+                        <modal.footer data-analytics-scope='Draft registrations delete modal'>
+                            <OsfButton
+                                data-analytics-name='Cancel delete'
+                                @onClick={{action modal.close}}
+                                @type='default'
+                            >
+                                {{t 'general.cancel'}}
+                            </OsfButton>
+                            <OsfButton
+                                data-analytics-name='Confirm delete'
+                                @onClick={{action this.confirmDelete}}
+                                @type='danger'
+                            >
+                                {{t 'general.delete'}}
+                            </OsfButton>
+                        </modal.footer>
+                    </BsModal>
+                </div>
+                <div class='col-md-1'>
+                    <OsfLink
+                        data-analytics-name='Review'
+                        class='btn btn-default'
+                        @route='registries.drafts.draft.review'
+                        @models={{array this.draftRegistration.id}}
+                    >
+                        {{t 'osf-components.draft-registration-card.review'}}
+                    </OsfLink>
+                </div>
             </div>
-            <div class='col-md-1'>
-                <OsfButton
-                    data-analytics-name='Register'
-                    @type='default'
-                    @onClick={{action this.register}}
-                    @disabled={{not this.enableRegister}}
-                >
-                    {{t 'osf-components.draft-registration-card.register'}}
-                </OsfButton>
-            </div>
-        </div>
-    </h4>
+        {{else}}
+            <ContentPlaceholders as |placeholder|>
+                <placeholder.text @lines={{3}} />
+            </ContentPlaceholders>
+        {{/if}}
+    </section>
 </div>

--- a/lib/osf-components/addon/components/draft-registration-card/template.hbs
+++ b/lib/osf-components/addon/components/draft-registration-card/template.hbs
@@ -10,7 +10,6 @@
                 @route='registries.drafts.draft'
                 @models={{array this.draftRegistration.id}}
             >
-
                 {{this.draftRegistration.title}}
             </OsfLink>
         {{else}}
@@ -105,7 +104,7 @@
             <ContentPlaceholders as |placeholder|>
                 <placeholder.text
                     data-test-content-placeholder
-                    @lines={{3}}
+                    @lines={{4}}
                 />
             </ContentPlaceholders>
         {{/if}}

--- a/lib/osf-components/addon/components/draft-registration-card/template.hbs
+++ b/lib/osf-components/addon/components/draft-registration-card/template.hbs
@@ -10,7 +10,8 @@
                 @route='registries.drafts.draft'
                 @models={{array this.draftRegistration.id}}
             >
-                {{this.draftRegistration.registrationSchema.name}}
+
+                {{this.draftRegistration.title}}
             </OsfLink>
         {{else}}
             <ContentPlaceholders as |placeholder|>
@@ -27,6 +28,10 @@
                 <p data-test-initiated-by>
                     {{t 'osf-components.draft-registration-card.initiated_by'}}
                     {{this.draftRegistration.initiator.fullName}}
+                </p>
+                <p data-test-form-type>
+                    {{t 'osf-components.draft-registration-card.form_type'}}
+                    {{this.draftRegistration.registrationSchema.name}}
                 </p>
                 <p data-test-time-initiated>
                     {{t 'osf-components.draft-registration-card.started'}}

--- a/lib/osf-components/addon/components/draft-registration-card/template.hbs
+++ b/lib/osf-components/addon/components/draft-registration-card/template.hbs
@@ -14,22 +14,25 @@
             </OsfLink>
         {{else}}
             <ContentPlaceholders as |placeholder|>
-                <placeholder.text @lines={{1}} />
+                <placeholder.text
+                    data-test-header-placeholder
+                    @lines={{1}}
+                />
             </ContentPlaceholders>
         {{/if}}
     </h4>
     <section local-class='DraftRegistrationCard__body' data-test-draft-registration-card-body>
         {{#if this.draftRegistration}}
             <small>
-                <p>
+                <p data-test-initiated-by>
                     {{t 'osf-components.draft-registration-card.initiated_by'}}
                     {{this.draftRegistration.initiator.fullName}}
                 </p>
-                <p>
+                <p data-test-time-initiated>
                     {{t 'osf-components.draft-registration-card.started'}}
                     {{moment this.draftRegistration.datetimeInitiated}}
                 </p>
-                <p>
+                <p data-test-time-updated>
                     {{t 'osf-components.draft-registration-card.last_updated'}}
                     {{moment this.draftRegistration.datetimeUpdated}}
                 </p>
@@ -95,7 +98,10 @@
             </div>
         {{else}}
             <ContentPlaceholders as |placeholder|>
-                <placeholder.text @lines={{3}} />
+                <placeholder.text
+                    data-test-content-placeholder
+                    @lines={{3}}
+                />
             </ContentPlaceholders>
         {{/if}}
     </section>

--- a/tests/acceptance/guid-node/registrations-test.ts
+++ b/tests/acceptance/guid-node/registrations-test.ts
@@ -223,16 +223,6 @@ module('Acceptance | guid-node/registrations', hooks => {
         assert.dom('[data-test-draft-registration-card-title]').includesText(
             'Prereg Challenge',
         );
-
-        assert.dom('[data-test-draft-registration-card-progress-bar]').exists({ count: 1 });
-
-        const progressBarElement =
-            document.querySelector('[data-test-draft-registration-card-progress-bar] .progress-bar') as HTMLElement;
-
-        assert.ok(
-            parseFloat(progressBarElement.style.width ? progressBarElement.style.width : '') > 0,
-            'Progress bar shows progress',
-        );
     });
 
     test('logged in admin, 12 draft registrations', async assert => {

--- a/tests/acceptance/guid-node/registrations-test.ts
+++ b/tests/acceptance/guid-node/registrations-test.ts
@@ -200,7 +200,15 @@ module('Acceptance | guid-node/registrations', hooks => {
             q1: { comments: [], value: 'Registration Title', extra: [] },
         };
 
-        draftRegisterNode(server, node, { initiator, registrationSchema, registrationMetadata });
+        const draftRegistration = draftRegisterNode(
+            server,
+            node,
+            {
+                initiator,
+                registrationSchema,
+                registrationMetadata,
+            },
+        );
 
         const url = `/${node.id}/registrations`;
 
@@ -220,9 +228,7 @@ module('Acceptance | guid-node/registrations', hooks => {
 
         assert.dom('[data-test-draft-registration-card]').exists({ count: 1 });
 
-        assert.dom('[data-test-draft-registration-card-title]').includesText(
-            'Prereg Challenge',
-        );
+        assert.dom('[data-test-draft-registration-card-title]').includesText(draftRegistration.title);
     });
 
     test('logged in admin, 12 draft registrations', async assert => {

--- a/tests/integration/components/draft-registration-card/component-test.ts
+++ b/tests/integration/components/draft-registration-card/component-test.ts
@@ -1,14 +1,57 @@
 import { render } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { TestContext } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import moment from 'moment';
 import { module, test } from 'qunit';
+import { OsfLinkRouterStub } from '../../helpers/osf-link-router-stub';
 
 module('Integration | Component | draft-registration-card', hooks => {
     setupRenderingTest(hooks);
+    setupMirage(hooks);
 
-    test('it renders', async function(assert) {
-        await render(hbs`{{draft-registration-card}}`);
+    hooks.beforeEach(function(this: TestContext) {
+        this.store = this.owner.lookup('service:store');
+        this.intl = this.owner.lookup('service:intl');
+        this.owner.register('service:router', OsfLinkRouterStub);
+        server.loadFixtures('schema-blocks');
+        server.loadFixtures('registration-schemas');
+        server.loadFixtures('registration-providers');
+        server.loadFixtures('licenses');
+    });
 
-        assert.dom(this.element).hasText('Edit Delete Review');
+    test('it renders draftRegistration', async function(this: TestContext, assert) {
+        const user = server.create('user');
+        const draft = server.create('draft-registration', {
+            id: 'pregc',
+            initiator: user,
+            registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
+        });
+        const draftRegistration = await this.store.findRecord('draft-registration', draft.id);
+        this.set('draftRegistration', draftRegistration);
+
+        /* eslint-disable max-len */
+        const initiated = `${this.intl.t('osf-components.draft-registration-card.initiated_by')} ${user.fullName}`;
+        const dateStarted = `${this.intl.t('osf-components.draft-registration-card.started')} ${moment(draftRegistration.datetimeInitiated)}`;
+        const dateUpdated = `${this.intl.t('osf-components.draft-registration-card.last_updated')} ${moment(draftRegistration.datetimeUpdated)}`;
+        /* eslint-enable max-len */
+
+        await render(hbs`<DraftRegistrationCard @draftRegistration={{this.draftRegistration}} />`);
+
+        assert.dom('[data-test-header-placeholder]').doesNotExist();
+        assert.dom('[data-test-content-placeholder]').doesNotExist();
+
+        assert.dom('[data-test-draft-registration-card-title]')
+            .hasText(draftRegistration.registrationSchema.get('name'));
+        assert.dom('[data-test-initiated-by]').containsText(initiated);
+        assert.dom('[data-test-time-initiated]').containsText(dateStarted);
+        assert.dom('[data-test-time-updated]').containsText(dateUpdated);
+    });
+
+    test('placeholders appear without draftRegistration', async assert => {
+        await render(hbs`<DraftRegistrationCard />`);
+        assert.dom('[data-test-header-placeholder]').exists();
+        assert.dom('[data-test-content-placeholder]').exists();
     });
 });

--- a/tests/integration/components/draft-registration-card/component-test.ts
+++ b/tests/integration/components/draft-registration-card/component-test.ts
@@ -9,6 +9,6 @@ module('Integration | Component | draft-registration-card', hooks => {
     test('it renders', async function(assert) {
         await render(hbs`{{draft-registration-card}}`);
 
-        assert.dom(this.element).hasText('Edit Delete Register');
+        assert.dom(this.element).hasText('Edit Delete Review');
     });
 });

--- a/tests/integration/components/draft-registration-card/component-test.ts
+++ b/tests/integration/components/draft-registration-card/component-test.ts
@@ -31,21 +31,24 @@ module('Integration | Component | draft-registration-card', hooks => {
         const draftRegistration = await this.store.findRecord('draft-registration', draft.id);
         this.set('draftRegistration', draftRegistration);
 
+        await render(hbs`<DraftRegistrationCard @draftRegistration={{this.draftRegistration}} />`);
+
         const initiated = `${this.intl.t('osf-components.draft-registration-card.initiated_by')} ` +
                         `${user.fullName}`;
+        const formType = `${this.intl.t('osf-components.draft-registration-card.form_type')} ` +
+                        `${draftRegistration.registrationSchema.get('name')}`;
         const dateStarted = `${this.intl.t('osf-components.draft-registration-card.started')} ` +
                             `${moment(draftRegistration.datetimeInitiated)}`;
         const dateUpdated = `${this.intl.t('osf-components.draft-registration-card.last_updated')} ` +
                             `${moment(draftRegistration.datetimeUpdated)}`;
 
-        await render(hbs`<DraftRegistrationCard @draftRegistration={{this.draftRegistration}} />`);
-
         assert.dom('[data-test-header-placeholder]').doesNotExist();
         assert.dom('[data-test-content-placeholder]').doesNotExist();
 
         assert.dom('[data-test-draft-registration-card-title]')
-            .hasText(draftRegistration.registrationSchema.get('name'));
+            .hasText(draftRegistration.title);
         assert.dom('[data-test-initiated-by]').containsText(initiated);
+        assert.dom('[data-test-form-type]').containsText(formType);
         assert.dom('[data-test-time-initiated]').containsText(dateStarted);
         assert.dom('[data-test-time-updated]').containsText(dateUpdated);
     });

--- a/tests/integration/components/draft-registration-card/component-test.ts
+++ b/tests/integration/components/draft-registration-card/component-test.ts
@@ -31,11 +31,12 @@ module('Integration | Component | draft-registration-card', hooks => {
         const draftRegistration = await this.store.findRecord('draft-registration', draft.id);
         this.set('draftRegistration', draftRegistration);
 
-        /* eslint-disable max-len */
-        const initiated = `${this.intl.t('osf-components.draft-registration-card.initiated_by')} ${user.fullName}`;
-        const dateStarted = `${this.intl.t('osf-components.draft-registration-card.started')} ${moment(draftRegistration.datetimeInitiated)}`;
-        const dateUpdated = `${this.intl.t('osf-components.draft-registration-card.last_updated')} ${moment(draftRegistration.datetimeUpdated)}`;
-        /* eslint-enable max-len */
+        const initiated = `${this.intl.t('osf-components.draft-registration-card.initiated_by')} ` +
+                        `${user.fullName}`;
+        const dateStarted = `${this.intl.t('osf-components.draft-registration-card.started')} ` +
+                            `${moment(draftRegistration.datetimeInitiated)}`;
+        const dateUpdated = `${this.intl.t('osf-components.draft-registration-card.last_updated')} ` +
+                            `${moment(draftRegistration.datetimeUpdated)}`;
 
         await render(hbs`<DraftRegistrationCard @draftRegistration={{this.draftRegistration}} />`);
 

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1334,6 +1334,7 @@ routes:
 osf-components:
     draft-registration-card:
         initiated_by: 'Initiated by:'
+        form_type: 'Form:'
         started: 'Started:'
         last_updated: 'Last updated:'
         review: Review

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1336,7 +1336,7 @@ osf-components:
         initiated_by: 'Initiated by:'
         started: 'Started:'
         last_updated: 'Last updated:'
-        register: Register
+        review: Review
         delete_draft_confirm: 'Are you sure you want to delete this draft registration?'
     copyable-text:
         copyToClipboard: 'Copy to clipboard'


### PR DESCRIPTION
- Ticket: [ENG-613](https://openscience.atlassian.net/browse/ENG-613)
- Feature flag: `N/A`

## Purpose

To remove the progress bar from the `DraftRegistrationCard` widget.

## Summary of Changes

- Remove the progress bar
- Change 'Register' to 'Review'
- Make the title a link
- Update title to be the draft's title instead of the schema
- Move schema to its own `Form` section

Final component will look like this:
<img width="757" alt="Screen Shot 2020-04-30 at 3 22 17 PM" src="https://user-images.githubusercontent.com/19379783/80784112-e8a19b00-8b49-11ea-8a9e-e354b703ef3a.png">


## Side Effects

`N/A`

## QA Notes

This should only affect the registration card on the `{node}/registrations` page. It should only have visual changes.
