### PR TITLE
Fix toast on moderator delete error

### DIFF
--- a/lib/osf-components/addon/components/moderators/manager/component.ts
+++ b/lib/osf-components/addon/components/moderators/manager/component.ts
@@ -147,29 +147,41 @@ export default class ModeratorManagerComponent extends Component {
             moderator.set('permissionGroup', newPermission);
             yield moderator.save();
             this.toast.success(this.intl.t(
-                'registries.moderation.moderators.updatedModeratorPermission',
+                'registries.moderation.moderators.updatedModeratorPermissionSuccess',
                 { userName: moderator.fullName, permission: newPermission },
             ));
         } catch (e) {
+            const errorMessage = this.intl.t(
+                'registries.moderation.moderators.updatedModeratorPermissionError',
+                { permission: newPermission },
+            );
             moderator.rollbackAttributes();
-            captureException(e);
-            this.toast.error(getApiErrorMessage(e));
+            captureException(e, { errorMessage });
+            this.toast.error(getApiErrorMessage(e), errorMessage);
         }
     });
 
     @task({ withTestWaiter: true })
     removeModeratorTask = task(function *(this: ModeratorManagerComponent, moderator: ModeratorModel) {
-        moderator.deleteRecord();
-        yield moderator.save();
+        try {
+            yield moderator.destroyRecord();
 
-        if (this.reloadModeratorList) {
-            this.reloadModeratorList();
+            this.toast.success(this.intl.t(
+                'registries.moderation.moderators.removedModeratorSuccess',
+                { userName: moderator.fullName },
+            ));
+        } catch (e) {
+            const errorMessage = this.intl.t(
+                'registries.moderation.moderators.removedModeratorError',
+                { permission: moderator.permissionGroup },
+            );
+            captureException(e, { errorMessage });
+            this.toast.error(getApiErrorMessage(e), errorMessage);
+        } finally {
+            if (this.reloadModeratorList) {
+                this.reloadModeratorList();
+            }
         }
-
-        this.toast.success(this.intl.t(
-            'registries.moderation.moderators.removedModeratorSuccess',
-            { userName: moderator.fullName },
-        ));
     });
 
     @action

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1004,7 +1004,8 @@ registries:
             addedNewModeratorError: 'Error adding {permission}'
             removedModeratorSuccess: 'Successfully removed {userName}'
             removedModeratorError: 'Error removing {permission}'
-            updatedModeratorPermission: 'Successfully updated {userName} to {permission}'
+            updatedModeratorPermissionSuccess: 'Successfully updated {userName} to {permission}'
+            updatedModeratorPermissionError: 'Error updating permission to {permission}'
         notifications:
             title: 'Notifications'
             heading: 'Configure reviews notification preferences'


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: []
- Feature flag: n/a

## Purpose

Error toast messages don't show when deleting a moderator

## Summary of Changes

- Wrap try catch, toast api error message, with frontend translated string as title.
- Reload the moderator list even after a delete error, so the UI gets the removed moderator back.


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
