### PR TITLE
[ENG-2409] Add license help text and link

### DIFF
--- a/lib/registries/addon/components/registries-license-picker/styles.scss
+++ b/lib/registries/addon/components/registries-license-picker/styles.scss
@@ -21,3 +21,8 @@
 .Required {
     color: $brand-danger;
 }
+
+.LicenseHelpText.LicenseHelpText {
+    font-style: italic;
+    color: $color-text-placeholder-grey-dark;
+}

--- a/lib/registries/addon/components/registries-license-picker/template.hbs
+++ b/lib/registries/addon/components/registries-license-picker/template.hbs
@@ -2,6 +2,7 @@
     @changeset={{@manager.changeset}}
     as |form|
 >
+    <p local-class='LicenseHelpText'>{{t 'registries.registration_metadata.license_help_text' htmlSafe=true}}</p>
     <div data-test-license-edit-form>
         {{#if @manager.licensesAcceptable}}
             <form.select

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1113,6 +1113,7 @@ registries:
     registration_metadata:
         add_description: 'Add description'
         add_license: 'Add license'
+        license_help_text: 'A license tells others how they can use your work in the future and only applies to the information and files submitted with the registration. For more information, see this <a href=''https://help.osf.io/hc/en-us/articles/360019739014-Licensing''>article on licenses</a>.'
         affiliated_institutions: 'Affiliated institutions'
         category: Category
         choose_license: 'Choose a License'


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-2409
- Feature flag: `N/A`

## Purpose

To add help text to the license metadata section when submitting a new registration.

## Summary of Changes

- Add translation for help text with link
- Add styling

<img width="681" alt="Screen Shot 2020-12-08 at 2 29 27 PM" src="https://user-images.githubusercontent.com/19379783/101540732-74946480-396e-11eb-8c74-90caf1548783.png">

## Side Effects

`N/A`

## QA Notes

This should only add help text to the license picker section of the submission form.
