### PR TITLE
[ENG-2151] Remove color change for disabled buttons

### DIFF
--- a/app/styles/_accessibility.scss
+++ b/app/styles/_accessibility.scss
@@ -18,8 +18,11 @@
     }
 }
 
+// stylelint-disable selector-no-qualifying-type
 .btn-success.disabled,
-.btn-success.disabled:hover {
+.btn-success.disabled:hover,
+button.btn-success[disabled],
+button.btn-success[disabled]:hover {
     color: darken($brand-success, 85%);
     background-color: lighten($brand-success, 50%);
     border-color: lighten($brand-success, 45%);

--- a/app/styles/_accessibility.scss
+++ b/app/styles/_accessibility.scss
@@ -9,6 +9,8 @@
         border-color: darken($brand-success, 15%);
     }
 
+    &[disabled],
+    &[disabled]:hover,
     :global(&.disabled),
     :global(&.disabled):hover {
         color: darken($brand-success, 85%);
@@ -18,11 +20,8 @@
     }
 }
 
-// stylelint-disable selector-no-qualifying-type
 .btn-success.disabled,
-.btn-success.disabled:hover,
-button.btn-success[disabled],
-button.btn-success[disabled]:hover {
+.btn-success.disabled:hover {
     color: darken($brand-success, 85%);
     background-color: lighten($brand-success, 50%);
     border-color: lighten($brand-success, 45%);
@@ -34,7 +33,7 @@ button.btn-success[disabled]:hover {
     background-color: $brand-info;
     border-color: darken($brand-info, 5%);
 
-    &:hover {
+    &:hover:not([disabled]) {
         background-color: darken($brand-info, 10%);
         border-color: darken($brand-info, 15%);
     }
@@ -45,7 +44,7 @@ button.btn-success[disabled]:hover {
     background-color: $brand-danger;
     border-color: darken($brand-danger, 5%);
 
-    &:hover {
+    &:hover:not([disabled]) {
         background-color: darken($brand-danger, 10%);
         border-color: darken($brand-danger, 15%);
     }

--- a/lib/osf-components/addon/components/button/styles.scss
+++ b/lib/osf-components/addon/components/button/styles.scss
@@ -42,7 +42,7 @@
     color: $color-text-white;
     font-weight: bold;
 
-    &:hover {
+    &:hover:not([disabled]) {
         background-color: var(--secondary-color);
     }
 }
@@ -52,7 +52,7 @@
     border: 1px solid $color-border-gray-light;
     color: var(--primary-color);
 
-    &:hover {
+    &:hover:not([disabled]) {
         border: 1px solid $color-bg-gray-blue;
         background-color: $color-bg-gray-blue-light;
     }


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-2151]
- Feature flag: n/a

## Purpose
- Remove color change on disabled buttons

## Summary of Changes
- Update global `_accessibility.scss` so hover does not change color (note: .disabled is used for `<a role='button'>`)
- Update Button component style to not change color on hover if the button is disabled.

## Side Effects
Some of the disabled buttons in the the app may look different

## QA Notes
- Branded buttons should not change colors if they are not disabled (ie: `/registries/<provider_id>/new`, the `start registraiton draft` button should no longer change colors if the project is not selected)


[ENG-2151]: https://openscience.atlassian.net/browse/ENG-2151