### PR TITLE
[ENG-2496] Replace validated models in settings.account route

### DIFF
--- a/app/models/user-email.ts
+++ b/app/models/user-email.ts
@@ -1,8 +1,5 @@
-import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
-import { buildValidations, validator } from 'ember-cp-validations';
 import DS from 'ember-data';
-import config from 'ember-get-config';
 import { Link } from 'jsonapi-typescript';
 
 import OsfModel, { OsfLinks } from './osf-model';

--- a/app/models/user-email.ts
+++ b/app/models/user-email.ts
@@ -10,38 +10,11 @@ import UserModel from './user';
 
 const { attr, belongsTo } = DS;
 
-const { support: { supportEmail } } = config;
-
-const Validations = buildValidations({
-    emailAddress: [
-        validator('presence', true),
-        validator('format', { type: 'email' }),
-        validator('length', {
-            max: 255,
-        }),
-        validator('exclusion', {
-            messageKey: 'validationErrors.email_duplicate',
-            in: computed(function(): string[] {
-                return [...this.model.existingEmails];
-            // eslint-disable-next-line ember/no-volatile-computed-properties
-            }).volatile(),
-        }),
-        validator('exclusion', {
-            messageKey: 'validationErrors.email_invalid',
-            supportEmail,
-            in: computed(function(): string[] {
-                return [...this.model.invalidEmails];
-            // eslint-disable-next-line ember/no-volatile-computed-properties
-            }).volatile(),
-        }),
-    ],
-});
-
 export interface UserEmailLinks extends OsfLinks {
     resend_confirmation: Link; // eslint-disable-line camelcase
 }
 
