### PR TITLE
[No ticket] Fix not found transition error.

### DIFF
--- a/lib/registries/addon/branded/discover/route.ts
+++ b/lib/registries/addon/branded/discover/route.ts
@@ -20,9 +20,7 @@ export default class BrandedRegistriesDiscoverRoute extends Route {
             if (provider.id === 'osf') {
                 this.transitionTo('discover');
             } else {
-                const { href, origin } = window.location;
-                const currentUrl = href.replace(origin, '');
-                this.transitionTo('page-not-found', currentUrl);
+                this.transitionTo('page-not-found', window.location.pathname.replace(/^\//, ''));
             }
         }
     }

--- a/lib/registries/addon/branded/discover/route.ts
+++ b/lib/registries/addon/branded/discover/route.ts
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 
 import RegistrationProviderModel from 'ember-osf-web/models/registration-provider';
 import Analytics from 'ember-osf-web/services/analytics';
+import { notFoundURL } from 'ember-osf-web/utils/clean-url';
 
 export default class BrandedRegistriesDiscoverRoute extends Route {
     // this route uses the registries.discover page template where the custom branding is handled
@@ -20,7 +21,7 @@ export default class BrandedRegistriesDiscoverRoute extends Route {
             if (provider.id === 'osf') {
                 this.transitionTo('discover');
             } else {
-                this.transitionTo('page-not-found', window.location.pathname.replace(/^\//, ''));
+                this.transitionTo('page-not-found', notFoundURL(window.location.pathname));
             }
         }
     }


### PR DESCRIPTION
- Ticket: []
- Feature flag: n/a

## Purpose

Currently, when going to a discover page of a provider whose `brandedDiscoveryPage` is `false`, the app doesn't transition to `page-not-found` route correctly. This PR fixes the problem. 

## Summary of Changes

Use `window.location.pathname` and remove starting slash because `transitionTo` doesn't like it.

## Side Effects

None.

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
