### PR TITLE
[No ticket] Fix contributor links

### DIFF
--- a/lib/osf-components/addon/components/contributors/card/editable/template.hbs
+++ b/lib/osf-components/addon/components/contributors/card/editable/template.hbs
@@ -13,7 +13,7 @@
                 data-test-contributor-link={{@contributor.id}}
                 data-analytics-name='View user'
                 @route='guid-user'
-                @models={{array @contributor.id}}
+                @models={{array @contributor.users.id}}
             >
                 {{@contributor.users.fullName}}
             </OsfLink>

--- a/lib/osf-components/addon/components/contributors/card/readonly/template.hbs
+++ b/lib/osf-components/addon/components/contributors/card/readonly/template.hbs
@@ -13,7 +13,7 @@
                 data-test-contributor-link={{@contributor.id}}
                 data-analytics-name='View user'
                 @route='guid-user'
-                @models={{array @contributor.id}}
+                @models={{array @contributor.users.id}}
             >
                 {{@contributor.users.fullName}}
             </OsfLink>


### PR DESCRIPTION
- Ticket: []
- Feature flag: n/a

## Purpose

Use the user's id instead of the concatenated contributor's id for the link.
