### PR TITLE
[ENG-2299] Use branded provider name for page title on registration overview

### DIFF
--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -8,6 +8,7 @@
         </div>
     {{else}}
         {{assert 'Registries::Overview - registration should not be null or undefined' this.registration}}
+        {{title this.registration.provider.name replace=true}}
         {{title this.registration.title prepend=false}}
         {{#if this.showTombstone}}
             <OsfLayout @backgroundClass='{{local-class 'ContentBackground'}}' as |layout|>

--- a/tests/engines/registries/acceptance/overview/overview-test.ts
+++ b/tests/engines/registries/acceptance/overview/overview-test.ts
@@ -81,10 +81,18 @@ module('Registries | Acceptance | overview.overview', hooks => {
                 favicon: 'fakelink',
             },
         }, 'withBrand');
+        const brandName = brandedProvider.name;
+
         const reg = server.create('registration', { provider: brandedProvider });
+        const registrationTitle = reg.title;
 
         await visit(`/${reg.id}/`);
         assert.ok(document.querySelector('link[rel="icon"][href="fakelink"]'));
+
+        const expectedPageTitle = `${brandName} | ${registrationTitle}`;
+        const pageTitle = document.getElementsByTagName('title')[0].textContent;
+        assert.equal(pageTitle, expectedPageTitle);
+
         await percySnapshot(assert);
     });
 

--- a/tests/engines/registries/acceptance/overview/overview-test.ts
+++ b/tests/engines/registries/acceptance/overview/overview-test.ts
@@ -81,17 +81,14 @@ module('Registries | Acceptance | overview.overview', hooks => {
                 favicon: 'fakelink',
             },
         }, 'withBrand');
-        const brandName = brandedProvider.name;
 
         const reg = server.create('registration', { provider: brandedProvider });
-        const registrationTitle = reg.title;
 
         await visit(`/${reg.id}/`);
         assert.ok(document.querySelector('link[rel="icon"][href="fakelink"]'));
 
-        const expectedPageTitle = `${brandName} | ${registrationTitle}`;
         const pageTitle = document.getElementsByTagName('title')[0].textContent;
-        assert.equal(pageTitle, expectedPageTitle);
+        assert.equal(pageTitle, `${brandedProvider.name} | ${reg.title}`);
 
         await percySnapshot(assert);
     });


### PR DESCRIPTION
- Ticket: [ENG-2299](https://openscience.atlassian.net/browse/ENG-2299)
- Feature flag: n/a

## Purpose

Ensure that the branded provider is used in the registration overview page title rather than always using OSF Registries.

## Summary of Changes

1. Override the page title from the overview page
2. Add a test assertion

## Side Effects

No

## QA Notes

Just make sure that this works with both branded providers and OSF Registries. This will not have an effect outside of the overview page.
