### PR TITLE
[ENG-2095]Reapply inert blur to global style

### DIFF
--- a/app/styles/_global.scss
+++ b/app/styles/_global.scss
@@ -22,5 +22,6 @@
 
 // Used for modal backdrops and loading states. See https://github.com/WICG/inert
 [inert] {
+    filter: grayscale(100%) blur(5px);
     overflow: hidden;
 }


### PR DESCRIPTION


- Ticket: [ENG-2095]
- Feature flag: n/a

## Purpose
Make subjects placeholder text blurred when searching

## Summary of Changes
- Re-added the blur property to `[inert]` in our global css

## Side Effects
- previously removed the inert blur as we thought it was redundant when updating styles for modal dialogs, so other parts that had the blur behavior removed should be fixed as well

## QA Notes
- Searching for subjects in the draft registration should be blurred again!


[ENG-2095]: https://openscience.atlassian.net/browse/ENG-2095