### PR TITLE
[hotfix][ENG-2010] send keen public pageviews into partitioned collections

### DIFF
--- a/app/metrics-adapters/keen.ts
+++ b/app/metrics-adapters/keen.ts
@@ -116,11 +116,12 @@ export default class KeenAdapter extends BaseAdapter {
         const node = await this.getCurrentNode();
         if (node) {
             sendPublicEvent = node.public;
+            if (sendPublicEvent) {
+                this.trackPublicEvent('pageviews', eventProperties);
+                this.trackPublicEvent(`pageviews-${node.id.charAt(0)}`, eventProperties);
+            }
         }
 
-        if (sendPublicEvent) {
-            this.trackPublicEvent('pageviews', eventProperties);
-        }
         this.trackPrivateEvent('pageviews', eventProperties);
     }
 

--- a/lib/collections/addon/components/discover-page/component.ts
+++ b/lib/collections/addon/components/discover-page/component.ts
@@ -318,7 +318,7 @@ export default class DiscoverPage extends Component {
     }
 
     trackDebouncedSearch() {
-        // For use in tracking debounced search of registries in Keen and GA
+        // For use in tracking debounced search of registries in GA
         this.analytics.track('input', 'onkeyup', 'Discover - Search', this.q);
     }
 


### PR DESCRIPTION

- Ticket: [ENG-2010]
- Feature flag: n/a

## Purpose

Send public pageview logs to two keen collections: `pageviews` and `pageviews-$foo`, where `$foo` is the first letter of the project guid.  After a month we can switch the analytics page to query the partitioned collection, which should be significantly faster.

## Summary of Changes

 * Log the public pageview events into collection buckets partitioned
   by the first letter of the project guid.  After one month, we will
   switch the analytics page to pull from the partitioned buckets.
   Since each bucket will have approximately 1/31 (there are 31
   possible letters or numbers that can appear in a guid) of the
   events in the common collection, it should make the analytics page
   more responsive.

## Side Effects

None expected.

## QA Notes

No QA needed, will be dev-tested.


[ENG-2010]: https://openscience.atlassian.net/browse/ENG-2010