### PR TITLE
[ENG-2095] Remove hover background on button link class

### DIFF
--- a/lib/osf-components/addon/components/button/styles.scss
+++ b/lib/osf-components/addon/components/button/styles.scss
@@ -77,5 +77,6 @@
     &:hover {
         color: var(--primary-color);
         text-decoration: underline;
+        background: none;
     }
 }

--- a/lib/osf-components/addon/components/button/styles.scss
+++ b/lib/osf-components/addon/components/button/styles.scss
@@ -77,6 +77,5 @@
     &:hover {
         color: var(--primary-color);
         text-decoration: underline;
-        background: none;
     }
 }

--- a/lib/osf-components/addon/components/editable-field/template.hbs
+++ b/lib/osf-components/addon/components/editable-field/template.hbs
@@ -8,7 +8,6 @@
                    aria-label={{t 'general.edit'}}
                    data-analytics-name='Edit'
                    local-class='EditButton'
-                   @type='primary'
                    @layout='fake-link'
                    {{on 'click' @manager.startEditing}}
                 >


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-2095
- Feature flag: `N/A`

## Purpose

To remove the hover background on fakelink buttons.

## Summary of Changes

Add `background: none` to the fakelink hover css

## Side Effects

`N/A`

## QA Notes

This should fix the issue of background colors being shown on hover over link buttons.
