### PR TITLE
[ENG-2414] Fix make-decision-dropdown comment label, placeholder

### DIFF
--- a/lib/registries/addon/components/make-decision-dropdown/component.ts
+++ b/lib/registries/addon/components/make-decision-dropdown/component.ts
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 
-import { action, computed } from '@ember/object';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency-decorators';
@@ -49,14 +49,19 @@ export default class MakeDecisionDropdown extends Component<Args> {
             this.intl.t('registries.makeDecisionDropdown.rejectWithdrawalDescription'),
     };
 
-    @computed('this.args.registration.reviewsState')
-    get commentLabel() {
-        const { reviewsState } = this.args.registration;
-        if (reviewsState === RegistrationReviewStates.Pending
-            || reviewsState === RegistrationReviewStates.PendingWithdraw) {
-            return this.intl.t('registries.makeDecisionDropdown.additionalComment');
+    get commentTextArea() {
+        if ([RegistrationReviewStates.Pending, RegistrationReviewStates.PendingWithdraw]
+            .includes(this.args.registration.reviewsState)) {
+            return {
+                label: this.intl.t('registries.makeDecisionDropdown.additionalComment'),
+                placeholder: this.intl.t('registries.makeDecisionDropdown.additionalCommentPlaceholder'),
+            };
         }
-        return this.intl.t('registries.makeDecisionDropdown.justificationForWithdrawal');
+
+        return {
+            label: this.intl.t('registries.makeDecisionDropdown.justificationForWithdrawal'),
+            placeholder: this.intl.t('registries.makeDecisionDropdown.justificationForWithdrawalPlaceholder'),
+        };
     }
 
     @task({ withTestWaiter: true })

--- a/lib/registries/addon/components/make-decision-dropdown/template.hbs
+++ b/lib/registries/addon/components/make-decision-dropdown/template.hbs
@@ -40,13 +40,13 @@
             </div>
         {{/each}}
         <label for='moderator-comment'>
-            {{this.commentLabel}}
+            {{this.commentTextArea.label}}
         </label>
         <Textarea
             data-test-moderation-dropdown-comment
             @id='moderator-comment'
             @value={{this.comment}}
-            placeholder={{t 'registries.makeDecisionDropdown.remarksToAdmin'}}
+            placeholder={{this.commentTextArea.placeholder}}
             local-class='Comment'
         />
         <Button

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1351,12 +1351,13 @@ registries:
         acceptWithdrawalDescription: 'Registration will be withdrawn but still have a tombstone page with a justification for withdrawal and subset of the metadata available'
         rejectWithdrawal: 'Reject Withdrawal'
         rejectWithdrawalDescription: 'Registration will remain fully public'
-        additionalComment: 'Additional comment'
         submit: 'Submit'
         success: 'Successfully submitted moderator decision.'
         failure: 'Failed to submit moderator decision.'
+        additionalComment: 'Additional comment'
+        additionalCommentPlaceholder: 'Add remarks to registration admins'
         justificationForWithdrawal: 'Justification for Withdrawal'
-        remarksToAdmin: 'Add remarks to registration admins'
+        justificationForWithdrawalPlaceholder: 'Provide justification for withdrawal'
 meetings:
     index:
         meetings-list:


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-2414]
- Feature flag: n/a

## Purpose

Fix make-decision-dropdown component comment label and placeholder

## Summary of Changes

- Fix computed property by removing `@computed` decorator usage
- Make computed property return an object with label and placeholder as keys for more readability.
- Add placeholder language to translations file 

## Side Effects

N/A

## QA Notes

N/A. Will be tested along with the release/20.22.0


[ENG-2414]: https://openscience.atlassian.net/browse/ENG-2414