### PR TITLE
[ENG-2211] Add model for moderator

### DIFF
--- a/app/adapters/moderator.ts
+++ b/app/adapters/moderator.ts
@@ -1,32 +1,7 @@
-import DS from 'ember-data';
 import OsfAdapter from './osf-adapter';
 
 export default class ModeratorAdapter extends OsfAdapter {
     parentRelationship = 'provider';
-
-    urlForUpdateRecord(id: string, modelName: string, snapshot: DS.Snapshot): string {
-        // @ts-ignore
-        const { provider } = snapshot.adapterOptions;
-        if (provider && provider.links) {
-            return [
-                provider.links.self,
-                `moderators/${id}`,
-            ].join('');
-        }
-        return super.urlForUpdateRecord(id, modelName, snapshot);
-    }
-
-    urlForDeleteRecord(id: string, modelName: string, snapshot: DS.Snapshot): string {
-        // @ts-ignore
-        const { provider } = snapshot.adapterOptions;
-        if (provider && provider.links) {
-            return [
-                provider.links.self,
-                `moderators/${id}`,
-            ].join('');
-        }
-        return super.urlForDeleteRecord(id, modelName, snapshot);
-    }
 }
 
 declare module 'ember-data/types/registries/adapter' {

--- a/app/adapters/provider.ts
+++ b/app/adapters/provider.ts
@@ -1,0 +1,10 @@
+import OsfAdapter from './osf-adapter';
+
+export default class ProviderAdapter extends OsfAdapter {
+}
+
+declare module 'ember-data/types/registries/adapter' {
+    export default interface AdapterRegistry {
+        provider: ProviderAdapter;
+    } // eslint-disable-line semi
+}

--- a/app/models/moderator.ts
+++ b/app/models/moderator.ts
@@ -15,7 +15,7 @@ export default class ModeratorModel extends OsfModel {
     @attr('string') fullName!: string;
     @attr('string') email!: string;
 
-    @belongsTo('moderator')
+    @belongsTo('provider', { polymorphic: true })
     provider?: ProviderModel;
 }
 

--- a/app/models/moderator.ts
+++ b/app/models/moderator.ts
@@ -1,8 +1,9 @@
 import DS from 'ember-data';
 
 import OsfModel from './osf-model';
+import ProviderModel from './provider';
 
-const { attr } = DS;
+const { attr, belongsTo } = DS;
 
 export enum PermissionGroup {
     Admin = 'admin',
@@ -13,6 +14,9 @@ export default class ModeratorModel extends OsfModel {
     @attr('string') permissionGroup!: PermissionGroup;
     @attr('string') fullName!: string;
     @attr('string') email!: string;
+
+    @belongsTo('moderator')
+    provider?: ProviderModel;
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/models/moderator.ts
+++ b/app/models/moderator.ts
@@ -4,8 +4,13 @@ import OsfModel from './osf-model';
 
 const { attr } = DS;
 
+export enum PermissionGroup {
+    Admin = 'admin',
+    Moderator = 'moderator',
+}
+
 export default class ModeratorModel extends OsfModel {
-    @attr('string') permissionGroup!: string;
+    @attr('string') permissionGroup!: PermissionGroup;
     @attr('string') fullName!: string;
     @attr('string') email!: string;
 }

--- a/app/models/provider.ts
+++ b/app/models/provider.ts
@@ -47,7 +47,7 @@ export default abstract class ProviderModel extends OsfModel {
     licensesAcceptable!: DS.PromiseManyArray<LicenseModel>;
 
     @hasMany('moderator')
-    moderators!: DS.PromiseManyArray<ModeratorModel>;
+    moderators!: DS.PromiseManyArray<ModeratorModel> | ModeratorModel[];
 }
 declare module 'ember-data/types/registries/model' {
     export default interface ModelRegistry {

--- a/app/models/provider.ts
+++ b/app/models/provider.ts
@@ -1,6 +1,7 @@
 import DS from 'ember-data';
 
 import LicenseModel from './license';
+import ModeratorModel from './moderator';
 import OsfModel from './osf-model';
 import SubjectModel from './subject';
 
@@ -44,4 +45,7 @@ export default abstract class ProviderModel extends OsfModel {
 
     @hasMany('license', { inverse: null })
     licensesAcceptable!: DS.PromiseManyArray<LicenseModel>;
+
+    @hasMany('moderator')
+    moderators!: DS.PromiseManyArray<ModeratorModel>;
 }

--- a/app/models/provider.ts
+++ b/app/models/provider.ts
@@ -49,3 +49,8 @@ export default abstract class ProviderModel extends OsfModel {
     @hasMany('moderator')
     moderators!: DS.PromiseManyArray<ModeratorModel>;
 }
+declare module 'ember-data/types/registries/model' {
+    export default interface ModelRegistry {
+        provider: ProviderModel;
+    } // eslint-disable-line semi
+}

--- a/app/serializers/moderator.ts
+++ b/app/serializers/moderator.ts
@@ -5,6 +5,6 @@ export default class ModeratorSerializer extends OsfSerializer {
 
 declare module 'ember-data/types/registries/serializer' {
     export default interface SerializerRegistry {
-        'moderator': ModeratorSerializer;
+        moderator: ModeratorSerializer;
     } // eslint-disable-line semi
 }

--- a/app/serializers/moderator.ts
+++ b/app/serializers/moderator.ts
@@ -5,6 +5,6 @@ export default class ModeratorSerializer extends OsfSerializer {
 
 declare module 'ember-data/types/registries/serializer' {
     export default interface SerializerRegistry {
-        moderator: ModeratorSerializer;
+        'moderator': ModeratorSerializer;
     } // eslint-disable-line semi
 }

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -6,6 +6,7 @@ import FileProvider from 'ember-osf-web/models/file-provider';
 import { Permission } from 'ember-osf-web/models/osf-model';
 import User from 'ember-osf-web/models/user';
 
+import { PermissionGroup } from 'ember-osf-web/models/moderator';
 import { draftRegisterNodeMultiple, forkNode, registerNodeMultiple } from '../helpers';
 
 const {
@@ -71,7 +72,7 @@ function registrationScenario(
         'withSchemas');
 
     const egapMod = server.create('moderator');
-    const egapAdmin = server.create('moderator', { id: currentUser.id, permissionGroup: 'admin' });
+    const egapAdmin = server.create('moderator', { id: currentUser.id, permissionGroup: PermissionGroup.Admin });
     const egap = server.create('registration-provider', { id: 'egap', name: 'EGAP' }, 'withBrand');
     egap.update({
         moderators: [egapMod, egapAdmin],


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-2211
- Feature flag: `N/A`

## Purpose

To add a moderator model in prep for registries moderation.

## Summary of Changes

- Add `moderator` model
- Add `moderator` serializer

## Side Effects

`N/A`

## QA Notes

Until this is used on the front end, there shouldn't be any noticeable changes.
