### PR TITLE
[No ticket] Additional dev for branded registries

### DIFF
--- a/app/guid-node/registrations/controller.ts
+++ b/app/guid-node/registrations/controller.ts
@@ -17,7 +17,7 @@ export default class GuidNodeRegistrations extends Controller {
     queryParams = ['tab'];
     tab?: string;
 
-    draftsQueryParams = { embed: ['initiator', 'registration_schema', 'branched_from'] };
+    draftsQueryParams = { embed: ['initiator', 'registration_schema', 'branched_from', 'provider'] };
     defaultSchema!: RegistrationSchema;
     selectedSchema!: RegistrationSchema;
     schemas: RegistrationSchema[] = [];

--- a/lib/osf-components/addon/components/osf-layout/template.hbs
+++ b/lib/osf-components/addon/components/osf-layout/template.hbs
@@ -5,15 +5,14 @@
     metadataGutterClosed=this.metadataGutterClosed
     toggleMetadata=(action this.toggleMetadata)
 )}}
-
+{{yield (hash
+    top=(
+        component 'osf-layout/top'
+        toggleSidenav=(action this.toggleSidenav)
+        sidenavGutterClosed=this.sidenavGutterClosed
+    )
+)}}
 <div class={{this.backgroundClass}}>
-    {{yield (hash
-        top=(
-            component 'osf-layout/top'
-            toggleSidenav=(action this.toggleSidenav)
-            sidenavGutterClosed=this.sidenavGutterClosed
-        )
-    )}}
     <Gutters
         @leftMode={{this.sidenavGutterMode}}
         @leftClosed={{this.sidenavGutterClosed}}

