### PR TITLE
[ENG-1899] Add education and employment dropdown

### DIFF
--- a/app/models/user.ts
+++ b/app/models/user.ts
@@ -59,25 +59,25 @@ export interface UserLinks extends OsfLinks {
 }
 
 export interface Employment {
-    title: string;
-    endYear: number;
-    ongoing: boolean;
-    endMonth: number;
-    startYear: number;
-    department: string;
-    startMonth: number;
-    institution: string;
+    title?: string;
+    endYear?: number;
+    ongoing?: boolean;
+    endMonth?: number;
+    startYear?: number;
+    department?: string;
+    startMonth?: number;
+    institution?: string;
 }
 
 export interface Education {
-    degree: string;
-    endYear: string;
-    startYear: string;
-    endMonth: number;
-    startMonth: number;
-    ongoing: boolean;
-    department: string;
-    institution: string;
+    degree?: string;
+    endYear?: string;
+    startYear?: string;
+    endMonth?: number;
+    startMonth?: number;
+    ongoing?: boolean;
+    department?: string;
+    institution?: string;
 }
 
 export default class UserModel extends OsfModel.extend(Validations) {

--- a/app/models/user.ts
+++ b/app/models/user.ts
@@ -69,6 +69,17 @@ export interface Employment {
     institution: string;
 }
 
+export interface Education {
+    degree: string;
+    endYear: string;
+    startYear: string;
+    endMonth: number;
+    startMonth: number;
+    ongoing: boolean;
+    department: string;
+    institution: string;
+}
+
 export default class UserModel extends OsfModel.extend(Validations) {
     @attr() links!: UserLinks;
     @attr('fixstring') fullName!: string;
@@ -84,6 +95,7 @@ export default class UserModel extends OsfModel.extend(Validations) {
     @attr('boolean') active!: boolean;
     @attr('object') social!: {};
     @attr('array') employment!: Employment[];
+    @attr('array') education!: Education[];
 
     @belongsTo('region', { async: false })
     defaultRegion!: DS.PromiseObject<RegionModel> & RegionModel;

--- a/lib/osf-components/addon/components/contributors/card/readonly/component.ts
+++ b/lib/osf-components/addon/components/contributors/card/readonly/component.ts
@@ -21,8 +21,8 @@ export default class ContributorsCardReadonly extends Component {
     @tracked showDropdown = false;
 
     didReceiveAttrs() {
-        const employment = this.contributor.users.get('employment');
-        const education = this.contributor.users.get('education');
+        const employment = this.contributor.users.get('employment') || [];
+        const education = this.contributor.users.get('education') || [];
         this.employmentList = Array.from(
             employment, item => [item.institution, item.department].join(', ').replace(/,\s*$/, ''),
         );

--- a/lib/osf-components/addon/components/contributors/card/readonly/component.ts
+++ b/lib/osf-components/addon/components/contributors/card/readonly/component.ts
@@ -5,6 +5,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { layout } from 'ember-osf-web/decorators/component';
 import ContributorModel from 'ember-osf-web/models/contributor';
+import { Education, Employment } from 'ember-osf-web/models/user';
 import styles from './styles';
 import template from './template';
 
@@ -15,20 +16,14 @@ export default class ContributorsCardReadonly extends Component {
     contributor!: ContributorModel;
 
     // private properties
-    employmentList!: string[];
-    educationList!: string[];
+    employmentList!: Employment[];
+    educationList!: Education[];
 
     @tracked showDropdown = false;
 
     didReceiveAttrs() {
-        const employment = this.contributor.users.get('employment') || [];
-        const education = this.contributor.users.get('education') || [];
-        this.employmentList = Array.from(
-            employment, item => [item.institution, item.department].join(', ').replace(/,\s*$/, ''),
-        );
-        this.educationList = Array.from(
-            education, item => [item.institution, item.department].join(', ').replace(/,\s*$/, ''),
-        );
+        this.employmentList = this.contributor.users.get('employment') || [];
+        this.educationList = this.contributor.users.get('education') || [];
     }
 
     @action

--- a/lib/osf-components/addon/components/contributors/card/readonly/component.ts
+++ b/lib/osf-components/addon/components/contributors/card/readonly/component.ts
@@ -1,11 +1,38 @@
 import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { layout } from 'ember-osf-web/decorators/component';
+import ContributorModel from 'ember-osf-web/models/contributor';
 import styles from './styles';
 import template from './template';
 
 @layout(template, styles)
 @tagName('')
 export default class ContributorsCardReadonly extends Component {
+    // required
+    contributor!: ContributorModel;
+
+    // private properties
+    employmentList!: string[];
+    educationList!: string[];
+
+    @tracked showDropdown = false;
+
+    didReceiveAttrs() {
+        const employment = this.contributor.users.get('employment');
+        const education = this.contributor.users.get('education');
+        this.employmentList = Array.from(
+            employment, item => [item.institution, item.department].join(', ').replace(/,\s*$/, ''),
+        );
+        this.educationList = Array.from(
+            education, item => [item.institution, item.department].join(', ').replace(/,\s*$/, ''),
+        );
+    }
+
+    @action
+    toggleDropdown() {
+        this.toggleProperty('showDropdown');
+    }
 }

--- a/lib/osf-components/addon/components/contributors/card/readonly/component.ts
+++ b/lib/osf-components/addon/components/contributors/card/readonly/component.ts
@@ -5,7 +5,6 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { layout } from 'ember-osf-web/decorators/component';
 import ContributorModel from 'ember-osf-web/models/contributor';
-import { Education, Employment } from 'ember-osf-web/models/user';
 import styles from './styles';
 import template from './template';
 
@@ -15,16 +14,7 @@ export default class ContributorsCardReadonly extends Component {
     // required
     contributor!: ContributorModel;
 
-    // private properties
-    employmentList!: Employment[];
-    educationList!: Education[];
-
     @tracked showDropdown = false;
-
-    didReceiveAttrs() {
-        this.employmentList = this.contributor.users.get('employment') || [];
-        this.educationList = this.contributor.users.get('education') || [];
-    }
 
     @action
     toggleDropdown() {

--- a/lib/osf-components/addon/components/contributors/card/readonly/styles.scss
+++ b/lib/osf-components/addon/components/contributors/card/readonly/styles.scss
@@ -9,3 +9,17 @@
 .CardSection {
     composes: CardSection from '../styles.scss';
 }
+
+.DropdownSection {
+    display: flex;
+}
+
+.DropdownList {
+    list-style: none;
+    padding-inline-start: 20px;
+}
+
+.DropdownCaret {
+    composes: CardSection from '../styles.scss';
+    max-width: 25px;
+}

--- a/lib/osf-components/addon/components/contributors/card/readonly/template.hbs
+++ b/lib/osf-components/addon/components/contributors/card/readonly/template.hbs
@@ -34,5 +34,26 @@
         >
             {{t (concat 'osf-components.contributors.citation.' @contributor.bibliographic)}}
         </span>
+        <span
+            data-test-contributor-caret={{@contributor.id}}
+            local-class='CardSection'
+        >
+            <FaIcon
+                @icon={{if this.showDropdown 'caret-up' 'caret-down'}}
+                {{on 'click' this.toggleDropdown}}
+            />
+        </span>
     </div>
+    {{#if this.showDropdown}}
+        <div data-test-contributor-card-dropdown local-class='DropdownSection'>
+            <ul local-class='DropdownList'>
+                {{#each this.employmentList as |item|}}
+                    <li>{{item}}</li>
+                {{/each}}
+                {{#each this.educationList as |item|}}
+                    <li>{{item}}</li>
+                {{/each}}
+            </ul>
+        </div>
+    {{/if}}
 </div>

--- a/lib/osf-components/addon/components/contributors/card/readonly/template.hbs
+++ b/lib/osf-components/addon/components/contributors/card/readonly/template.hbs
@@ -1,4 +1,8 @@
-<div data-test-contributor-card local-class='CardContainer'>
+<div
+    data-test-contributor-card
+    data-analytics-scope='Contributor card'
+    local-class='CardContainer'
+>
     <div data-test-contributor-card-main local-class='MainSection'>
         <span local-class='CardSection'>
             <img
@@ -36,23 +40,33 @@
         </span>
         <span
             data-test-contributor-caret={{@contributor.id}}
+            data-analytics-name={{
+                if this.showDropdown
+                'Expand employment and education info'
+                'Collapse employment and education info'
+            }}
             local-class='CardSection'
+            role='button'
+            {{on 'click' this.toggleDropdown}}
         >
             <FaIcon
                 @icon={{if this.showDropdown 'caret-up' 'caret-down'}}
-                {{on 'click' this.toggleDropdown}}
             />
         </span>
     </div>
     {{#if this.showDropdown}}
         <div data-test-contributor-card-dropdown local-class='DropdownSection'>
             <ul local-class='DropdownList'>
-                {{#each this.employmentList as |item|}}
-                    <li>{{item}}</li>
-                {{/each}}
-                {{#each this.educationList as |item|}}
-                    <li>{{item}}</li>
-                {{/each}}
+                {{#if (or this.employmentList this.educationList)}}
+                    {{#each this.employmentList as |item|}}
+                        <li>{{item}}</li>
+                    {{/each}}
+                    {{#each this.educationList as |item|}}
+                        <li>{{item}}</li>
+                    {{/each}}
+                {{else}}
+                    {{t 'osf-components.contributors.noAffiliations'}}
+                {{/if}}
             </ul>
         </div>
     {{/if}}

--- a/lib/osf-components/addon/components/contributors/card/readonly/template.hbs
+++ b/lib/osf-components/addon/components/contributors/card/readonly/template.hbs
@@ -59,10 +59,20 @@
             <ul local-class='DropdownList'>
                 {{#if (or this.employmentList this.educationList)}}
                     {{#each this.employmentList as |item|}}
-                        <li>{{item}}</li>
+                        <li>
+                            {{#if (and item.institution item.department)}}
+                                {{concat item.institution ', ' item.department}}
+                            {{else}}
+                                {{item.institution}}
+                            {{/if}}
+                        </li>
                     {{/each}}
                     {{#each this.educationList as |item|}}
-                        <li>{{item}}</li>
+                        {{#if (and item.institution item.department)}}
+                            {{concat item.institution ', ' item.department}}
+                        {{else}}
+                            {{item.institution}}
+                        {{/if}}
                     {{/each}}
                 {{else}}
                     {{t 'osf-components.contributors.noAffiliations'}}

--- a/lib/osf-components/addon/components/contributors/card/readonly/template.hbs
+++ b/lib/osf-components/addon/components/contributors/card/readonly/template.hbs
@@ -40,11 +40,7 @@
         </span>
         <span
             data-test-contributor-caret={{@contributor.id}}
-            data-analytics-name={{
-                if this.showDropdown
-                'Expand employment and education info'
-                'Collapse employment and education info'
-            }}
+            data-analytics-name='{{if this.showDropdown 'Expand'  'Collapse'}} employment and education info'
             local-class='CardSection'
             role='button'
             {{on 'click' this.toggleDropdown}}
@@ -57,8 +53,8 @@
     {{#if this.showDropdown}}
         <div data-test-contributor-card-dropdown local-class='DropdownSection'>
             <ul local-class='DropdownList'>
-                {{#if (or this.employmentList this.educationList)}}
-                    {{#each this.employmentList as |item|}}
+                {{#if @contributor.users.employment}}
+                    {{#each @contributor.users.employment as |item|}}
                         <li>
                             {{#if (and item.institution item.department)}}
                                 {{concat item.institution ', ' item.department}}
@@ -67,15 +63,25 @@
                             {{/if}}
                         </li>
                     {{/each}}
-                    {{#each this.educationList as |item|}}
-                        {{#if (and item.institution item.department)}}
-                            {{concat item.institution ', ' item.department}}
-                        {{else}}
-                            {{item.institution}}
-                        {{/if}}
+                {{else}}
+                    <li>
+                        {{t 'osf-components.contributors.noEmployment'}}    
+                    </li>
+                {{/if}}
+                {{#if @contributor.users.education}}
+                    {{#each @contributor.users.education as |item|}}
+                        <li>
+                            {{#if (and item.institution item.department)}}
+                                {{concat item.institution ', ' item.department}}
+                            {{else}}
+                                {{item.institution}}
+                            {{/if}}
+                        </li>
                     {{/each}}
                 {{else}}
-                    {{t 'osf-components.contributors.noAffiliations'}}
+                    <li>    
+                        {{t 'osf-components.contributors.noEducation'}}
+                    </li>
                 {{/if}}
             </ul>
         </div>

--- a/lib/osf-components/addon/components/contributors/card/styles.scss
+++ b/lib/osf-components/addon/components/contributors/card/styles.scss
@@ -1,13 +1,14 @@
 .CardContainer {
     margin: 0;
-    height: 60px;
     border-bottom: 1px solid $color-border-gray;
     background-color: #fff;
+    display: flex;
+    flex-direction: column;
 }
 
 .MainSection {
     display: flex;
-    height: inherit;
+    height: 60px;
     align-items: center;
     padding-left: 20px;
 }

--- a/mirage/factories/node.ts
+++ b/mirage/factories/node.ts
@@ -47,7 +47,7 @@ export default Factory.extend<MirageNode & NodeTraits>({
     currentUserIsContributor: false,
     preprint: false,
     description() {
-        return faker.lorem.sentences(faker.random.number({ min: 0, max: 4 }));
+        return faker.lorem.paragraph();
     },
     currentUserPermissions: [],
     dateModified() {

--- a/mirage/factories/user.ts
+++ b/mirage/factories/user.ts
@@ -71,6 +71,23 @@ export default Factory.extend<MirageUser & UserTraits>({
         }
         return employers;
     },
+    education() {
+        const institutionCount = faker.random.number({ min: 1, max: 3 });
+        const institutions = [];
+        for (let i = 0; i < institutionCount; i++) {
+            institutions.push({
+                degree: faker.lorem,
+                endYear: faker.date.between('2005', '2020').getFullYear(),
+                ongoing: faker.random.boolean(),
+                endMonth: faker.random.number(11),
+                startYear: faker.date.between('1990', '2005').getFullYear(),
+                department: faker.company.bsNoun(),
+                startMonth: faker.random.number(11),
+                institution: faker.company.companyName(),
+            });
+        }
+        return institutions;
+    },
     defaultRegion: association(),
     dateRegistered() {
         return faker.date.past(2, new Date(2018, 0, 0));

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1610,6 +1610,8 @@ osf-components:
             error: 'Error updating contributor bibliographic status.'
         reorderContributor:
             success: 'Contributor order updated.'
+        noAffiliations: 'No institutional affiliations to show'
+            
     subscriptions:
         frequency:
             daily: 'Daily'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1610,7 +1610,8 @@ osf-components:
             error: 'Error updating contributor bibliographic status.'
         reorderContributor:
             success: 'Contributor order updated.'
-        noAffiliations: 'No institutional affiliations to show'
+        noEducation: 'No education history to show'
+        noEmployment: 'No employment history to show'
             
     subscriptions:
         frequency:


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-1899]
- Feature flag: n/a

## Purpose

Add education and employment dropdown to readonly contributor cards.

## Summary of Changes

Modified the readonly contributor card component to show education and employment dropdown

## Side Effects

None.

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-1899]: https://openscience.atlassian.net/browse/ENG-1899