### PR TITLE
[ENG-2573] Add hasProject boolean to draft-registrations

### DIFF
--- a/app/models/draft-registration.ts
+++ b/app/models/draft-registration.ts
@@ -37,6 +37,7 @@ export default class DraftRegistrationModel extends OsfModel {
     @attr('fixstringarray') tags!: string[];
     @attr('node-license') nodeLicense!: NodeLicense | null;
     @attr('node-category') category!: NodeCategory;
+    @attr('boolean') hasProject!: boolean;
 
     @belongsTo('node', { inverse: 'draftRegistrations' })
     branchedFrom!: DS.PromiseObject<NodeModel> & NodeModel;

--- a/mirage/factories/draft-registration.ts
+++ b/mirage/factories/draft-registration.ts
@@ -65,6 +65,8 @@ export default Factory.extend<DraftRegistration & DraftRegistrationTraits>({
 
     category: NodeCategory.Uncategorized,
 
+    hasProject: true,
+
     withRegistrationMetadata: trait<DraftRegistration>({
         afterCreate(draftRegistration) {
             draftRegistration.update({


### PR DESCRIPTION
- Ticket: [ENG-2573](https://openscience.atlassian.net/browse/ENG-2573)
- Feature flag: n/a

## Purpose

Add the hasProject boolean to draft-registrations. This matches up with the Platform PR https://github.com/CenterForOpenScience/osf.io/pull/9607

## Summary of Changes

1. Add the attribute to the DraftRegistration model
2. Add the attribute to the mirage factory

## Side Effects

No, all additive. I made the mirage factory default work with all of the existing draft registrations in the default scenario and tests, so going forward with no project we can override as necessary.

## QA Notes

Nothing testable yet.