### PR TITLE
Add default permission to add moderator modal

### DIFF
--- a/lib/osf-components/addon/components/moderators/add-modal/component.ts
+++ b/lib/osf-components/addon/components/moderators/add-modal/component.ts
@@ -79,12 +79,12 @@ export default class AddModalComponent extends Component {
     inviteChangeset = buildChangeset({
         fullName: null,
         email: null,
-        permissionGroup: null,
+        permissionGroup: PermissionGroup.Moderator,
     }, InviteFormValidations);
 
     userChangeset = buildChangeset({
         user: null,
-        permissionGroup: null,
+        permissionGroup: PermissionGroup.Moderator,
     }, UserFormValidations);
 
     @task({ withTestWaiter: true, restartable: true })

--- a/lib/osf-components/addon/components/moderators/add-modal/template.hbs
+++ b/lib/osf-components/addon/components/moderators/add-modal/template.hbs
@@ -56,6 +56,7 @@
                         </form.select>
                         <form.select
                             @options={{this.permissionOptions}}
+                            @searchEnabled={{false}}
                             @valuePath={{'permissionGroup'}}
                             @label={{t 'osf-components.moderators.add.modal.selectPermission'}}
                             data-test-select-permission
@@ -95,6 +96,7 @@
                         />
                         <form.select
                             @options={{this.permissionOptions}}
+                            @searchEnabled={{false}}
                             @valuePath={{'permissionGroup'}}
                             @label={{t 'osf-components.moderators.add.modal.selectPermission'}}
                             data-test-select-permission

--- a/tests/integration/components/moderators/component-test.ts
+++ b/tests/integration/components/moderators/component-test.ts
@@ -175,7 +175,6 @@ module('Integration | Component | moderators', hooks => {
         await click('[data-test-confirm-add-moderator-button]');
         assert.dom('[data-test-confirm-add-moderator-button]').isDisabled();
         assert.dom('[data-test-validation-errors="user"]').hasText(this.intl.t('validationErrors.empty'));
-        assert.dom('[data-test-validation-errors="permissionGroup"]').hasText(this.intl.t('validationErrors.empty'));
         await selectSearch('[data-test-select-user]', 'Yeji');
         await selectChoose('[data-test-select-user]', 'Hwang Yeji');
         await selectChoose('[data-test-select-permission]', 'Moderator');
@@ -222,9 +221,7 @@ module('Integration | Component | moderators', hooks => {
             this.intl.t('validationErrors.email', { description: 'This field' }),
         );
         assert.dom('[data-test-validation-errors="fullName"]').containsText(this.intl.t('validationErrors.empty'));
-        assert.dom('[data-test-validation-errors="permissionGroup"]').containsText(
-            this.intl.t('validationErrors.empty'),
-        );
+
         await fillIn('[data-test-email-input]>div>input', 'testing@cos.io');
         await fillIn('[data-test-full-name-input]>div>input', 'Hwang Yeji');
         await selectChoose('[data-test-select-permission]', 'Moderator');


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-2368
- Feature flag: n/a

## Purpose

To add a default permission to the 'Add moderator' modal.

## Summary of Changes

- Set default permission to 'moderator' in the form changesets

## Side Effects

`N/A`

## QA Notes

`N/A`
