### PR TITLE
[ENG-2413] Check provider permissions

### DIFF
--- a/lib/registries/addon/branded/moderation/route.ts
+++ b/lib/registries/addon/branded/moderation/route.ts
@@ -4,6 +4,7 @@ import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 import DS from 'ember-data';
 
+import { ReviewPermissions } from 'ember-osf-web/models/provider';
 import RegistrationProviderModel from 'ember-osf-web/models/registration-provider';
 import Analytics from 'ember-osf-web/services/analytics';
 import CurrentUserService from 'ember-osf-web/services/current-user';
@@ -16,7 +17,8 @@ export default class BrandedModerationRoute extends Route {
 
     afterModel(model: RegistrationProviderModel) {
         const { user } = this.currentUser;
-        if (!user || !user.canViewReviews || model.reviewsWorkflow !== 'pre-moderation') {
+        if (!user || !user.canViewReviews || model.reviewsWorkflow !== 'pre-moderation'
+            || !model.permissions.includes(ReviewPermissions.ViewSubmissions)) {
             this.transitionTo('page-not-found', window.location.pathname.slice(1));
         }
     }

--- a/lib/registries/addon/branded/moderation/route.ts
+++ b/lib/registries/addon/branded/moderation/route.ts
@@ -4,7 +4,6 @@ import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 import DS from 'ember-data';
 
-import { ReviewPermissions } from 'ember-osf-web/models/provider';
 import RegistrationProviderModel from 'ember-osf-web/models/registration-provider';
 import Analytics from 'ember-osf-web/services/analytics';
 import CurrentUserService from 'ember-osf-web/services/current-user';
@@ -18,7 +17,7 @@ export default class BrandedModerationRoute extends Route {
     afterModel(model: RegistrationProviderModel) {
         const { user } = this.currentUser;
         if (!user || model.reviewsWorkflow !== 'pre-moderation'
-            || !model.permissions.includes(ReviewPermissions.ViewSubmissions)) {
+            || !model.currentUserCanReview) {
             this.transitionTo('page-not-found', window.location.pathname.slice(1));
         }
     }

--- a/lib/registries/addon/branded/moderation/route.ts
+++ b/lib/registries/addon/branded/moderation/route.ts
@@ -17,7 +17,7 @@ export default class BrandedModerationRoute extends Route {
 
     afterModel(model: RegistrationProviderModel) {
         const { user } = this.currentUser;
-        if (!user || !user.canViewReviews || model.reviewsWorkflow !== 'pre-moderation'
+        if (!user || model.reviewsWorkflow !== 'pre-moderation'
             || !model.permissions.includes(ReviewPermissions.ViewSubmissions)) {
             this.transitionTo('page-not-found', window.location.pathname.slice(1));
         }

--- a/mirage/factories/registration-provider.ts
+++ b/mirage/factories/registration-provider.ts
@@ -34,6 +34,7 @@ export default Factory.extend<MirageRegistrationProvider & RegistrationProviderT
     brandedDiscoveryPage: true,
     assets: randomAssets(),
     reviewsWorkflow: 'pre-moderation',
+    permissions: [],
 
     afterCreate(provider, server) {
         provider.update({

--- a/tests/engines/registries/acceptance/branded/moderation/moderators-test.ts
+++ b/tests/engines/registries/acceptance/branded/moderation/moderators-test.ts
@@ -30,6 +30,7 @@ module('Registries | Acceptance | branded.moderation | moderators', hooks => {
         const regProvider = server.schema.registrationProviders.find('mdr8n');
         const currentUser = server.create('user', 'loggedIn');
         server.create('moderator', { id: currentUser.id, user: currentUser, provider: regProvider }, 'asModerator');
+        regProvider.update({ permissions: ['view_submissions'] });
         await visit('/registries/mdr8n/moderation/moderators');
         await percySnapshot('moderation moderators page: moderator view');
         assert.equal(currentRouteName(), 'registries.branded.moderation.moderators',
@@ -48,6 +49,7 @@ module('Registries | Acceptance | branded.moderation | moderators', hooks => {
         const regProvider = server.schema.registrationProviders.find('mdr8n');
         const currentUser = server.create('user', 'loggedIn');
         server.create('moderator', { id: currentUser.id, user: currentUser, provider: regProvider }, 'asAdmin');
+        regProvider.update({ permissions: ['view_submissions'] });
         await visit('/registries/mdr8n/moderation/moderators');
         await percySnapshot('moderation moderators page: admin view');
         assert.equal(currentRouteName(), 'registries.branded.moderation.moderators',

--- a/tests/engines/registries/acceptance/branded/moderation/submissions-test.ts
+++ b/tests/engines/registries/acceptance/branded/moderation/submissions-test.ts
@@ -34,6 +34,7 @@ module('Registries | Acceptance | branded.moderation | submissions', hooks => {
     });
 
     test('Submissions pending: no registrations', async function(this: ModerationSubmissionsTestContext, assert) {
+        this.registrationProvider.update({ permissions: ['view_submissions'] });
         const currentUser = server.create('user', 'loggedIn');
         server.create('moderator', {
             id: currentUser.id,
@@ -119,6 +120,7 @@ module('Registries | Acceptance | branded.moderation | submissions', hooks => {
                 reviewsState: RegistrationReviewStates.Withdrawn, provider: this.registrationProvider,
             },
         );
+        this.registrationProvider.update({ permissions: ['view_submissions'] });
         const currentUser = server.create('user', 'loggedIn');
         server.create('moderator', {
             id: currentUser.id,


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-2413]
- Feature flag: n/a

## Purpose
Check if user has permission to access the provider's registration route

## Summary of Changes
- add a condition to check if the user has `view_submissions` permission for a given provider
- the old way of doing things just checked if the user was a moderator on _any_ provider, so a moderator for provider A could still go to provider B's moderation route (although they wouldn't get to see any of the submissions or moderators as the backend would return 403Forbidden for those requests)

## Side Effects
`NA`

## QA Notes
- Please verify that a moderator/admin for can only access the moderation app for providers that they are admins in.
- going to https://staging2.osf.io/registries/<not_a_moderator>/moderation should take them to page not found. same behavior for all routes within the moderation route (ie: registries/<not_a_moderator>/moderation/submissions, moderators, notifications)


[ENG-2413]: https://openscience.atlassian.net/browse/ENG-2413