### PR TITLE
[ENG-1799] Put "Read more" link in a new line

### DIFF
--- a/app/institutions/index/template.hbs
+++ b/app/institutions/index/template.hbs
@@ -15,6 +15,7 @@
                     <div local-class='Institutions__header-logo'></div>
                     <p class='lead'>
                         {{t 'institutions.description'}}
+                        <br>
                         <OsfLink
                             data-test-read-more-link
                             data-analytics-name='Read more'


### PR DESCRIPTION
- Ticket: [ENG-1799]
- Feature flag: n/a

## Purpose
- Put the `Read more` link in a new line

## Summary of Changes
- Add a `<br>` between the description and the link

## Side Effects
`NA`

## QA Notes
- I've put the `Learn more` link to a new line. Please verify there are not any unexpected text-wrapping at reasonable screen-sizes (particularly mobile view)

[ENG-1799]: https://openscience.atlassian.net/browse/ENG-1799