### PR TITLE
[ENG-1611] Small visual changes to Institutional Dashboard

### DIFF
--- a/app/institutions/dashboard/-components/institutional-users-list/template.hbs
+++ b/app/institutions/dashboard/-components/institutional-users-list/template.hbs
@@ -15,6 +15,7 @@
             local-class='table'
             @isTable={{true}}
             @model={{this.institution}}
+            @usePlaceholders={{false}}
             @relationshipName='userMetrics'
             @bindReload={{action (mut this.reloadUserList)}}
             @query={{this.queryUsers}} as |list|

--- a/app/institutions/dashboard/-components/institutional-users-list/template.hbs
+++ b/app/institutions/dashboard/-components/institutional-users-list/template.hbs
@@ -60,7 +60,7 @@
                             @route='guid-user'
                             @models={{array institutionalUser.userGuid}}
                         >
-                            {{institutionalUser.userName}} - {{institutionalUser.userGuid}}
+                            {{institutionalUser.userName}} ({{institutionalUser.userGuid}})
                         </OsfLink>
                     </td>
                     <td data-test-item-department>{{institutionalUser.department}}</td>

--- a/app/institutions/dashboard/styles.scss
+++ b/app/institutions/dashboard/styles.scss
@@ -44,7 +44,7 @@
     :global(.panel-body) {
         h3 {
             margin: 0;
-            font-size: 7.5vw;
+            font-size: 6vw;
             font-weight: bold;
         }
     }
@@ -70,7 +70,7 @@
     .sso-users-connected {
         :global(.panel-body) {
             h3 {
-                font-size: 120px;
+                font-size: 96px;
             }
         }
     }


### PR DESCRIPTION
- Ticket: [ENG-1611]
- Feature flag: n/a

## Purpose
- Put user guid in parentheses as requested in the requirements doc
![image](https://user-images.githubusercontent.com/51409893/82489421-9e0fa080-9aaf-11ea-9b7d-3d9f1631546e.png)

- Update usage of `paginated-list/has-many` to no longer throw error in the console
- SSO-users shows the number of users in an institution. Percy has found that this number can wrap when it is 3-digits or more.

![Screen Shot 2020-05-19 at 1 43 07 PM](https://user-images.githubusercontent.com/4511563/82469017-79a4cb80-9a91-11ea-88b2-6ad42abcca33.png)


## Summary of Changes
- Users list will now show users' guid in parentheses, instead of being separated with a `-`
- Set `usePlaceholders=false` for `PaginatedList::HasMany` invocation to prevent the console error regarding "`institution.userMetrics` related counts not found"
- Update the CSS for the panel to lower the font size

## Side Effects
`NA`

## QA Notes
- The requirements ask that the user's guid is shown in parentheses. I've put the guid after the users full name, but the guid will be hidden if the user's name is abnormally long 
![image](https://user-images.githubusercontent.com/51409893/82489264-59840500-9aaf-11ea-8e07-92a882e22097.png)
- There was an error that was being thrown when invoking the users list table, but that should be gone now. Please check the browser console and double check that there are no errors.
- Please check the SSO-users panel. When there are multiple (100s or 1000s) users
- There is a threshold where the CSS changes at a window width of 1200px, so please check that the number in the panel does not wrap below and above this threshold.

[ENG-1611]: https://openscience.atlassian.net/browse/ENG-1611