### PR TITLE
[ENG-2538] Make registration doi controls admin-only

### DIFF
--- a/lib/osf-components/addon/components/editable-field/doi-manager/component.ts
+++ b/lib/osf-components/addon/components/editable-field/doi-manager/component.ts
@@ -42,7 +42,7 @@ export default class DoiManagerComponent extends Component {
 
     requestedEditMode: boolean = false;
 
-    @alias('node.userHasWritePermission') userCanEdit!: boolean;
+    @alias('node.userHasAdminPermission') userCanEdit!: boolean;
     @and('userCanEdit', 'requestedEditMode') inEditMode!: boolean;
     @not('nodeDoi') fieldIsEmpty!: boolean;
 

--- a/tests/engines/registries/acceptance/overview/overview-test.ts
+++ b/tests/engines/registries/acceptance/overview/overview-test.ts
@@ -405,25 +405,31 @@ module('Registries | Acceptance | overview.overview', hooks => {
         assert.dom('[data-test-edit-button="publication DOI"]').doesNotExist();
     });
 
-    test('Check only admin and write can mint registration DOI', async assert => {
+    test('Check only admin can mint registration DOI', async assert => {
         const reg = server.create('registration', {
             registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
         });
 
         await visit(`/${reg.id}/`);
+        assert.dom('[data-test-edit-button="doi"]').doesNotExist();
         assert.dom('[data-test-create-doi]').doesNotExist();
+
+        reg.update({ currentUserPermissions: [Permission.Read] });
+        await visit(`/${reg.id}/`);
+        assert.dom('[data-test-edit-button="doi"]').doesNotExist();
+        assert.dom('[data-test-create-doi]').doesNotExist();
+
+        reg.update({ currentUserPermissions: [Permission.Write, Permission.Read] });
+        await visit(`/${reg.id}/`);
+        assert.dom('[data-test-edit-button="doi"]').doesNotExist();
+        assert.dom('[data-test-create-doi]').doesNotExist();
+
         reg.update({ currentUserPermissions: Object.values(Permission) });
         await visit(`/${reg.id}/`);
         await click('[data-test-edit-button="doi"]');
 
         assert.dom('[data-test-create-doi]').isVisible();
 
-        reg.update({ currentUserPermissions: [Permission.Read] });
-        await visit(`/${reg.id}/`);
-        assert.dom('[data-test-edit-button="doi"]').doesNotExist();
-
-        reg.update({ currentUserPermissions: [Permission.Write, Permission.Read] });
-        await visit(`/${reg.id}/`);
         await click('[data-test-edit-button="doi"]');
 
         assert.dom('[data-test-create-doi]').isVisible();


### PR DESCRIPTION
- Ticket: [ENG-2538](https://openscience.atlassian.net/browse/ENG-2538)
- Feature flag: n/a

## Purpose

Revert back part of https://github.com/CenterForOpenScience/ember-osf-web/pull/1123 because the back-end doesn't support it. Also, in the very near future, all Registrations will be given a DOI from us, so this feature will no longer need to be.

## Summary of Changes

1. Make Registration DOI admin-only
2. Update tests

## Side Effects

No

## QA Notes

This is a pretty straightforward change, and should only restore previous functionality. 