### PR TITLE
[ENG-2095] Remove conflicting z-index

### DIFF
--- a/lib/osf-components/addon/components/container/styles.scss
+++ b/lib/osf-components/addon/components/container/styles.scss
@@ -5,7 +5,6 @@
     margin-left: auto;
     margin-right: auto;
     padding: 0 15px;
-    z-index: 2;
 
     &:global(.media-desktop) {
         max-width: 1140px;


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-2095
- Feature flag: `N/A`

## Purpose

To fix the issue of the navbar being below other items on the page.

## Summary of Changes

- Remove z-index from gutters and main container class

## Side Effects

This will effect items using the `<Container>` element, namely the gutters and the navbar.

## QA Notes

Should affect the z-index on the navbar and the gutters.
