### PR TITLE
[ENG-2158] Update page title to have osf brand display first

### DIFF
--- a/lib/registries/addon/branded/new/template.hbs
+++ b/lib/registries/addon/branded/new/template.hbs
@@ -1,4 +1,4 @@
-{{title (t 'registries.new.page_title')}}
+{{title (t 'registries.new.page_title') prepend=false}}
 
 <RegistriesWrapper
     {{with-branding this.model.brand}}

--- a/lib/registries/addon/discover/template.hbs
+++ b/lib/registries/addon/discover/template.hbs
@@ -1,4 +1,4 @@
-{{title (t 'registries.discover.page_title')}}
+{{title (t 'registries.discover.page_title') prepend=false}}
 
 <RegistriesWrapper
     @provider={{this.providerModel}}

--- a/lib/registries/addon/drafts/template.hbs
+++ b/lib/registries/addon/drafts/template.hbs
@@ -1,2 +1,2 @@
-{{title (t 'registries.drafts.page_title')}}
+{{title (t 'registries.drafts.page_title') prepend=false}}
 {{outlet}}

--- a/lib/registries/addon/forms/template.hbs
+++ b/lib/registries/addon/forms/template.hbs
@@ -1,2 +1,2 @@
-{{title (t 'registries.forms.page_title')}}
+{{title (t 'registries.forms.page_title') prepend=false}}
 {{outlet}}

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -7,7 +7,7 @@
         </div>
     {{else}}
         {{assert 'Registries::Overview - registration should not be null or undefined' this.registration}}
-        {{title this.registration.title}}
+        {{title this.registration.title prepend=false}}
         {{#if (or this.registration.withdrawn this.registration.archiving)}}
             <OsfLayout @backgroundClass='{{local-class 'ContentBackground'}}' as |layout|>
                 <layout.heading>

--- a/lib/registries/addon/page-not-found/template.hbs
+++ b/lib/registries/addon/page-not-found/template.hbs
@@ -1,4 +1,4 @@
-{{title (t 'not_found.title')}}
+{{title (t 'not_found.title') prepend=false}}
 
 <RegistriesWrapper>
     <div local-class='Registries404Page'>


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-2158
- Feature flag: `N/A`

## Purpose

To switch the order of the information in page tabs to have the provider first before additional info (Search, registration title, etc)

## Summary of Changes

- Add `prepend=false` to the `{{title}}` helper on registries pages

## Side Effects

This should affect and update all registries pages.

## QA Notes

This should change the order of the information in the page tab for both branded and non-branded pages. The brand name should always come first on all registries tabs.
