### PR TITLE
[No ticket] Use node10 ember-base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ### App code
-FROM quay.io/centerforopenscience/ember-base AS app
+FROM quay.io/centerforopenscience/ember-base-10 AS app
 
 COPY ./package.json ./yarn.lock ./.yarnrc ./
 RUN yarn --frozen-lockfile

--- a/README.md
+++ b/README.md
@@ -78,43 +78,6 @@ To integrate with the legacy front end at [localhost:5000](http://localhost:5000
         # ...
     ```
 
-### Developer Handbook
-
-To enable the [developer handbook](https://centerforopenscience.github.io/ember-osf-web/handbook) locally,
-add the following to your `config/local.js`:
-```ts
-module.exports = {
-    HANDBOOK_ENABLED: true,
-};
-```
-The handbook will be available at [http://localhost:4200/handbook](http://localhost:4200/handbook).
-
-To enable (experimental) auto-generated docs in the handbook, you can also set
-`HANDBOOK_DOC_GENERATION_ENABLED: true` in your local config.
-
-#### Enable handbook on your fork
-
-1. [Generate a deploy key](https://developer.github.com/v3/guides/managing-deploy-keys/)
-  * `ssh-keygen -t rsa -b 4096 -C <your@email.com>`
-  * Enter file in which to save the key (~/.ssh/id_rsa): `~/deploy_key`
-  * Press enter twice for no passphrase
-2. Add the public key in your GitHub repository settings
-  * `cat ~/deploy_key.pub | pbcopy`
-  * Go to `https://github.com/<org>/<repo>/settings/keys/new`
-  * Title: `Travis CI`
-  * Key: paste in the public key
-  * ☑️ Allow write access
-3. Add the base64-encoded private key to Travis CI
-  * `cat ~/deploy_key | base64 | pbcopy`
-  * Go to `https://travis-ci.org/<org>/<repo>/settings`
-  * Under Environment Variables, add
-    * Name: `DEPLOY_KEY`
-    * Value: paste in the private key
-    * 'Leave Display Value in Build log' off
-    * Click Add
-4. Delete the keypair
-  * `rm ~/deploy_key ~/deploy_key.pub`
-
 ### Code Generators
 
 Make use of the many generators for code, try `ember help generate` for more details


### PR DESCRIPTION
- Ticket: []
- Feature flag: n/a

## Purpose
Fix broken staging deploy builds

What: It turns out our ember-osf-web docker container was still configured to run on top of a node8 base (starting image)
despite us having migrate to Node 10. This was not breaking anything till we installed `ember-exam` which has
`fs-extra @9.0` as a dependency.`fs-extra @9.0` requires Node 10.

Fix: @mattclark added a [new node10 ember-base](https://github.com/CenterForOpenScience/docker-library/blob/master/ember-base-10/Dockerfile). Here, I am simply pointing to the new image. We are contemplating using
volta in our docker setup in the near future that way we obviate the need to sync the versions.


## Summary of Changes

- Point to the new ember-base quay image
- Bonus: remove handbook deploy/travis config

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
