### PR TITLE
[ENG-2152] Remove tags toggle

### DIFF
--- a/lib/registries/addon/components/registries-search-result/component.ts
+++ b/lib/registries/addon/components/registries-search-result/component.ts
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { action, computed } from '@ember/object';
+import { computed } from '@ember/object';
 import { localClassNames } from 'ember-css-modules';
 
 import { layout } from 'ember-osf-web/decorators/component';
@@ -14,9 +14,6 @@ const OSF_GUID_REGEX = /^https?:\/\/.*osf\.io\/([^/]+)/;
 export default class RegistriesSearchResult extends Component {
     // Required
     result!: ShareRegistration;
-
-    // Private
-    expanded = false;
 
     // For use later, when the registration overview page is implemented
     // @computed('result')
@@ -38,15 +35,5 @@ export default class RegistriesSearchResult extends Component {
             name: contrib.name,
             link: contrib.identifiers.filter(ident => OSF_GUID_REGEX.test(ident))[0],
         }));
-    }
-
-    @computed('expanded')
-    get footerIcon() {
-        return this.expanded ? 'caret-up' : 'caret-down';
-    }
-
-    @action
-    toggleExpanded() {
-        this.set('expanded', !this.expanded);
     }
 }

--- a/lib/registries/addon/components/registries-search-result/styles.scss
+++ b/lib/registries/addon/components/registries-search-result/styles.scss
@@ -20,29 +20,11 @@ h3.RegistriesSearchResult__Title {
 }
 
 .Description {
-    max-height: 42px;  // Roughtly 2x line height;
-    overflow-y: hidden;
+    height: 42px;  // Roughtly 2x line height;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
     transition: max-height 0.5s cubic-bezier(0, 1, 0, 1);
-
-    &.Expanded {
-        max-height: 500px;
-        transition: max-height 1s ease-in-out;
-    }
-}
-
-.Details {
-    max-height: 0;
-    overflow-y: hidden;
-    transition: max-height 0.5s cubic-bezier(0, 1, 0, 1);
-
-    &.Expanded {
-        max-height: 500px;
-        transition: max-height 1s ease-in-out;
-    }
-
-    .Details__Badge {
-        background-color: $color-bg-gray-darker;
-    }
 }
 
 .Contributors {

--- a/lib/registries/addon/components/registries-search-result/template.hbs
+++ b/lib/registries/addon/components/registries-search-result/template.hbs
@@ -65,29 +65,8 @@
             </span>
         </div>
 
-        <p local-class='Description {{if this.expanded 'Expanded' 'Collapsed'}}' class='text-muted m-t-sm'>
+        <p local-class='Description' class='text-muted m-t-sm'>
             {{math @result.description}}
         </p>
-
-        <div local-class='Details {{if this.expanded 'Expanded' 'Collapsed'}}'>
-            {{#each @result.tags as |tag|}}
-                <span local-class='Details__Badge' class='badge'>{{math tag}}</span>
-            {{/each}}
-        </div>
-
-        <div class='text-center'>
-            <button
-                data-test-result-toggle-id={{@result.id}}
-                type='button'
-                local-class='RegistriesSearchResult__Toggle'
-                class='btn btn-link'
-                aria-label={{t 'registries.discover.search_result.toggle_result'}}
-                data-analytics-name='Expand button'
-                {{action this.toggleExpanded}}
-            >
-                {{fa-icon this.footerIcon size=1 ariaHidden=false}}
-            </button>
-        </div>
-
     </div>
 </div>


### PR DESCRIPTION
- Ticket: [ENG-2152]
- Feature flag: n/a

## Purpose
- Remove dropdown on registries discover search results

## Summary of Changes
- Remove dropdown icon on search result card
- Truncate registration description to one line with ellipsis

**Before (Closed):**
![image](https://user-images.githubusercontent.com/51409893/90926984-2c066a80-e3c2-11ea-85bf-aa30312c5ef4.png)

**Before (Expanded):**
![image](https://user-images.githubusercontent.com/51409893/90927001-33c60f00-e3c2-11ea-93f4-dad78908afe6.png)

**Before (Closed, mobile):**
![image](https://user-images.githubusercontent.com/51409893/90927620-68869600-e3c3-11ea-892a-c9099638f01f.png)

**Before (Expanded, mobile):**
![image](https://user-images.githubusercontent.com/51409893/90927646-763c1b80-e3c3-11ea-905b-3a3bc5afccf0.png)

**After:**
![image](https://user-images.githubusercontent.com/51409893/90927015-3aed1d00-e3c2-11ea-9e4f-ea5fe14eb965.png)

**After (mobile):**
![image](https://user-images.githubusercontent.com/51409893/90927688-87852800-e3c3-11ea-990f-4b82566d1102.png)



## Side Effects
We lose the functionality to view tags and the full description of a registration

## QA Notes
Tags should no longer be visible on the registries search results on the registries discover page, and registrations with long descriptions should be truncated in this view as well.

[ENG-2152]: https://openscience.atlassian.net/browse/ENG-2152