### PR TITLE
[ENG-2156] Fix missing contributor names

### DIFF
--- a/app/models/contributor.ts
+++ b/app/models/contributor.ts
@@ -41,9 +41,11 @@ export default class ContributorModel extends OsfModel.extend(Validations) {
     @attr('boolean') bibliographic!: boolean;
     @attr('fixstring') unregisteredContributor?: string;
     @attr('number') index!: number;
+    @attr('string') sendEmail!: 'default' | 'preprint' | 'false';
+
+    // Write-only attributes
     @attr('fixstring') fullName!: string;
     @attr('fixstring') email!: string;
-    @attr('string') sendEmail!: 'default' | 'preprint' | 'false';
 
     @belongsTo('user', { inverse: 'contributors' })
     users!: DS.PromiseObject<UserModel> & UserModel;

--- a/lib/registries/addon/components/registries-recent-list/template.hbs
+++ b/lib/registries/addon/components/registries-recent-list/template.hbs
@@ -32,9 +32,14 @@
             </div>
             <div class='row'>
                 <div class='col-xs-12'>
-                    <ul local-class='RecentList__Contributors'>
+                    <ul
+                        data-test-recent-registration-contrib-list={{reg.id}}
+                        local-class='RecentList__Contributors'
+                    >
                         {{#each reg.bibliographicContributors as |contrib|}}
-                            <li>{{contrib.fullName}}</li>
+                            <li data-test-recent-registration-contrib={{contrib.bibliographic}}>
+                                {{contrib.users.fullName}}
+                            </li>
                         {{/each}}
                     </ul>
                 </div>

--- a/mirage/factories/contributor.ts
+++ b/mirage/factories/contributor.ts
@@ -1,5 +1,4 @@
 import { association, Collection, Factory, trait, Trait } from 'ember-cli-mirage';
-import faker from 'faker';
 
 import Contributor from 'ember-osf-web/models/contributor';
 import { Permission } from 'ember-osf-web/models/osf-model';
@@ -20,13 +19,6 @@ export default Factory.extend<Contributor & ContributorTraits>({
         return i;
     },
     users: association() as Contributor['users'],
-
-    fullName() {
-        return `${faker.name.firstName()} ${faker.name.lastName()}`;
-    },
-    email() {
-        return faker.internet.email();
-    },
 
     afterCreate(contributor) {
         if (contributor.bibliographic) {

--- a/tests/engines/registries/acceptance/index/index-test.ts
+++ b/tests/engines/registries/acceptance/index/index-test.ts
@@ -25,8 +25,10 @@ module('Registries | Acceptance | registries index (landing page)', hooks => {
                 .hasProperty('href', new RegExp(`.*/${reg.id}$`));
             assert.dom(`[data-test-recent-registration-id=${reg.id}]`)
                 .hasText(reg.title);
+            assert.dom(`[data-test-recent-registration-contrib-list=${reg.id}]`).hasAnyText();
         }
 
+        assert.dom('[data-test-recent-registration-contrib=false]').doesNotExist();
         assert.dom('[data-test-recent-registration-id]').exists({ count: recentRegs.length },
             'non-recent registrations don\'t show');
 


### PR DESCRIPTION
- Ticket: [ENG-2156]
- Feature flag: n/a

## Purpose

Fix missing contributor names

<img width="1038" alt="Screen Shot 2020-09-15 at 9 20 15 AM" src="https://user-images.githubusercontent.com/4511563/93215659-b4afc680-f734-11ea-80d7-e978f5f8788b.png">


## Summary of Changes

- Contributor `fullName` is a write-only field
- Use `contributor.users.fullName`
- Update tests

## Side Effects

N/A

## QA Notes



[ENG-2156]: https://openscience.atlassian.net/browse/ENG-2156