### PR TITLE
[ENG-2391] Revamp notifications tests

### DIFF
--- a/tests/engines/registries/acceptance/branded/moderation/notifications-test.ts
+++ b/tests/engines/registries/acceptance/branded/moderation/notifications-test.ts
@@ -1,0 +1,63 @@
+import { currentRouteName } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { percySnapshot } from 'ember-percy';
+import { module, test } from 'qunit';
+
+import { SubscriptionFrequency } from 'ember-osf-web/models/subscription';
+import { visit } from 'ember-osf-web/tests/helpers';
+import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
+
+module('Registries | Acceptance | branded.moderation | notifications', hooks => {
+    setupEngineApplicationTest(hooks, 'registries');
+    setupMirage(hooks);
+
+    hooks.beforeEach(() => {
+        server.create('registration-provider', { id: 'mdr8n' });
+        server.create('subscription', {
+            id: 'mdr8n_new_pending_submissions',
+            eventName: 'new_pending_submissions',
+            frequency: SubscriptionFrequency.Instant,
+        });
+        server.create('subscription', {
+            id: 'mdr8n_new_pending_withdraw_requests',
+            eventName: 'new_pending_withdraw_requests',
+            frequency: SubscriptionFrequency.Instant,
+        });
+        server.create('subscription', {
+            id: 'cat_photo_repository_subscription',
+            eventName: 'cat_photo_repository_subscription',
+            frequency: SubscriptionFrequency.Daily,
+        });
+    });
+
+    test('logged out users are rerouted', async assert => {
+        await visit('/registries/mdr8n/moderation/notifications');
+        assert.equal(currentRouteName(), 'registries.page-not-found', 'Non-moderators are rerouted');
+    });
+
+    test('logged in, non-moderators are rerouted', async assert => {
+        server.create('user', 'loggedIn');
+        await visit('/registries/mdr8n/moderation/notifications');
+        assert.equal(currentRouteName(), 'registries.page-not-found', 'Non-moderators are rerouted');
+    });
+
+    test('notifications list for moderators', async assert => {
+        const regProvider = server.schema.registrationProviders.find('mdr8n');
+        const currentUser = server.create('user', 'loggedIn');
+        server.create('moderator', { id: currentUser.id, user: currentUser, provider: regProvider }, 'asModerator');
+        regProvider.update({ permissions: ['view_submissions'] });
+        await visit('/registries/mdr8n/moderation/notifications');
+        await percySnapshot('moderation notifications page');
+        assert.equal(currentRouteName(), 'registries.branded.moderation.notifications',
+            'On the notifications page of registries reviews');
+        assert.dom('[data-test-subscription-list]').exists('Subscription list shown');
+        assert.dom('[data-test-subscription-list-row="mdr8n_new_pending_submissions"]')
+            .exists('Pending submissions notification shown');
+        assert.dom('[data-test-subscription-list-row="mdr8n_new_pending_withdraw_requests"]')
+            .exists('Pending withdraw requests notification shown');
+        assert.dom('[data-test-subscription-list-row="cat_photo_repository_subscription"]')
+            .doesNotExist('Other subscriptions are not shown');
+        assert.dom('[data-test-subscription-list-row="mdr8n_new_pending_withdraw_requests"] [data-test-power-select]')
+            .hasText('Instant', 'Subscription frequency is shown correctly');
+    });
+});

--- a/tests/integration/components/subscriptions/component-test.ts
+++ b/tests/integration/components/subscriptions/component-test.ts
@@ -73,9 +73,9 @@ module('Integration | Component | subscriptions', hooks => {
                 <Subscriptions::List @manager={{manager}} />
             </Subscriptions::Manager>
         `);
-        assert.dom('[data-test-power-select').hasText('Instant');
+        assert.dom('[data-test-power-select]').hasText('Instant');
         await clickTrigger();
         await click('[data-test-subscription-option="daily"]');
-        assert.dom('[data-test-power-select').hasText('Daily');
+        assert.dom('[data-test-power-select]').hasText('Daily');
     });
 });


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-2391]
- Feature flag: n/a

## Purpose
- Make better tests for notifications/subscriptions of moderation app

## Summary of Changes
- add acceptance test for notifications
- update component test for subscriptions

## Side Effects
`NA`

## QA Notes


[ENG-2391]: https://openscience.atlassian.net/browse/ENG-2391