### PR TITLE
[ENG-1611] Department update + mobile view for institutional dashboard

### DIFF
--- a/app/institutions/dashboard/-components/departments-panel/component.ts
+++ b/app/institutions/dashboard/-components/departments-panel/component.ts
@@ -5,7 +5,7 @@ import { Department } from 'ember-osf-web/models/institution';
 import InstitutionDepartmentsModel from 'ember-osf-web/models/institution-department';
 
 export default class DepartmentsPanel extends Component {
-    departments!: InstitutionDepartmentsModel[];
+    topDepartments!: InstitutionDepartmentsModel[];
 
     chartHoverIndex: number = -1;
 
@@ -23,6 +23,10 @@ export default class DepartmentsPanel extends Component {
     };
 
     didReceiveAttrs() {
+    }
+
+    @computed('topDepartments')
+    get chartHoverIndex() {
         if (this.departments) {
             const departmentNumbers = this.departments.map(x => x.numberOfUsers);
             this.set('chartHoverIndex', departmentNumbers.indexOf(Math.max(...departmentNumbers)));

--- a/app/institutions/dashboard/-components/departments-panel/component.ts
+++ b/app/institutions/dashboard/-components/departments-panel/component.ts
@@ -1,13 +1,17 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
 import { ChartData, ChartOptions, Shape } from 'ember-cli-chart';
+import Intl from 'ember-intl/services/intl';
 import { Department } from 'ember-osf-web/models/institution';
 import InstitutionDepartmentsModel from 'ember-osf-web/models/institution-department';
 
 export default class DepartmentsPanel extends Component {
+    @service intl!: Intl;
+
     topDepartments!: InstitutionDepartmentsModel[];
 
-    chartHoverIndex: number = -1;
+    chartHoverIndex: number = 0;
 
     chartOptions: ChartOptions = {
         aspectRatio: 1,
@@ -22,22 +26,12 @@ export default class DepartmentsPanel extends Component {
         },
     };
 
-    didReceiveAttrs() {
-    }
-
-    @computed('topDepartments')
-    get chartHoverIndex() {
-        if (this.departments) {
-            const departmentNumbers = this.departments.map(x => x.numberOfUsers);
-            this.set('chartHoverIndex', departmentNumbers.indexOf(Math.max(...departmentNumbers)));
-        }
-    }
-
-    @computed('chartHoverIndex', 'departments')
+    @computed('chartHoverIndex', 'topDepartments')
     get chartData(): ChartData {
-        const departmentNames = this.departments.map(x => x.name);
-        const departmentNumbers = this.departments.map(x => x.numberOfUsers);
+        const departmentNames = this.topDepartments.map(x => x.name);
+        const departmentNumbers = this.topDepartments.map(x => x.numberOfUsers);
 
+        const displayDepartmentNames = [...departmentNames, this.intl.t('general.other')];
         const backgroundColors = [];
         for (const index of departmentNumbers.keys()) {
             if (index === this.chartHoverIndex) {
@@ -56,14 +50,14 @@ export default class DepartmentsPanel extends Component {
         };
     }
 
-    @computed('chartHoverIndex', 'departments')
+    @computed('chartHoverIndex', 'topDepartments')
     get activeDepartment(): Department {
-        return this.departments.toArray()[this.chartHoverIndex];
+        return this.topDepartments.toArray()[this.chartHoverIndex];
     }
 
-    @computed('activeDepartment', 'departments')
+    @computed('activeDepartment', 'topDepartments')
     get activeDepartmentPercentage(): string {
-        const count = this.departments.reduce((total, currentValue) => total + currentValue.numberOfUsers, 0);
+        const count = this.topDepartments.reduce((total, currentValue) => total + currentValue.numberOfUsers, 0);
         return ((this.activeDepartment.numberOfUsers / count) * 100).toFixed(2);
     }
 }

--- a/app/institutions/dashboard/-components/departments-panel/component.ts
+++ b/app/institutions/dashboard/-components/departments-panel/component.ts
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { action, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { ChartData, ChartOptions, Shape } from 'ember-cli-chart';
 import Intl from 'ember-intl/services/intl';
@@ -14,18 +14,23 @@ export default class DepartmentsPanel extends Component {
 
     chartHoverIndex: number = 0;
 
-    chartOptions: ChartOptions = {
-        aspectRatio: 1,
-        legend: {
-            display: false,
-        },
-        onHover: (_: MouseEvent, shapes: Shape[]): void => {
-            if (shapes.length === 0 || this.chartHoverIndex === shapes[0]._index) {
-                return;
-            }
-            this.set('chartHoverIndex', shapes[0]._index);
-        },
-    };
+    get chartOptions(): ChartOptions {
+        return {
+            aspectRatio: 1,
+            legend: {
+                display: false,
+            },
+            onHover: this.onChartHover,
+        };
+    }
+
+    @action
+    onChartHover(_: MouseEvent, shapes: Shape[]) {
+        if (shapes.length === 0 || this.chartHoverIndex === shapes[0]._index) {
+            return;
+        }
+        this.set('chartHoverIndex', shapes[0]._index);
+    }
 
     @computed('topDepartments')
     get displayDepartments() {
@@ -36,7 +41,7 @@ export default class DepartmentsPanel extends Component {
         return [...departments, { name: this.intl.t('general.other'), numberOfUsers: otherDepartmentNumber }];
     }
 
-    @computed('chartHoverIndex', 'displayDepartments')
+    @computed('chartHoverIndex', 'displayDepartments.[]')
     get chartData(): ChartData {
         const backgroundColors = this.displayDepartments.map((_, i) => {
             if (i === this.chartHoverIndex) {
@@ -56,7 +61,7 @@ export default class DepartmentsPanel extends Component {
         };
     }
 
-    @computed('chartHoverIndex', 'displayDepartments')
+    @computed('chartHoverIndex', 'displayDepartments.[]')
     get activeDepartment(): Department {
         return this.displayDepartments[this.chartHoverIndex];
     }

--- a/app/institutions/dashboard/-components/departments-panel/component.ts
+++ b/app/institutions/dashboard/-components/departments-panel/component.ts
@@ -10,6 +10,7 @@ export default class DepartmentsPanel extends Component {
     @service intl!: Intl;
 
     topDepartments!: InstitutionDepartmentsModel[];
+    totalUsers!: number;
 
     chartHoverIndex: number = 0;
 
@@ -30,8 +31,10 @@ export default class DepartmentsPanel extends Component {
     get chartData(): ChartData {
         const departmentNames = this.topDepartments.map(x => x.name);
         const departmentNumbers = this.topDepartments.map(x => x.numberOfUsers);
+        const otherDepartmentNumber = this.totalUsers - departmentNumbers.reduce((a, b) => a + b);
 
         const displayDepartmentNames = [...departmentNames, this.intl.t('general.other')];
+        const displayDepartmentNumbers = [...departmentNumbers, otherDepartmentNumber];
         const backgroundColors = [];
         for (const index of departmentNumbers.keys()) {
             if (index === this.chartHoverIndex) {
@@ -42,9 +45,9 @@ export default class DepartmentsPanel extends Component {
         }
 
         return {
-            labels: departmentNames,
+            labels: displayDepartmentNames,
             datasets: [{
-                data: departmentNumbers,
+                data: displayDepartmentNumbers,
                 backgroundColor: backgroundColors,
             }],
         };

--- a/app/institutions/dashboard/-components/departments-panel/template.hbs
+++ b/app/institutions/dashboard/-components/departments-panel/template.hbs
@@ -1,4 +1,4 @@
-{{#if this.departments}}
+{{#if this.topDepartments}}
     <div
         data-test-chart
         local-class='ember-chart'

--- a/app/institutions/dashboard/-components/institutional-users-list/component.ts
+++ b/app/institutions/dashboard/-components/institutional-users-list/component.ts
@@ -66,10 +66,7 @@ export default class InstitutionalUsersList extends Component {
     }
 
     @task({ restartable: true })
-    searchDepartment = task(function *(
-        this: InstitutionalUsersList,
-        name: string,
-    ): InstitutionDepartmentsModel[] {
+    searchDepartment = task(function *(this: InstitutionalUsersList, name: string) {
         yield timeout(500);
         if (this.institution) {
             const depts: InstitutionDepartmentsModel[] = yield this.institution.queryHasMany('departmentMetrics', {

--- a/app/institutions/dashboard/-components/institutional-users-list/component.ts
+++ b/app/institutions/dashboard/-components/institutional-users-list/component.ts
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 import { action, computed } from '@ember/object';
 import { reads } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
-import { TaskInstance } from 'ember-concurrency';
+import { TaskInstance, task, timeout } from 'ember-concurrency';
 import Intl from 'ember-intl/services/intl';
 
 import { InstitutionsDashboardModel } from 'ember-osf-web/institutions/dashboard/route';
@@ -64,6 +64,19 @@ export default class InstitutionalUsersList extends Component {
         }
         return query;
     }
+
+    @task({ restartable: true })
+    searchDepartment = task(function *(this: InstitutionalUsersList, name: string) {
+        yield timeout(500);
+        if (this.institution) {
+            const depts: InstitutionDepartmentsModel[] = yield this.institution.queryHasMany('departmentMetrics', {
+                filter: {
+                    name,
+                },
+            });
+            return depts.map(dept => dept.name);
+        }
+    });
 
     @action
     onSelectChange(department: string) {

--- a/app/institutions/dashboard/-components/institutional-users-list/component.ts
+++ b/app/institutions/dashboard/-components/institutional-users-list/component.ts
@@ -2,7 +2,8 @@ import Component from '@ember/component';
 import { action, computed } from '@ember/object';
 import { reads } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
-import { task, TaskInstance, timeout } from 'ember-concurrency';
+import { TaskInstance, timeout } from 'ember-concurrency';
+import { task } from 'ember-concurrency-decorators';
 import Intl from 'ember-intl/services/intl';
 
 import { InstitutionsDashboardModel } from 'ember-osf-web/institutions/dashboard/route';

--- a/app/institutions/dashboard/-components/institutional-users-list/component.ts
+++ b/app/institutions/dashboard/-components/institutional-users-list/component.ts
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 import { action, computed } from '@ember/object';
 import { reads } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
-import { TaskInstance, task, timeout } from 'ember-concurrency';
+import { task, TaskInstance, timeout } from 'ember-concurrency';
 import Intl from 'ember-intl/services/intl';
 
 import { InstitutionsDashboardModel } from 'ember-osf-web/institutions/dashboard/route';
@@ -66,7 +66,10 @@ export default class InstitutionalUsersList extends Component {
     }
 
     @task({ restartable: true })
-    searchDepartment = task(function *(this: InstitutionalUsersList, name: string) {
+    searchDepartment = task(function *(
+        this: InstitutionalUsersList,
+        name: string,
+    ): InstitutionDepartmentsModel[] {
         yield timeout(500);
         if (this.institution) {
             const depts: InstitutionDepartmentsModel[] = yield this.institution.queryHasMany('departmentMetrics', {
@@ -76,6 +79,7 @@ export default class InstitutionalUsersList extends Component {
             });
             return depts.map(dept => dept.name);
         }
+        return [];
     });
 
     @action

--- a/app/institutions/dashboard/-components/institutional-users-list/template.hbs
+++ b/app/institutions/dashboard/-components/institutional-users-list/template.hbs
@@ -6,6 +6,7 @@
         @searchEnabled={{true}}
         @selected={{this.department}}
         @triggerClass={{local-class 'select'}}
+        @search={{perform this.searchDepartment}}
         @onchange={{action this.onSelectChange}} as |department|
     >
         {{department}}

--- a/app/institutions/dashboard/controller.ts
+++ b/app/institutions/dashboard/controller.ts
@@ -14,13 +14,9 @@ export default class InstitutionsDashboardController extends Controller {
     @alias('modelValue.institution') institution?: InstitutionModel;
     @alias('modelValue.summaryMetrics') summaryMetrics?: InstitutionSummaryMetricModel;
     @alias('modelValue.departmentMetrics') departmentMetrics?: InstitutionDepartmentModel[];
+    @alias('modelValue.totalUsers') totalUsers?: number;
 
     csvImgSrc: string = '/assets/images/institutions/csv.svg';
-
-    @computed('institution')
-    get totalUsers(): number {
-        const userMetrics = this.institution.queryHasMany('userMetrics');
-    }
 
     @computed('institution.lastUpdated')
     get lastUpdatedFromNow(): string {

--- a/app/institutions/dashboard/controller.ts
+++ b/app/institutions/dashboard/controller.ts
@@ -13,10 +13,14 @@ export default class InstitutionsDashboardController extends Controller {
     @alias('model.taskInstance.value') modelValue?: InstitutionsDashboardModel;
     @alias('modelValue.institution') institution?: InstitutionModel;
     @alias('modelValue.summaryMetrics') summaryMetrics?: InstitutionSummaryMetricModel;
-    @alias('modelValue.userMetrics') userMetrics?: InstitutionUserModel[];
     @alias('modelValue.departmentMetrics') departmentMetrics?: InstitutionDepartmentModel[];
 
     csvImgSrc: string = '/assets/images/institutions/csv.svg';
+
+    @computed('institution')
+    get totalUsers(): number {
+        const userMetrics = this.institution.queryHasMany('userMetrics');
+    }
 
     @computed('institution.lastUpdated')
     get lastUpdatedFromNow(): string {

--- a/app/institutions/dashboard/controller.ts
+++ b/app/institutions/dashboard/controller.ts
@@ -1,6 +1,5 @@
 import { action, computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
-import moment from 'moment';
 
 import Controller from '@ember/controller';
 import { InstitutionsDashboardModel } from 'ember-osf-web/institutions/dashboard/route';
@@ -16,12 +15,6 @@ export default class InstitutionsDashboardController extends Controller {
     @alias('modelValue.totalUsers') totalUsers?: number;
 
     csvImgSrc: string = '/assets/images/institutions/csv.svg';
-
-    @computed('institution.lastUpdated')
-    get lastUpdatedFromNow(): string {
-        const lastUpdated = this.institution ? moment(this.institution.lastUpdated) : moment();
-        return lastUpdated.fromNow();
-    }
 
     // TODO: add csv link back when ENG-1810 is done
     @computed('institution.links.csv')

--- a/app/institutions/dashboard/controller.ts
+++ b/app/institutions/dashboard/controller.ts
@@ -7,7 +7,6 @@ import { InstitutionsDashboardModel } from 'ember-osf-web/institutions/dashboard
 import InstitutionModel from 'ember-osf-web/models/institution';
 import InstitutionDepartmentModel from 'ember-osf-web/models/institution-department';
 import InstitutionSummaryMetricModel from 'ember-osf-web/models/institution-summary-metric';
-import InstitutionUserModel from 'ember-osf-web/models/institution-user';
 
 export default class InstitutionsDashboardController extends Controller {
     @alias('model.taskInstance.value') modelValue?: InstitutionsDashboardModel;

--- a/app/institutions/dashboard/route.ts
+++ b/app/institutions/dashboard/route.ts
@@ -27,7 +27,7 @@ export default class InstitutionsDashboardRoute extends Route {
                     include: ['summary_metrics'],
                 },
             });
-            const departmentMetrics = yield institution.queryHasMany('departmentMetrics'); // ordering = ('-number_of_users', 'name’,) <<< is this true??
+            const departmentMetrics = yield institution.queryHasMany('departmentMetrics');
             const summaryMetrics = yield institution.summaryMetrics;
             return { institution, departmentMetrics, summaryMetrics };
         } catch (error) {

--- a/app/institutions/dashboard/route.ts
+++ b/app/institutions/dashboard/route.ts
@@ -7,6 +7,7 @@ import { task } from 'ember-concurrency-decorators';
 import InstitutionModel from 'ember-osf-web/models/institution';
 import InstitutionDepartmentModel from 'ember-osf-web/models/institution-department';
 import InstitutionSummaryMetricModel from 'ember-osf-web/models/institution-summary-metric';
+import { QueryHasManyResult } from 'ember-osf-web/models/osf-model';
 import Analytics from 'ember-osf-web/services/analytics';
 import captureException from 'ember-osf-web/utils/capture-exception';
 
@@ -29,7 +30,17 @@ export default class InstitutionsDashboardRoute extends Route {
             });
             const departmentMetrics = yield institution.queryHasMany('departmentMetrics');
             const summaryMetrics = yield institution.summaryMetrics;
-            return { institution, departmentMetrics, summaryMetrics };
+            const userMetricInfo: QueryHasManyResult<never> = yield institution.queryHasMany(
+                'userMetrics',
+                { size: 0 },
+            );
+
+            return {
+                institution,
+                departmentMetrics,
+                summaryMetrics,
+                totalUsers: userMetricInfo.meta.total,
+            };
         } catch (error) {
             captureException(error);
             this.transitionTo('not-found', this.get('router').get('currentURL').slice(1));

--- a/app/institutions/dashboard/route.ts
+++ b/app/institutions/dashboard/route.ts
@@ -27,7 +27,7 @@ export default class InstitutionsDashboardRoute extends Route {
                     include: ['summary_metrics'],
                 },
             });
-            const departmentMetrics = yield institution.loadAll('departmentMetrics');
+            const departmentMetrics = yield institution.queryHasMany('departmentMetrics'); // ordering = ('-number_of_users', 'name’,) <<< is this true??
             const summaryMetrics = yield institution.summaryMetrics;
             return { institution, departmentMetrics, summaryMetrics };
         } catch (error) {

--- a/app/institutions/dashboard/styles.scss
+++ b/app/institutions/dashboard/styles.scss
@@ -87,4 +87,13 @@
     .dashboard-wrapper {
         flex-wrap: wrap-reverse;
     }
+
+    .panel-wrapper {
+        padding-left: 0;
+        width: 100%;
+    }
+
+    .table-wrapper {
+        padding-right: 0;
+    }
 }

--- a/app/institutions/dashboard/styles.scss
+++ b/app/institutions/dashboard/styles.scss
@@ -85,6 +85,6 @@
 
 @media (max-width: 767px) {
     .dashboard-wrapper {
-        flex-wrap: wrap;
+        flex-wrap: wrap-reverse;
     }
 }

--- a/app/institutions/dashboard/styles.scss
+++ b/app/institutions/dashboard/styles.scss
@@ -11,15 +11,15 @@
 
 .dashboard-wrapper {
     display: flex;
+    flex-wrap: wrap;
 }
 
 .table-wrapper {
-    width: 75%;
     padding-right: 15px;
+    flex-grow: 1;
 }
 
 .panel-wrapper {
-    width: 25%;
     padding-left: 15px;
     text-align: right;
 }

--- a/app/institutions/dashboard/styles.scss
+++ b/app/institutions/dashboard/styles.scss
@@ -11,7 +11,6 @@
 
 .dashboard-wrapper {
     display: flex;
-    flex-wrap: wrap;
 }
 
 .table-wrapper {
@@ -81,5 +80,11 @@
                 font-size: 72px;
             }
         }
+    }
+}
+
+@media (max-width: 767px) {
+    .dashboard-wrapper {
+        flex-wrap: wrap;
     }
 }

--- a/app/institutions/dashboard/template.hbs
+++ b/app/institutions/dashboard/template.hbs
@@ -3,7 +3,7 @@
     <div local-class='banner'>
         <img src='{{this.institution.assets.banner}}' alt='{{this.institution.name}}'>
         <div>
-            {{t 'institutions.dashboard.last_update'}}: {{this.lastUpdatedFromNow}}
+            {{t 'institutions.dashboard.last_update'}}
         </div>
     </div>
     <div local-class='dashboard-wrapper'>

--- a/app/institutions/dashboard/template.hbs
+++ b/app/institutions/dashboard/template.hbs
@@ -8,7 +8,9 @@
     </div>
     <div local-class='dashboard-wrapper'>
         <div local-class='table-wrapper'>
-            <Institutions::Dashboard::-Components::InstitutionalUsersList @modelTaskInstance={{this.model.taskInstance}} />
+            <Institutions::Dashboard::-Components::InstitutionalUsersList
+                @modelTaskInstance={{this.model.taskInstance}}
+            />
         </div>
         <div local-class='panel-wrapper'>
             <OsfLink
@@ -40,14 +42,19 @@
                     @isLoading={{this.model.taskInstance.isRunning}}
                     @title={{t 'institutions.dashboard.projects_panel'}}
             >
-                <Institutions::Dashboard::-Components::ProjectsPanel @summaryMetrics={{this.summaryMetrics}} />
+                <Institutions::Dashboard::-Components::ProjectsPanel
+                    @summaryMetrics={{this.summaryMetrics}}
+                />
             </Institutions::Dashboard::-Components::Panel>
             <Institutions::Dashboard::-Components::Panel
                     local-class='departments'
                     @isLoading={{this.model.taskInstance.isRunning}}
                     @title={{t 'institutions.dashboard.departments_panel'}}
             >
-                <Institutions::Dashboard::-Components::DepartmentsPanel @departments={{this.departmentMetrics}} />
+            <Institutions::Dashboard::-Components::DepartmentsPanel
+                @topDepartments={{this.departmentMetrics}}
+                @totalUsers={{this.totalUsers}}
+            />
             </Institutions::Dashboard::-Components::Panel>
         </div>
     </div>

--- a/app/institutions/dashboard/template.hbs
+++ b/app/institutions/dashboard/template.hbs
@@ -51,10 +51,10 @@
                     @isLoading={{this.model.taskInstance.isRunning}}
                     @title={{t 'institutions.dashboard.departments_panel'}}
             >
-            <Institutions::Dashboard::-Components::DepartmentsPanel
-                @topDepartments={{this.departmentMetrics}}
-                @totalUsers={{this.totalUsers}}
-            />
+                <Institutions::Dashboard::-Components::DepartmentsPanel
+                    @topDepartments={{this.departmentMetrics}}
+                    @totalUsers={{this.totalUsers}}
+                />
             </Institutions::Dashboard::-Components::Panel>
         </div>
     </div>

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -92,6 +92,7 @@ general:
         institutions: Institutions
         preprints: Preprints
         registries: Registries
+    other: Other
 node_categories:
     analysis: Analysis
     communication: Communication

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -643,7 +643,7 @@ institutions:
     search_placeholder: 'Search institutions'
     dashboard:
         title: '{institutionName} Dashboard'
-        last_update: 'Last update'
+        last_update: 'Updated every 24 hours'
         download_csv: 'Download CSV'
         select_default: 'All Departments'
         users_list:


### PR DESCRIPTION
- Ticket: [ENG-1611]
- Feature flag: n/a

## Purpose
- Update mobile view
- Load only 10 depts at a time

## Summary of Changes
- New breakpoint added in CSS to account for mobile view
- Replace use of `loadAll` for departments and just fetch the first 10 depts (these should be the top 10 depts with the most users)
- Update department pie chart to only show the top 10 depts with most users and added an `Other` slice and refactored how that pie chart data is created

## Side Effects
`NA`

## QA Notes
- Please take a look at the Inst. Dashboard in mobile views and make sure nothing is "gross"
- The departments pie chart should have, at most, 11 slices. The top 10 with most users and "Other". Please verify that those numbers are correct when there are less than 10 depts as well as more than 10 depts

[ENG-1611]: https://openscience.atlassian.net/browse/ENG-1611