### PR TITLE
[ENG-2367] Add notification subscription ids

### DIFF
--- a/lib/osf-components/addon/components/subscriptions/list/styles.scss
+++ b/lib/osf-components/addon/components/subscriptions/list/styles.scss
@@ -1,3 +1,25 @@
 ul {
     list-style-type: none;
+    padding: 0;
+}
+
+.SubscriptionPlaceholder {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 75%;
+    height: 45px;
+    border-top: 1px solid $color-bg-gray-dark;
+
+    &:global(.ember-content-placeholders-text) {
+        margin-top: 0 !important;
+
+        :global(.ember-content-placeholders-text__line) {
+            width: 100%;
+        }
+    }
+
+    &:last-of-type {
+        border-bottom: 1px solid $color-bg-gray-dark;
+    }
 }

--- a/lib/osf-components/addon/components/subscriptions/list/template.hbs
+++ b/lib/osf-components/addon/components/subscriptions/list/template.hbs
@@ -1,5 +1,15 @@
-<ul data-test-subscription-list>
-    {{#each @manager.subscriptions as |subscription|}}
-        <Subscriptions::ListRow @manager={{@manager}} @subscription={{subscription}} />
-    {{/each}}
-</ul>
+{{#if @manager.fetchSubscriptions.isRunning}}
+    <ContentPlaceholders as |placeholder|>
+        {{placeholder.text local-class='SubscriptionPlaceholder' lines=1}}
+        {{placeholder.text local-class='SubscriptionPlaceholder' lines=1}}
+    </ContentPlaceholders>
+{{else}}
+    <ul data-test-subscription-list>
+        {{#each @manager.subscriptions as |subscription|}}
+            <Subscriptions::ListRow
+                @manager={{@manager}}
+                @subscription={{subscription}}
+            />
+        {{/each}}
+    </ul>
+{{/if}}

--- a/lib/osf-components/addon/components/subscriptions/manager/component.ts
+++ b/lib/osf-components/addon/components/subscriptions/manager/component.ts
@@ -5,10 +5,11 @@ import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency-decorators';
 import DS from 'ember-data';
 import Intl from 'ember-intl/services/intl';
+import Toast from 'ember-toastr/services/toast';
+
 import { layout } from 'ember-osf-web/decorators/component';
 import SubscriptionModel, { SubscriptionFrequency } from 'ember-osf-web/models/subscription';
 import captureException, { getApiErrorMessage } from 'ember-osf-web/utils/capture-exception';
-import Toast from 'ember-toastr/services/toast';
 import template from './template';
 
 @tagName('')
@@ -26,7 +27,7 @@ export default class SubscriptionsManager extends Component {
     @task({ withTestWaiter: true, enqueue: true, on: 'didReceiveAttrs' })
     fetchSubscriptions = task(function *(this: SubscriptionsManager) {
         try {
-            if (this.subscriptionIds) {
+            if (Array.isArray(this.subscriptionIds) && this.subscriptionIds.length) {
                 this.subscriptions = yield this.store.query('subscription', {
                     'filter[id]': this.subscriptionIds.join(','),
                 });

--- a/lib/osf-components/addon/components/subscriptions/manager/template.hbs
+++ b/lib/osf-components/addon/components/subscriptions/manager/template.hbs
@@ -1,4 +1,5 @@
 {{yield (hash
     subscriptions=this.subscriptions
+    fetchSubscriptions=this.fetchSubscriptions
     updateSubscriptionFrequency=(perform this.updateSubscriptionFrequency)
 )}}

--- a/lib/registries/addon/branded/moderation/notifications/controller.ts
+++ b/lib/registries/addon/branded/moderation/notifications/controller.ts
@@ -1,10 +1,20 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
 import config from 'ember-get-config';
-import CurrentUserService from 'ember-osf-web/services/current-user';
 import pathJoin from 'ember-osf-web/utils/path-join';
 
 export default class BrandedModerationNotificationsController extends Controller {
-    @service currentUser!: CurrentUserService;
     userSettingsLink: string = pathJoin(config.OSF.url, 'settings', 'notifications');
+    @alias('model.id') providerId?: string;
+
+    @computed('providerId')
+    get subscriptionIds() {
+        return this.providerId
+            ? [
+                `${this.providerId}_new_pending_withdraw_requests`,
+                `${this.providerId}_new_pending_submissions`,
+            ]
+            : [];
+    }
 }

--- a/lib/registries/addon/branded/moderation/notifications/template.hbs
+++ b/lib/registries/addon/branded/moderation/notifications/template.hbs
@@ -6,6 +6,12 @@
 <p>
     {{t 'registries.moderation.notifications.paragraph' link=this.userSettingsLink htmlSafe=true}}
 </p>
-<Subscriptions::Manager as |manager|>
-    <Subscriptions::List @manager={{manager}} />
+
+<Subscriptions::Manager
+    @subscriptionIds={{this.subscriptionIds}}
+    as |manager|
+>
+    <Subscriptions::List
+        @manager={{manager}}
+    />
 </Subscriptions::Manager>


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-2367]
- Feature flag: n/a

## Purpose

Add notification subscription ids and loading state content placeholders

## Summary of Changes

- Build subscription ids based on the provider model.id
- Add content placeholders for consistency with other moderation routes and style them.

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-2367]: https://openscience.atlassian.net/browse/ENG-2367