### PR TITLE
[ENG-2497] Remove validated-model-forms from developer-apps pages

### DIFF
--- a/app/models/developer-app.ts
+++ b/app/models/developer-app.ts
@@ -1,4 +1,5 @@
-import { buildValidations, validator } from 'ember-cp-validations';
+import { ValidationObject } from 'ember-changeset-validations';
+import { validateFormat, validateLength, validatePresence } from 'ember-changeset-validations/validators';
 import DS from 'ember-data';
 import { Link } from 'jsonapi-typescript';
 
@@ -6,31 +7,77 @@ import OsfModel, { OsfLinks } from './osf-model';
 
 const { attr } = DS;
 
-const Validations = buildValidations({
+interface DeveloperAppValidations {
+    name: string;
+    description: string;
+    homeUrl: string;
+    callbackUrl: string;
+}
+
+export const developerAppValidations: ValidationObject<DeveloperAppValidations> = {
     name: [
-        validator('presence', true),
-        validator('length', { min: 1, max: 200 }),
-    ],
-    homeUrl: [
-        validator('presence', true),
-        validator('length', { min: 1, max: 200 }),
-        validator('httpUrl'),
+        validatePresence({
+            type: 'blank',
+            presence: true,
+            translationArgs: { description: 'Name' },
+        }),
+        validateLength({
+            max: 200,
+            type: 'tooLong',
+            translationArgs: { description: 'Name' },
+        }),
     ],
     description: [
-        validator('length', { min: 0, max: 1000 }),
+        validateLength({
+            max: 1000,
+            type: 'tooLong',
+            translationArgs: { description: 'Description' },
+        }),
+    ],
+    homeUrl: [
+        validateLength({
+            max: 200,
+            type: 'tooLong',
+            translationArgs: { description: 'Homepage URL' },
+        }),
+        validatePresence({
+            max: 200,
+            presence: true,
+            type: 'blank',
+            translationArgs: { description: 'Homepage URL' },
+        }),
+        validateFormat({
+            allowBlank: false,
+            type: 'url',
+            translationArgs: { description: 'Homepage URL' },
+        }),
     ],
     callbackUrl: [
-        validator('presence', true),
-        validator('length', { min: 1, max: 200 }),
-        validator('httpUrl', { requireHttps: true }),
+        validateLength({
+            max: 200,
+            type: 'tooLong',
+            translationArgs: { description: 'Callback URL' },
+        }),
+        validatePresence({
+            presence: true,
+            max: 200,
+            type: 'blank',
+            translationArgs: { description: 'Callback URL' },
+        }),
+        validateFormat({
+            allowBlank: false,
+            type: 'url',
+            regex: /^https:\/\//,
+            translationArgs: { description: 'Callback URL' },
+        }),
     ],
-});
+};
 
 export interface DeveloperAppLinks extends OsfLinks {
     reset: Link;
 }
 
