### PR TITLE
[ENG-2320] Update support language for archiving registrations

### DIFF
--- a/lib/registries/addon/overview/styles.scss
+++ b/lib/registries/addon/overview/styles.scss
@@ -59,5 +59,4 @@
 .NoticeText {
     color: $primary-red;
     font-weight: bold;
-    text-transform: uppercase;
 }

--- a/lib/registries/addon/overview/styles.scss
+++ b/lib/registries/addon/overview/styles.scss
@@ -55,3 +55,9 @@
     padding: 20px;
     min-width: 300px;
 }
+
+.NoticeText {
+    color: $primary-red;
+    font-weight: bold;
+    text-transform: uppercase;
+}

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -35,6 +35,9 @@
                     {{else}}
                         <Overview::-Components::TombstonePage @registration={{this.registration}} @icon='hourglass-half'
                             @titleText={{t 'registries.overview.archiving.currently_archiving'}}>
+                            <div local-class='NoticeText'>
+                                {{t 'registries.overview.archiving.please_note'}}
+                            </div>
                             {{t 'registries.overview.archiving.email_support' supportEmail=this.supportEmail htmlSafe=true}}
                         </Overview::-Components::TombstonePage>
                     {{/if}}

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1243,7 +1243,8 @@ registries:
             warning: 'Withdrawing a registration will remove its content from the OSF, but leave basic metadata behind. The title of a withdrawn registration and its contributor list will remain, as will justification or explanation of the withdrawal, should you wish to provide it. Withdrawn registrations will be marked with a "withdrawn" tag. This action is irreversible.'
         archiving:
             currently_archiving: 'This registration is currently archiving, and no changes can be made at this time.'
-            email_support: 'If this registration has been archiving for more than 72 hours, please email <a data-analytics-name="Email support" href="mailto:{supportEmail}">{supportEmail}</a> for assistance.'
+            please_note: 'Please note:'
+            email_support: 'Changes to any files (1) in the projects or components being registered, (2) uploaded or selected as prompt responses, including those connected through add-ons during archiving will result in archiving failure and loss of your registration timestamp. Please do not modify your files until after you have received email confirmation of archiving completion. If this registration has been archiving for more than 72 hours, please email <a data-analytics-name="Email support" href="mailto:{supportEmail}">{supportEmail}</a> for assistance.'
         pendingRegistrationApproval:
             text: 'Pending registration'
             short_description: 'Pending registration approval'


### PR DESCRIPTION
- Ticket: [ENG-2320](https://openscience.atlassian.net/browse/ENG-2320)
- Feature flag: n/a

## Purpose

Update the archiving tombstone page to give better warnings to users about what will cause problems with the archiving process, as requested by Product.

<img width="1156" alt="Screen Shot 2021-01-05 at 4 16 57 PM" src="https://user-images.githubusercontent.com/6599111/103699907-a69ae580-4f71-11eb-8e87-102b5d16491f.png">


## Summary of Changes

1. Add text to support email
2. Add a call to action to notice the support

## Side Effects

Shouldn't be

## QA Notes

Make sure these changes show up where they're supposed to and nowhere else.
