### PR TITLE
Fix CSS issues caused by bad use of :global

### DIFF
--- a/lib/osf-components/addon/components/moderators/add-modal/styles.scss
+++ b/lib/osf-components/addon/components/moderators/add-modal/styles.scss
@@ -1,39 +1,40 @@
-:global(.cp-Panel) {
-    border: 1px solid $color-border-gray;
+.dialogMain {
+    min-width: 40vw;
 
-    &:not(:last-of-type) {
-        border-bottom: 0;
+    :global(.cp-Panel) {
+        border: 1px solid $color-border-gray;
+
+        &:not(:last-of-type) {
+            border-bottom: 0;
+        }
+    }
+
+    :global(.cp-Panel-toggle) {
+        display: block;
+        padding: 1em;
+
+        &:global(.cp-is-open),
+        &:hover {
+            background: $color-bg-gray-light;
+        }
+    }
+
+    :global(.cp-Panel-toggle:link) {
+        text-decoration: none;
+
+        &:global(.cp-is-open) {
+            font-weight: 700;
+        }
+    }
+
+    :global(.cp-Panel-body-inner) {
+        padding: 1em;
     }
 }
 
-:global(.cp-Panel-toggle) {
-    display: block;
-    padding: 1em;
-
-    &:global(.cp-is-open),
-    &:hover {
-        background: $color-bg-gray-light;
-    }
-}
-
-:global(.cp-Panel-toggle:link) {
-    text-decoration: none;
-
-    &:global(.cp-is-open) {
-        font-weight: 700;
-    }
-}
-
-:global(.cp-Panel-body-inner) {
-    padding: 1em;
-}
 
 .panelBody {
     label:last-of-type {
         margin-top: 15px;
     }
-}
-
-.dialogMain {
-    min-width: 40vw;
 }


### PR DESCRIPTION
- Ticket: [NA]
- Feature flag: n/a

## Purpose
- Address unintended CSS changes caught by percy
- Atone for my CSS sins

## Summary of Changes
- Wrap all `:global()` CSS rules in a local-class

## Side Effects
- there should be none _this time_

## QA Notes
NA
