### PR TITLE
[ENG-2368] Demo followup

### DIFF
--- a/lib/registries/addon/branded/moderation/submissions/controller.ts
+++ b/lib/registries/addon/branded/moderation/submissions/controller.ts
@@ -5,6 +5,8 @@ import { tracked } from '@glimmer/tracking';
 import { RegistrationReviewStates } from 'ember-osf-web/models/registration';
 
 export default class RegistriesModerationSubmissionController extends Controller {
+    queryParams = ['filterState'];
+
     @tracked filterState: RegistrationReviewStates = RegistrationReviewStates.Pending;
 
     @action

--- a/lib/registries/addon/components/make-decision-dropdown/template.hbs
+++ b/lib/registries/addon/components/make-decision-dropdown/template.hbs
@@ -40,12 +40,13 @@
             </div>
         {{/each}}
         <label for='moderator-comment'>
-            {{t 'registries.makeDecisionDropdown.additionalComment'}}
+            {{this.commentLabel}}
         </label>
         <Textarea
             data-test-moderation-dropdown-comment
             @id='moderator-comment'
             @value={{this.comment}}
+            placeholder={{t 'registries.makeDecisionDropdown.remarksToAdmin'}}
             local-class='Comment'
         />
         <Button

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1352,6 +1352,8 @@ registries:
         submit: 'Submit'
         success: 'Successfully submitted moderator decision.'
         failure: 'Failed to submit moderator decision.'
+        justificationForWithdrawal: 'Justification for Withdrawal'
+        remarksToAdmin: 'Remarks to registration admin'
 meetings:
     index:
         meetings-list:

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1353,7 +1353,7 @@ registries:
         success: 'Successfully submitted moderator decision.'
         failure: 'Failed to submit moderator decision.'
         justificationForWithdrawal: 'Justification for Withdrawal'
-        remarksToAdmin: 'Remarks to registration admin'
+        remarksToAdmin: 'Add remarks to registration admins'
 meetings:
     index:
         meetings-list:


### PR DESCRIPTION
- Ticket: [ENG-2368]
- Feature flag: n/a

## Purpose

Follow up on demo requests.

## Summary of Changes

- Added `filterState` query param to the moderation submissions route.
  - After rejecting submission, transition to the submissions route with `?filterState=rejected`
- Force withdraw comment should have label `Justification for Withdrawal`
- Comment should have placeholder `Remarks to registration admin`.

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-2368]: https://openscience.atlassian.net/browse/ENG-2368