### PR TITLE
[ENG-2182] Add moderator action navbar

### DIFF
--- a/lib/registries/addon/overview/-components/overview-topbar/component.ts
+++ b/lib/registries/addon/overview/-components/overview-topbar/component.ts
@@ -30,6 +30,8 @@ export default class OverviewTopbar extends Component {
 
     bookmarksCollection!: CollectionModel;
     isBookmarked?: boolean;
+    mode?: string = 'default';
+    showDropdown: boolean = false;
 
     @task({ withTestWaiter: true, drop: true })
     forkRegistration = task(function *(this: OverviewTopbar, closeDropdown: () => void) {

--- a/lib/registries/addon/overview/-components/overview-topbar/template.hbs
+++ b/lib/registries/addon/overview/-components/overview-topbar/template.hbs
@@ -1,98 +1,110 @@
 <div data-test-topbar-states>
     <RegistriesStates @registration={{@registration}} />
 </div>
-<div data-test-topbar-share-bookmark-fork
-    local-class='RightActionsContainer'
->
-    <ResponsiveDropdown as |dd|>
-        <dd.trigger
-            data-test-forks-dropdown-button
-            data-analytics-name='Expand fork dropdown'
-            local-class='Action'
-        >
-            <FaIcon
-                local-class='Icon'
-                @icon='code-fork'
-            />
-            <BsTooltip
-                @placement='top'
-                @triggerEvents='hover'
-            >
-                {{t 'registries.overview.tooltips.fork'}}
-            </BsTooltip>
-        </dd.trigger>
-        <dd.content>
-            <div data-test-forks-dropdown-options local-class='ForksMenu'>
-                <OsfLink
-                    data-analytics-name='Go to forks page'
-                    data-test-go-to-forks-view
-                    @route='guid-registration.forks'
-                    @models={{array @registration.id}}
-                >
-                    {{t 'registries.overview.view_forks'}}
-                </OsfLink>
-                <OsfButton
-                    data-analytics-name='Fork registration'
-                    data-test-fork-registration
-                    @type='link'
-                    @disabled={{this.forkRegistration.isRunning}}
-                    @onClick={{action (perform this.forkRegistration (action dd.close))}}
-                    local-class='ForkButton'
-                >
-                    {{t 'registries.overview.fork_registration'}}
-                </OsfButton>
-            </div>
-        </dd.content>
-    </ResponsiveDropdown>
-
+{{#if (eq this.mode 'moderator')}}
     <OsfButton
-        data-test-bookmarks-button
-        data-analytics-name={{if this.isBookmarked 'Remove from bookmarks' 'Bookmark'}}
-        data-analytics-extra='Registration ID: {{this.registration.id}}'
-        @type='link'
-        @onClick={{action (perform this.bookmark)}}
-        @disabled={{or this.bookmark.isRunning @registration.isAnonymous}}
-        local-class='ActionButton'
+        data-test-moderation-dropdown-button
+        data-analytics-name='Display Moderation Actions'
+        @type='success'
+        @onClick={{fn (mut this.showDropdown) (not this.showDropdown)}}
     >
-        <FaIcon
-            local-class='Icon'
-            @icon='{{if this.isBookmarked 'bookmark' 'bookmark-o'}}'
-        />
-        <BsTooltip
-            @placement='top'
-            @triggerEvents='hover'
-        >
-            {{#if this.isBookmarked}}
-                {{t 'registries.overview.tooltips.remove_bookmark'}}
-            {{else}}
-                {{t 'registries.overview.tooltips.bookmark'}}
-            {{/if}}
-        </BsTooltip>
+        {{t 'registries.overview.makeDecision'}}
+        <FaIcon @icon='caret-down' />
     </OsfButton>
-
-    <SharingIcons::Dropdown
-        @title={{@registration.title}}
-        @description={{@registration.description}}
-        @hyperlink={{this.registrationURL}}
-        @showText={{true}}
-        @registration={{@registration}}
-        as |dd|
+{{else}}
+    <div data-test-topbar-share-bookmark-fork
+        local-class='RightActionsContainer'
     >
-        <dd.trigger
-            data-test-social-sharing-button
-            data-analytics-name='Expand sharing menu'
-            local-class='Action'
+        <ResponsiveDropdown as |dd|>
+            <dd.trigger
+                data-test-forks-dropdown-button
+                data-analytics-name='Expand fork dropdown'
+                local-class='Action'
+            >
+                <FaIcon
+                    local-class='Icon'
+                    @icon='code-fork'
+                />
+                <BsTooltip
+                    @placement='top'
+                    @triggerEvents='hover'
+                >
+                    {{t 'registries.overview.tooltips.fork'}}
+                </BsTooltip>
+            </dd.trigger>
+            <dd.content>
+                <div data-test-forks-dropdown-options local-class='ForksMenu'>
+                    <OsfLink
+                        data-analytics-name='Go to forks page'
+                        data-test-go-to-forks-view
+                        @route='guid-registration.forks'
+                        @models={{array @registration.id}}
+                    >
+                        {{t 'registries.overview.view_forks'}}
+                    </OsfLink>
+                    <OsfButton
+                        data-analytics-name='Fork registration'
+                        data-test-fork-registration
+                        @type='link'
+                        @disabled={{this.forkRegistration.isRunning}}
+                        @onClick={{action (perform this.forkRegistration (action dd.close))}}
+                        local-class='ForkButton'
+                    >
+                        {{t 'registries.overview.fork_registration'}}
+                    </OsfButton>
+                </div>
+            </dd.content>
+        </ResponsiveDropdown>
+
+        <OsfButton
+            data-test-bookmarks-button
+            data-analytics-name={{if this.isBookmarked 'Remove from bookmarks' 'Bookmark'}}
+            data-analytics-extra='Registration ID: {{this.registration.id}}'
+            @type='link'
+            @onClick={{action (perform this.bookmark)}}
+            @disabled={{or this.bookmark.isRunning @registration.isAnonymous}}
+            local-class='ActionButton'
         >
             <FaIcon
                 local-class='Icon'
-                @icon='share-alt'
+                @icon='{{if this.isBookmarked 'bookmark' 'bookmark-o'}}'
             />
             <BsTooltip
                 @placement='top'
                 @triggerEvents='hover'
             >
-                {{t 'registries.overview.tooltips.share'}}
+                {{#if this.isBookmarked}}
+                    {{t 'registries.overview.tooltips.remove_bookmark'}}
+                {{else}}
+                    {{t 'registries.overview.tooltips.bookmark'}}
+                {{/if}}
             </BsTooltip>
-        </dd.trigger>
-    </SharingIcons::Dropdown>
-</div>
+        </OsfButton>
+
+        <SharingIcons::Dropdown
+            @title={{@registration.title}}
+            @description={{@registration.description}}
+            @hyperlink={{this.registrationURL}}
+            @showText={{true}}
+            @registration={{@registration}}
+            as |dd|
+        >
+            <dd.trigger
+                data-test-social-sharing-button
+                data-analytics-name='Expand sharing menu'
+                local-class='Action'
+            >
+                <FaIcon
+                    local-class='Icon'
+                    @icon='share-alt'
+                />
+                <BsTooltip
+                    @placement='top'
+                    @triggerEvents='hover'
+                >
+                    {{t 'registries.overview.tooltips.share'}}
+                </BsTooltip>
+            </dd.trigger>
+        </SharingIcons::Dropdown>
+    </div>
+{{/if}}

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1270,6 +1270,7 @@ registries:
             text: 'Embargoed registration'
             short_description: Embargoed
             long_description: 'This registration is embargoed. It will remain private until {embargoEndDate}.'
+        makeDecision: 'Make decision'
         bookmark:
             add:
                 text: Bookmark


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-2182
- Feature flag: n/a

## Purpose

To add a `Make decision` button to the `overview-topbar` component if the user is a moderator.

Note: This adds a button for registration actions, but it doesn't include the dropdown (to be done in a separate ticket).

## Summary of Changes

- Add state to the `overview-topbar` component to check if the user is a moderator
- Add button to the `overview-topbar`

<img width="1146" alt="Screen Shot 2020-10-26 at 12 52 25 PM" src="https://user-images.githubusercontent.com/19379783/97202561-2ba39a80-178a-11eb-82e5-8e1b11554ddb.png">


## Side Effects

`N/A`

## QA Notes

This should only add the 'Make decision' button if the user is a moderator. Otherwise the topbar should show up like normal.
