### PR TITLE
[ENG-1694] Allow write users to edit registration metadata

### DIFF
--- a/lib/osf-components/addon/components/editable-field/category-manager/component.ts
+++ b/lib/osf-components/addon/components/editable-field/category-manager/component.ts
@@ -33,7 +33,7 @@ export default class CategoryManagerComponent extends Component {
     fieldIsEmpty = false;
     selectedCategory!: NodeCategory;
 
-    @alias('node.userHasAdminPermission') userCanEdit!: boolean;
+    @alias('node.userHasWritePermission') userCanEdit!: boolean;
     @alias('node.category') category!: NodeCategory;
 
     @computed('fieldIsEmpty', 'userCanEdit')

--- a/lib/osf-components/addon/components/editable-field/description-manager/component.ts
+++ b/lib/osf-components/addon/components/editable-field/description-manager/component.ts
@@ -34,7 +34,7 @@ export default class DescriptionManagerComponent extends Component {
     requestedEditMode: boolean = false;
     currentDescription!: string;
 
-    @alias('node.userHasAdminPermission') userCanEdit!: boolean;
+    @alias('node.userHasWritePermission') userCanEdit!: boolean;
     @and('userCanEdit', 'requestedEditMode') inEditMode!: boolean;
 
     @computed('node.description')

--- a/lib/osf-components/addon/components/editable-field/doi-manager/component.ts
+++ b/lib/osf-components/addon/components/editable-field/doi-manager/component.ts
@@ -42,7 +42,7 @@ export default class DoiManagerComponent extends Component {
 
     requestedEditMode: boolean = false;
 
-    @alias('node.userHasAdminPermission') userCanEdit!: boolean;
+    @alias('node.userHasWritePermission') userCanEdit!: boolean;
     @and('userCanEdit', 'requestedEditMode') inEditMode!: boolean;
     @not('nodeDoi') fieldIsEmpty!: boolean;
 

--- a/lib/osf-components/addon/components/editable-field/institutions-manager/component.ts
+++ b/lib/osf-components/addon/components/editable-field/institutions-manager/component.ts
@@ -42,7 +42,7 @@ export default class InstitutionsManagerComponent extends Component {
     reloadList!: (page?: number) => void;
     requestedEditMode: boolean = false;
 
-    @alias('node.userHasAdminPermission') userCanEdit!: boolean;
+    @alias('node.userHasWritePermission') userCanEdit!: boolean;
 
     @and('userCanEdit', 'requestedEditMode') inEditMode!: boolean;
 

--- a/lib/osf-components/addon/components/editable-field/publication-doi-manager/component.ts
+++ b/lib/osf-components/addon/components/editable-field/publication-doi-manager/component.ts
@@ -51,7 +51,7 @@ export default class PublicationDoiManagerComponent extends Component {
     didValidate = false;
 
     @not('didValidate') didNotValidate!: boolean;
-    @alias('node.userHasAdminPermission') userCanEdit!: boolean;
+    @alias('node.userHasWritePermission') userCanEdit!: boolean;
     @and('userCanEdit', 'requestedEditMode') inEditMode!: boolean;
     @alias('node.category') category!: boolean;
 

--- a/lib/osf-components/addon/components/editable-field/tags-manager/component.ts
+++ b/lib/osf-components/addon/components/editable-field/tags-manager/component.ts
@@ -43,7 +43,7 @@ export default class TagsManagerComponent extends Component {
     requestedEditMode: boolean = false;
     currentTags: string[] = [];
 
-    @alias('registration.userHasAdminPermission') userCanEdit!: boolean;
+    @alias('registration.userHasWritePermission') userCanEdit!: boolean;
 
     @and('userCanEdit', 'requestedEditMode') inEditMode!: boolean;
 

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -54,6 +54,14 @@ function registrationScenario(
 
     server.create('registration', { id: 'beefs' });
 
+    const currentUserWrite = server.create('registration', {
+        id: 'writr',
+        registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
+        currentUserPermissions: [Permission.Read, Permission.Write],
+    });
+
+    server.create('contributor', { users: currentUser, node: currentUserWrite });
+
     const registrationResponses = {
         'page-one_long-text': '',
         'page-one_multi-select': ['Crocs'],

--- a/tests/engines/registries/acceptance/overview/overview-test.ts
+++ b/tests/engines/registries/acceptance/overview/overview-test.ts
@@ -130,7 +130,7 @@ module('Registries | Acceptance | overview.overview', hooks => {
             }
         });
 
-    test('only admin can edit registration tags', async assert => {
+    test('only write and admin can edit registration tags', async assert => {
         const tags = ['Suspendisse', 'Mauris', 'ipsum', 'facilisis'];
         const reg = server.create('registration', {
             registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
@@ -147,6 +147,11 @@ module('Registries | Acceptance | overview.overview', hooks => {
         assert.dom('[data-test-tags-widget-tag-input="edit"] input').isVisible();
         tags.forEach(tag => assert.dom(`[data-test-tags-widget-tag="${tag}"]`).exists());
 
+        reg.update({ currentUserPermissions: [Permission.Write, Permission.Read] });
+        await visit(`/${reg.id}/`);
+
+        assert.dom('[data-test-tags-widget-tag-input="edit"] input').isVisible();
+
         reg.update({ currentUserPermissions: [Permission.Read] });
         await visit(`/${reg.id}/`);
 
@@ -155,22 +160,28 @@ module('Registries | Acceptance | overview.overview', hooks => {
         tags.forEach(tag => assert.dom(`[data-test-tags-widget-tag="${tag}"]`).exists());
     });
 
-    test('only admin can edit affiliated institutions', async assert => {
+    test('only write and admin can edit affiliated institutions', async assert => {
         const user = server.create('user', {
             institutions: server.createList('institution', 2),
         }, 'loggedIn');
 
         const reg = server.create('registration', {
             registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
-            currentUserPermissions: [Permission.Write, Permission.Read],
+            currentUserPermissions: [Permission.Read],
         }, 'withAffiliatedInstitutions');
 
-        // Non admin: read only view
+        // Read user: read only view
         await visit(`/${reg.id}/`);
         assert.dom('[data-test-edit-button="affiliated institutions"]').isNotVisible();
         reg.affiliatedInstitutionIds.forEach(institutionId => assert
             .dom(`[data-test-institution-list-institution="${institutionId}"]`)
             .exists('registration institution list is correct'));
+
+        // Write user: editable view
+        reg.update({ currentUserPermissions: [Permission.Read, Permission.Write] });
+
+        await visit(`/${reg.id}/`);
+        assert.dom('[data-test-edit-button="affiliated institutions"]').isVisible();
 
         // Admin: editable view
         reg.update({ currentUserPermissions: Object.values(Permission) });
@@ -294,6 +305,11 @@ module('Registries | Acceptance | overview.overview', hooks => {
         assert.dom('[data-test-node-description-wrapper]').hasStyle({
             maxHeight: 'none',
         });
+
+        reg.update({ currentUserPermissions: [Permission.Write, Permission.Read] });
+        await visit(`/${reg.id}/`);
+        assert.dom('[data-test-edit-button="description"]').isVisible();
+
         reg.update({ currentUserPermissions: [] });
         await visit(`/${reg.id}/`);
         assert.dom('[data-test-edit-button="description"]').isNotVisible();
@@ -320,11 +336,17 @@ module('Registries | Acceptance | overview.overview', hooks => {
         reg.reload();
         assert.equal(reg.category, NodeCategory.Instrumentation);
 
-        // Non-admin cannot edit
-        reg.update({ currentUserPermissions: [Permission.Read, Permission.Write] });
+        // Read user cannot edit
+        reg.update({ currentUserPermissions: [Permission.Read] });
 
         await visit(`/${reg.id}/`);
         assert.dom('[data-test-edit-button="category"]').doesNotExist();
+
+        // Write user can edit
+        reg.update({ currentUserPermissions: [Permission.Read, Permission.Write] });
+
+        await visit(`/${reg.id}/`);
+        assert.dom('[data-test-edit-button="category"]').exists();
     });
 
     test('editable publication doi', async assert => {
@@ -365,14 +387,20 @@ module('Registries | Acceptance | overview.overview', hooks => {
         reg.reload();
         assert.notOk(reg.articleDoi);
 
-        // Non-admin cannot edit
-        reg.update({ currentUserPermissions: [] });
+        // Read-Write can edit
+        reg.update({ currentUserPermissions: [Permission.Write, Permission.Read] });
+
+        await visit(`/${reg.id}/`);
+        assert.dom('[data-test-edit-button="publication DOI"]').exists();
+
+        // Read-only cannot edit
+        reg.update({ currentUserPermissions: [Permission.Read] });
 
         await visit(`/${reg.id}/`);
         assert.dom('[data-test-edit-button="publication DOI"]').doesNotExist();
     });
 
-    test('Check only admin can mint registration DOI', async assert => {
+    test('Check only admin and write can mint registration DOI', async assert => {
         const reg = server.create('registration', {
             registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
         });
@@ -384,6 +412,17 @@ module('Registries | Acceptance | overview.overview', hooks => {
         await click('[data-test-edit-button="doi"]');
 
         assert.dom('[data-test-create-doi]').isVisible();
+
+        reg.update({ currentUserPermissions: [Permission.Read] });
+        await visit(`/${reg.id}/`);
+        assert.dom('[data-test-edit-button="doi"]').doesNotExist();
+
+        reg.update({ currentUserPermissions: [Permission.Write, Permission.Read] });
+        await visit(`/${reg.id}/`);
+        await click('[data-test-edit-button="doi"]');
+
+        assert.dom('[data-test-create-doi]').isVisible();
+
         assert.dom('[data-test-registration-doi]').isNotVisible();
         assert.notOk(Boolean(reg.identifierIds.length));
 


### PR DESCRIPTION
- Ticket: [ENG-1694](https://openscience.atlassian.net/browse/ENG-1694)
- Feature flag: n/a

## Purpose

Allow R+W users to be able to edit metadata on registrations.

<img width="1166" alt="Screen Shot 2021-01-08 at 3 50 23 PM" src="https://user-images.githubusercontent.com/6599111/104062907-4c945d00-51c9-11eb-871a-5134a87b0350.png">


## Summary of Changes

1. Add a mirage scenario for current user to be write contributor to a registration
2. Update managers' components to use `userHasWritePermission` instead of `userHasAdminPermission` for:

- Description
- Category
- Registration DOI (can create one)
- Publication DOI
- ~~Subjects~~ This is not supported by the back-end
- Affiliation (add or remove their own affiliation)
- Tags

3. Update tests

## Side Effects

No

## QA Notes

This shoooould only affect the registration overview page.