-export default class DeveloperAppModel extends OsfModel.extend(Validations) {
+export default class DeveloperAppModel extends OsfModel {
     @attr() links!: DeveloperAppLinks;
     @attr() callbackUrl!: string;
     @attr() clientId!: string;

--- a/app/settings/developer-apps/-components/app-form/component.ts
+++ b/app/settings/developer-apps/-components/app-form/component.ts
@@ -1,0 +1,93 @@
+import { tagName } from '@ember-decorators/component';
+import Component from '@ember/component';
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+import RouterService from '@ember/routing/router-service';
+import { inject as service } from '@ember/service';
+import { ChangesetDef } from 'ember-changeset/types';
+import { TaskInstance } from 'ember-concurrency';
+import { task } from 'ember-concurrency-decorators';
+import Intl from 'ember-intl/services/intl';
+import Toast from 'ember-toastr/services/toast';
+
+import DeveloperApp, { developerAppValidations } from 'ember-osf-web/models/developer-app';
+import buildChangeset from 'ember-osf-web/utils/build-changeset';
+import captureException, { getApiErrorMessage } from 'ember-osf-web/utils/capture-exception';
+
+@tagName('')
+export default class DeveloperAppForm extends Component {
+    @service intl!: Intl;
+    @service router!: RouterService;
+    @service toast!: Toast;
+
+    // Required arguments
+    developerApp?: DeveloperApp;
+    appTaskInstance?: TaskInstance<DeveloperApp>;
+    mode!: string;
+
+    changeset!: ChangesetDef;
+    appInstance?: DeveloperApp;
+
+    @task({ withTestWaiter: true })
+    createChangeset = task(function *(this: DeveloperAppForm) {
+        this.appInstance = this.developerApp;
+        if (this.appTaskInstance) {
+            yield this.appTaskInstance;
+            this.appInstance = this.appTaskInstance.value;
+        }
+
+        if (this.appInstance) {
+            this.changeset = buildChangeset(this.appInstance, developerAppValidations, { skipValidate: true });
+        }
+    });
+
+    @task({ withTestWaiter: true })
+    createNewApp = task(function *(this: DeveloperAppForm) {
+        this.changeset.validate();
+        try {
+            if (this.appInstance && this.changeset.isValid) {
+                yield this.changeset.save({});
+                this.toast.success(this.intl.t('settings.developer-apps.created'));
+                this.router.transitionTo('settings.developer-apps.edit', this.appInstance.get('id'));
+            }
+        } catch (e) {
+            captureException(e);
+            this.toast.error(getApiErrorMessage(e));
+        }
+    });
+
+    @task({ withTestWaiter: true })
+    updateApp = task(function *(this: DeveloperAppForm) {
+        this.changeset.validate();
+        try {
+            if (this.changeset.isValid) {
+                yield this.changeset.save({});
+                this.toast.success(this.intl.t('settings.developer-apps.saved'));
+                this.router.transitionTo('settings.developer-apps');
+            }
+        } catch (e) {
+            captureException(e);
+            this.toast.error(getApiErrorMessage(e));
+        }
+    });
+
+    init() {
+        super.init();
+        assert(
+            'AppForm requires either @developerApp xor @taskInstance',
+            Boolean(this.developerApp) !== Boolean(this.appTaskInstance),
+        );
+        this.createChangeset.perform();
+    }
+
+    @action
+    async deleteApp() {
+        // Analytics and errors handled by delete-button
+        if (this.developerApp) {
+            await this.developerApp.destroyRecord();
+            this.toast.success(this.intl.t('settings.developer-apps.deleted'));
+        }
+
+        this.router.transitionTo('settings.developer-apps');
+    }
+}

--- a/app/settings/developer-apps/-components/app-form/component.ts
+++ b/app/settings/developer-apps/-components/app-form/component.ts
@@ -23,7 +23,7 @@ export default class DeveloperAppForm extends Component {
     // Required arguments
     developerApp?: DeveloperApp;
     appTaskInstance?: TaskInstance<DeveloperApp>;
-    mode!: string;
+    createMode: boolean = false;
 
     changeset!: ChangesetDef;
     appInstance?: DeveloperApp;

--- a/app/settings/developer-apps/-components/app-form/template.hbs
+++ b/app/settings/developer-apps/-components/app-form/template.hbs
@@ -1,0 +1,69 @@
+{{#if this.createChangeset.isRunning}}
+    <LoadingIndicator @dark={{true}}/>
+{{else}}
+    <FormControls
+        data-analytics-scope={{if (eq this.mode 'create') 'Create form' 'Form'}}
+        @changeset={{this.changeset}}
+        as |form|
+    >
+        <form.text
+            data-test-developer-app-name
+            @valuePath={{'name'}}
+            @label={{t 'settings.developer-apps.appName'}}
+            @placeholder={{t 'general.required'}}
+        />
+        <form.text
+            data-test-developer-app-homepage
+            @valuePath={{'homeUrl'}}
+            @label={{t 'settings.developer-apps.appHomepage'}}
+            @placeholder={{t 'general.required'}}
+        />
+        <form.textarea 
+            data-test-developer-app-description
+            @valuePath={{'description'}}
+            @label={{t 'settings.developer-apps.appDescription'}}
+        />
+        <form.text
+            data-test-developer-app-callback-url
+            @valuePath={{'callbackUrl'}}
+            @label={{t 'settings.developer-apps.appCallbackUrl'}}
+            @placeholder={{t 'general.required'}}
+        />
+
+        <div>
+            {{#if (eq this.mode 'create')}}
+                <OsfButton
+                    data-test-create-developer-app-button
+                    data-analytics-name='Create'
+                    @type='primary'
+                    @buttonType='submit'
+                    @disabled={{or this.changeset.isInvalid this.createNewApp.isRunning}}
+                    {{on 'click' (perform this.createNewApp)}}
+                >
+                    {{t 'settings.developer-apps.createApp'}}
+                </OsfButton>
+            {{else}}
+                <DeleteButton
+                    @delete={{action this.deleteApp}}
+                    @disabled={{form.disabled}}
+                    @modalTitle={{t
+                        'settings.developer-apps.confirmDelete.title'
+                        appName=this.developerApp.name
+                        htmlSafe=true
+                    }}
+                    @modalBody={{t 'settings.developer-apps.confirmDelete.body'}}
+                />
+                <OsfButton
+                    data-test-save-developer-app-button
+                    data-analytics-name='Save'
+                    @type='primary'
+                    @buttonType='submit'
+                    @disabled={{not this.appInstance}}
+                    {{on 'click' (perform this.updateApp)}}
+                >
+                    {{t 'general.save'}}
+                </OsfButton>
+            {{/if}}
+        </div>
+    </FormControls>
+{{/if}}

--- a/app/settings/developer-apps/-components/app-form/template.hbs
+++ b/app/settings/developer-apps/-components/app-form/template.hbs
@@ -31,7 +31,7 @@
         />
 
         <div>
-            {{#if (eq this.mode 'create')}}
+            {{#if this.createMode}}
                 <OsfButton
                     data-test-create-developer-app-button
                     data-analytics-name='Create'

--- a/app/settings/developer-apps/-components/app-form/template.hbs
+++ b/app/settings/developer-apps/-components/app-form/template.hbs
@@ -8,24 +8,24 @@
     >
         <form.text
             data-test-developer-app-name
-            @valuePath={{'name'}}
+            @valuePath='name'
             @label={{t 'settings.developer-apps.appName'}}
             @placeholder={{t 'general.required'}}
         />
         <form.text
             data-test-developer-app-homepage
-            @valuePath={{'homeUrl'}}
+            @valuePath='homeUrl'
             @label={{t 'settings.developer-apps.appHomepage'}}
             @placeholder={{t 'general.required'}}
         />
         <form.textarea 
             data-test-developer-app-description
-            @valuePath={{'description'}}
+            @valuePath='description'
             @label={{t 'settings.developer-apps.appDescription'}}
         />
         <form.text
             data-test-developer-app-callback-url
-            @valuePath={{'callbackUrl'}}
+            @valuePath='callbackUrl'
             @label={{t 'settings.developer-apps.appCallbackUrl'}}
             @placeholder={{t 'general.required'}}
         />

--- a/app/settings/developer-apps/create/controller.ts
+++ b/app/settings/developer-apps/create/controller.ts
@@ -1,12 +1,10 @@
 import Controller from '@ember/controller';
-import { action } from '@ember/object';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
-import { ChangesetDef } from 'ember-changeset/types';
 import Intl from 'ember-intl/services/intl';
 import Toast from 'ember-toastr/services/toast';
 
-import DeveloperApp from 'ember-osf-web/models/developer-app';
+import DeveloperAppModel from 'ember-osf-web/models/developer-app';
 import Analytics from 'ember-osf-web/services/analytics';
 
 export default class SettingsApplicationCreateController extends Controller {
@@ -14,10 +12,10 @@ export default class SettingsApplicationCreateController extends Controller {
     @service intl!: Intl;
     @service router!: RouterService;
     @service toast!: Toast;
+    developerApp!: DeveloperAppModel;
 
-    @action
-    onSave(developerApp: DeveloperApp & ChangesetDef) {
-        this.toast.success(this.intl.t('settings.developer-apps.created'));
-        this.router.transitionTo('settings.developer-apps.edit', developerApp.get('id'));
+    init() {
+        super.init();
+        this.developerApp = this.store.createRecord('developer-app');
     }
 }

--- a/app/settings/developer-apps/create/controller.ts
+++ b/app/settings/developer-apps/create/controller.ts
@@ -1,21 +1,6 @@
 import Controller from '@ember/controller';
-import RouterService from '@ember/routing/router-service';
-import { inject as service } from '@ember/service';
-import Intl from 'ember-intl/services/intl';
-import Toast from 'ember-toastr/services/toast';
-
 import DeveloperAppModel from 'ember-osf-web/models/developer-app';
-import Analytics from 'ember-osf-web/services/analytics';
 
 export default class SettingsApplicationCreateController extends Controller {
-    @service analytics!: Analytics;
-    @service intl!: Intl;
-    @service router!: RouterService;
-    @service toast!: Toast;
     developerApp!: DeveloperAppModel;
-
-    init() {
-        super.init();
-        this.developerApp = this.store.createRecord('developer-app');
-    }
 }

--- a/app/settings/developer-apps/create/route.ts
+++ b/app/settings/developer-apps/create/route.ts
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+import SettingsApplicationCreateController from './controller';
+
+export default class SettingsDeveloperAppsCreateRoute extends Route {
+    setupController(controller: SettingsApplicationCreateController) {
+        controller.set('developerApp', this.store.createRecord('developer-app'));
+    }
+}

--- a/app/settings/developer-apps/create/template.hbs
+++ b/app/settings/developer-apps/create/template.hbs
@@ -11,5 +11,5 @@
 <h4>{{t 'settings.developer-apps.createApp'}}</h4>
 <Settings::DeveloperApps::-Components::AppForm
     @developerApp={{this.developerApp}}
-    @mode='create'
+    @createMode={{true}}
 />

--- a/app/settings/developer-apps/create/template.hbs
+++ b/app/settings/developer-apps/create/template.hbs
@@ -9,43 +9,7 @@
     </OsfLink>
 </div>
 <h4>{{t 'settings.developer-apps.createApp'}}</h4>
-
-<ValidatedModelForm
-    data-analytics-scope='Create form'
-    @modelName='developer-app'
-    @onSave={{action this.onSave}}
-    as |form|
->
-    <form.text
-        data-test-developer-app-name
-        @valuePath='name'
-        @label={{t 'settings.developer-apps.appName'}}
-    />
-    <form.text
-        data-test-developer-app-homepage
-        @valuePath='homeUrl'
-        @label={{t 'settings.developer-apps.appHomepage'}}
-    />
-    <form.textarea 
-        data-test-developer-app-description
-        @valuePath='description'
-        @label={{t 'settings.developer-apps.appDescription'}}
-    />
-    <form.text
-        data-test-developer-app-callback-url
-        @valuePath='callbackUrl'
-        @label={{t 'settings.developer-apps.appCallbackUrl'}}
-    />
-
-    <div>
-        <OsfButton
-            data-test-create-developer-app-button
-            data-analytics-name='Create'
-            @type='primary'
-            @buttonType='submit'
-            @disabled={{form.submitting}}
-        >
-            {{t 'settings.developer-apps.createApp'}}
-        </OsfButton>
-    </div>
-</ValidatedModelForm>
+<Settings::DeveloperApps::-Components::AppForm
+    @developerApp={{this.developerApp}}
+    @mode='create'
+/>

--- a/app/settings/developer-apps/edit/controller.ts
+++ b/app/settings/developer-apps/edit/controller.ts
@@ -1,5 +1,4 @@
 import Controller from '@ember/controller';
-import { action } from '@ember/object';
 import { reads } from '@ember/object/computed';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
@@ -17,22 +16,4 @@ export default class SettingsDeveloperAppsEditController extends Controller {
 
     @reads('model.taskInstance.value')
     developerApp?: DeveloperApp;
-
-    @action
-    appSaved() {
-        // Analytics handled by validated-model-form
-        this.toast.success(this.intl.t('settings.developer-apps.saved'));
-        this.router.transitionTo('settings.developer-apps');
-    }
-
-    @action
-    async deleteApp() {
-        // Analytics and errors handled by delete-button
-        if (this.developerApp) {
-            await this.developerApp.destroyRecord();
-            this.toast.success(this.intl.t('settings.developer-apps.deleted'));
-        }
-
-        this.router.transitionTo('settings.developer-apps');
-    }
 }

--- a/app/settings/developer-apps/edit/template.hbs
+++ b/app/settings/developer-apps/edit/template.hbs
@@ -32,7 +32,7 @@
         <h4>{{t 'settings.developer-apps.editApp'}}</h4>
         <Settings::DeveloperApps::-Components::AppForm
             @appTaskInstance={{this.model.taskInstance}}
-            @mode='edit'
+            @createMode={{false}}
         />
     {{/if}}
 </div>

--- a/app/settings/developer-apps/edit/template.hbs
+++ b/app/settings/developer-apps/edit/template.hbs
@@ -30,56 +30,9 @@
         </dl>
 
         <h4>{{t 'settings.developer-apps.editApp'}}</h4>
-        <ValidatedModelForm
-            data-analytics-scope='Form'
-            @model={{this.developerApp}}
-            @disabled={{this.model.taskInstance.isRunning}}
-            @onSave={{action this.appSaved}}
-            as |form|
-        >
-            <form.text
-                data-test-developer-app-name
-                @valuePath='name'
-                @label={{t 'settings.developer-apps.appName'}}
-            />
-            <form.text
-                data-test-developer-app-homepage
-                @valuePath='homeUrl'
-                @label={{t 'settings.developer-apps.appHomepage'}}
-            />
-            <form.textarea
-                data-test-developer-app-description
-                @valuePath='description'
-                @label={{t 'settings.developer-apps.appDescription'}}
-            />
-            <form.text
-                data-test-developer-app-callback-url
-                @valuePath='callbackUrl'
-                @label={{t 'settings.developer-apps.appCallbackUrl'}}
-            />
-
-            <div>
-                <DeleteButton
-                    @delete={{action this.deleteApp}}
-                    @disabled={{form.disabled}}
-                    @modalTitle={{t
-                        'settings.developer-apps.confirmDelete.title'
-                        appName=this.developerApp.name
-                        htmlSafe=true
-                    }}
-                    @modalBody={{t 'settings.developer-apps.confirmDelete.body'}}
-                />
-
-                <OsfButton
-                    data-test-save-developer-app-button
-                    data-analytics-name='Save'
-                    @type='primary'
-                    @buttonType='submit'
-                    @disabled={{form.disabled}}
-                >
-                    {{t 'general.save'}}
-                </OsfButton>
-            </div>
-        </ValidatedModelForm>
+        <Settings::DeveloperApps::-Components::AppForm
+            @appTaskInstance={{this.model.taskInstance}}
+            @mode='edit'
+        />
     {{/if}}
 </div>


### PR DESCRIPTION
- Ticket: [ENG-2497]
- Feature flag: n/a

## Purpose
- Phase out validated-model-forms as a way of validating forms and instead using form-controls and changesets for the settings.applications route

## Summary of Changes
- Create a new component that is shared between the developer-apps/create and developer-apps/edit pages
- Removing validated-model-forms from these forms and replacing them with form-controls

## Side Effects
- I think there is a small side-effect with how validation errors go away. When a user hits the `create`/`save` button and tries to submit an invalid form (e.g. they try to create/edit an app with an invalid callbackUrl), validation errors will show. When they go to edit the callbackUrl by typing anything into that text field, the validation error goes away, whereas before it would stay until the user clicks the `create` or `save` button. It's not a major issue, but I think it's a small deviation from before.

https://user-images.githubusercontent.com/51409893/103942860-0ecb0200-50ff-11eb-91c7-2303a210275f.mov



## QA Notes
- A quick look at the developer-apps page would be appreciated. None of the functionality should be different (aside from the small deviation with regards to the validation errors stated above)


[ENG-2497]: https://openscience.atlassian.net/browse/ENG-2497