### PR TITLE
[ENG-1135] Update collections analytics to include provider

### DIFF
--- a/lib/app-components/addon/components/branded-navbar/template.hbs
+++ b/lib/app-components/addon/components/branded-navbar/template.hbs
@@ -43,7 +43,7 @@
                     <li>
                         {{#link-to
                             'provider.submit'
-                            click=(action 'click' 'link' (concat 'Navbar - ' (t @addLinkKey)) target=this.analytics)
+                            click=(action 'click' 'link' (concat this.theme.id ' Navbar - ' (t @addLinkKey)) target=this.analytics)
                         }}
                             <span role='button'>{{t @addLinkKey}}</span>
                         {{/link-to}}

--- a/lib/app-components/addon/components/branded-navbar/template.hbs
+++ b/lib/app-components/addon/components/branded-navbar/template.hbs
@@ -43,7 +43,7 @@
                     <li>
                         {{#link-to
                             'provider.submit'
-                            click=(action 'click' 'link' (concat this.theme.id ' Navbar - ' (t @addLinkKey)) target=this.analytics)
+                            click=(action 'click' 'link' (concat ' Navbar - ' (t @addLinkKey) ' - ' this.theme.id) target=this.analytics)
                         }}
                             <span role='button'>{{t @addLinkKey}}</span>
                         {{/link-to}}

--- a/lib/app-components/addon/components/branded-navbar/template.hbs
+++ b/lib/app-components/addon/components/branded-navbar/template.hbs
@@ -43,7 +43,7 @@
                     <li>
                         {{#link-to
                             'provider.submit'
-                            click=(action 'click' 'link' (concat ' Navbar - ' (t @addLinkKey) ' - ' this.theme.id) target=this.analytics)
+                            click=(action 'click' 'link' (concat 'Navbar - ' (t @addLinkKey) ' - ' this.theme.id) target=this.analytics)
                         }}
                             <span role='button'>{{t @addLinkKey}}</span>
                         {{/link-to}}

--- a/lib/collections/addon/components/collection-search-result/node/template.hbs
+++ b/lib/collections/addon/components/collection-search-result/node/template.hbs
@@ -1,6 +1,6 @@
 <div
     data-test-collection-search-result-node={{this.item.id}}
-    data-analytics-scope='Collections search results'
+    data-analytics-scope={{concat this.theme.id ' collections search results'}}
     class='row'
 >
     <div class='col-xs-12'>

--- a/lib/collections/addon/components/collection-search-result/node/template.hbs
+++ b/lib/collections/addon/components/collection-search-result/node/template.hbs
@@ -1,6 +1,6 @@
 <div
     data-test-collection-search-result-node={{this.item.id}}
-    data-analytics-scope={{concat this.theme.id ' collections search results'}}
+    data-analytics-scope={{concat 'Collections search results - ' this.theme.id}}
     class='row'
 >
     <div class='col-xs-12'>

--- a/lib/collections/addon/components/discover-page/component.ts
+++ b/lib/collections/addon/components/discover-page/component.ts
@@ -338,8 +338,7 @@ export default class DiscoverPage extends Component {
 
     @action
     clearFilters() {
-        this.analytics.track('button', 'click', 'Discover - Clear Filters');
-
+        this.analytics.track('button', 'click', `${this.theme.id} Discover - Clear Filters`);
         if (this.facetContexts) {
             // Clear all of the activeFilters
             this.facetContexts
@@ -366,7 +365,7 @@ export default class DiscoverPage extends Component {
     @action
     searchAction() {
         // Only want to track search here when button clicked. Keypress search tracking is debounced in trackSearch
-        this.analytics.track('button', 'click', 'Discover - Search', this.q);
+        this.analytics.track('button', 'click', `${this.theme.id} Discover - Search`, this.q);
         this.search();
     }
 

--- a/lib/collections/addon/components/discover-page/component.ts
+++ b/lib/collections/addon/components/discover-page/component.ts
@@ -338,7 +338,7 @@ export default class DiscoverPage extends Component {
 
     @action
     clearFilters() {
-        this.analytics.track('button', 'click', `${this.theme.id} Discover - Clear Filters`);
+        this.analytics.track('button', 'click', `Discover - Clear Filters - ${this.theme.id}`);
         if (this.facetContexts) {
             // Clear all of the activeFilters
             this.facetContexts
@@ -365,7 +365,7 @@ export default class DiscoverPage extends Component {
     @action
     searchAction() {
         // Only want to track search here when button clicked. Keypress search tracking is debounced in trackSearch
-        this.analytics.track('button', 'click', `${this.theme.id} Discover - Search`, this.q);
+        this.analytics.track('button', 'click', `Discover - Search - ${this.theme.id}`, this.q);
         this.search();
     }
 

--- a/lib/collections/addon/components/discover-page/facets/checklist/component.ts
+++ b/lib/collections/addon/components/discover-page/facets/checklist/component.ts
@@ -87,7 +87,7 @@ export default abstract class SearchFacetChecklist extends Base {
                     analytics.track(
                         'filter',
                         filterAction,
-                        `${theme.id} Discover - Filter ${context.title} ${item}`,
+                        `Discover - Filter ${context.title} ${item} - ${theme.id}`,
                     );
                 }
 

--- a/lib/collections/addon/components/discover-page/facets/checklist/component.ts
+++ b/lib/collections/addon/components/discover-page/facets/checklist/component.ts
@@ -74,7 +74,7 @@ export default abstract class SearchFacetChecklist extends Base {
     didInsertElement(this: SearchFacetChecklist) {
         super.didInsertElement();
 
-        const { analytics, context, filterChanged, filterProperty } = this;
+        const { analytics, context, filterChanged, filterProperty, theme } = this;
 
         setProperties(context, {
             updateFilters(item?: string) {
@@ -84,7 +84,11 @@ export default abstract class SearchFacetChecklist extends Base {
                     const method = activeFilter.includes(item) ? 'removeObject' : 'pushObject';
                     activeFilter[method](item);
                     const filterAction = method === 'removeObject' ? 'remove' : 'add';
-                    analytics.track('filter', filterAction, `Collections Discover - Filter ${context.title} ${item}`);
+                    analytics.track(
+                        'filter',
+                        filterAction,
+                        `${theme.id} Discover - Filter ${context.title} ${item}`,
+                    );
                 }
 
                 setProperties(context, {


### PR DESCRIPTION
- Ticket: [ENG-1135](https://openscience.atlassian.net/browse/ENG-1135)
- Feature flag: `N/A`

## Purpose

A quick PR to add the provider theme id to the analytics on the collection's discover page.

## Summary of Changes

Updates the analytics for:

- search bar
- `Add to collection` button on the branded navbar
- filter facets (adding and removing)
- search result link (to view project)

## Side Effects

`N/A`

## QA Notes

You should be able to see the provider's id at the beginning of the label now and should look something like the following:

- Search bar: `category: button, action: click, label: studyswap Discover - Search, extra: t`
- Navbar `Add to Collection` button: `category: link, action: click, label: studyswap Navbar - Add to Collection, extra: undefined`
- Add facet: `category: filter, action: add, label: studyswap Discover - Filter Type esse, extra: undefined` (esse being an example filter locally)
- Remove facet: `filter, action: remove, label: studyswap Discover - Filter Type esse, extra: undefined`