--- a/lib/registries/addon/drafts/draft/-components/register/component.ts
+++ b/lib/registries/addon/drafts/draft/-components/register/component.ts
@@ -36,6 +36,7 @@ export default class Register extends Component {
             const registration = this.store.createRecord('registration', {
                 draftRegistrationId: this.draftRegistration.id,
                 registeredFrom: this.draftRegistration.branchedFrom,
+                provider: this.draftRegistration.provider,
             });
 
             this.setProperties({ registration });

--- a/lib/registries/addon/drafts/draft/-components/top-nav/template.hbs
+++ b/lib/registries/addon/drafts/draft/-components/top-nav/template.hbs
@@ -3,82 +3,80 @@
 {{assert 'Drafts::Draft::-Components::TopNav requires a navigation-manager' @navManager}}
 {{assert 'Drafts::Draft::-Components::TopNav requires a onSubmitRedirect' @onSubmitRedirect}}
 
-<@layout.top as |layout|>
-    <Navbar local-class='SideBarToggle' ...attributes as |nav|>
-        <nav.bordered-section>
-            <nav.buttons.default
-                data-analytics-name='Show sidenav'
-                aria-label={{t 'osf-components.registries-top-nav.showRegistrationNavigation'}}
-                @onclick={{action layout.toggleSidenav}}
-            >
-                <nav.icon @icon={{if layout.sidenavGutterClosed 'bars' 'times'}} />
-            </nav.buttons.default>
-        </nav.bordered-section>
-        <nav.bordered-section local-class='MobileNavPageLabelSection'>
-            <div local-class='MobileNavPageLabel' data-test-page-label>
-                {{#if @navManager.inReview}}
-                    {{t 'registries.drafts.draft.review.page_label'}}
-                {{else if @navManager.inMetadata}}
-                    {{t 'registries.drafts.draft.metadata.page_label'}}
-                {{else}}
-                    {{@navManager.currentPageManager.pageHeadingText}}
-                {{/if}}
-            </div>
-        </nav.bordered-section>
-        <nav.bordered-section>
-            {{#if @navManager.isFirstPage}}
-                <nav.links.default
-                    data-test-goto-metadata
-                    data-analytics-name='Sidenav back to metadata'
-                    aria-label={{t 'osf-components.registries-top-nav.metadata'}}
-                    local-class='MetadataButton'
-                    @route='registries.drafts.draft.metadata'
-                    @models={{array @draftManager.draftId }}
-                >
-                    {{t 'registries.drafts.draft.metadata.page_label'}}
-                </nav.links.default>
-            {{/if}}
-            {{#if @navManager.prevPageParam}}
-                <nav.links.default
-                    data-test-goto-previous-page
-                    data-analytics-name='Sidenav back'
-                    aria-label={{t 'osf-components.registries-top-nav.previousPage'}}
-                    @route='registries.drafts.draft.page'
-                    @models={{array @draftManager.draftId @navManager.prevPageParam}}
-                >
-                    <nav.icon @icon='arrow-left' />
-                </nav.links.default>
-            {{/if}}
-            {{#if @navManager.nextPageParam}}
-                <nav.links.default
-                    data-test-goto-next-page
-                    data-analytics-name='Sidenav next'
-                    aria-label={{t 'osf-components.registries-top-nav.nextPage'}}
-                    @route='registries.drafts.draft.page'
-                    @models={{array @draftManager.draftId @navManager.nextPageParam}}
-                    @onClick={{@navManager.currentPageManager.setPageIsVisited}}
-                >
-                    <nav.icon @icon='arrow-right' />
-                </nav.links.default>
-            {{/if}}
-            {{#if @navManager.isLastPage}}
-                <nav.links.default
-                    data-test-goto-review
-                    data-analytics-name='Sidenav review'
-                    aria-label={{t 'osf-components.registries-top-nav.reviewRegistration'}}
-                    @route='registries.drafts.draft.review'
-                    @models={{array @draftManager.draftId}}
-                >
-                    <nav.icon @icon='arrow-right' />
-                </nav.links.default>
-            {{/if}}
+<Navbar local-class='SideBarToggle' ...attributes as |nav|>
+    <nav.bordered-section>
+        <nav.buttons.default
+            data-analytics-name='Show sidenav'
+            aria-label={{t 'osf-components.registries-top-nav.showRegistrationNavigation'}}
+            @onclick={{action @layout.toggleSidenav}}
+        >
+            <nav.icon @icon={{if @layout.sidenavGutterClosed 'bars' 'times'}} />
+        </nav.buttons.default>
+    </nav.bordered-section>
+    <nav.bordered-section local-class='MobileNavPageLabelSection'>
+        <div local-class='MobileNavPageLabel' data-test-page-label>
             {{#if @navManager.inReview}}
-                <Drafts::Draft::-Components::Register
-                    @draftManager={{@draftManager}}
-                    @onSubmitRedirect={{action @onSubmitRedirect}}
-                    @showMobileView={{true}}
-                />
+                {{t 'registries.drafts.draft.review.page_label'}}
+            {{else if @navManager.inMetadata}}
+                {{t 'registries.drafts.draft.metadata.page_label'}}
+            {{else}}
+                {{@navManager.currentPageManager.pageHeadingText}}
             {{/if}}
-        </nav.bordered-section>
-    </Navbar>
-</@layout.top>
+        </div>
+    </nav.bordered-section>
+    <nav.bordered-section>
+        {{#if @navManager.isFirstPage}}
+            <nav.links.default
+                data-test-goto-metadata
+                data-analytics-name='Sidenav back to metadata'
+                aria-label={{t 'osf-components.registries-top-nav.metadata'}}
+                local-class='MetadataButton'
+                @route='registries.drafts.draft.metadata'
+                @models={{array @draftManager.draftId }}
+            >
+                {{t 'registries.drafts.draft.metadata.page_label'}}
+            </nav.links.default>
+        {{/if}}
+        {{#if @navManager.prevPageParam}}
+            <nav.links.default
+                data-test-goto-previous-page
+                data-analytics-name='Sidenav back'
+                aria-label={{t 'osf-components.registries-top-nav.previousPage'}}
+                @route='registries.drafts.draft.page'
+                @models={{array @draftManager.draftId @navManager.prevPageParam}}
+            >
+                <nav.icon @icon='arrow-left' />
+            </nav.links.default>
+        {{/if}}
+        {{#if @navManager.nextPageParam}}
+            <nav.links.default
+                data-test-goto-next-page
+                data-analytics-name='Sidenav next'
+                aria-label={{t 'osf-components.registries-top-nav.nextPage'}}
+                @route='registries.drafts.draft.page'
+                @models={{array @draftManager.draftId @navManager.nextPageParam}}
+                @onClick={{@navManager.currentPageManager.setPageIsVisited}}
+            >
+                <nav.icon @icon='arrow-right' />
+            </nav.links.default>
+        {{/if}}
+        {{#if @navManager.isLastPage}}
+            <nav.links.default
+                data-test-goto-review
+                data-analytics-name='Sidenav review'
+                aria-label={{t 'osf-components.registries-top-nav.reviewRegistration'}}
+                @route='registries.drafts.draft.review'
+                @models={{array @draftManager.draftId}}
+            >
+                <nav.icon @icon='arrow-right' />
+            </nav.links.default>
+        {{/if}}
+        {{#if @navManager.inReview}}
+            <Drafts::Draft::-Components::Register
+                @draftManager={{@draftManager}}
+                @onSubmitRedirect={{action @onSubmitRedirect}}
+                @showMobileView={{true}}
+            />
+        {{/if}}
+    </nav.bordered-section>
+</Navbar>

--- a/lib/registries/addon/drafts/draft/template.hbs
+++ b/lib/registries/addon/drafts/draft/template.hbs
@@ -30,12 +30,14 @@
                     </HeroOverlay>
                 </layout.heading>
                 {{#if this.showMobileView}}
-                    <Drafts::Draft::-Components::TopNav
-                        @layout={{layout}}
-                        @draftManager={{draftManager}}
-                        @navManager={{navManager}}
-                        @onSubmitRedirect={{this.onSubmitRedirect}}
-                    />
+                    <layout.top as |topLayout|>
+                        <Drafts::Draft::-Components::TopNav
+                            @layout={{topLayout}}
+                            @draftManager={{draftManager}}
+                            @navManager={{navManager}}
+                            @onSubmitRedirect={{this.onSubmitRedirect}}
+                        />
+                    </layout.top>
                 {{/if}}
                 <layout.leftNav as |leftNav|>
                     <PageLink


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: []
- Feature flag: n/a

## Purpose
- Fix broken layout on draft-registration detail page
- Prevent brand flickering between default brand and provider.brand on following transitions:
    - project registrations/drafts to draft-registration detail
    - draft-registration to registration

## Summary of Changes
- Embed `provider` on project registrations (drafts request)
- Add provider to (frontend) created registration
- Move layout.top out of `backgroundClass` div

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
