### PR TITLE
[No ticket] Fix sorting

### DIFF
--- a/lib/registries/addon/discover/controller.ts
+++ b/lib/registries/addon/discover/controller.ts
@@ -58,12 +58,12 @@ const sortOptions = [
     new SearchOrder({
         ascending: true,
         display: 'registries.discover.order.modified_ascending',
-        key: 'date_updated',
+        key: 'date',
     }),
     new SearchOrder({
         ascending: false,
         display: 'registries.discover.order.modified_descending',
-        key: 'date_updated',
+        key: 'date',
     }),
 ];
 

--- a/lib/registries/addon/index/controller.ts
+++ b/lib/registries/addon/index/controller.ts
@@ -24,7 +24,7 @@ export default class Index extends Controller {
     getRecentRegistrations = task(function *(this: Index) {
         const [recentResults, totalResults]: Array<SearchResults<ShareRegistration>> = yield RSVP.all([
             this.shareSearch.registrations(new SearchOptions({
-                order: new SearchOrder({ display: '', ascending: false, key: 'date_updated' }),
+                order: new SearchOrder({ display: '', ascending: false, key: 'date' }),
                 query: config.indexPageRegistrationsQuery,
                 size: 5,
             })),

--- a/tests/engines/registries/integration/discover/discover-test.ts
+++ b/tests/engines/registries/integration/discover/discover-test.ts
@@ -77,24 +77,24 @@ const QueryParamTestCases: Array<{
         },
     }, {
         name: 'Sort',
-        params: { sort: 'date_updated' },
+        params: { sort: 'date' },
         expected: {
             query: '',
             order: new SearchOrder({
                 ascending: true,
                 display: 'registries.discover.order.modified_ascending',
-                key: 'date_updated',
+                key: 'date',
             }),
         },
     }, {
         name: 'Sort decending',
-        params: { sort: '-date_updated' },
+        params: { sort: '-date' },
         expected: {
             query: '',
             order: new SearchOrder({
                 ascending: false,
                 display: 'registries.discover.order.modified_descending',
-                key: 'date_updated',
+                key: 'date',
             }),
         },
     }, {
@@ -252,7 +252,7 @@ module('Registries | Integration | discover', hooks => {
             order: new SearchOrder({
                 ascending: true,
                 display: 'registries.discover.order.modified_ascending',
-                key: 'date_updated',
+                key: 'date',
             }),
         }));
     });


### PR DESCRIPTION
- Ticket: []
- Feature flag: n/a

## Purpose

Currently, sorting by date doesn't work for registries discover page because the `date_updated` field is null in share. 

## Summary of Changes

Change `date_updated` to `date`

## Side Effects

None