### PR TITLE
[ENG-2454] Update date-registered sort on registration-list

### DIFF
--- a/lib/registries/addon/components/registration-list/manager/component.ts
+++ b/lib/registries/addon/components/registration-list/manager/component.ts
@@ -7,7 +7,7 @@ export default class RegistrationListManager extends Component {
     reloadRegistrationsList!: () => void;
     state!: RegistrationReviewStates | string;
 
-    sort: string = 'date_registered';
+    sort: string = '-date_registered';
 
     @computed('state', 'sort')
     get filterParams() {


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-2454
- Feature flag: `N/A`

## Purpose

To update the default sort parameter for the `registration-list` to be newest to oldest.

## Summary of Changes

- Update the `date_registered` parameter to be `-date_registered`

## Side Effects

`N/A`

## QA Notes

This should make the sort on all states be newest first.
