### PR TITLE
[ENG-2095] Fix claim contributor modal for Safari

### DIFF
--- a/lib/osf-components/addon/components/contributor-list/unregistered-contributor/template.hbs
+++ b/lib/osf-components/addon/components/contributor-list/unregistered-contributor/template.hbs
@@ -29,7 +29,6 @@
     <OsfDialog
         @isOpen={{this.shouldOpenClaimDialog}}
         @onClose={{this.closeDialog}}
-        @renderInPlace={{true}}
         as |dialog|
     >
         <dialog.heading data-test-modal-heading>


### PR DESCRIPTION
- Ticket: [ENG-2095]
- Feature flag: n/a

## Purpose
- Allow users to interact with the Claim unregistered Contributor modal dialog in Safari

## Summary of Changes
- Removed `renderInPlace={{true}}` for the dialog

## Side Effects
- The dialog will not longer be branded :(

## QA Notes
- The dialog should be usable in Safari, but we had to compromise so it will no longer be branded

[ENG-2095]: https://openscience.atlassian.net/browse/ENG-2095