-export default class UserEmailModel extends OsfModel.extend(Validations) {
+export default class UserEmailModel extends OsfModel {
     @attr() links!: UserEmailLinks;
     @attr() emailAddress!: string;
     @attr('boolean') confirmed!: boolean;

--- a/app/settings/account/-components/connected-emails/component.ts
+++ b/app/settings/account/-components/connected-emails/component.ts
@@ -143,7 +143,7 @@ export default class ConnectedEmails extends Component {
             this.changeset.validate();
             if (this.changeset.get('isValid') && this.changeset.get('emailAddress')) {
                 this.set('lastUserEmail', this.changeset.get('emailAddress'));
-                newEmail = yield this.store.createRecord('user-email', {
+                newEmail = this.store.createRecord('user-email', {
                     emailAddress: this.changeset.get('emailAddress'),
                     user: this.currentUser.user,
                 });
@@ -157,7 +157,7 @@ export default class ConnectedEmails extends Component {
                 newEmail.unloadRecord();
             }
             captureException(e);
-            this.toast.error(getApiErrorMessage(e));
+            this.toast.error(getApiErrorMessage(e), this.intl.t('settings.account.connected_emails.save_fail'));
         }
     });
 

--- a/app/settings/account/-components/connected-emails/component.ts
+++ b/app/settings/account/-components/connected-emails/component.ts
@@ -20,16 +20,6 @@ interface EmailValidation {
     emailAddress: string;
 }
 
-const emailValidations: ValidationObject<EmailValidation> = {
-    emailAddress: [
-        validateFormat({
-            allowBlank: false,
-            type: 'email',
-            translationArgs: { description: 'Email address' },
-        }),
-    ],
-};
-
 export default class ConnectedEmails extends Component {
     // Private properties
     @service currentUser!: CurrentUser;
@@ -45,6 +35,16 @@ export default class ConnectedEmails extends Component {
     reloadUnconfirmedList!: (page?: number) => void; // bound by paginated-list
     alternateQueryParams = { 'filter[primary]': false, 'filter[confirmed]': true };
     unconfirmedQueryParams = { 'filter[primary]': false, 'filter[confirmed]': false };
+
+    emailValidations: ValidationObject<EmailValidation> = {
+        emailAddress: [
+            validateFormat({
+                allowBlank: false,
+                type: 'email',
+                translationArgs: { description: this.intl.t('settings.account.connected_emails.email_address') },
+            }),
+        ],
+    };
 
     @task({ withTestWaiter: true, restartable: true })
     loadPrimaryEmail = task(function *(this: ConnectedEmails) {
@@ -164,7 +164,7 @@ export default class ConnectedEmails extends Component {
     init() {
         super.init();
         this.loadPrimaryEmail.perform();
-        this.changeset = buildChangeset({ emailAddress: '' }, emailValidations);
+        this.changeset = buildChangeset({ emailAddress: '' }, this.emailValidations, { skipValidate: true });
     }
 
     @action

--- a/app/settings/account/-components/connected-emails/component.ts
+++ b/app/settings/account/-components/connected-emails/component.ts
@@ -151,6 +151,7 @@ export default class ConnectedEmails extends Component {
                 this.set('showAddModal', true);
                 this.reloadUnconfirmedList();
                 this.toast.success(this.intl.t('settings.account.connected_emails.save_success'));
+                this.changeset.set('emailAddress', '');
             }
         } catch (e) {
             if (newEmail) {

--- a/app/settings/account/-components/connected-emails/component.ts
+++ b/app/settings/account/-components/connected-emails/component.ts
@@ -1,6 +1,9 @@
 import Component from '@ember/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { ValidationObject } from 'ember-changeset-validations';
+import { validateFormat } from 'ember-changeset-validations/validators';
+import { ChangesetDef } from 'ember-changeset/types';
 import { task } from 'ember-concurrency-decorators';
 import DS from 'ember-data';
 import Intl from 'ember-intl/services/intl';
@@ -9,10 +12,23 @@ import Toast from 'ember-toastr/services/toast';
 import { QueryHasManyResult } from 'ember-osf-web/models/osf-model';
 import UserEmail from 'ember-osf-web/models/user-email';
 import CurrentUser from 'ember-osf-web/services/current-user';
+import buildChangeset from 'ember-osf-web/utils/build-changeset';
 import captureException, { getApiErrorMessage } from 'ember-osf-web/utils/capture-exception';
-
-import { ChangesetDef } from 'ember-changeset/types';
 import getHref from 'ember-osf-web/utils/get-href';
+
+interface EmailValidation {
+    emailAddress: string;
+}
+
+const emailValidations: ValidationObject<EmailValidation> = {
+    emailAddress: [
+        validateFormat({
+            allowBlank: false,
+            type: 'email',
+            translationArgs: { description: 'Email address' },
+        }),
+    ],
+};
 
 export default class ConnectedEmails extends Component {
     // Private properties
@@ -20,12 +36,11 @@ export default class ConnectedEmails extends Component {
     @service store!: DS.Store;
     @service intl!: Intl;
     @service toast!: Toast;
-    userEmail!: UserEmail;
     showAddModal = false;
     showMergeModal = false;
     didValidate = false;
     lastUserEmail = '';
-    modelProperties = { user: this.currentUser.user };
+    changeset!: ChangesetDef;
     reloadAlternateList!: (page?: number) => void; // bound by paginated-list
     reloadUnconfirmedList!: (page?: number) => void; // bound by paginated-list
     alternateQueryParams = { 'filter[primary]': false, 'filter[confirmed]': true };
@@ -121,34 +136,35 @@ export default class ConnectedEmails extends Component {
         return this.toast.success(successMessage);
     });
 
+    @task({ withTestWaiter: true })
+    onSave = task(function *(this: ConnectedEmails) {
+        let newEmail;
+        try {
+            this.changeset.validate();
+            if (this.changeset.get('isValid') && this.changeset.get('emailAddress')) {
+                this.set('lastUserEmail', this.changeset.get('emailAddress'));
+                newEmail = yield this.store.createRecord('user-email', {
+                    emailAddress: this.changeset.get('emailAddress'),
+                    user: this.currentUser.user,
+                });
+                yield newEmail.save();
+                this.set('showAddModal', true);
+                this.reloadUnconfirmedList();
+                this.toast.success(this.intl.t('settings.account.connected_emails.save_success'));
+            }
+        } catch (e) {
+            if (newEmail) {
+                newEmail.unloadRecord();
+            }
+            captureException(e);
+            this.toast.error(getApiErrorMessage(e));
+        }
+    });
+
     init() {
         super.init();
         this.loadPrimaryEmail.perform();
-    }
-
-    @action
-    onSave(changeset: ChangesetDef & UserEmail) {
-        if (changeset.get('emailAddress')) {
-            this.set('lastUserEmail', changeset.get('emailAddress'));
-            this.set('showAddModal', true);
-            this.reloadUnconfirmedList();
-
-            this.toast.success(this.intl.t('settings.account.connected_emails.save_success'));
-        }
-    }
-    @action
-    onError(e: DS.AdapterError | Error, changeset: ChangesetDef & UserEmail) {
-        if (e instanceof DS.ConflictError) {
-            const emailSet = changeset.get('existingEmails');
-            emailSet.add(changeset.get('emailAddress'));
-            changeset.validate();
-        } else if (e instanceof DS.AdapterError) {
-            const emailSet = changeset.get('invalidEmails');
-            emailSet.add(changeset.get('emailAddress'));
-            changeset.validate();
-        } else {
-            this.toast.error(e.message);
-        }
+        this.changeset = buildChangeset({ emailAddress: '' }, emailValidations);
     }
 
     @action

--- a/app/settings/account/-components/connected-emails/template.hbs
+++ b/app/settings/account/-components/connected-emails/template.hbs
@@ -191,7 +191,7 @@
                     data-analytics-name='add email'
                     @buttonType='submit'
                     @local-class='add-email-button'
-                    @disabled={{this.changeset.isInvalid}}
+                    @disabled={{or this.changeset.isInvalid this.onSave.isRunning}}
                     {{on 'click' (perform this.onSave)}}
                 >
                     {{t 'settings.account.connected_emails.add_email'}}

--- a/app/settings/account/-components/connected-emails/template.hbs
+++ b/app/settings/account/-components/connected-emails/template.hbs
@@ -175,15 +175,10 @@
             <p local-class='merge-explanation'>
                 {{t 'settings.account.connected_emails.merge_explanation'}}
             </p>
-            <ValidatedModelForm
+            <FormControls
                 data-analytics-scope='Add email form'
-                @onSave={{action this.onSave}}
-                @onError={{action this.onError}}
-                @modelName='userEmail'
-                @modelProperties={{this.modelProperties}}
-                @recreateModel={{true}}
-                as |form|
-            >
+                @changeset={{this.changeset}}
+            as |form|>
                 <form.text
                     data-test-add-email
                     @local-class='input-form'
@@ -196,10 +191,12 @@
                     data-analytics-name='add email'
                     @buttonType='submit'
                     @local-class='add-email-button'
+                    @disabled={{this.changeset.isInvalid}}
+                    {{on 'click' (perform this.onSave)}}
                 >
                     {{t 'settings.account.connected_emails.add_email'}}
                 </OsfButton>
-            </ValidatedModelForm>
+            </FormControls>
             <BsModal
                 @open={{this.showAddModal}}
                 @tagName='span'

--- a/app/settings/account/-components/default-region/component.ts
+++ b/app/settings/account/-components/default-region/component.ts
@@ -25,8 +25,6 @@ const regionValidation: ValidationObject<RegionValidation> = {
     defaultRegion: [
         validatePresence({
             presence: true,
-            ignoreBlank: true,
-            allowBlank: false,
             allowNone: false,
         }),
     ],
@@ -64,7 +62,7 @@ export default class DefaultRegionPane extends Component {
     @task({ withTestWaiter: true })
     updateRegion = task(function *(this: DefaultRegionPane) {
         this.changeset.validate();
-        if (this.changeset.get('isValid') && this.user) {
+        if (this.changeset.isValid && this.user) {
             try {
                 yield this.changeset.save({});
                 this.toast.success(

--- a/app/settings/account/-components/default-region/component.ts
+++ b/app/settings/account/-components/default-region/component.ts
@@ -57,7 +57,7 @@ export default class DefaultRegionPane extends Component {
             return;
         }
         this.set('user', user);
-        this.changeset = buildChangeset(user, regionValidation);
+        this.changeset = buildChangeset(user, regionValidation, { skipValidate: true });
         yield user.belongsTo('defaultRegion').reload();
     });
 

--- a/app/settings/account/-components/default-region/template.hbs
+++ b/app/settings/account/-components/default-region/template.hbs
@@ -4,13 +4,10 @@
 >
     <panel.heading @title={{t 'settings.account.defaultRegion.title'}} />
     <panel.body data-analytics-scope='Default region panel'>
-        <ValidatedModelForm
-            @onSave={{action this.updateRegion}}
-            @onError={{action this.updateError}}
-            @model={{this.user}}
+        <FormControls
             @disabled={{or this.loadDefaultRunning this.loadRegionsRunning}}
-            as |form|
-        >
+            @changeset={{this.changeset}}
+        as |form|>
             {{#if (or this.loadDefaultRunning this.loadRegionsRunning)}}
                 <ContentPlaceholders as |placeholder|>
                     <placeholder.text @lines={{1}} />
@@ -19,12 +16,11 @@
                 <form.select
                     data-test-region-selector
                     @renderInPlace={{true}}
-                    @selected={{this.user.defaultRegion.name}}
-                    @model={{this.user}}
-                    @valuePath='defaultRegion'
+                    @selected={{this.selectedRegion}}
+                    @valuePath={{'defaultRegion'}}
                     @options={{this.regions}}
                     @searchEnabled={{false}}
-                    @placeholder={{this.user.defaultRegion.name}}
+                    @placeholder={{this.selectedRegion.name}}
                     as |regionOption|
                 >
                     {{regionOption.name}}
@@ -38,9 +34,10 @@
                 data-analytics-name='Submit'
                 type='submit'
                 @disabled={{form.disabled}}
+                {{on 'click' (perform this.updateRegion)}}
             >
                 {{t 'settings.account.defaultRegion.updateButton'}}
             </OsfButton>
-        </ValidatedModelForm>
+        </FormControls>
     </panel.body>
 </Panel>

--- a/app/settings/account/-components/default-region/template.hbs
+++ b/app/settings/account/-components/default-region/template.hbs
@@ -33,7 +33,7 @@
                 data-test-update-region-button
                 data-analytics-name='Submit'
                 type='submit'
-                @disabled={{form.disabled}}
+                @disabled={{or form.disabled this.updateRegion.isRunning}}
                 {{on 'click' (perform this.updateRegion)}}
             >
                 {{t 'settings.account.defaultRegion.updateButton'}}

--- a/app/settings/account/-components/security/component.ts
+++ b/app/settings/account/-components/security/component.ts
@@ -25,24 +25,6 @@ interface SecurityValidation {
     twoFactorVerification: string;
 }
 
-const securityValidations: ValidationObject<SecurityValidation> = {
-    twoFactorVerification: [
-        validatePresence({
-            presence: true,
-            ignoreBlank: true,
-            type: 'empty',
-        }),
-        validateNumber({
-            allowBlank: false,
-            allowNone: false,
-            allowString: true,
-            integer: true,
-            positive: true,
-            type: 'invalid',
-            translationArgs: { description: 'Verification code' },
-        }),
-    ],
-};
 @tagName('')
 export default class SecurityPane extends Component {
     @service currentUser!: CurrentUser;
@@ -57,6 +39,25 @@ export default class SecurityPane extends Component {
 
     @tracked showError = false;
 
+    securityValidations: ValidationObject<SecurityValidation> = {
+        twoFactorVerification: [
+            validatePresence({
+                presence: true,
+                ignoreBlank: true,
+                type: 'empty',
+            }),
+            validateNumber({
+                allowBlank: false,
+                allowNone: false,
+                allowString: true,
+                integer: true,
+                positive: true,
+                type: 'invalid',
+                translationArgs: { description: this.intl.t('settings.account.security.verificationCode') },
+            }),
+        ],
+    };
+
     @task({ withTestWaiter: true })
     loadSettings = task(function *(this: SecurityPane) {
         const { user } = this.currentUser;
@@ -66,7 +67,7 @@ export default class SecurityPane extends Component {
         }
         const settings = yield user.belongsTo('settings').reload();
         this.set('settings', settings);
-        this.changeset = buildChangeset(settings, securityValidations);
+        this.changeset = buildChangeset(settings, this.securityValidations, { skipValidate: true });
     });
 
     @task({ withTestWaiter: true })

--- a/app/settings/account/-components/security/template.hbs
+++ b/app/settings/account/-components/security/template.hbs
@@ -44,7 +44,7 @@
                     <div>
                         <form.text
                             data-test-verification-code-field
-                            @valuePath={{'twoFactorVerification'}}
+                            @valuePath='twoFactorVerification'
                             @label={{t 'settings.account.security.enterVerification'}}
                         />
                         {{#if this.showError}}

--- a/app/settings/account/-components/security/template.hbs
+++ b/app/settings/account/-components/security/template.hbs
@@ -37,17 +37,14 @@
                     @height={{260}}
                     @correctLevel='L'
                 />
-                <ValidatedModelForm
+                <FormControls
                     data-analytics-scope='Verification form'
-                    @model={{this.settings}}
-                    @onSave={{action this.verifySecret}}
-                    @onError={{action this.verificationError}}
-                    as |form|
-                >
+                    @changeset={{this.changeset}}
+                as |form|>
                     <div>
                         <form.text
                             data-test-verification-code-field
-                            @valuePath='twoFactorVerification'
+                            @valuePath={{'twoFactorVerification'}}
                             @label={{t 'settings.account.security.enterVerification'}}
                         />
                         {{#if this.showError}}
@@ -63,7 +60,8 @@
                             data-analytics-name='Submit verification'
                             @type='primary'
                             @buttonType='submit'
-                            @disabled={{form.submitting}}
+                            @disabled={{or this.changeset.isInvalid this.verifySecret.isRunning}}
+                            {{on 'click' (perform this.verifySecret)}}
                         >
                             {{t 'settings.account.security.submitVerification'}}
                         </BsButton>
@@ -75,7 +73,7 @@
                             {{t 'general.cancel'}}
                         </BsButton>
                     </div>
-                </ValidatedModelForm>
+                </FormControls>
             {{/if}}
             {{#if (and this.settings.twoFactorEnabled this.settings.twoFactorConfirmed)}}
                 <BsButton

--- a/tests/acceptance/settings/account/security-test.ts
+++ b/tests/acceptance/settings/account/security-test.ts
@@ -145,6 +145,7 @@ module('Acceptance | settings/account | security', hooks => {
         assert.dom('[data-test-verification-code-field] .help-block')
             .includesText('Verification code is invalid');
         await fillIn('[data-test-verification-code-field] input', 'a');
+        await click('[data-test-verify-button]');
         assert.dom('[data-test-verification-code-field] .help-block')
             .includesText('Verification code is invalid.');
 

--- a/tests/acceptance/settings/account/security-test.ts
+++ b/tests/acceptance/settings/account/security-test.ts
@@ -141,10 +141,12 @@ module('Acceptance | settings/account | security', hooks => {
         assertionsEnabledNotConfirmed(assert, 'Initial state');
         await click('[data-test-verify-button]');
         assert.dom('[data-test-verification-code-field] .help-block')
-            .containsText('This field can\'t be blank');
+            .includesText('This field can\'t be empty');
+        assert.dom('[data-test-verification-code-field] .help-block')
+            .includesText('Verification code is invalid');
         await fillIn('[data-test-verification-code-field] input', 'a');
         assert.dom('[data-test-verification-code-field] .help-block')
-            .containsText('This field must be a number.');
+            .includesText('Verification code is invalid.');
 
         /* I don't think I can test this properly right now. Ember qunit has a problem with waiting
         so long for catching the assertion.

--- a/tests/acceptance/settings/settings-test.ts
+++ b/tests/acceptance/settings/settings-test.ts
@@ -26,6 +26,8 @@ function assertionsEnabledNotConfirmed(assert: Assert, testState: string) {
         .exists(`${testState} - Verification field exists`);
     assert.dom('[data-test-verify-button]')
         .exists(`${testState} - Verify button is shown`);
+    assert.dom('[data-test-verification-code-field] .help-block')
+        .doesNotExist(`${testState} - No error from security panel`);
 }
 
 module('Acceptance | settings', hooks => {
@@ -45,16 +47,12 @@ module('Acceptance | settings', hooks => {
         );
         await visit('/settings/account');
         assertionsEnabledNotConfirmed(assert, 'Initital state');
-        assert.dom('[data-test-verification-code-field] .help-block')
-            .doesNotExist('Initital state - No error from security panel');
         await fillIn('[data-test-verification-code-field] input', 'a');
         await click('[data-analytics-name="Deactivation request"]');
         await click('[data-test-confirm-deactivation-submit]');
         assertionsEnabledNotConfirmed(assert, 'After deactivation');
-        assert.dom('[data-test-verification-code-field] .help-block')
-            .exists('After deactivation - Error exists from security panel');
         await click('[data-test-verify-button]');
         assert.dom('[data-test-verification-code-field] .help-block')
-            .containsText('Verification code is invalid.');
+            .containsText('Verification code is invalid.', 'End test');
     });
 });

--- a/tests/acceptance/settings/settings-test.ts
+++ b/tests/acceptance/settings/settings-test.ts
@@ -26,8 +26,6 @@ function assertionsEnabledNotConfirmed(assert: Assert, testState: string) {
         .exists(`${testState} - Verification field exists`);
     assert.dom('[data-test-verify-button]')
         .exists(`${testState} - Verify button is shown`);
-    assert.dom('[data-test-verification-code-field] .help-block')
-        .doesNotExist(`${testState} - No error from security panel`);
 }
 
 module('Acceptance | settings', hooks => {
@@ -47,12 +45,16 @@ module('Acceptance | settings', hooks => {
         );
         await visit('/settings/account');
         assertionsEnabledNotConfirmed(assert, 'Initital state');
+        assert.dom('[data-test-verification-code-field] .help-block')
+            .doesNotExist('Initital state - No error from security panel');
         await fillIn('[data-test-verification-code-field] input', 'a');
         await click('[data-analytics-name="Deactivation request"]');
         await click('[data-test-confirm-deactivation-submit]');
         assertionsEnabledNotConfirmed(assert, 'After deactivation');
+        assert.dom('[data-test-verification-code-field] .help-block')
+            .exists('After deactivation - Error exists from security panel');
         await click('[data-test-verify-button]');
         assert.dom('[data-test-verification-code-field] .help-block')
-            .containsText('This field must be a number.');
+            .containsText('Verification code is invalid.');
     });
 });

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1705,6 +1705,7 @@ settings:
             disableButton: Disable
             saveError: 'Could not make this change. Try again in a few minutes. If the issue persists, please report it to <a href="mailto:{supportEmail}">{supportEmail}</a>.'
             submitVerification: Enable
+            verificationCode: 'Verification code'
         title: 'Account settings'
         connected_emails:
             add_email: 'Add email'
@@ -1737,6 +1738,7 @@ settings:
             unconfirmed_emails: 'Unconfirmed emails'
             update_fail: 'Unable to update email'
             update_success: 'Email updated'
+            email_address: 'Email address'
         changePassword:
             title: 'Change password'
             updateButton: 'Update password'


### PR DESCRIPTION
- Ticket: [ENG-2496]
- Feature flag: n/a

## Purpose
- Replace validated-model-form with form-controls

## Summary of Changes
- Replaced validated model form in Settings::Account::-Components::ConnectedEmails
- Replaced validated model form in Settings::Account::-Components::DefaultRegion
- Replaced validated model form in Settings::Account::-Components::Security

## Side Effects
NA

## QA Notes
- The connected emails panel (adding a new email for the user), the default storage location panel, and security settings panel on osf.io/settings/account _should_ function the same, but a quick spot check is always appreciated! 


[ENG-1528]: https://openscience.atlassian.net/browse/ENG-1528

[ENG-2496]: https://openscience.atlassian.net/browse/ENG-2496