### PR TITLE
[ENG-2095] Link provider logo to (branded) discover route

### DIFF
--- a/lib/app-components/addon/helpers/get-model.ts
+++ b/lib/app-components/addon/helpers/get-model.ts
@@ -1,0 +1,13 @@
+import Helper from '@ember/component/helper';
+import ObjectProxy from '@ember/object/proxy';
+import DS from 'ember-data';
+import OsfModel from 'ember-osf-web/models/osf-model';
+
+export default class GetModelHelper extends Helper {
+    compute([model]: [DS.PromiseObject<OsfModel> | OsfModel]) {
+        if (!model) {
+            return undefined;
+        }
+        return model instanceof ObjectProxy ? model.content : model;
+    }
+}

--- a/lib/app-components/app/helpers/get-model.js
+++ b/lib/app-components/app/helpers/get-model.js
@@ -1,0 +1,1 @@
+export { default } from 'app-components/helpers/get-model';

--- a/lib/osf-components/addon/modifiers/with-branding.ts
+++ b/lib/osf-components/addon/modifiers/with-branding.ts
@@ -1,20 +1,18 @@
-import DS from 'ember-data';
 import Modifier from 'ember-oo-modifiers';
 import BrandModel from 'ember-osf-web/models/brand';
 
 class WithBrandingModifier extends Modifier {
-    didReceiveArguments([brand]: [BrandModel | DS.PromiseObject<BrandModel> | null]) {
-        const brandModel = (brand && 'content' in brand) ? brand.content : brand;
+    didReceiveArguments([brand]: [BrandModel | null]) {
         const { element } = this;
         const elementStyle = element.style;
 
-        if (brandModel) {
+        if (brand) {
             element.classList.add('with-custom-branding');
-            elementStyle.setProperty('--primary-color', brandModel.primaryColor);
-            elementStyle.setProperty('--secondary-color', brandModel.secondaryColor);
-            elementStyle.setProperty('--navbar-logo-img-url', `url(${brandModel.topnavLogoImage})`);
-            elementStyle.setProperty('--hero-logo-img-url', `url(${brandModel.heroLogoImage})`);
-            elementStyle.setProperty('--hero-background-img-url', `url(${brandModel.heroBackgroundImage})`);
+            elementStyle.setProperty('--primary-color', brand.primaryColor);
+            elementStyle.setProperty('--secondary-color', brand.secondaryColor);
+            elementStyle.setProperty('--navbar-logo-img-url', `url(${brand.topnavLogoImage})`);
+            elementStyle.setProperty('--hero-logo-img-url', `url(${brand.heroLogoImage})`);
+            elementStyle.setProperty('--hero-background-img-url', `url(${brand.heroBackgroundImage})`);
         } else {
             element.classList.remove('with-custom-branding');
             elementStyle.removeProperty('--primary-color');

--- a/lib/registries/addon/branded/new/template.hbs
+++ b/lib/registries/addon/branded/new/template.hbs
@@ -1,7 +1,7 @@
 {{title (t 'registries.new.page_title')}}
 
 <RegistriesWrapper
-    {{with-branding this.model.brand}}
+    {{with-branding (get-model this.model.brand)}}
     data-analytics-scope='New Registration Page'
     @provider={{this.model}}
 >

--- a/lib/registries/addon/components/registries-navbar/template.hbs
+++ b/lib/registries/addon/components/registries-navbar/template.hbs
@@ -9,7 +9,8 @@
             <OsfLink
                 data-test-brand
                 data-analytics-name='Brand'
-                @route='home'
+                @route='{{if @provider 'registries.branded.discover' 'registries.discover'}}'
+                @models={{if @provider (array @provider.id)}}
                 local-class='Logo'
                 aria-label={{t 'navbar.go_home'}}
             />

--- a/lib/registries/addon/discover/template.hbs
+++ b/lib/registries/addon/discover/template.hbs
@@ -2,11 +2,11 @@
 
 <RegistriesWrapper
     @provider={{this.providerModel}}
-    {{with-branding this.providerModel.brand}}
+    {{with-branding (get-model this.providerModel.brand)}}
     data-analytics-scope='Registries Discover page'
 >
     <HeroOverlay local-class='DiscoverHero'>
-        {{#registries-header 
+        {{#registries-header
             providerModel=this.providerModel
             showHelp=true
             value=(mut this.query)

--- a/lib/registries/addon/drafts/draft/controller.ts
+++ b/lib/registries/addon/drafts/draft/controller.ts
@@ -6,6 +6,7 @@ import { inject as service } from '@ember/service';
 import Media from 'ember-responsive';
 
 import BrandModel from 'ember-osf-web/models/brand';
+import ProviderModel from 'ember-osf-web/models/provider';
 import Registration from 'ember-osf-web/models/registration';
 
 export default class RegistriesDraft extends Controller {
@@ -13,7 +14,10 @@ export default class RegistriesDraft extends Controller {
 
     @not('media.isDesktop') showMobileView!: boolean;
 
-    @alias('model.draftRegistrationManager.draftRegistration.provider.brand')
+    @alias('model.draftRegistrationManager.provider')
+    provider?: ProviderModel;
+
+    @alias('model.draftRegistrationManager.provider.brand')
     brand?: BrandModel;
 
     @action

--- a/lib/registries/addon/drafts/draft/draft-registration-manager.ts
+++ b/lib/registries/addon/drafts/draft/draft-registration-manager.ts
@@ -10,6 +10,7 @@ import Toast from 'ember-toastr/services/toast';
 
 import DraftRegistration, { DraftMetadataProperties } from 'ember-osf-web/models/draft-registration';
 import NodeModel from 'ember-osf-web/models/node';
+import ProviderModel from 'ember-osf-web/models/provider';
 import SchemaBlock from 'ember-osf-web/models/schema-block';
 import captureException, { getApiErrorMessage } from 'ember-osf-web/utils/capture-exception';
 
@@ -21,9 +22,15 @@ import {
 } from 'ember-osf-web/packages/registration-schema';
 import buildChangeset from 'ember-osf-web/utils/build-changeset';
 
+type DraftsDraftModelTaskInstance = TaskInstance<{
+    draftRegistration: DraftRegistration,
+    node: NodeModel,
+    provider: ProviderModel,
+}>;
+
 export default class DraftRegistrationManager {
     // Required
-    draftRegistrationAndNodeTask!: TaskInstance<{draftRegistration: DraftRegistration, node: NodeModel}>;
+    draftRegistrationAndNodeTask!: DraftsDraftModelTaskInstance;
 
     // Private
     @service intl!: Intl;
@@ -45,6 +52,7 @@ export default class DraftRegistrationManager {
 
     draftRegistration!: DraftRegistration;
     node!: NodeModel;
+    provider!: ProviderModel;
 
     @computed('pageManagers.{[],@each.pageIsValid}')
     get registrationResponsesIsValid() {
@@ -66,9 +74,10 @@ export default class DraftRegistrationManager {
 
     @task({ withTestWaiter: true })
     initializePageManagers = task(function *(this: DraftRegistrationManager) {
-        const { draftRegistration, node } = yield this.draftRegistrationAndNodeTask;
+        const { draftRegistration, node, provider } = yield this.draftRegistrationAndNodeTask;
         set(this, 'draftRegistration', draftRegistration);
         set(this, 'node', node);
+        set(this, 'provider', provider);
         const registrationSchema = yield this.draftRegistration.registrationSchema;
         const schemaBlocks: SchemaBlock[] = yield registrationSchema.loadAll('schemaBlocks');
         set(this, 'schemaBlocks', schemaBlocks);
@@ -153,7 +162,7 @@ export default class DraftRegistrationManager {
         }
     });
 
-    constructor(draftRegistrationAndNodeTask: TaskInstance<{draftRegistration: DraftRegistration, node: NodeModel}>) {
+    constructor(draftRegistrationAndNodeTask: DraftsDraftModelTaskInstance) {
         set(this, 'draftRegistrationAndNodeTask', draftRegistrationAndNodeTask);
         this.initializePageManagers.perform();
         this.initializeMetadataChangeset.perform();

--- a/lib/registries/addon/drafts/draft/draft-registration-manager.ts
+++ b/lib/registries/addon/drafts/draft/draft-registration-manager.ts
@@ -22,7 +22,7 @@ import {
 } from 'ember-osf-web/packages/registration-schema';
 import buildChangeset from 'ember-osf-web/utils/build-changeset';
 
-type DraftsDraftModelTaskInstance = TaskInstance<{
+type LoadDraftModelTask = TaskInstance<{
     draftRegistration: DraftRegistration,
     node: NodeModel,
     provider: ProviderModel,
@@ -30,7 +30,7 @@ type DraftsDraftModelTaskInstance = TaskInstance<{
 
 export default class DraftRegistrationManager {
     // Required
-    draftRegistrationAndNodeTask!: DraftsDraftModelTaskInstance;
+    draftRegistrationAndNodeTask!: LoadDraftModelTask;
 
     // Private
     @service intl!: Intl;
@@ -162,7 +162,7 @@ export default class DraftRegistrationManager {
         }
     });
 
-    constructor(draftRegistrationAndNodeTask: DraftsDraftModelTaskInstance) {
+    constructor(draftRegistrationAndNodeTask: LoadDraftModelTask) {
         set(this, 'draftRegistrationAndNodeTask', draftRegistrationAndNodeTask);
         this.initializePageManagers.perform();
         this.initializeMetadataChangeset.perform();

--- a/lib/registries/addon/drafts/draft/route.ts
+++ b/lib/registries/addon/drafts/draft/route.ts
@@ -8,6 +8,8 @@ import DS from 'ember-data';
 import requireAuth from 'ember-osf-web/decorators/require-auth';
 import DraftRegistration from 'ember-osf-web/models/draft-registration';
 import NodeModel from 'ember-osf-web/models/node';
+import ProviderModel from 'ember-osf-web/models/provider';
+import SubjectModel from 'ember-osf-web/models/subject';
 import Analytics from 'ember-osf-web/services/analytics';
 import DraftRegistrationManager from 'registries/drafts/draft/draft-registration-manager';
 import NavigationManager from 'registries/drafts/draft/navigation-manager';
@@ -31,10 +33,14 @@ export default class DraftRegistrationRoute extends Route {
                 draftId,
                 { adapterOptions: { include: 'branched_from' } },
             );
-            const draftRegistrationSubjects = yield draftRegistration.loadAll('subjects');
-            draftRegistration.set('subjects', draftRegistrationSubjects);
-            const node: NodeModel = yield draftRegistration.branchedFrom;
-            return { draftRegistration, node };
+            const [subjects, node, provider]: [SubjectModel[], NodeModel, ProviderModel] = yield Promise.all([
+                draftRegistration.loadAll('subjects'),
+                draftRegistration.branchedFrom,
+                draftRegistration.provider,
+            ]);
+
+            draftRegistration.setProperties({ subjects });
+            return { draftRegistration, node, provider };
         } catch (error) {
             this.transitionTo('page-not-found', this.router.currentURL.slice(1));
             return undefined;

--- a/lib/registries/addon/drafts/draft/template.hbs
+++ b/lib/registries/addon/drafts/draft/template.hbs
@@ -1,4 +1,5 @@
 <RegistriesWrapper
+    @provider={{this.provider}}
     {{with-branding this.brand}}
 >
     {{#if this.model.draftRegistrationManager.initializing}}

--- a/lib/registries/addon/drafts/draft/template.hbs
+++ b/lib/registries/addon/drafts/draft/template.hbs
@@ -1,6 +1,6 @@
 <RegistriesWrapper
     @provider={{this.provider}}
-    {{with-branding this.brand}}
+    {{with-branding (get-model this.brand)}}
 >
     {{#if this.model.draftRegistrationManager.initializing}}
         <div local-class='ContentBackground Loading'>

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -1,6 +1,6 @@
 <RegistriesWrapper
-    @provider={{this.registration.provider}}
-    {{with-branding (if this.model.task.isIdle this.registration.provider.brand)}}
+    @provider={{if this.model.task.isIdle (get-model this.registration.provider)}}
+    {{with-branding (if this.model.task.isIdle (get-model this.registration.provider.brand))}}
 >
     {{#if this.model.task.isRunning}}
         <div local-class='ContentBackground Loading'>

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -1,4 +1,5 @@
 <RegistriesWrapper
+    @provider={{this.registration.provider}}
     {{with-branding (if this.model.task.isIdle this.registration.provider.brand)}}
 >
     {{#if this.model.task.isRunning}}

--- a/tests/engines/app-components/integration/helpers/get-model-test.ts
+++ b/tests/engines/app-components/integration/helpers/get-model-test.ts
@@ -1,0 +1,28 @@
+import ObjectProxy from '@ember/object/proxy';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupEngineRenderingTest } from 'ember-osf-web/tests/helpers/engines';
+import { module, test } from 'qunit';
+
+module('Integration | Helper | get-model', hooks => {
+    setupEngineRenderingTest(hooks, 'registries');
+
+    test('get-model works', async function(assert) {
+        const scenarios = [
+            { model: null, expected: '' },
+            { model: Object.create(null), expected: '' },
+            { model: Object.create({ content: { id: 'draft' } }), expected: '' },
+            { model: ObjectProxy.create({ content: { id: 'draft' } }), expected: 'draft' },
+        ];
+
+        for (const scenario of scenarios) {
+            this.set('model', scenario.model);
+            await render(hbs`
+                {{#let (get-model this.model) as |model|}}
+                    {{model.id}}
+                {{/let}}
+            `);
+            assert.dom(this.element).hasText(scenario.expected);
+        }
+    });
+});


### PR DESCRIPTION
- Ticket: []
- Feature flag: n/a

## Purpose

Link registries navbar provider logo to (branded) discover route.

## Summary of Changes
- Link to `branded.discover` if provider else `registries.discover`
- Pass down provider to navbar component in `draft`, `overview` routes.
- Refactor draftRegistrationManager class to add provider property.

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
