### PR TITLE
[ENG-2246] Make registries search button clickable

### DIFF
--- a/lib/registries/addon/components/registries-header/styles.scss
+++ b/lib/registries/addon/components/registries-header/styles.scss
@@ -45,8 +45,8 @@
 
 .SearchIcon {
     position: absolute;
-    top: 10px;
-    left: 14px;
+    top: 9px;
+    left: 8px;
     font-size: 24px;
     color: var(--primary-color);
 

--- a/lib/registries/addon/components/registries-header/styles.scss
+++ b/lib/registries/addon/components/registries-header/styles.scss
@@ -31,7 +31,7 @@
 
     input {
         font-size: 18px;
-        padding: 28px 70px 28px 28px;
+        padding: 28px 50px;
     }
 }
 
@@ -46,7 +46,7 @@
 .SearchIcon {
     position: absolute;
     top: 10px;
-    right: 10px;
+    left: 14px;
     font-size: 24px;
     color: var(--primary-color);
 
@@ -58,7 +58,7 @@
 .HelpIcon {
     position: absolute;
     top: 10px;
-    right: 44px;
+    right: 10px;
     font-size: 24px;
     color: var(--primary-color);
 

--- a/lib/registries/addon/components/registries-header/styles.scss
+++ b/lib/registries/addon/components/registries-header/styles.scss
@@ -31,7 +31,7 @@
 
     input {
         font-size: 18px;
-        padding: 28px 50px;
+        padding: 28px 70px 28px 28px;
     }
 }
 
@@ -45,16 +45,20 @@
 
 .SearchIcon {
     position: absolute;
-    top: 16px;
-    left: 14px;
+    top: 10px;
+    right: 10px;
     font-size: 24px;
     color: var(--primary-color);
+
+    &:hover {
+        color: var(--secondary-color);
+    }
 }
 
 .HelpIcon {
     position: absolute;
     top: 10px;
-    right: 10px;
+    right: 44px;
     font-size: 24px;
     color: var(--primary-color);
 

--- a/lib/registries/addon/components/registries-header/template.hbs
+++ b/lib/registries/addon/components/registries-header/template.hbs
@@ -21,13 +21,6 @@
                 data-test-search-form
                 {{action 'onSubmit' on='submit'}}
             >
-                <Button
-                    local-class='SearchIcon'
-                    @layout='fake-link'
-                    {{on 'click' (action this.onSubmit)}}
-                >
-                    <FaIcon @icon='search' />
-                </Button>
                 <label local-class='SearchForm__HiddenLabel' for='search'>{{t 'registries.header.search_label'}}</label>
                 <Input
                     data-test-search-box={{true}}
@@ -46,6 +39,14 @@
                         {{fa-icon 'question'}}
                     </Button>
                 {{/if}}
+                <Button
+                    aria-label={{t 'registries.header.search_button'}}
+                    local-class='SearchIcon'
+                    @layout='fake-link'
+                    {{on 'click' (action this.onSubmit)}}
+                >
+                    <FaIcon @icon='search' />
+                </Button>
             </form>
         </div>
     </div>

--- a/lib/registries/addon/components/registries-header/template.hbs
+++ b/lib/registries/addon/components/registries-header/template.hbs
@@ -21,6 +21,15 @@
                 data-test-search-form
                 {{action 'onSubmit' on='submit'}}
             >
+                <Button
+                    data-test-perform-search-button
+                    aria-label={{t 'registries.header.search_button'}}
+                    local-class='SearchIcon'
+                    @layout='fake-link'
+                    {{on 'click' this.onSubmit}}
+                >
+                    <FaIcon @icon='search' />
+                </Button>
                 <label local-class='SearchForm__HiddenLabel' for='search'>{{t 'registries.header.search_label'}}</label>
                 <Input
                     data-test-search-box={{true}}
@@ -40,15 +49,6 @@
                         {{fa-icon 'question'}}
                     </Button>
                 {{/if}}
-                <Button
-                    data-test-perform-search-button
-                    aria-label={{t 'registries.header.search_button'}}
-                    local-class='SearchIcon'
-                    @layout='fake-link'
-                    {{on 'click' this.onSubmit}}
-                >
-                    <FaIcon @icon='search' />
-                </Button>
             </form>
         </div>
     </div>

--- a/lib/registries/addon/components/registries-header/template.hbs
+++ b/lib/registries/addon/components/registries-header/template.hbs
@@ -21,7 +21,13 @@
                 data-test-search-form
                 {{action 'onSubmit' on='submit'}}
             >
-                {{fa-icon 'search' class=(local-class 'SearchIcon')}}
+                <Button
+                    local-class='SearchIcon'
+                    @layout='fake-link'
+                    {{on 'click' (action this.onSubmit)}}
+                >
+                    <FaIcon @icon='search' />
+                </Button>
                 <label local-class='SearchForm__HiddenLabel' for='search'>{{t 'registries.header.search_label'}}</label>
                 <Input
                     data-test-search-box={{true}}

--- a/lib/registries/addon/components/registries-header/template.hbs
+++ b/lib/registries/addon/components/registries-header/template.hbs
@@ -31,6 +31,7 @@
                 />
                 {{#if this.showHelp}}
                     <Button
+                        data-test-search-help-button
                         aria-label={{t 'registries.header.search_help'}}
                         local-class='HelpIcon'
                         @layout='fake-link'
@@ -40,10 +41,11 @@
                     </Button>
                 {{/if}}
                 <Button
+                    data-test-perform-search-button
                     aria-label={{t 'registries.header.search_button'}}
                     local-class='SearchIcon'
                     @layout='fake-link'
-                    {{on 'click' (action this.onSubmit)}}
+                    {{on 'click' this.onSubmit}}
                 >
                     <FaIcon @icon='search' />
                 </Button>

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -967,6 +967,7 @@ registries:
         osf_registrations: 'OSF Registrations'
         registrations: 'Registrations'
         search_placeholder: 'Search registrations...'
+        search_button: 'Perform search'
         search_label: 'Search'
         search_help: 'Search help'
     facets:


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: https://openscience.atlassian.net/browse/ENG-2246
- Feature flag: n/a

## Purpose

Make the search icon clickable for registries discovery without changing the layout.


## Summary of Changes

1. Make the search icon a button
2. Adjust the styling for hover and to make it stay in the same spot
3. Make the search button accessible
4. Add data-test selectors

## Side Effects

None

## QA Notes

This is a fairly innocuous change. The search button needs to function, and the ability to press return to search should be preserved. Text should overflow in a decent manner.
