### PR TITLE
[ENG-2169] Remove old style for navbar buttons

### DIFF
--- a/app/styles/_components.scss
+++ b/app/styles/_components.scss
@@ -420,11 +420,16 @@
     color: rgba(255, 255, 255, 0.8);
 }
 
-#navbarScope .btn-top-login,
 #navbarScope .btn-top-signup {
-    padding: 2px 30px;
-    margin-top: 5px;
-    line-height: 1.7;
+    padding: 4px 13px;
+    margin-top: 3px;
+    font-size: 15px;
+}
+
+#navbarScope .btn-top-login {
+    padding: 4px 17px;
+    margin-top: 3px;
+    font-size: 15px;
 }
 
 .navbar-default {
@@ -850,20 +855,6 @@
             top: -8px;
             left: 126px;
         }
-    }
-
-    /* Overrides for signup button */
-    #navbarScope .btn-top-signup {
-        padding: 4px 13px;
-        margin-top: 3px;
-        font-size: 15px;
-    }
-
-    /* Overrides for Sign in button */
-    #navbarScope .btn-top-login {
-        padding: 4px 17px;
-        margin-top: 3px;
-        font-size: 15px;
     }
 
     /* sm screen formatting */


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-2169
- Feature flag: `N/A`

## Purpose

The `Sign Up` and `Sign In` buttons on the collections navbar are different sizes. We should fix that.

## Summary of Changes

- Update the styles to use the new navbar button styles so match the navbar on the rest of the site.

Before:
<img width="257" alt="Screen Shot 2020-08-20 at 12 21 15 PM" src="https://user-images.githubusercontent.com/19379783/90798246-ae6a2e00-e2df-11ea-908d-66d6204bd1c4.png">

After:
<img width="204" alt="Screen Shot 2020-08-20 at 11 52 13 AM" src="https://user-images.githubusercontent.com/19379783/90797975-529fa500-e2df-11ea-8864-9b525f434c45.png">


## Side Effects

This will change the buttons only on the navbar. It shouldn't affect any other part of the navbar or the pages it's on.

## QA Notes

This will mainly affect the collections navbar, but the default style was updated to be the style used on the newer osf-navbar. This could potentially affect the navbars used on Collections and emberized OSF pages.

