### PR TITLE
[ENG-2095] Redirect branded index to discover

### DIFF
--- a/app/models/registration-provider.ts
+++ b/app/models/registration-provider.ts
@@ -19,6 +19,9 @@ export default class RegistrationProviderModel extends ProviderModel {
 
     @attr('fixstring')
     shareSource?: string;
+
+    @attr('boolean')
+    brandedDiscoveryPage?: boolean;
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/lib/registries/addon/branded/discover/route.ts
+++ b/lib/registries/addon/branded/discover/route.ts
@@ -2,6 +2,7 @@ import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
+import RegistrationProviderModel from 'ember-osf-web/models/registration-provider';
 import Analytics from 'ember-osf-web/services/analytics';
 
 export default class BrandedRegistriesDiscoverRoute extends Route {
@@ -12,6 +13,18 @@ export default class BrandedRegistriesDiscoverRoute extends Route {
 
     model() {
         return this.modelFor('branded');
+    }
+
+    afterModel(provider: RegistrationProviderModel) {
+        if (!provider.brandedDiscoveryPage) {
+            if (provider.id === 'osf') {
+                this.transitionTo('discover');
+            } else {
+                const { href, origin } = window.location;
+                const currentUrl = href.replace(origin, '');
+                this.transitionTo('page-not-found', currentUrl);
+            }
+        }
     }
 
     @action

--- a/lib/registries/addon/branded/index/route.ts
+++ b/lib/registries/addon/branded/index/route.ts
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 
-export default class BrandedRegistriesRoute extends Route {
+export default class BrandedRegistriesIndexRoute extends Route {
     beforeModel() {
         const params: { providerId?: string } = this.paramsFor('branded');
         return this.replaceWith('branded.discover', params.providerId);

--- a/lib/registries/addon/branded/index/route.ts
+++ b/lib/registries/addon/branded/index/route.ts
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+
+export default class BrandedRegistriesRoute extends Route {
+    beforeModel() {
+        const params: { providerId?: string } = this.paramsFor('branded');
+        return this.replaceWith('branded.discover', params.providerId);
+    }
+}

--- a/mirage/factories/registration-provider.ts
+++ b/mirage/factories/registration-provider.ts
@@ -29,6 +29,7 @@ export default Factory.extend<MirageRegistrationProvider & RegistrationProviderT
         return faker.lorem.sentence();
     },
     allowSubmissions: true,
+    brandedDiscoveryPage: true,
     assets: randomAssets(),
 
     afterCreate(provider, server) {

--- a/tests/engines/registries/acceptance/branded/discover-test.ts
+++ b/tests/engines/registries/acceptance/branded/discover-test.ts
@@ -51,4 +51,30 @@ module('Registries | Acceptance | branded.discover', hooks => {
             'registries.branded.discover', 'successfully redirects index to discover');
         assert.dom(`[data-test-source-filter-id="${this.brandedProvider.shareSource}"]`).exists({ count: 1 });
     });
+
+    test('redirects', async assert => {
+        const provider = server.create('registration-provider', {
+            brandedDiscoveryPage: false,
+        }, 'withBrand');
+
+        await visit(`/registries/${provider.id}/discover`);
+        assert.equal(currentRouteName(),
+            'registries.page-not-found',
+            'Gets page-not-found if provider.brandedDiscoveryPage set to False');
+
+        const osfProvider = server.create('registration-provider', {
+            id: 'osf',
+            brandedDiscoveryPage: false,
+        });
+
+        await visit(`/registries/${osfProvider.id}/discover`);
+        assert.equal(currentRouteName(),
+            'registries.discover',
+            '/registries/osf/discover redirects to registries/discover');
+
+        await visit(`/registries/${osfProvider.id}`);
+        assert.equal(currentRouteName(),
+            'registries.discover',
+            '/registries/osf redirects to registries/discover');
+    });
 });

--- a/tests/engines/registries/acceptance/branded/discover-test.ts
+++ b/tests/engines/registries/acceptance/branded/discover-test.ts
@@ -1,22 +1,29 @@
 import { currentRouteName } from '@ember/test-helpers';
+import { ModelInstance } from 'ember-cli-mirage';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { percySnapshot } from 'ember-percy';
+import { TestContext } from 'ember-test-helpers';
 import { module, test } from 'qunit';
 
+import RegistrationProvider from 'ember-osf-web/models/registration-provider';
 import { visit } from 'ember-osf-web/tests/helpers';
 import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
+
+interface ThisTestContext extends TestContext {
+    brandedProvider: ModelInstance<RegistrationProvider>;
+}
 
 module('Registries | Acceptance | branded.discover', hooks => {
     setupEngineApplicationTest(hooks, 'registries');
     setupMirage(hooks);
 
-    hooks.beforeEach(() => {
-        const brandedProvider = server.create('registration-provider', { id: 'brand' }, 'withBrand');
-        server.createList('registration', 3, { provider: brandedProvider });
+    hooks.beforeEach(function(this: ThisTestContext) {
+        this.brandedProvider = server.create('registration-provider', { id: 'brand' }, 'withBrand');
+        server.createList('registration', 3, { provider: this.brandedProvider });
     });
 
-    test('branded discover with no external providers', async assert => {
-        await visit('/registries/brand/discover');
+    test('branded discover with no external providers', async function(this: ThisTestContext, assert) {
+        await visit(`/registries/${this.brandedProvider.id}/discover`);
         await percySnapshot('branded discover page');
         assert.equal(currentRouteName(), 'registries.branded.discover', 'On the branded discover page');
 
@@ -27,13 +34,21 @@ module('Registries | Acceptance | branded.discover', hooks => {
         assert.dom('[data-test-link-other-registries]').exists('Link to other registries is shown');
     });
 
-    test('branded discover with external providers', async assert => {
+    test('branded discover with external providers', async function(this: ThisTestContext, assert) {
         const externalProvider = server.create('external-provider', { shareSource: 'ClinicalTrials.gov' });
         server.createList('external-registration', 3, { provider: externalProvider });
 
-        await visit('/registries/brand/discover');
+        await visit(`/registries/${this.brandedProvider.id}/discover`);
         assert.dom('[data-test-source-filter-id]').exists({ count: 1 }, 'Only brand provider is shown');
         assert.dom(`[data-test-source-filter-id="${externalProvider.shareSource}"]`)
             .doesNotExist('External provider is not shown');
+    });
+
+    test('redirects branded.index to branded.discover', async function(this: ThisTestContext, assert) {
+        await visit(`/registries/${this.brandedProvider.id}`);
+
+        assert.equal(currentRouteName(),
+            'registries.branded.discover', 'successfully redirects index to discover');
+        assert.dom(`[data-test-source-filter-id="${this.brandedProvider.shareSource}"]`).exists({ count: 1 });
     });
 });


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-2095]
- Feature flag: n/a

## Purpose

branded index `(/registries/<providerId>/)` is a blank page

## Summary of Changes

- Redirect branded index `(/registries/<providerId>/)` to discover `(/registries/<providerId>/discover)`
- Redirect `/registries/osf/discover` to /registries/discover/
- Special case for `provider.brandedDiscoveryPage`
- Update tests

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-2095]: https://openscience.atlassian.net/browse/ENG-2095