### PR TITLE
[ENG-2278] Add file/folder delete to <Files::widget>

### DIFF
--- a/app/models/file.ts
+++ b/app/models/file.ts
@@ -1,3 +1,4 @@
+import { assert } from '@ember/debug';
 import DS from 'ember-data';
 import { Link } from 'jsonapi-typescript';
 
@@ -151,6 +152,15 @@ export default class FileModel extends BaseFileItem {
                 resource: node.id,
             }),
         }).then(() => this.reload());
+    }
+
+    delete(): Promise<null> {
+        assert('links.delete is required to remove a file or folder', Boolean(this.links.delete));
+        return this.currentUser.authenticatedAJAX({
+            url: getHref(this.links.delete),
+            type: 'DELETE',
+            xhrFields: { withCredentials: true },
+        });
     }
 }
 

--- a/lib/osf-components/addon/components/delete-button/component.ts
+++ b/lib/osf-components/addon/components/delete-button/component.ts
@@ -31,6 +31,7 @@ export default class DeleteButton extends Component {
     noBackground: boolean = defaultTo(this.noBackground, false);
     hardConfirm: boolean = defaultTo(this.hardConfirm, false);
     disabled: boolean = defaultTo(this.disabled, false);
+    shouldStopPropagation = false;
     buttonLabel: string = defaultTo(
         this.buttonLabel,
         this.intl.t('osf-components.delete-button.buttonLabel'),
@@ -80,8 +81,11 @@ export default class DeleteButton extends Component {
     });
 
     @action
-    _show() {
+    _show(event: Event) {
         this.set('modalShown', true);
+        if (this.shouldStopPropagation) {
+            event.stopPropagation();
+        }
         if (this.hardConfirm) {
             this.setProperties({
                 scientistName: randomScientist(),

--- a/lib/osf-components/addon/components/files/item/styles.scss
+++ b/lib/osf-components/addon/components/files/item/styles.scss
@@ -4,11 +4,6 @@
     width: 100%;
     padding: 20px 15px;
 
-    i,
-    .filename {
-        color: $color-text-blue-dark;
-    }
-
     &:hover {
         cursor: pointer;
         background-color: $color-bg-gray-light;
@@ -22,9 +17,15 @@
         display: flex;
         flex-grow: 1;
         align-items: center;
+        flex-basis: 50%;
 
         span {
             padding-right: 10px;
+        }
+
+        i,
+        .filename {
+            color: $color-text-blue-dark;
         }
     }
 
@@ -34,4 +35,14 @@
         justify-content: flex-end;
         width: 40%;
     }
+
+    .delete-button {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+    }
+}
+
+.destroy-red {
+    color: $brand-danger;
 }

--- a/lib/osf-components/addon/components/files/item/template.hbs
+++ b/lib/osf-components/addon/components/files/item/template.hbs
@@ -11,6 +11,20 @@
             <FaIcon @icon='angle-left' @fixedWidth={{true}} />
             <span local-class='filename'>{{this.item.itemName}}</span>
         </div>
+        <span local-class='delete-button'>
+            <DeleteButton
+                data-test-delete-current-folder='{{this.item.id}}'
+                @buttonLabel={{t 'osf-components.files-widget.delete'}}
+                @delete={{fn @filesManager.deleteFileTask this.item}}
+                @small={{true}}
+                @noBackground={{true}}
+                @modalTitle={{t 'osf-components.files-widget.confirm_delete.title_folder' filename=this.item.itemName}}
+                @confirmButtonText={{t 'osf-components.files-widget.delete'}}
+                @shouldStopPropagation={{true}}
+            >
+                <div local-class='destroy-red'>{{t 'osf-components.files-widget.confirm_delete.body'}}</div>
+            </DeleteButton>
+        </span>
     {{else}}
         <div local-class='name-container'>
             <FileIcon @item={{this.item}} />
@@ -20,6 +34,20 @@
             <time local-class='date-modified' data-test-file-date-modified>
                 {{this.date}}
             </time>
+            <span local-class='delete-button'>
+                <DeleteButton
+                    data-test-delete-file='{{this.item.id}}'
+                    @buttonLabel={{t 'osf-components.files-widget.delete'}}
+                    @delete={{fn @filesManager.deleteFileTask this.item}}
+                    @small={{true}}
+                    @noBackground={{true}}
+                    @modalTitle={{t 'osf-components.files-widget.confirm_delete.title_file' filename=this.item.itemName}}
+                    @confirmButtonText={{t 'osf-components.files-widget.delete'}}
+                    @shouldStopPropagation={{true}}
+                >
+                    <div local-class='destroy-red'>{{t 'osf-components.files-widget.confirm_delete.body'}}</div>
+                </DeleteButton>
+            </span>
         {{/unless}}
     {{/if}}
 </div>

--- a/lib/osf-components/addon/components/files/manager/template.hbs
+++ b/lib/osf-components/addon/components/files/manager/template.hbs
@@ -16,4 +16,5 @@
     addFile=(perform this.addFile)
     loadMore=(perform this.loadMore)
     sortItems=(action this.sortItems)
+    deleteFileTask=(perform this.deleteFileTask)
 )}}

--- a/lib/osf-components/addon/components/files/widget/template.hbs
+++ b/lib/osf-components/addon/components/files/widget/template.hbs
@@ -3,6 +3,7 @@
         @node={{@node}}
         @onSelectFile={{@onSelectFile}}
         @onAddFile={{@onAddFile}}
+        @onDeleteFile={{@onDeleteFile}}
         as |filesManager|
     >
         <Files::Browse @filesManager={{filesManager}} />

--- a/lib/osf-components/addon/components/registries/page-renderer/template.hbs
+++ b/lib/osf-components/addon/components/registries/page-renderer/template.hbs
@@ -5,6 +5,7 @@
             component 'registries/schema-block-renderer/editable/mapper'
                 changeset=this.pageManager.changeset
                 node=@node
+                nodeIsDraftNode=@nodeIsDraftNode
                 onInput=@onInput
         }}
     />

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/component.ts
@@ -99,4 +99,24 @@ export default class Files extends Component {
     onAddFile(addedFile: File) {
         this.select(addedFile);
     }
+
+    @action
+    onDeleteFile(deleteFileOrFolder: File, options: { callback?: () => void }) {
+        let filesToUnselect: File[] = [];
+        if (deleteFileOrFolder.isFolder) {
+            filesToUnselect = this.selectedFiles
+                .filter(({ materializedPath }) => materializedPath.includes(deleteFileOrFolder.materializedPath));
+        } else {
+            const isSelected = this.selectedFiles.some(file => deleteFileOrFolder.id === file.id);
+            if (isSelected) {
+                filesToUnselect = [deleteFileOrFolder];
+            }
+        }
+
+        filesToUnselect.forEach(file => this.unselect(file));
+
+        if (options && options.callback) {
+            options.callback();
+        }
+    }
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/template.hbs
@@ -2,11 +2,17 @@
     data-test-files-instructions
     local-class='FilesInstructions'
 >
-    {{t 'osf-components.registries.schema-block-renderer/editable/files.instructions'
-        projectOrComponent=(if @node.isRoot 'project' 'component')
-        nodeUrl=this.nodeUrl
-        htmlSafe=true
-    }}
+    {{#if @nodeIsDraftNode}}
+        {{t 'osf-components.registries.schema-block-renderer/editable/files.instructionsNoProject'
+            htmlSafe=true
+        }}
+    {{else}}
+        {{t 'osf-components.registries.schema-block-renderer/editable/files.instructions'
+            projectOrComponent=(if @node.isRoot 'project' 'component')
+            nodeUrl=this.nodeUrl
+            htmlSafe=true
+        }}
+    {{/if}}
 </p>
 <Files::SelectedList
     local-class='SelectedList'

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/files/template.hbs
@@ -25,5 +25,6 @@
     @node={{@node}}
     @onSelectFile={{action this.onSelectFile}}
     @onAddFile={{action this.onAddFile}}
+    @onDeleteFile={{this.onDeleteFile}}
     ...attributes
 />

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/editable/mapper/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/editable/mapper/template.hbs
@@ -59,6 +59,7 @@
         'registries/schema-block-renderer/editable/files'
         changeset=@changeset
         node=@node
+        nodeIsDraftNode=@nodeIsDraftNode
         onInput=@onInput
     )
 )}}

