### PR TITLE
[ENG-2192] Add registry brand name to navbar

### DIFF
--- a/lib/registries/addon/components/registries-navbar/component.ts
+++ b/lib/registries/addon/components/registries-navbar/component.ts
@@ -35,6 +35,11 @@ export default class RegistriesNavbar extends AuthBase {
 
     @and('media.isMobile', 'searchDropdownOpen') showSearchDropdown!: boolean;
 
+    @computed('media.isMobile', 'provider.brand')
+    get shouldShowProviderName() {
+        return !this.media.isMobile && this.provider && this.provider.brand;
+    }
+
     @computed('provider.{allowSubmissions,id}')
     get showAddRegistrationButton() {
         if (!this.provider) {

--- a/lib/registries/addon/components/registries-navbar/styles.scss
+++ b/lib/registries/addon/components/registries-navbar/styles.scss
@@ -70,8 +70,8 @@
 
 .HomeLink {
     color: $white;
-    font-size: 15px;
-    font-weight: 700;
+    font-size: 18px;
+    font-weight: 400;
     text-decoration: none;
     margin: 0 16px 0 10px;
 

--- a/lib/registries/addon/components/registries-navbar/styles.scss
+++ b/lib/registries/addon/components/registries-navbar/styles.scss
@@ -68,6 +68,19 @@
     background-repeat: no-repeat;
 }
 
+.HomeLink {
+    color: $white;
+    font-size: 15px;
+    font-weight: 700;
+    text-decoration: none;
+    margin: 0 16px 0 10px;
+
+    &.HomeLink:hover {
+        color: $white;
+        text-decoration: none;
+    }
+}
+
 .Service {
     color: $white;
     font-size: 20px;

--- a/lib/registries/addon/components/registries-navbar/template.hbs
+++ b/lib/registries/addon/components/registries-navbar/template.hbs
@@ -16,6 +16,7 @@
             {{#if this.shouldShowProviderName}}
                 <OsfLink
                     data-test-brand-link
+                    data-analytics-name='Brand'
                     @route='home'
                     local-class='HomeLink'
                 >

--- a/lib/registries/addon/components/registries-navbar/template.hbs
+++ b/lib/registries/addon/components/registries-navbar/template.hbs
@@ -13,7 +13,15 @@
                 local-class='Logo'
                 aria-label={{t 'navbar.go_home'}}
             />
-
+            {{#if this.provider.brand}}
+                <OsfLink
+                    data-test-brand-link
+                    @route='home'
+                    local-class='HomeLink'
+                >
+                    {{this.provider.name}} {{t 'general.services.registries'}}
+                </OsfLink>
+            {{/if}}
             {{! Left Side (Band, Service Dropdown) }}
             <BsDropdown
                 data-test-service-list

--- a/lib/registries/addon/components/registries-navbar/template.hbs
+++ b/lib/registries/addon/components/registries-navbar/template.hbs
@@ -13,13 +13,13 @@
                 local-class='Logo'
                 aria-label={{t 'navbar.go_home'}}
             />
-            {{#if this.provider.brand}}
+            {{#if this.shouldShowProviderName}}
                 <OsfLink
                     data-test-brand-link
                     @route='home'
                     local-class='HomeLink'
                 >
-                    {{this.provider.name}} {{t 'general.services.registries'}}
+                    {{this.provider.name}}
                 </OsfLink>
             {{/if}}
             {{! Left Side (Band, Service Dropdown) }}

--- a/tests/engines/registries/integration/components/registries-navbar/component-test.ts
+++ b/tests/engines/registries/integration/components/registries-navbar/component-test.ts
@@ -104,7 +104,7 @@ module('Registries | Integration | Component | registries-navbar', hooks => {
         await percySnapshot(assert);
 
         // Don't show provider name unless provider is branded
-        assert.dom('[data-test-brand-link]').doesNotExist('Branded provider name exists');
+        assert.dom('[data-test-brand-link]').doesNotExist('Branded provider name does not exists');
 
         assert.equal(visibleText('[data-test-service]'), `${t('general.OSF')}${t('general.services.registries')}`);
         assert.dom('[data-test-search-bar]').isVisible('Search bar is visible');
@@ -331,6 +331,6 @@ module('Registries | Integration | Component | registries-navbar', hooks => {
         await render(hbs`<RegistriesNavbar @provider={{this.provider}} />`);
         await percySnapshot(assert);
 
-        assert.dom('[data-test-brand-link]').doesNotExist('Branded provider name exists');
+        assert.dom('[data-test-brand-link]').doesNotExist('Branded provider name does not exists');
     });
 });


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-2192
- Feature flag: `N/A`

## Purpose

To add the brand name to the navbar.

## Summary of Changes

- Add brand name to navbar as a link that will take the user to the same page as the logo
- Add conditional to remove brand name on mobile screens
- Add styling

<img width="961" alt="Screen Shot 2020-08-28 at 3 17 08 PM" src="https://user-images.githubusercontent.com/19379783/91753727-4e547100-eb96-11ea-9f67-a9a9fd13e5ae.png">


## Side Effects

This should only add a name to the navbar in the case that it's a branded provider.

## QA Notes

This should only affect the navbar for branded providers. The name is a link that will take the user to the same page the logo does. On mobile screen sizes, the branded name should disappear.
