### PR TITLE
[ENG-2095] Update dropdown styles for multi-line items

### DIFF
--- a/lib/registries/addon/branded/new/styles.scss
+++ b/lib/registries/addon/branded/new/styles.scss
@@ -15,6 +15,10 @@
     display: block;
 }
 
+.projectHeading {
+    text-align: center;
+}
+
 .registrationForm {
     display: flex;
     align-items: center;

--- a/lib/registries/addon/branded/new/template.hbs
+++ b/lib/registries/addon/branded/new/template.hbs
@@ -24,7 +24,10 @@
                     <p local-class='stepLabel'>
                         {{t 'registries.new.step_one'}}
                     </p>
-                    <h2 data-test-project-select-title>
+                    <h2
+                        data-test-project-select-title
+                        local-class='projectHeading'
+                    >
                         {{t 'registries.new.select_project'}}
                         <span local-class='required' aria-label={{t 'registries.new.required'}}>*</span>
                     </h2>

--- a/lib/registries/addon/drafts/draft/metadata/styles.scss
+++ b/lib/registries/addon/drafts/draft/metadata/styles.scss
@@ -83,7 +83,7 @@
     margin: 10px 0 0;
 
     :global(.ember-power-select-trigger) {
-        padding: 10px 20px;
+        padding: 10px;
         color: $color-text-gray-blue;
         background-color: $color-bg-gray-blue-light;
         border: 1px solid $color-border-gray;

--- a/lib/registries/addon/drafts/draft/metadata/styles.scss
+++ b/lib/registries/addon/drafts/draft/metadata/styles.scss
@@ -83,7 +83,7 @@
     margin: 10px 0 0;
 
     :global(.ember-power-select-trigger) {
-        line-height: 40px;
+        padding: 10px 20px;
         color: $color-text-gray-blue;
         background-color: $color-bg-gray-blue-light;
         border: 1px solid $color-border-gray;

--- a/lib/registries/addon/drafts/draft/metadata/styles.scss
+++ b/lib/registries/addon/drafts/draft/metadata/styles.scss
@@ -90,6 +90,11 @@
         border-radius: 2px;
         font-size: 14px;
         box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);
+        margin: auto;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        max-width: 80%;
     }
 }
 


### PR DESCRIPTION
- Ticket: [ENG-2095]
- Feature flag: n/a

## Purpose
Update style for dropdowns to better render multi-line items

## Summary of Changes
- change style for ember dropdown to use `padding` instead of `line-height` to render multi-line items differently

BEFORE:
![image](https://user-images.githubusercontent.com/51409893/89688984-5b50ae00-d8d1-11ea-9194-df7db98c7276.png)

AFTER:
![image](https://user-images.githubusercontent.com/51409893/89689112-b1255600-d8d1-11ea-9133-c5234d1cf5eb.png)

## Side Effects
- Dropdowns in the draft metadata page will look differently too, since the dropdown on the `/registries/<provider_id>/new` page uses the same style used in the `draft metadata` workflow

## QA Notes
- when the selected item in a dropdown wraps to the next line, the spacing between these lines should be much smaller now

[ENG-2095]: https://openscience.atlassian.net/browse/ENG-2095