### PR TITLE
Comment out CSV export and update banner image to fall back to use logo

### DIFF
--- a/app/institutions/dashboard/template.hbs
+++ b/app/institutions/dashboard/template.hbs
@@ -1,7 +1,7 @@
 {{title (t 'institutions.dashboard.title' institutionName=this.institution.unsafeName)}}
 <div class='container' data-analytics-scope='Dashboard'>
     <div local-class='banner'>
-        <img src='{{this.institution.assets.banner}}' alt='{{this.institution.name}}'>
+        <img src='{{this.institution.bannerUrl}}' alt='{{this.institution.name}}'>
         <div>
             {{t 'institutions.dashboard.last_update'}}
         </div>
@@ -13,7 +13,8 @@
             />
         </div>
         <div local-class='panel-wrapper'>
-            <OsfLink
+            {{!-- TODO: comment this back in when ENG-1810 is implemented + tested + merged--}}
+            {{!-- <OsfLink
                 data-analytics-name='Download CSV'
                 class='btn btn-primary'
                 local-class='csv-button'
@@ -25,7 +26,7 @@
                 <img src={{this.csvImgSrc}}
                      alt={{t 'institutions.dashboard.download_csv'}}
                 >
-            </OsfLink>
+            </OsfLink> --}}
             <Institutions::Dashboard::-Components::Panel
                     local-class='sso-users-connected'
                     @isLoading={{this.model.taskInstance.isRunning}}

--- a/app/models/institution.ts
+++ b/app/models/institution.ts
@@ -18,9 +18,9 @@ export interface InstitutionLinks extends OsfLinks {
 
 /* eslint-disable camelcase */
 export interface Assets {
-    banner: string;
-    logo: string;
-    logo_rounded: string;
+    banner?: string;
+    logo?: string;
+    logo_rounded?: string;
 }
 /* eslint-enable camelcase */
 
@@ -33,9 +33,8 @@ export default class InstitutionModel extends OsfModel {
     @attr() links!: InstitutionLinks;
     @attr('string') name!: string;
     @attr('fixstring') description!: string;
-    @attr('string') logoPath!: string;
     @attr('string') authUrl!: string;
-    @attr('object') assets!: Partial<Assets>;
+    @attr('object') assets?: Assets;
     @attr('boolean', { defaultValue: false }) currentUserIsAdmin!: boolean;
     @attr('date') lastUpdated!: Date;
 
@@ -64,12 +63,18 @@ export default class InstitutionModel extends OsfModel {
         return htmlSafe(this.name);
     }
 
-    @computed('assets', 'assets.logo', 'logoPath', 'id')
+    @computed('assets.banner', 'logoUrl')
+    get bannerUrl(): string {
+        if (this.assets && this.assets.banner) {
+            return this.assets.banner;
+        }
+        return this.logoUrl;
+    }
+
+    @computed('assets', 'assets.logo', 'id')
     get logoUrl(): string {
         if (this.assets && this.assets.logo) {
             return this.assets.logo;
-        } else if (this.logoPath) {
-            return this.logoPath;
         }
         return `/static/img/institutions/shields-rounded-corners/${this.id}-shield-rounded-corners.png`;
     }


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [NA]
- Feature flag: n/a

## Purpose
Remove the CSV export button until it is ready
If there is no banner image, use the Logo image instead

## Summary of Changes
- Added new computed property in institution that will look for the banner image, otherwise use the logo image
- Update the template for institutional dashboard to use new computed property that looks for the banner image
- comment out CSV
- remove deprecated attribute `logoPath`

## Side Effects
- Deprecated `logoPath` property was removed, but this is not used anywhere else.

## QA Notes
The banner should no longer be broken!
