### PR TITLE
[ENG-2095] Registries discover page form type facet

### DIFF
--- a/lib/registries/addon/components/registries-registration-type-facet/component.ts
+++ b/lib/registries/addon/components/registries-registration-type-facet/component.ts
@@ -70,7 +70,7 @@ export default class RegistriesRegistrationTypeFacet extends Component {
         const osfSelected = this.searchOptions.filters.find(
             item => item instanceof ShareTermsFilter
                 && item.key === 'sources'
-                && item.value === 'OSF',
+                && item.value === 'OSF Registries',
         );
         return this.searchOptions.filters.filter(filter => filter.key === 'sources').size === 1 && osfSelected;
     }

--- a/lib/registries/addon/discover/controller.ts
+++ b/lib/registries/addon/discover/controller.ts
@@ -253,7 +253,7 @@ export default class Discover extends Controller.extend(discoverQueryParams.Mixi
         // TODO-mob don't hard-code 'OSF'
 
         // Unless OSF is the only source, registration_type filters must be cleared
-        if (!(this.sourceNames.length === 1 && this.sourceNames[0]! === 'OSF')) {
+        if (!(this.sourceNames.length === 1 && this.sourceNames[0]! === 'OSF Registries')) {
             this.set('registrationTypes', A([]));
         }
 

--- a/mirage/factories/draft-registration.ts
+++ b/mirage/factories/draft-registration.ts
@@ -22,7 +22,7 @@ export default Factory.extend<DraftRegistration & DraftRegistrationTraits>({
             const defaultProvider = server.schema.registrationProviders.find('osf')
                 || server.create('registration-provider', {
                     id: 'osf',
-                    shareSource: 'OSF',
+                    shareSource: 'OSF Registries',
                     name: 'OSF Registries',
                 });
             newDraft.update({

--- a/mirage/factories/registration.ts
+++ b/mirage/factories/registration.ts
@@ -118,7 +118,7 @@ export default NodeFactory.extend<MirageRegistration & RegistrationTraits>({
                 provider: server.schema.registrationProviders.find('osf')
                     || server.create('registration-provider', {
                         id: 'osf',
-                        shareSource: 'OSF',
+                        shareSource: 'OSF Registries',
                         name: 'OSF Registries',
                     }),
             });

--- a/mirage/fixtures/registration-providers.ts
+++ b/mirage/fixtures/registration-providers.ts
@@ -19,7 +19,7 @@ const registrationProviders: Array<Partial<MirageRegistrationProvider>> = [
         description: 'The open registries network',
         allowSubmissions: true,
         assets: randomAssets(),
-        shareSource: 'OSF',
+        shareSource: 'OSF Registries',
         licensesAcceptableIds: [
             '5c252c8e0989e100220edb70',
             '5c252c8e0989e100220edb7a',

--- a/tests/engines/registries/integration/discover/discover-test.ts
+++ b/tests/engines/registries/integration/discover/discover-test.ts
@@ -56,22 +56,22 @@ const QueryParamTestCases: Array<{
         expected: { order, query: 'What', page: 10 },
     }, {
         name: 'Providers Filters',
-        params: { q: 'Foo', provider: 'OSF' },
+        params: { q: 'Foo', provider: 'OSF Registries' },
         expected: {
             order,
             query: 'Foo',
             filters: OrderedSet([
-                new ShareTermsFilter('sources', 'OSF', 'OSF Registries'),
+                new ShareTermsFilter('sources', 'OSF Registries', 'OSF Registries'),
             ]),
         },
     }, {
         name: 'Multiple Providers Filters With Validation',
-        params: { q: 'Foo', provider: 'OSF|ClinicalTrials.gov|Bar' },
+        params: { q: 'Foo', provider: 'OSF Registries|ClinicalTrials.gov|Bar' },
         expected: {
             order,
             query: 'Foo',
             filters: OrderedSet([
-                new ShareTermsFilter('sources', 'OSF', 'OSF Registries'),
+                new ShareTermsFilter('sources', 'OSF Registries', 'OSF Registries'),
                 new ShareTermsFilter('sources', 'ClinicalTrials.gov', 'ClinicalTrials.gov'),
             ]),
         },
@@ -108,13 +108,13 @@ const QueryParamTestCases: Array<{
     }, {
     // NOTE: Not currently validated :(
         name: 'Registration Types',
-        params: { q: 'What', page: 10, provider: 'OSF', type: 'Foo|BAR' },
+        params: { q: 'What', page: 10, provider: 'OSF Registries', type: 'Foo|BAR' },
         expected: {
             order,
             query: 'What',
             page: 10,
             filters: OrderedSet([
-                new ShareTermsFilter('sources', 'OSF', 'OSF Registries'),
+                new ShareTermsFilter('sources', 'OSF Registries', 'OSF Registries'),
                 new ShareTermsFilter('registration_type', 'Foo', 'Foo'),
                 new ShareTermsFilter('registration_type', 'BAR', 'BAR'),
             ]),
@@ -130,13 +130,18 @@ module('Registries | Integration | discover', hooks => {
         server.create('registration-schema', { name: 'Close Fronted' });
         server.create('registration-provider', {
             id: 'osf',
-            shareSource: 'OSF',
+            shareSource: 'OSF Registries',
             name: 'OSF Registries',
         });
         server.create('registration-provider', {
             id: 'someother',
             shareSource: 'someother',
             name: 'Some Other',
+        });
+        server.create('registration-provider', {
+            id: 'clinicaltrials',
+            shareSource: 'ClinicalTrials.gov',
+            name: 'ClinicalTrials.gov',
         });
 
         const engine = await loadEngine('registries', 'registries');
@@ -183,7 +188,7 @@ module('Registries | Integration | discover', hooks => {
             aggregations: {
                 sources: {
                     buckets: [
-                        { key: 'OSF', doc_count: 10 },
+                        { key: 'OSF Registries', doc_count: 10 },
                         { key: 'someother', doc_count: 10 },
                     ],
                 },
@@ -209,7 +214,7 @@ module('Registries | Integration | discover', hooks => {
             page: 1,
             order,
             filters: OrderedSet([
-                new ShareTermsFilter('sources', 'OSF', 'OSF Registries'),
+                new ShareTermsFilter('sources', 'OSF Registries', 'OSF Registries'),
             ]),
         }));
     });
@@ -220,7 +225,7 @@ module('Registries | Integration | discover', hooks => {
             results: [],
             aggregations: {
                 sources: {
-                    buckets: [{ key: 'OSF', doc_count: 10 }],
+                    buckets: [{ key: 'OSF Registries', doc_count: 10 }],
                 },
             },
         });
@@ -257,7 +262,7 @@ module('Registries | Integration | discover', hooks => {
             results: [],
             aggregations: {
                 sources: {
-                    buckets: [{ key: 'OSF', doc_count: 10 }],
+                    buckets: [{ key: 'OSF Registries', doc_count: 10 }],
                 },
             },
         });
@@ -294,7 +299,7 @@ module('Registries | Integration | discover', hooks => {
             results: [],
             aggregations: {
                 sources: {
-                    buckets: [{ key: 'OSF', doc_count: 10 }],
+                    buckets: [{ key: 'OSF Registries', doc_count: 10 }],
                 },
             },
         });

--- a/tests/engines/registries/integration/discover/discover-test.ts
+++ b/tests/engines/registries/integration/discover/discover-test.ts
@@ -190,6 +190,7 @@ module('Registries | Integration | discover', hooks => {
                     buckets: [
                         { key: 'OSF Registries', doc_count: 10 },
                         { key: 'someother', doc_count: 10 },
+                        { key: 'clinicaltrials', doc_count: 10 },
                     ],
                 },
             },
@@ -207,7 +208,7 @@ module('Registries | Integration | discover', hooks => {
             }),
         }));
 
-        await click('[data-test-source-filter-id="OSF"]');
+        await click('[data-test-source-filter-id="OSF Registries"]');
 
         sinon.assert.calledWith(stub, new SearchOptions({
             query: '',

--- a/tests/engines/registries/unit/services/share-search-test.ts
+++ b/tests/engines/registries/unit/services/share-search-test.ts
@@ -27,7 +27,7 @@ function getSearchResponse(identifiers?: string[]) {
                     justification: null,
                     tags: ['&amp;', 'Foo'],
                     identifiers: identifiers || ['http://osf.io/w4yhb/'],
-                    sources: ['OSF'],
+                    sources: ['OSF', 'OSF Registries'],
                     subjects: [],
                     subject_synonyms: [],
                     lists: {
@@ -88,7 +88,7 @@ module('Registries | Unit | Service | share-search', hooks => {
     test('recognizes all OSF source envs', function(this: TestContext, assert) {
         const service = this.owner.lookup('service:share-search') as ShareSearch;
         service.set('osfProviders', [{
-            name: 'OSF',
+            name: 'OSF Registries',
             urlRegex: 'https://osf.io/',
             https: true,
         }, {


### PR DESCRIPTION
- Ticket: [ENG-2095]
- Feature flag: n/a

## Purpose
- Allow users to filter by registration form type on the registries discover page when `OSF Registries` is the only provider selected

## Summary of Changes
- Update some of the logic that uses hardcoded `OSF` to `OSF Registries` to match what is implemented (Eventually this filter method will be available for other providers, but now is not the time)

## Side Effects
`NA`

## QA Notes
- The registration form filter should show up when a user filters by OSF Registries (and _only_ OSF Registries)
- When a user selects a form type to filter by, that form type should be in the URL as a query parameter as well
- When a user deselects OSF Registries as a provider filter, or adds another provider in the provider filter, the form filter should go away

[ENG-2095]: https://openscience.atlassian.net/browse/ENG-2095