### PR TITLE
[ENG-2050] Add campaign queryParam for collections and registries

### DIFF
--- a/lib/app-components/addon/components/branded-navbar/component.ts
+++ b/lib/app-components/addon/components/branded-navbar/component.ts
@@ -27,6 +27,7 @@ export default class BrandedNavbar extends Component {
     signupUrl: string = this.signupUrl;
     translateKey: string = this.translateKey;
     showNavLinks: boolean = false;
+    campaign: string = `${this.theme.id}-collections`;
 
     myProjectsUrl = serviceLinks.myProjects;
 

--- a/lib/app-components/addon/components/branded-navbar/template.hbs
+++ b/lib/app-components/addon/components/branded-navbar/template.hbs
@@ -71,6 +71,7 @@
                         @onLinkClicked={{action (mut this.showNavLinks) false}}
                         @headline={{t 'app_components.branded_navbar.on_the_osf'}}
                         @externalLink={{true}}
+                        @campaign={{this.campaign}}
                     />
                 </ul>
             </BsCollapse>

--- a/lib/osf-components/addon/components/osf-navbar/auth-dropdown/component.ts
+++ b/lib/osf-components/addon/components/osf-navbar/auth-dropdown/component.ts
@@ -58,6 +58,8 @@ export class AuthBase extends Component {
 
         if (this.campaign) {
             params.campaign = this.campaign;
+        } else {
+            params.campaign = '';
         }
 
         if (this.router.currentRouteName !== 'register') {

--- a/lib/osf-components/addon/components/osf-navbar/auth-dropdown/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/auth-dropdown/template.hbs
@@ -74,7 +74,7 @@
         <div>
             <OsfLink
                 data-test-ad-sign-up-button
-                data-analytics-name='SignUp'
+                data-analytics-name='SignUp {{@campaign}}'
                 class='btn btn-success btn-top-signup m-l-sm m-r-xs'
                 @route='register'
                 @queryParams={{this.signUpQueryParams}}

--- a/lib/registries/addon/components/registries-navbar/component.ts
+++ b/lib/registries/addon/components/registries-navbar/component.ts
@@ -34,6 +34,15 @@ export default class RegistriesNavbar extends AuthBase {
     provider?: RegistrationProviderModel;
 
     @and('media.isMobile', 'searchDropdownOpen') showSearchDropdown!: boolean;
+
+    @computed('provider')
+    get signUpQueryParams() {
+        if (this.provider) {
+            return { campaign: `${this.provider.id}-registries` };
+        }
+        return { campaign: 'osf-registries' };
+    }
+
     @computed('provider.{allowSubmissions,id}')
     get showAddRegistrationButton() {
         if (!this.provider) {

--- a/lib/registries/addon/components/registries-navbar/component.ts
+++ b/lib/registries/addon/components/registries-navbar/component.ts
@@ -35,14 +35,6 @@ export default class RegistriesNavbar extends AuthBase {
 
     @and('media.isMobile', 'searchDropdownOpen') showSearchDropdown!: boolean;
 
-    @computed('provider')
-    get signUpQueryParams() {
-        if (this.provider) {
-            return { campaign: `${this.provider.id}-registries` };
-        }
-        return { campaign: 'osf-registries' };
-    }
-
     @computed('provider.{allowSubmissions,id}')
     get showAddRegistrationButton() {
         if (!this.provider) {

--- a/lib/registries/addon/components/registries-navbar/template.hbs
+++ b/lib/registries/addon/components/registries-navbar/template.hbs
@@ -101,7 +101,7 @@
 
                 <nav.links.secondary
                     data-test-join='1'
-                    data-analytics-name='Sign up'
+                    data-analytics-name='Sign up {{@campaign}}'
                     @route='register'
                     @queryParams={{this.signUpQueryParams}}
                     local-class='HideOnMobile'
@@ -187,7 +187,7 @@
                         <menu.item role='menuitem' local-class='OnlyOnMobile'>
                             <OsfLink
                                 data-test-join-mobile
-                                data-analytics-name='Sign up'
+                                data-analytics-name='Sign up {{@campaign}}'
                                 @route='register'
                                 @queryParams={{this.signUpQueryParams}}
                             >

--- a/lib/registries/addon/components/registries-wrapper/template.hbs
+++ b/lib/registries/addon/components/registries-wrapper/template.hbs
@@ -4,7 +4,7 @@
     class='RegistriesStyle'
     ...attributes
 >
-    <RegistriesNavbar class='RegistriesStyle' @campaign='osf-registries' @provider={{@provider}}/>
+    <RegistriesNavbar class='RegistriesStyle' @campaign='{{if @provider @provider.id 'osf'}}-registries' @provider={{@provider}}/>
     <MaintenanceBanner />
     <StatusBanner />
     <TosConsentBanner />


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-2050
- Feature flag: `N/A`

## Purpose

To add the `campaign` queryParam to the signup button on registries and collections.

## Summary of Changes

- Add `campaign` queryParam to the registries and branded osf navbar

## Side Effects

This should only affect the queryparam passed through the navbar when clicking the signup button.

## QA Notes

`TODO`
