### PR TITLE
Update navbar styling to have buttons as same height

### DIFF
--- a/app/styles/_components.scss
+++ b/app/styles/_components.scss
@@ -420,6 +420,10 @@
     color: rgba(255, 255, 255, 0.8);
 }
 
+#navbarScope .button-container {
+    display: flex;
+}
+
 #navbarScope .btn-top-signup {
     padding: 4px 13px;
     margin-top: 3px;

--- a/lib/osf-components/addon/components/osf-navbar/auth-dropdown/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/auth-dropdown/template.hbs
@@ -71,7 +71,7 @@
     </BsDropdown>
 {{else}}
     <li class='sign-in'>
-        <div>
+        <div class='button-container'>
             <OsfLink
                 data-test-ad-sign-up-button
                 data-analytics-name='SignUp {{@campaign}}'


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-2169
- Feature flag: `N/A`

## Purpose

Fix the slight difference in height between buttons on the collections navbar.

## Summary of Changes

- Add `display: flex` on the wrapping div to ensure that both buttons end up being the same height.
<img width="221" alt="Screen Shot 2020-09-28 at 12 33 11 PM" src="https://user-images.githubusercontent.com/19379783/94461676-7086e200-0188-11eb-8928-e988f8d0b453.png">


## Side Effects

`N/A`

## QA Notes

This should fix the slight height difference between buttons. Both buttons should now be 32px in height.
