### PR TITLE
[ENG-2155] Reduce font-size for Registry Discover search results

### DIFF
--- a/lib/registries/addon/components/registries-search-result/styles.scss
+++ b/lib/registries/addon/components/registries-search-result/styles.scss
@@ -1,7 +1,6 @@
 // stylelint-disable selector-no-qualifying-type
 h3.RegistriesSearchResult__Title {
-    font-weight: 400;
-    font-size: 24px;
+    line-height: inherit;
     margin-top: 10px;
 }
 


### PR DESCRIPTION
- Ticket: [ENG-2155]
- Feature flag: n/a

## Purpose
Reduce font size for the Registration Search Results cards to accommodate longer registration titles and make the `Withdrawn` tag smaller

## Summary of Changes
- Reduce font size on the `registries-search-result` component titles
- Increase font weight to default for registries
- Increase line-height for titles that wrap into multiple lines

Before:
![image](https://user-images.githubusercontent.com/51409893/91068322-1e3f2800-e602-11ea-9405-09ff25c43a13.png)

Before (mobile):
![image](https://user-images.githubusercontent.com/51409893/91068529-6bbb9500-e602-11ea-9fa1-ff87ad12a59f.png)


After:
![image](https://user-images.githubusercontent.com/51409893/91068439-4af33f80-e602-11ea-8b54-db902dd41498.png)

After (mobile):
![image](https://user-images.githubusercontent.com/51409893/91068561-7ece6500-e602-11ea-95cc-3397a1b51bd5.png)


## Side Effects
`NA`

## QA Notes
- the font size and line-spacing have been adjusted, so hopefully it is easier to read and the `Withdrawn` tag is less chunky

[ENG-2155]: https://openscience.atlassian.net/browse/ENG-2155