### PR TITLE
[ENG-2412] Add "My Reviewing" button to registries-navbar

### DIFF
--- a/app/models/provider.ts
+++ b/app/models/provider.ts
@@ -20,6 +20,24 @@ export interface Assets {
     wide_white: string;
 }
 
+export enum ReviewPermissions {
+    SetUpModeration = 'set_up_moderation',
+    ViewSubmissions = 'view_submissions',
+    AcceptSubmissions = 'accept_submissions',
+    RejectSubmissions = 'reject_submissions',
+    WithdrawSubmissions = 'withdraw_submissions',
+    EditReviewComments = 'edit_review_comments',
+    ViewActions = 'view_actions',
+    AddModerator = 'add_moderator',
+    UpdateModerator = 'update_moderator',
+    RemoveModerator = 'remove_moderator',
+    EditReviewSettings = 'edit_review_settings',
+    AddReviewer = 'add_reviewer',
+    AssignReviewer = 'assign_reviewer',
+    ViewAssignedSubmissions = 'view_assigned_submissions',
+    ReviewAssignedSubmissions = 'review_assigned_submissions',
+}
+
 /* eslint-enable camelcase */
 
 export default abstract class ProviderModel extends OsfModel {

--- a/app/models/registration-provider.ts
+++ b/app/models/registration-provider.ts
@@ -37,7 +37,10 @@ export default class RegistrationProviderModel extends ProviderModel {
 
     @computed('permissions')
     get currentUserCanReview() {
-        return this.permissions.includes(ReviewPermissions.ViewSubmissions);
+        if (this.permissions) {
+            return this.permissions.includes(ReviewPermissions.ViewSubmissions);
+        }
+        return false;
     }
 }
 

--- a/app/models/registration-provider.ts
+++ b/app/models/registration-provider.ts
@@ -1,10 +1,11 @@
 import DS from 'ember-data';
 import ReviewActionModel from 'ember-osf-web/models/review-action';
 
+import { computed } from '@ember/object';
 import RegistrationSchemaModel from 'ember-osf-web/models/registration-schema';
 import BrandModel from './brand';
 import ModeratorModel from './moderator';
-import ProviderModel from './provider';
+import ProviderModel, { ReviewPermissions } from './provider';
 import RegistrationModel from './registration';
 
 const { attr, hasMany, belongsTo } = DS;
@@ -30,6 +31,14 @@ export default class RegistrationProviderModel extends ProviderModel {
 
     @attr('boolean')
     brandedDiscoveryPage?: boolean;
+
+    @attr('array')
+    permissions!: ReviewPermissions[];
+
+    @computed('permissions')
+    get currentUserCanReview() {
+        return this.permissions.includes(ReviewPermissions.ViewSubmissions);
+    }
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/lib/registries/addon/components/registries-navbar/styles.scss
+++ b/lib/registries/addon/components/registries-navbar/styles.scss
@@ -105,7 +105,7 @@
     text-transform: uppercase;
 }
 
-.AddRegistrationButton {
+.SecondaryNavLinkButton {
     margin-left: 25px;
 }
 

--- a/lib/registries/addon/components/registries-navbar/template.hbs
+++ b/lib/registries/addon/components/registries-navbar/template.hbs
@@ -68,6 +68,8 @@
                 >
                     {{t 'navbar.add_registration'}}
                 </nav.links.secondary>
+            {{/if}}
+            {{#if this.provider.currentUserCanReview}}
                 <nav.links.secondary
                     data-test-my-reviewing-button
                     data-analytics-name='Go to moderation view'

--- a/lib/registries/addon/components/registries-navbar/template.hbs
+++ b/lib/registries/addon/components/registries-navbar/template.hbs
@@ -62,11 +62,20 @@
                 <nav.links.secondary
                     data-test-add-new-button
                     data-analytics-name='Create new registration'
-                    local-class='AddRegistrationButton'
+                    local-class='SecondaryNavLinkButton'
                     @route='registries.branded.new'
                     @models={{array this.provider.id}}
                 >
                     {{t 'navbar.add_registration'}}
+                </nav.links.secondary>
+                <nav.links.secondary
+                    data-test-my-reviewing-button
+                    data-analytics-name='Go to moderation view'
+                    local-class='SecondaryNavLinkButton'
+                    @route='registries.branded.moderation'
+                    @models={{array this.provider.id}}
+                >
+                    {{t 'navbar.my_reviewing'}}
                 </nav.links.secondary>
             {{/if}}
 

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -266,6 +266,7 @@ navbar:
     add: Add
     # add_a_preprint: 'Add a {preprintWords.preprint}'
     add_registration: 'Add New'
+    my_reviewing: 'My Reviewing'
     browse: Browse
     cancel_search: 'Cancel search'
     donate: Donate


### PR DESCRIPTION
- Ticket: [ENG-2412]
- Feature flag: n/a

## Purpose

Add "My Reviewing" button to the `registries-navbar` component. Make it show conditionally depending on whether the user has permission to review submissions.

## Summary of Changes

Added enum `ReviewPermissions`. Added `permissions` field to registration-provider model. Add a computed to the same model to show whether the user can use the review app.

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-2412]: https://openscience.atlassian.net/browse/ENG-2412