### PR TITLE
[ENG-2391] Add make-decision-dropdown component tests

### DIFF
--- a/lib/osf-components/addon/components/registries/review-actions-list/component.ts
+++ b/lib/osf-components/addon/components/registries/review-actions-list/component.ts
@@ -1,3 +1,4 @@
+import { A } from '@ember/array';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -28,14 +29,13 @@ export default class ReviewActionsList extends Component<Args> {
 
     get latestAction() {
         const { reviewActions } = this;
-        return (reviewActions || [])[0];
+        return A(reviewActions || []).objectAt(0);
     }
 
     @task({ withTestWaiter: true })
     fetchActions = task(function *(this: ReviewActionsList) {
         try {
-            const reviewActions = yield this.args.registration.reviewActions;
-            this.reviewActions = reviewActions.toArray();
+            this.reviewActions = yield this.args.registration.reviewActions;
         } catch (e) {
             captureException(e);
             this.toast.error(getApiErrorMessage(e));

--- a/lib/registries/addon/components/make-decision-dropdown/component.ts
+++ b/lib/registries/addon/components/make-decision-dropdown/component.ts
@@ -28,7 +28,7 @@ export default class MakeDecisionDropdown extends Component<Args> {
     @tracked comment?: string;
 
     reviewsStateToDecisionMap = reviewsStateToDecisionMap;
-    decisionDescriptionMap = {
+    actionTriggerToDescriptionMap = {
         [ReviewActionTrigger.ForceWithdraw]: this.intl.t('registries.makeDecisionDropdown.forceWithdrawDescription'),
         [ReviewActionTrigger.AcceptSubmission]:
             this.intl.t('registries.makeDecisionDropdown.acceptSubmissionDescription'),
@@ -38,6 +38,14 @@ export default class MakeDecisionDropdown extends Component<Args> {
             this.intl.t('registries.makeDecisionDropdown.acceptWithdrawalDescription'),
         [ReviewActionTrigger.RejectWithdrawal]:
             this.intl.t('registries.makeDecisionDropdown.rejectWithdrawalDescription'),
+    };
+
+    actionTriggerToTextMap = {
+        [ReviewActionTrigger.ForceWithdraw]: this.intl.t('registries.makeDecisionDropdown.forceWithdraw'),
+        [ReviewActionTrigger.AcceptSubmission]: this.intl.t('registries.makeDecisionDropdown.acceptSubmission'),
+        [ReviewActionTrigger.RejectSubmission]: this.intl.t('registries.makeDecisionDropdown.rejectSubmission'),
+        [ReviewActionTrigger.AcceptWithdrawal]: this.intl.t('registries.makeDecisionDropdown.acceptWithdrawal'),
+        [ReviewActionTrigger.RejectWithdrawal]: this.intl.t('registries.makeDecisionDropdown.rejectWithdrawal'),
     };
 
     get commentTextArea() {

--- a/lib/registries/addon/components/make-decision-dropdown/component.ts
+++ b/lib/registries/addon/components/make-decision-dropdown/component.ts
@@ -9,7 +9,8 @@ import Intl from 'ember-intl/services/intl';
 import Toast from 'ember-toastr/services/toast';
 
 import RouterService from '@ember/routing/router-service';
-import RegistrationModel, { RegistrationReviewStates } from 'ember-osf-web/models/registration';
+import RegistrationModel,
+{ RegistrationReviewStates, reviewsStateToDecisionMap } from 'ember-osf-web/models/registration';
 import { ReviewActionTrigger } from 'ember-osf-web/models/review-action';
 import captureException, { getApiErrorMessage } from 'ember-osf-web/utils/capture-exception';
 
@@ -26,17 +27,7 @@ export default class MakeDecisionDropdown extends Component<Args> {
     @tracked decisionTrigger?: ReviewActionTrigger;
     @tracked comment?: string;
 
-    reviewsStateDecisionMap = {
-        [RegistrationReviewStates.Accepted]: [ReviewActionTrigger.ForceWithdraw],
-        [RegistrationReviewStates.Embargo]: [ReviewActionTrigger.ForceWithdraw],
-        [RegistrationReviewStates.Pending]:
-            [ReviewActionTrigger.AcceptSubmission, ReviewActionTrigger.RejectSubmission],
-        [RegistrationReviewStates.PendingWithdraw]:
-            [ReviewActionTrigger.AcceptWithdrawal, ReviewActionTrigger.RejectWithdrawal],
-        [RegistrationReviewStates.PendingWithdrawRequest]: [ReviewActionTrigger.ForceWithdraw],
-        [RegistrationReviewStates.PendingEmbargoTermination]: [ReviewActionTrigger.ForceWithdraw],
-    };
-
+    reviewsStateToDecisionMap = reviewsStateToDecisionMap;
     decisionDescriptionMap = {
         [ReviewActionTrigger.ForceWithdraw]: this.intl.t('registries.makeDecisionDropdown.forceWithdrawDescription'),
         [ReviewActionTrigger.AcceptSubmission]:
@@ -62,6 +53,14 @@ export default class MakeDecisionDropdown extends Component<Args> {
             label: this.intl.t('registries.makeDecisionDropdown.justificationForWithdrawal'),
             placeholder: this.intl.t('registries.makeDecisionDropdown.justificationForWithdrawalPlaceholder'),
         };
+    }
+
+    get hasModeratorActions() {
+        return ![
+            RegistrationReviewStates.Initial,
+            RegistrationReviewStates.Withdrawn,
+            RegistrationReviewStates.Rejected,
+        ].includes(this.args.registration.reviewsState);
     }
 
     @task({ withTestWaiter: true })

--- a/lib/registries/addon/components/make-decision-dropdown/template.hbs
+++ b/lib/registries/addon/components/make-decision-dropdown/template.hbs
@@ -14,53 +14,62 @@
         </Button>
     </dd.trigger>
     <dd.content @class={{local-class 'Dropdown'}}>
-        <Registries::ReviewActionsList @registration={{@registration}} />
-        {{#each (get this.reviewsStateDecisionMap @registration.reviewsState) as |option|}}
-            <div>
-                {{#let (unique-id 'radio' option) as |uniqueId|}}
-                    <Input
-                        data-test-moderation-dropdown-decision-checkbox={{option}}
-                        data-analytics-name={{concat 'clicking checkbox for' option}}
-                        @type='radio'
-                        @id={{uniqueId}}
-                        @value={{option}}
-                        checked={{if (eq this.decisionTrigger option) true false}}
-                        {{on 'click' (fn this.updateDecisionTrigger option)}}
-                    />
-                    <label
-                        data-test-moderation-dropdown-decision-label={{option}}
-                        for={{uniqueId}}
-                    >
-                        {{humanize option}}
-                    </label>
-                    <p
-                        data-test-moderation-dropdown-decision-description={{option}}
-                        local-class='Description'
-                    >
-                        {{get this.decisionDescriptionMap option}}
-                    </p>
-                {{/let}}
+        <Registries::ReviewActionsList data-test-review-actions-list  @registration={{@registration}} />
+        {{#if this.hasModeratorActions}}
+            {{#each (get this.reviewsStateToDecisionMap @registration.reviewsState) as |option|}}
+                <div>
+                    {{#let (unique-id 'radio' option) as |uniqueId|}}
+                        <Input
+                            data-test-moderation-dropdown-decision-checkbox={{option}}
+                            data-analytics-name='Select checkbox for {{option}}'
+                            @type='radio'
+                            @id={{uniqueId}}
+                            @value={{option}}
+                            checked={{if (eq this.decisionTrigger option) true false}}
+                            {{on 'click' (fn this.updateDecisionTrigger option)}}
+                        />
+                        <label
+                            data-test-moderation-dropdown-decision-label={{option}}
+                            for={{uniqueId}}
+                        >
+                            {{humanize option}}
+                        </label>
+                        <p
+                            data-test-moderation-dropdown-decision-description={{option}}
+                            local-class='Description'
+                        >
+                            {{get this.decisionDescriptionMap option}}
+                        </p>
+                    {{/let}}
+                </div>
+            {{/each}}
+            <label
+                data-test-moderation-dropdown-action-label
+                for='moderator-comment'
+            >
+                {{this.commentTextArea.label}}
+            </label>
+            <Textarea
+                data-test-moderation-dropdown-comment
+                @id='moderator-comment'
+                @value={{this.comment}}
+                placeholder={{this.commentTextArea.placeholder}}
+                local-class='Comment'
+            />
+            <Button
+                data-test-moderation-dropdown-submit
+                data-analytics-name='Submit decision'
+                @type='create'
+                disabled={{or (not this.decisionTrigger) this.submitDecision.isRunning}}
+                local-class='SubmitButton'
+                {{on 'click' (queue (perform this.submitDecision) dd.close)}}
+            >
+                {{t 'registries.makeDecisionDropdown.submit'}}
+            </Button>
+        {{else}}
+            <div data-test-no-moderator-actions>
+                {{t 'registries.makeDecisionDropdown.noModeratorActions'}}
             </div>
-        {{/each}}
-        <label for='moderator-comment'>
-            {{this.commentTextArea.label}}
-        </label>
-        <Textarea
-            data-test-moderation-dropdown-comment
-            @id='moderator-comment'
-            @value={{this.comment}}
-            placeholder={{this.commentTextArea.placeholder}}
-            local-class='Comment'
-        />
-        <Button
-            data-test-moderation-dropdown-submit
-            data-analytics-name='Submit decision'
-            @type='create'
-            disabled={{or (not this.decisionTrigger) this.submitDecision.isRunning}}
-            local-class='SubmitButton'
-            {{on 'click' (queue (perform this.submitDecision) dd.close)}}
-        >
-            {{t 'registries.makeDecisionDropdown.submit'}}
-        </Button>
+        {{/if}}
     </dd.content>
 </ResponsiveDropdown>

--- a/lib/registries/addon/components/make-decision-dropdown/template.hbs
+++ b/lib/registries/addon/components/make-decision-dropdown/template.hbs
@@ -32,13 +32,13 @@
                             data-test-moderation-dropdown-decision-label={{option}}
                             for={{uniqueId}}
                         >
-                            {{humanize option}}
+                            {{get this.actionTriggerToTextMap option}}
                         </label>
                         <p
                             data-test-moderation-dropdown-decision-description={{option}}
                             local-class='Description'
                         >
-                            {{get this.decisionDescriptionMap option}}
+                            {{get this.actionTriggerToDescriptionMap option}}
                         </p>
                     {{/let}}
                 </div>

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -242,10 +242,6 @@ export default function(this: Server) {
         relatedModelName: 'registration',
     });
     this.get('/providers/registrations/:parentID/registrations/', getProviderRegistrations);
-    osfNestedResource(this, 'registration-provider', 'actions', {
-        path: '/providers/registrations/:parentID/actions/',
-        relatedModelName: 'review-action',
-    });
     osfNestedResource(this, 'registration-provider', 'licensesAcceptable', {
         only: ['index'],
         path: '/providers/registrations/:parentID/licenses/',

--- a/tests/engines/registries/acceptance/overview/moderator-mode-test.ts
+++ b/tests/engines/registries/acceptance/overview/moderator-mode-test.ts
@@ -41,7 +41,7 @@ module('Registries | Acceptance | overview.moderator-mode', hooks => {
         await visit(`/${registration.id}?mode=moderator`);
         assert.dom('[data-test-state-description-short]').exists('Short description for pending status exists');
         assert.dom('[data-test-state-description-short]').hasText(
-            t('registries.overview.pending.short_description').toString(),
+            t('registries.overview.pending.short_description'),
             'The registration is pending',
         );
         assert.dom('[data-test-state-description-long]').hasText(
@@ -54,14 +54,14 @@ module('Registries | Acceptance | overview.moderator-mode', hooks => {
             'Option to accept submission exists',
         );
         assert.dom('[data-test-moderation-dropdown-decision-label="accept_submission"]').hasText(
-            'Accept submission',
+            t('registries.makeDecisionDropdown.acceptSubmission'),
             'Accept submission option has correct text',
         );
         assert.dom('[data-test-moderation-dropdown-decision-label="reject_submission"]').exists(
             'Option to reject submission exists',
         );
         assert.dom('[data-test-moderation-dropdown-decision-label="reject_submission"]').hasText(
-            'Reject submission',
+            t('registries.makeDecisionDropdown.rejectSubmission'),
             'Reject submission option has correct text',
         );
         await percySnapshot(assert);
@@ -70,7 +70,7 @@ module('Registries | Acceptance | overview.moderator-mode', hooks => {
         await click('[data-test-state-button]');
         assert.dom('[data-test-state-description-short]').exists('Short description for accepted status exists');
         assert.dom('[data-test-state-description-short]').hasText(
-            t('registries.overview.accepted.short_description').toString(),
+            t('registries.overview.accepted.short_description'),
             'The registration is now accepted',
         );
         assert.dom('[data-test-state-description-long]').hasText(
@@ -112,7 +112,7 @@ module('Registries | Acceptance | overview.moderator-mode', hooks => {
             'Short description for pending_withdraw_request status exists',
         );
         assert.dom('[data-test-state-description-short]').hasText(
-            t('registries.overview.pendingWithdrawRequest.short_description').toString(),
+            t('registries.overview.pendingWithdrawRequest.short_description'),
             'The registration is pending withdraw request',
         );
         assert.dom('[data-test-state-description-long]').hasText(
@@ -128,7 +128,7 @@ module('Registries | Acceptance | overview.moderator-mode', hooks => {
             'Option to force withdraw exists',
         );
         assert.dom('[data-test-moderation-dropdown-decision-label="force_withdraw"]').hasText(
-            'Force withdraw',
+            t('registries.makeDecisionDropdown.forceWithdraw'),
             'Force withdraw option has correct text',
         );
         await percySnapshot(assert);
@@ -149,7 +149,7 @@ module('Registries | Acceptance | overview.moderator-mode', hooks => {
             'Short description for pending_withdraw status exists',
         );
         assert.dom('[data-test-state-description-short]').hasText(
-            t('registries.overview.pendingWithdraw.short_description').toString(),
+            t('registries.overview.pendingWithdraw.short_description'),
             'The registration is pending withdraw',
         );
         assert.dom('[data-test-state-description-long]').hasText(
@@ -162,14 +162,14 @@ module('Registries | Acceptance | overview.moderator-mode', hooks => {
             'Option to accept withdraw exists',
         );
         assert.dom('[data-test-moderation-dropdown-decision-label="accept_withdrawal"]').hasText(
-            'Accept withdrawal',
+            t('registries.makeDecisionDropdown.acceptWithdrawal'),
             'Accept withdrawal option has correct text',
         );
         assert.dom('[data-test-moderation-dropdown-decision-label="reject_withdrawal"]').exists(
             'Option to reject withdraw exists',
         );
         assert.dom('[data-test-moderation-dropdown-decision-label="reject_withdrawal"]').hasText(
-            'Reject withdrawal',
+            t('registries.makeDecisionDropdown.rejectWithdrawal'),
             'Reject withdrawal option has correct text',
         );
         await percySnapshot(assert);
@@ -193,7 +193,7 @@ module('Registries | Acceptance | overview.moderator-mode', hooks => {
         await click('[data-test-state-button]');
         assert.dom('[data-test-state-description-short]').exists('Short description for accepted status exists');
         assert.dom('[data-test-state-description-short]').hasText(
-            t('registries.overview.accepted.short_description').toString(),
+            t('registries.overview.accepted.short_description'),
             'The registration is now accepted',
         );
         assert.dom('[data-test-state-description-long]').hasText(
@@ -215,7 +215,7 @@ module('Registries | Acceptance | overview.moderator-mode', hooks => {
             'Short description for accepted status exists',
         );
         assert.dom('[data-test-state-description-short]').hasText(
-            t('registries.overview.accepted.short_description').toString(),
+            t('registries.overview.accepted.short_description'),
             'The registration is accepted',
         );
         assert.dom('[data-test-state-description-long]').hasText(
@@ -231,7 +231,7 @@ module('Registries | Acceptance | overview.moderator-mode', hooks => {
             'Option to force withdraw exists',
         );
         assert.dom('[data-test-moderation-dropdown-decision-label="force_withdraw"]').hasText(
-            'Force withdraw',
+            t('registries.makeDecisionDropdown.forceWithdraw'),
             'Force withdraw option has correct text',
         );
         await percySnapshot(assert);
@@ -253,7 +253,7 @@ module('Registries | Acceptance | overview.moderator-mode', hooks => {
             'Short description for embargo status exists',
         );
         assert.dom('[data-test-state-description-short]').hasText(
-            t('registries.overview.embargo.short_description').toString(),
+            t('registries.overview.embargo.short_description'),
             'The registration is in embargo',
         );
         assert.dom('[data-test-state-description-long]').hasText(
@@ -273,7 +273,7 @@ module('Registries | Acceptance | overview.moderator-mode', hooks => {
             'Option to force withdraw exists',
         );
         assert.dom('[data-test-moderation-dropdown-decision-label="force_withdraw"]').hasText(
-            'Force withdraw',
+            t('registries.makeDecisionDropdown.forceWithdraw'),
             'Force withdraw option has correct text',
         );
         await percySnapshot(assert);
@@ -294,7 +294,7 @@ module('Registries | Acceptance | overview.moderator-mode', hooks => {
             'Short description for pending_embargo_termination status exists',
         );
         assert.dom('[data-test-state-description-short]').hasText(
-            t('registries.overview.pendingEmbargoTermination.short_description').toString(),
+            t('registries.overview.pendingEmbargoTermination.short_description'),
             'The registration is pending embargo termination',
         );
         assert.dom('[data-test-state-description-long]').hasText(
@@ -314,7 +314,7 @@ module('Registries | Acceptance | overview.moderator-mode', hooks => {
             'Option to force withdraw exists',
         );
         assert.dom('[data-test-moderation-dropdown-decision-label="force_withdraw"]').hasText(
-            'Force withdraw',
+            t('registries.makeDecisionDropdown.forceWithdraw'),
             'Force withdraw option has correct text',
         );
         await percySnapshot(assert);

--- a/tests/engines/registries/integration/components/make-decision-dropdown/component-test.ts
+++ b/tests/engines/registries/integration/components/make-decision-dropdown/component-test.ts
@@ -80,8 +80,8 @@ module('Registries | Integration | Component | make-decision-dropdown', hooks =>
                     .isVisible(`'${actionTrigger}' checkbox option is visible`);
                 assert.dom(`[data-test-moderation-dropdown-decision-checkbox=${actionTrigger}]`)
                     .isNotChecked(`'${actionTrigger}' checkbox option is not checked by default`);
-                assert.dom('[data-test-moderation-action-text]').hasAnyText();
-                assert.dom(`[data-test-moderation-action-text=${actionTrigger}`).hasText(
+                assert.dom('[data-test-moderation-dropdown-decision-label]').hasAnyText();
+                assert.dom(`[data-test-moderation-dropdown-decision-label=${actionTrigger}]`).hasText(
                     t(`registries.makeDecisionDropdown.${camelize(actionTrigger)}`),
                     'has the right action trigger text',
                 );

--- a/tests/engines/registries/integration/components/make-decision-dropdown/component-test.ts
+++ b/tests/engines/registries/integration/components/make-decision-dropdown/component-test.ts
@@ -1,0 +1,109 @@
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupIntl, t } from 'ember-intl/test-support';
+import { TestContext } from 'ember-test-helpers';
+
+import { RegistrationReviewStates } from 'ember-osf-web/models/registration';
+import { ReviewActionTrigger } from 'ember-osf-web/models/review-action';
+import { setupEngineRenderingTest } from 'ember-osf-web/tests/helpers/engines';
+import { module, test } from 'qunit';
+
+module('Registries | Integration | Component | make-decision-dropdown', hooks => {
+    setupEngineRenderingTest(hooks, 'registries');
+    setupIntl(hooks);
+    setupMirage(hooks);
+
+    const testCases: {
+        [key in RegistrationReviewStates]: {
+            actions: ReviewActionTrigger[],
+            commentLabel?: string,
+            commentPlaceholder?: string,
+        }
+    } = {
+        [RegistrationReviewStates.Pending]: {
+            actions: [ReviewActionTrigger.AcceptSubmission, ReviewActionTrigger.RejectSubmission],
+            commentLabel: 'registries.makeDecisionDropdown.additionalComment',
+            commentPlaceholder: 'registries.makeDecisionDropdown.additionalCommentPlaceholder',
+        },
+        [RegistrationReviewStates.PendingWithdraw]: {
+            actions: [ReviewActionTrigger.AcceptWithdrawal, ReviewActionTrigger.RejectWithdrawal],
+            commentLabel: 'registries.makeDecisionDropdown.additionalComment',
+            commentPlaceholder: 'registries.makeDecisionDropdown.additionalCommentPlaceholder',
+        },
+        [RegistrationReviewStates.Accepted]: {
+            actions: [ReviewActionTrigger.ForceWithdraw],
+            commentLabel: 'registries.makeDecisionDropdown.justificationForWithdrawal',
+            commentPlaceholder: 'registries.makeDecisionDropdown.justificationForWithdrawalPlaceholder',
+        },
+        [RegistrationReviewStates.Embargo]: {
+            actions: [ReviewActionTrigger.ForceWithdraw],
+            commentLabel: 'registries.makeDecisionDropdown.justificationForWithdrawal',
+            commentPlaceholder: 'registries.makeDecisionDropdown.justificationForWithdrawalPlaceholder',
+        },
+        [RegistrationReviewStates.PendingWithdrawRequest]: {
+            actions: [ReviewActionTrigger.ForceWithdraw],
+            commentLabel: 'registries.makeDecisionDropdown.justificationForWithdrawal',
+            commentPlaceholder: 'registries.makeDecisionDropdown.justificationForWithdrawalPlaceholder',
+        },
+        [RegistrationReviewStates.PendingEmbargoTermination]: {
+            actions: [ReviewActionTrigger.ForceWithdraw],
+            commentLabel: 'registries.makeDecisionDropdown.justificationForWithdrawal',
+            commentPlaceholder: 'registries.makeDecisionDropdown.justificationForWithdrawalPlaceholder',
+        },
+        [RegistrationReviewStates.Rejected]: {
+            actions: [],
+        },
+        [RegistrationReviewStates.Initial]: {
+            actions: [],
+        },
+        [RegistrationReviewStates.Withdrawn]: {
+            actions: [],
+        },
+    };
+
+    for (const reviewsState of (Object.keys(testCases) as RegistrationReviewStates[])) {
+        test(`shows the right actions based on state: ${reviewsState}`, async function(this: TestContext, assert) {
+            const registration = server.create('registration', {
+                provider: server.create('registration-provider', 'currentUserIsModerator'),
+                reviewsState,
+            }, 'withReviewActions');
+
+            this.set('registration', registration);
+
+            await render(hbs`<MakeDecisionDropdown @registration={{this.registration}} />`);
+            await click('[data-test-moderation-dropdown-button]');
+
+            testCases[reviewsState].actions.forEach(actionTrigger => {
+                assert.dom(`[data-test-moderation-dropdown-decision-checkbox=${actionTrigger}]`)
+                    .isVisible(`'${actionTrigger}' checkbox option is visible`);
+                assert.dom(`[data-test-moderation-dropdown-decision-checkbox=${actionTrigger}]`)
+                    .isNotChecked(`'${actionTrigger}' checkbox option is not checked by default`);
+                assert.dom('[data-test-moderation-action-text]').hasAnyText();
+                assert.dom(`[data-test-moderation-action-text=${actionTrigger}`).hasText(
+                    (actionTrigger.charAt(0).toUpperCase() + actionTrigger.slice(1)).replace('_', ' '),
+                    'has the right action trigger text',
+                );
+            });
+
+            if (testCases[reviewsState].actions.length) {
+                assert.dom('[data-test-moderation-dropdown-action-label]')
+                    .hasText(`${t(testCases[reviewsState].commentLabel!)}`, 'Comment label has the right text');
+                assert.dom('[data-test-moderation-dropdown-comment]')
+                    .hasAttribute('placeholder', `${t(testCases[reviewsState].commentPlaceholder!)}`,
+                        'Comment placeholder has the right text');
+                assert.dom('[data-test-moderation-dropdown-submit]')
+                    .isDisabled('Submit button is disabled by default');
+            } else {
+                assert.dom('[data-test-moderation-dropdown-comment]')
+                    .doesNotExist('No actions in non-actionable states');
+                assert.dom('[data-test-moderation-dropdown-action-label]')
+                    .doesNotExist('No comment label in non-actionable states');
+                assert.dom('[data-test-moderation-dropdown-submit]')
+                    .doesNotExist('No submit button in non-actionable states');
+                assert.dom('[data-test-no-moderator-actions]')
+                    .isVisible('No moderator action text in non-actionable states');
+            }
+        });
+    }
+});

--- a/tests/engines/registries/integration/components/make-decision-dropdown/component-test.ts
+++ b/tests/engines/registries/integration/components/make-decision-dropdown/component-test.ts
@@ -1,3 +1,4 @@
+import { camelize } from '@ember/string';
 import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -81,7 +82,7 @@ module('Registries | Integration | Component | make-decision-dropdown', hooks =>
                     .isNotChecked(`'${actionTrigger}' checkbox option is not checked by default`);
                 assert.dom('[data-test-moderation-action-text]').hasAnyText();
                 assert.dom(`[data-test-moderation-action-text=${actionTrigger}`).hasText(
-                    (actionTrigger.charAt(0).toUpperCase() + actionTrigger.slice(1)).replace('_', ' '),
+                    t(`registries.makeDecisionDropdown.${camelize(actionTrigger)}`),
                     'has the right action trigger text',
                 );
             });

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1364,6 +1364,7 @@ registries:
         additionalCommentPlaceholder: 'Add remarks to registration admins'
         justificationForWithdrawal: 'Justification for Withdrawal'
         justificationForWithdrawalPlaceholder: 'Provide justification for withdrawal'
+        noModeratorActions: 'No moderator decision can be made at this time'
 meetings:
     index:
         meetings-list:

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1347,15 +1347,15 @@ registries:
         label: 'Share this registration via {mediaType}'
     makeDecisionDropdown:
         makeDecision: 'Make Decision'
-        acceptSubmission: 'Accept Submission'
+        acceptSubmission: 'Accept submission'
         acceptSubmissionDescription: 'Registration will appear in search results and be made public. Embargoed registrations will only become public after embargo end date.'
-        rejectSubmission: 'Reject Submission'
+        rejectSubmission: 'Reject submission'
         rejectSubmissionDescription: 'Registration will not appear in search results and will return to a private draft state'
-        forceWithdraw: 'Force Withdraw'
+        forceWithdraw: 'Force withdraw'
         forceWithdrawDescription: 'Registration will be withdrawn but still have a tombstone page with a justification for withdrawal and a subset of the metadata available'
-        acceptWithdrawal: 'Accept Withdrawal'
+        acceptWithdrawal: 'Accept withdrawal'
         acceptWithdrawalDescription: 'Registration will be withdrawn but still have a tombstone page with a justification for withdrawal and subset of the metadata available'
-        rejectWithdrawal: 'Reject Withdrawal'
+        rejectWithdrawal: 'Reject withdrawal'
         rejectWithdrawalDescription: 'Registration will remain fully public'
         submit: 'Submit'
         success: 'Successfully submitted moderator decision.'
@@ -1364,7 +1364,7 @@ registries:
         additionalCommentPlaceholder: 'Add remarks to registration admins'
         justificationForWithdrawal: 'Justification for Withdrawal'
         justificationForWithdrawalPlaceholder: 'Provide justification for withdrawal'
-        noModeratorActions: 'No moderator decision can be made at this time'
+        noModeratorActions: 'No moderator decisions can be made at this time'
 meetings:
     index:
         meetings-list:


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-2391]
- Feature flag: n/a

## Purpose

Add `make-decision-dropdown` component tests

## Summary of Changes
- Add tests
- Added `hasModeratorActions` to fix an edge-case where comment box and submit button show
despite no action trigger. The edge case occurs when `reviewsState` is `initial` and current user is a moderator and contributor on the registration.
For documentation purposes, I also added `withdrawn`, `rejected` even though this dropdown is currently not shown
in those `reviewsState`s

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-2391]: https://openscience.atlassian.net/browse/ENG-2391