--- a/lib/registries/addon/drafts/draft/page/template.hbs
+++ b/lib/registries/addon/drafts/draft/page/template.hbs
@@ -17,6 +17,7 @@
                     @pageManager={{navManager.currentPageManager}}
                     @onInput={{perform draftManager.onPageInput navManager.currentPageManager}}
                     @node={{this.node}}
+                    @nodeIsDraftNode={{not draftManager.draftRegistration.hasProject}}
                 />
             {{/if}}
         </main>

--- a/mirage/views/wb.ts
+++ b/mirage/views/wb.ts
@@ -1,4 +1,4 @@
-import { HandlerContext, Schema } from 'ember-cli-mirage';
+import { HandlerContext, Response, Schema } from 'ember-cli-mirage';
 
 export function moveFile(this: HandlerContext, schema: Schema) {
     const fileId = this.request.params.id;
@@ -25,7 +25,7 @@ export function deleteFile(this: HandlerContext, schema: Schema) {
     const fileId = this.request.params.id;
     const file = schema.files.find(fileId);
     file.destroy();
-    return null;
+    return new Response(204);
 }
 
 export function fileVersions(this: HandlerContext) {

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1567,6 +1567,7 @@ osf-components:
             editButtonAriaLabel: 'Edit {questionLabel}'
         schema-block-renderer/editable/files:
             instructions: 'You may attach up to 5 file(s) to this question. You may attach files that you already have in OSF Storage in this <a href={nodeUrl}>{projectOrComponent}</a> or upload (drag and drop) a new file from your computer. Uploaded files will automatically be added to this <a href={nodeUrl}>{projectOrComponent}</a> so that they can be registered. To attach files from other components or an add-on, first add them to this <a href={nodeUrl}>{projectOrComponent}</a>.'
+            instructionsNoProject: 'You may attach up to 5 file(s) to this question. Files cannot total over 5GB in size.<br><br>Uploaded files will automatically be archived in this registration. They will also be added to a related project that will be created for this registration.'
         schema-block-renderer/read-only/response:
             noResponse: 'No response'
         schema-block-renderer/read-only/files:
@@ -1582,6 +1583,15 @@ osf-components:
         folder_name_placeholder: 'New folder name'
         create_folder_failed: 'Failed to create folder'
         insufficient_storage_error: 'This file cannot be uploaded to this project/component because it has exceeded the storage limit for OSF Storage.'
+        delete_failed: 'Failed to delete {filename}'
+        delete_success: 'Successfully deleted {filename}'
+        delete: Delete
+        confirm_delete:
+            title_file: 'Delete "{filename}"?'
+            title_folder: 'Delete "{filename}" and all its contents?'
+            body: 'This action is irreversible.'
+            button: Delete
+
     subjects:
         browse:
             browse_all: 'Browse all subjects'


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-2278]
- Feature flag: n/a

## Purpose
Add file/folder delete to the files widget

- [x] Add file/folder delete to the files widget
- [x] Language warning users about the 5GB limit
- [x] Update language `You may attach up to 5 file(s) to this question. You may attach files... to account for no-project workflows`
- [x] Language for file/folder delete confirmation modal.

~Waiting on product for language updates.~
<img width="711" alt="Screen Shot 2021-02-02 at 5 17 29 PM" src="https://user-images.githubusercontent.com/4511563/106670051-8c592500-657a-11eb-8354-a77047aab741.png">

## Summary of Changes
- Update `<DeleteButton />` to not propagate click by default.
- Add file/folder delete button to `<Files::Item />`
- Add a file/folder delete task to `<Files::Manager />`
- Update `<Files::Manager >` to use `onDeleteFile` and allow consumers of the file widget to dictate what happens
upon successful delete in this case `<Registries/SchemaBlockRenderer::Editable />`
- Add `onDeleteFile` action to `<Registries/SchemaBlockRenderer::Editable::Files />` 
- Add acceptance tests

## Side Effects

## QA Notes
Regression test for files widget on draft registrations.

[ENG-2278]: https://openscience.atlassian.net/browse/ENG-2278