### PR TITLE
[ENG-2095]Replace shareSourceKey with shareSource

### DIFF
--- a/app/models/registration-provider.ts
+++ b/app/models/registration-provider.ts
@@ -18,7 +18,7 @@ export default class RegistrationProviderModel extends ProviderModel {
     schemas!: DS.PromiseManyArray<RegistrationSchemaModel> | RegistrationSchemaModel[];
 
     @attr('fixstring')
-    shareSourceKey?: string;
+    shareSource?: string;
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/lib/registries/addon/branded/discover/controller.ts
+++ b/lib/registries/addon/branded/discover/controller.ts
@@ -9,10 +9,10 @@ export default class Discover extends DiscoverController {
     }
 
     get additionalFilters() {
-        const { shareSourceKey, name } = this.model;
+        const { shareSource, name } = this.model;
 
         return [
-            new ShareTermsFilter('sources', shareSourceKey, name),
+            new ShareTermsFilter('sources', shareSource, name),
         ];
     }
 }

--- a/lib/registries/addon/discover/controller.ts
+++ b/lib/registries/addon/discover/controller.ts
@@ -213,8 +213,8 @@ export default class Discover extends Controller.extend(discoverQueryParams.Mixi
 
         // Setting osfProviders on the share-search service
         const urlRegex = config.OSF.url.replace(/^https?/, '^https?');
-        const filteredProviders = osfProviders.filter(provider => provider.shareSourceKey).map(provider => ({
-            name: provider.shareSourceKey!, // `name` should match what SHARE calls it
+        const filteredProviders = osfProviders.filter(provider => provider.shareSource).map(provider => ({
+            name: provider.shareSource!, // `name` should match what SHARE calls it
             display: provider.name,
             https: true,
             urlRegex,

--- a/mirage/factories/draft-registration.ts
+++ b/mirage/factories/draft-registration.ts
@@ -22,7 +22,7 @@ export default Factory.extend<DraftRegistration & DraftRegistrationTraits>({
             const defaultProvider = server.schema.registrationProviders.find('osf')
                 || server.create('registration-provider', {
                     id: 'osf',
-                    shareSourceKey: 'OSF',
+                    shareSource: 'OSF',
                     name: 'OSF Registries',
                 });
             newDraft.update({

--- a/mirage/factories/external-provider.ts
+++ b/mirage/factories/external-provider.ts
@@ -3,7 +3,7 @@ import { MirageExternalProvider } from 'ember-osf-web/mirage/models/external-pro
 import faker from 'faker';
 
 export default Factory.extend<MirageExternalProvider>({
-    shareSourceKey() {
+    shareSource() {
         return faker.random.words(2);
     },
 });

--- a/mirage/factories/registration-provider.ts
+++ b/mirage/factories/registration-provider.ts
@@ -45,8 +45,8 @@ export default Factory.extend<MirageRegistrationProvider & RegistrationProviderT
                 }),
             ],
         });
-        if (!provider.shareSourceKey) {
-            provider.update({ shareSourceKey: `share-${provider.name}` });
+        if (!provider.shareSource) {
+            provider.update({ shareSource: `share-${provider.name}` });
         }
     },
 

--- a/mirage/factories/registration.ts
+++ b/mirage/factories/registration.ts
@@ -118,7 +118,7 @@ export default NodeFactory.extend<MirageRegistration & RegistrationTraits>({
                 provider: server.schema.registrationProviders.find('osf')
                     || server.create('registration-provider', {
                         id: 'osf',
-                        shareSourceKey: 'OSF',
+                        shareSource: 'OSF',
                         name: 'OSF Registries',
                     }),
             });

--- a/mirage/fixtures/registration-providers.ts
+++ b/mirage/fixtures/registration-providers.ts
@@ -19,7 +19,7 @@ const registrationProviders: Array<Partial<MirageRegistrationProvider>> = [
         description: 'The open registries network',
         allowSubmissions: true,
         assets: randomAssets(),
-        shareSourceKey: 'OSF',
+        shareSource: 'OSF',
         licensesAcceptableIds: [
             '5c252c8e0989e100220edb70',
             '5c252c8e0989e100220edb7a',

--- a/mirage/models/external-provider.ts
+++ b/mirage/models/external-provider.ts
@@ -3,7 +3,7 @@ import { MirageExternalRegistration } from './external-registration';
 
 export interface MirageExternalProvider {
     registrations: Collection<MirageExternalRegistration>;
-    shareSourceKey: string;
+    shareSource: string;
 }
 
 export default Model.extend({

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -112,10 +112,10 @@ function registrationScenario(
     });
 
     const clinicalTrials = server.create('external-provider', {
-        shareSourceKey: 'ClinicalTrials.gov',
+        shareSource: 'ClinicalTrials.gov',
     });
     const researchRegistry = server.create('external-provider', {
-        shareSourceKey: 'Research Registry',
+        shareSource: 'Research Registry',
     });
 
     server.createList('external-registration', 3, { provider: clinicalTrials });

--- a/mirage/views/share-search.ts
+++ b/mirage/views/share-search.ts
@@ -85,9 +85,9 @@ function hasProviderAggregation(request: Request): boolean {
 function buildProviderBuckets(registrations: MixedResult[]): ProviderBucket[] {
     const providerBuckets = registrations.reduce(
         (counts, reg) => {
-            const count = counts[reg.provider.shareSourceKey!] || 0;
+            const count = counts[reg.provider.shareSource!] || 0;
             // eslint-disable-next-line no-param-reassign
-            counts[reg.provider.shareSourceKey!] = count + 1;
+            counts[reg.provider.shareSource!] = count + 1;
             return counts;
         },
         {} as Record<string, number | undefined>,
@@ -103,7 +103,7 @@ function serializeExternalRegistration(
     return {
         date_registered: externalReg.dateRegistered,
         date_published: externalReg.dateRegistered,
-        sources: [externalReg.provider.shareSourceKey],
+        sources: [externalReg.provider.shareSource],
         registration_type: 'yes this is a schema',
         type: 'registration',
         subject_synonyms: [],
@@ -157,7 +157,7 @@ function serializeRegistration(reg: ModelInstance<RegistrationModel>): Serialize
         date_registered: reg.dateRegistered.toString(),
         date_published: reg.dateRegistered.toString(),
         justification: reg.withdrawalJustification,
-        sources: [reg.provider.shareSourceKey!],
+        sources: [reg.provider.shareSource!],
         registration_type: reg.registrationSchema.name,
         type: 'registration',
         subject_synonyms: [],
@@ -196,11 +196,11 @@ function serializeMixedResult(reg: MixedResult): SearchHit {
 function getResultsForProviders(schema: Schema, providerShareKeys: string[]): MixedResult[] {
     const results: MixedResult[] = [];
     for (const providerShareKey of providerShareKeys) {
-        const provider = schema.registrationProviders.findBy({ shareSourceKey: providerShareKey });
+        const provider = schema.registrationProviders.findBy({ shareSource: providerShareKey });
         if (provider) {
             results.push(...provider.registrations.models);
         } else {
-            const externalProvider = schema.externalProviders.findBy({ shareSourceKey: providerShareKey });
+            const externalProvider = schema.externalProviders.findBy({ shareSource: providerShareKey });
             if (externalProvider) {
                 results.push(...externalProvider.registrations.models);
             }

--- a/tests/engines/registries/acceptance/branded/discover-test.ts
+++ b/tests/engines/registries/acceptance/branded/discover-test.ts
@@ -28,12 +28,12 @@ module('Registries | Acceptance | branded.discover', hooks => {
     });
 
     test('branded discover with external providers', async assert => {
-        const externalProvider = server.create('external-provider', { shareSourceKey: 'ClinicalTrials.gov' });
+        const externalProvider = server.create('external-provider', { shareSource: 'ClinicalTrials.gov' });
         server.createList('external-registration', 3, { provider: externalProvider });
 
         await visit('/registries/brand/discover');
         assert.dom('[data-test-source-filter-id]').exists({ count: 1 }, 'Only brand provider is shown');
-        assert.dom(`[data-test-source-filter-id="${externalProvider.shareSourceKey}"]`)
+        assert.dom(`[data-test-source-filter-id="${externalProvider.shareSource}"]`)
             .doesNotExist('External provider is not shown');
     });
 });

--- a/tests/engines/registries/acceptance/discover-page-test.ts
+++ b/tests/engines/registries/acceptance/discover-page-test.ts
@@ -14,7 +14,7 @@ module('Registries | Acceptance | aggregate discover', hooks => {
     hooks.beforeEach(() => {
         const osfProvider = server.create('registration-provider', { id: 'osf' });
         const anotherProvider = server.create('registration-provider', { id: 'another' });
-        const externalProvider = server.create('external-provider', { shareSourceKey: 'ClinicalTrials.gov' });
+        const externalProvider = server.create('external-provider', { shareSource: 'ClinicalTrials.gov' });
         server.createList('external-registration', 3, { provider: externalProvider });
         server.createList('registration', 3, { provider: osfProvider });
         server.createList('registration', 3, { provider: anotherProvider });
@@ -41,7 +41,7 @@ module('Registries | Acceptance | aggregate discover', hooks => {
 
         await fillIn('[data-test-search-box]', '');
 
-        await click(`[data-test-source-filter-id="${osfProvider.shareSourceKey}"]`);
+        await click(`[data-test-source-filter-id="${osfProvider.shareSource}"]`);
         assert.dom('[data-test-result-title-id]').exists({ count: 3 }, 'Provider filter works');
 
         await fillIn('[data-test-search-box]', 'kjafnsdflkjhsdfnasdkndfa random string');
@@ -70,15 +70,15 @@ module('Registries | Acceptance | aggregate discover', hooks => {
         const anotherProvider = server.schema.registrationProviders.find('another');
         const searchableReg = anotherProvider.registrations.models[0];
 
-        await visit(`/registries/discover?provider=${anotherProvider.shareSourceKey}&q=${searchableReg.title}`);
+        await visit(`/registries/discover?provider=${anotherProvider.shareSource}&q=${searchableReg.title}`);
 
         await percySnapshot('with initial query params');
 
         assert.dom('[data-test-search-box]').hasValue(searchableReg.title, 'Search box has initial value');
 
-        assert.dom(`[data-test-source-filter-id='${anotherProvider.shareSourceKey}']`).isChecked();
+        assert.dom(`[data-test-source-filter-id='${anotherProvider.shareSource}']`).isChecked();
         assert.dom(
-            `[data-test-source-filter-id]:not([data-test-source-filter-id='${anotherProvider.shareSourceKey}'])`,
+            `[data-test-source-filter-id]:not([data-test-source-filter-id='${anotherProvider.shareSource}'])`,
         ).isNotChecked();
 
         assert.dom('[data-test-result-title-id]').exists({ count: 1 }, 'Initial search uses initial params');

--- a/tests/engines/registries/integration/discover/discover-test.ts
+++ b/tests/engines/registries/integration/discover/discover-test.ts
@@ -130,12 +130,12 @@ module('Registries | Integration | discover', hooks => {
         server.create('registration-schema', { name: 'Close Fronted' });
         server.create('registration-provider', {
             id: 'osf',
-            shareSourceKey: 'OSF',
+            shareSource: 'OSF',
             name: 'OSF Registries',
         });
         server.create('registration-provider', {
             id: 'someother',
-            shareSourceKey: 'someother',
+            shareSource: 'someother',
             name: 'Some Other',
         });
 


### PR DESCRIPTION
- Ticket: [ENG-2095]
- Feature flag: n/a

## Purpose
Update the shareSourceKey property on registration providers to be shareSource to match what is implemented in the backend

## Summary of Changes
Same as above

## Side Effects
NA
## QA Notes
This should fix the broken discover page!


[ENG-2095]: https://openscience.atlassian.net/browse/ENG-2095