### PR TITLE
[hotfix][ENG-2147] pull keen analytics from partitioned collections

### DIFF
--- a/app/metrics-adapters/keen.ts
+++ b/app/metrics-adapters/keen.ts
@@ -117,7 +117,6 @@ export default class KeenAdapter extends BaseAdapter {
         if (node) {
             sendPublicEvent = node.public;
             if (sendPublicEvent) {
-                this.trackPublicEvent('pageviews', eventProperties);
                 this.trackPublicEvent(`pageviews-${node.id.charAt(0)}`, eventProperties);
             }
         }

--- a/lib/analytics-page/addon/components/analytics-charts/component.ts
+++ b/lib/analytics-page/addon/components/analytics-charts/component.ts
@@ -14,7 +14,7 @@ import template from './template';
 export interface ChartSpec {
     titleKey: string;
     keenQueryType: string;
-    keenQueryOptions: any;
+    keenQueryOptions: (node: Node) => any;
     processData?: (data: any, intl: Intl, node: Node) => any;
     fakeData?: () => any;
     configureChart(chart: KeenDataviz, intl: Intl): void;
@@ -39,10 +39,12 @@ export default class AnalyticsChart extends Component {
         {
             titleKey: 'analytics.uniqueVisits',
             keenQueryType: 'count_unique',
-            keenQueryOptions: {
-                event_collection: 'pageviews',
-                interval: 'daily',
-                target_property: 'anon.id',
+            keenQueryOptions(node: Node) {
+                return {
+                    event_collection: `pageviews-${node.id.charAt(0)}`,
+                    interval: 'daily',
+                    target_property: 'anon.id',
+                };
             },
             configureChart(chart: KeenDataviz, intl: Intl) {
                 chart.type('line')
@@ -85,10 +87,12 @@ export default class AnalyticsChart extends Component {
         {
             titleKey: 'analytics.visitTimes',
             keenQueryType: 'count_unique',
-            keenQueryOptions: {
-                event_collection: 'pageviews',
-                target_property: 'anon.id',
-                group_by: 'time.local.hour_of_day',
+            keenQueryOptions(node: Node) {
+                return {
+                    event_collection: `pageviews-${node.id.charAt(0)}`,
+                    target_property: 'anon.id',
+                    group_by: 'time.local.hour_of_day',
+                };
             },
             configureChart(chart: KeenDataviz, intl: Intl) {
                 chart.type('bar')
@@ -159,12 +163,14 @@ export default class AnalyticsChart extends Component {
         {
             titleKey: 'analytics.topReferrers',
             keenQueryType: 'count_unique',
-            keenQueryOptions: {
-                event_collection: 'pageviews',
-                target_property: 'anon.id',
-                group_by: 'referrer.info.domain',
-                order_by: [{ property_name: 'result', direction: 'DESC' }],
-                limit: 10,
+            keenQueryOptions(node: Node) {
+                return {
+                    event_collection: `pageviews-${node.id.charAt(0)}`,
+                    target_property: 'anon.id',
+                    group_by: 'referrer.info.domain',
+                    order_by: [{ property_name: 'result', direction: 'DESC' }],
+                    limit: 10,
+                };
             },
             configureChart(chart: KeenDataviz, intl: Intl) {
                 chart.type('pie')
@@ -200,15 +206,17 @@ export default class AnalyticsChart extends Component {
         {
             titleKey: 'analytics.popularPages',
             keenQueryType: 'count',
-            keenQueryOptions: {
-                event_collection: 'pageviews',
-                target_property: 'anon.id',
-                group_by: ['page.info.path', 'page.title'],
-                filters: [{
-                    property_name: 'page.info.path',
-                    operator: 'not_contains',
-                    property_value: '/project/',
-                }],
+            keenQueryOptions(node: Node) {
+                return {
+                    event_collection: `pageviews-${node.id.charAt(0)}`,
+                    target_property: 'anon.id',
+                    group_by: ['page.info.path', 'page.title'],
+                    filters: [{
+                        property_name: 'page.info.path',
+                        operator: 'not_contains',
+                        property_value: '/project/',
+                    }],
+                };
             },
             configureChart(chart: KeenDataviz, intl: Intl) {
                 chart.type('horizontal-bar')

--- a/lib/analytics-page/addon/components/analytics-charts/x-chart-wrapper/component.ts
+++ b/lib/analytics-page/addon/components/analytics-charts/x-chart-wrapper/component.ts
@@ -50,7 +50,7 @@ export default class ChartWrapper extends Component {
                 this.startDate,
                 this.endDate,
                 this.chartSpec.keenQueryType,
-                this.chartSpec.keenQueryOptions,
+                this.chartSpec.keenQueryOptions(node),
             );
 
             if (this.chartSpec.processData) {


### PR DESCRIPTION
- Ticket: [ENG-2147](https://openscience.atlassian.net/browse/ENG-2147)
- Feature flag: n/a

## Purpose

Now that we've gathered a month worth's of data in the partitioned collection, switch the analytics page over to using them and stop logging to the common collection.

## Summary of Changes

 * Pull from collections partitioned by the first character of the project guid instead of the monolithic collection.  This will reduce scanning costs.

 * Update the analytics chart specs to make the `keenQueryOptions` key a function.  Previously this had been static data, once all projects used the same collection.  It is now a function whose only argument is the node.  The function can parameterize the collection name based off the properties of the node.

 * Stop logging to the monolithic collection.  Now that the previous month's data has been filled, it is no longer necessary to log to both the monolithic and partitioned collections.

## Side Effects

None expected!

## QA Notes

No QA needed, will be dev-tested.
