### PR TITLE
Setting collection enable variable to true for local development

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -18,7 +18,7 @@ const {
     BACKEND: backend = 'local',
     CAS_URL: casUrl = 'http://192.168.168.167:8080',
     CLIENT_ID: clientId,
-    COLLECTIONS_ENABLED = false,
+    COLLECTIONS_ENABLED = true,
     REGISTRIES_ENABLED = true,
     HANDBOOK_ENABLED = false,
     HANDBOOK_DOC_GENERATION_ENABLED = false,


### PR DESCRIPTION

- Ticket: []
- Feature flag: n/a

## Purpose

For collections to run on a local environment, `COLLECTIONS_ENABLE` must be set to true in config/environment.js

## Summary of Changes

Changing variable

## Side Effects

Hopefully not

## QA Notes

Does not need QA.
