### PR TITLE
[ENG-2095]Update project loading filter

### DIFF
--- a/lib/registries/addon/branded/new/controller.ts
+++ b/lib/registries/addon/branded/new/controller.ts
@@ -7,6 +7,7 @@ import { task } from 'ember-concurrency-decorators';
 import DS from 'ember-data';
 
 import NodeModel from 'ember-osf-web/models/node';
+import { Permission } from 'ember-osf-web/models/osf-model';
 import RegistrationSchemaModel from 'ember-osf-web/models/registration-schema';
 import Analytics from 'ember-osf-web/services/analytics';
 import CurrentUserService from 'ember-osf-web/services/current-user';
@@ -65,6 +66,7 @@ export default class BrandedRegistriesNewSubmissionController extends Controller
                 {
                     filter: {
                         title: query,
+                        current_user_permissions: Permission.Admin,
                     },
                 });
             this.projectOptions = nodes;

--- a/tests/engines/registries/acceptance/branded/new-test.ts
+++ b/tests/engines/registries/acceptance/branded/new-test.ts
@@ -56,7 +56,9 @@ module('Registries | Acceptance | branded.new', hooks => {
         server.loadFixtures('schema-blocks');
         const currentUser = server.create('user', 'loggedIn');
         const node = server.create('node', { id: 'decaf', title: 'This is your project' }, 'currentUserAdmin');
+        const nonAdminNode = server.create('node', { id: 'badmin', title: 'User is not admin' });
         server.create('contributor', { node, users: currentUser });
+        server.create('contributor', { node: nonAdminNode, users: currentUser });
         const brandedProvider = server.create('registration-provider', 'withBrand', 'withSchemas');
         await visit(`/registries/${brandedProvider.id}/new`);
 
@@ -65,6 +67,8 @@ module('Registries | Acceptance | branded.new', hooks => {
         await click('[data-test-project-select] .ember-power-select-trigger');
         assert.dom('.ember-power-select-options > li.ember-power-select-option:first-of-type')
             .hasText('This is your project', 'Project dropdown shows project title');
+        assert.dom('.ember-power-select-options > li.ember-power-select-option')
+            .doesNotContainText('User is not admin', 'Project dropdown only shows projects the user is admin for');
         await click('.ember-power-select-options > li.ember-power-select-option:first-of-type');
         assert.dom('[data-test-schema-select] .ember-power-select-trigger')
             .hasText('This is a Test Schema', 'Schema dropdown is autopopulated with first schema available');


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-2095]
- Feature flag: n/a

## Purpose
Only show the projects that a user can create a registration for in the branded submission page

## Summary of Changes
- add filter to show only projects that user has admin privileges on

## Side Effects
NA

## QA Notes
- On `registries/<provider_id>/new` the dropdown to select the project to register should now only show projects that the current user is an admin on

[ENG-2095]: https://openscience.atlassian.net/browse/ENG-2095