### PR TITLE
Update contributor card to handle unregistered users

### DIFF
--- a/lib/osf-components/addon/components/contributors/card/readonly/template.hbs
+++ b/lib/osf-components/addon/components/contributors/card/readonly/template.hbs
@@ -9,14 +9,18 @@
                 height='30'
                 width='30'
             >
-            <OsfLink
-                data-test-contributor-link={{@contributor.id}}
-                data-analytics-name='View user'
-                @route='guid-user'
-                @models={{array @contributor.users.id}}
-            >
-                {{@contributor.users.fullName}}
-            </OsfLink>
+            {{#if @contributor.unregisteredContributor}}
+                {{@contributor.unregisteredContributor}}
+            {{else}}
+                <OsfLink
+                    data-test-contributor-link={{@contributor.id}}
+                    data-analytics-name='View user'
+                    @route='guid-user'
+                    @models={{array @contributor.users.id}}
+                >
+                    {{@contributor.users.fullName}}
+                </OsfLink>
+            {{/if}}
         </span>
         <span
             data-test-contributor-permission={{@contributor.id}}

--- a/mirage/factories/contributor.ts
+++ b/mirage/factories/contributor.ts
@@ -11,9 +11,7 @@ interface ContributorTraits {
 export default Factory.extend<Contributor & ContributorTraits>({
     permission: faker.list.cycle(...Object.values(Permission)),
     bibliographic: true,
-    unregisteredContributor() {
-        return faker.random.number(5) ? undefined : faker.name.firstName();
-    },
+    unregisteredContributor: undefined,
     index(i: number) {
         return i;
     },

--- a/tests/integration/components/contributors/component-test.ts
+++ b/tests/integration/components/contributors/component-test.ts
@@ -70,6 +70,32 @@ module('Integration | Component | contributors', hooks => {
         assert.ok(true, 'No a11y errors on page');
     });
 
+    test('read-only user card renders unregistered contributor', async function(assert) {
+        const registration = server.create('draft-registration');
+        const unregContributor = server.create('contributor', {
+            draftRegistration: registration,
+        }, 'unregistered');
+        const registrationModel = await this.store.findRecord('draft-registration', registration.id);
+        this.set('node', registrationModel);
+
+        await render(hbs`<Contributors::Widget @node={{this.node}} />`);
+        const userPermission = t(`osf-components.contributors.permissions.${unregContributor.permission}`);
+        const userCitation = t(`osf-components.contributors.citation.${unregContributor.bibliographic}`);
+
+        assert.dom('[data-test-contributor-card]').exists();
+        assert.dom('[data-test-contributor-card-main]').exists();
+        assert.dom('[data-test-contributor-gravatar]').exists();
+        assert.dom('[data-test-contributor-link]').doesNotExist();
+        assert.dom('[data-test-contributor-card-main] CardSection')
+            .containsText(unregContributor.unregisteredContributor!);
+        assert.dom(`[data-test-contributor-permission="${unregContributor.id}"]`)
+            .hasText(userPermission);
+        assert.dom(`[data-test-contributor-citation="${unregContributor.id}"]`)
+            .hasText(userCitation);
+        await a11yAudit(this.element);
+        assert.ok(true, 'No a11y errors on page');
+    });
+
     test('editable user card renders', async function(assert) {
         const draftRegistration = server.create('draft-registration');
         const contributor = server.create('contributor', {

--- a/tests/integration/components/contributors/component-test.ts
+++ b/tests/integration/components/contributors/component-test.ts
@@ -86,7 +86,7 @@ module('Integration | Component | contributors', hooks => {
         assert.dom('[data-test-contributor-card-main]').exists();
         assert.dom('[data-test-contributor-gravatar]').exists();
         assert.dom('[data-test-contributor-link]').doesNotExist();
-        assert.dom('[data-test-contributor-card-main] CardSection')
+        assert.dom('[data-test-contributor-card-main]')
             .containsText(unregContributor.unregisteredContributor!);
         assert.dom(`[data-test-contributor-permission="${unregContributor.id}"]`)
             .hasText(userPermission);


### PR DESCRIPTION
- Ticket: [N/A]
- Feature flag: n/a

## Purpose
Update read-only contributor cards to show unregistered contributors as plain text, as opposed to a link to their profile page

## Summary of Changes
- Added condition to check if a contributor is registered or not
- Added test to verify if unregistered contributor is rendered as plain text and not a link

## Side Effects
- Should be none

## QA Notes
- this should address the bug found for read-only contributor management