### PR TITLE
[ENG-2276] Update add-new page to allow no project registration

### DIFF
--- a/app/adapters/draft-registration.ts
+++ b/app/adapters/draft-registration.ts
@@ -1,7 +1,6 @@
 import OsfAdapter from './osf-adapter';
 
 export default class DraftRegistrationAdapter extends OsfAdapter {
-    parentRelationship = 'branchedFrom';
 }
 
 declare module 'ember-data/types/registries/adapter' {

--- a/app/models/node.ts
+++ b/app/models/node.ts
@@ -152,7 +152,7 @@ export default class NodeModel extends BaseFileItem.extend(Validations, Collecta
     registrations!: DS.PromiseManyArray<RegistrationModel>;
 
     @hasMany('draft-registration', { inverse: 'branchedFrom' })
-    draftRegistrations!: DS.PromiseManyArray<DraftRegistrationModel>;
+    draftRegistrations?: DS.PromiseManyArray<DraftRegistrationModel>;
 
     @hasMany('node', { inverse: 'forkedFrom' })
     forks!: DS.PromiseManyArray<NodeModel>;

--- a/lib/registries/addon/branded/new/controller.ts
+++ b/lib/registries/addon/branded/new/controller.ts
@@ -25,16 +25,16 @@ export default class BrandedRegistriesNewSubmissionController extends Controller
     @tracked selectedSchema?: RegistrationSchemaModel;
     @tracked schemaOptions: RegistrationSchemaModel[] = [];
     @tracked projectOptions: NodeModel[] = [];
-    @tracked shouldShowProjectSelect: boolean = false;
+    @tracked isBasedOnProject: boolean = false;
 
     get disableCreateDraft(): boolean {
-        return this.shouldShowProjectSelect ? !(this.selectedSchema && this.selectedProject) : !this.selectedSchema;
+        return this.isBasedOnProject ? !(this.selectedSchema && this.selectedProject) : !this.selectedSchema;
     }
 
     @task({ withTestWaiter: true })
     createNewDraftRegistration = task(function *(this: BrandedRegistriesNewSubmissionController) {
         let newRegistration: DraftRegistrationModel;
-        if (this.shouldShowProjectSelect) {
+        if (this.isBasedOnProject) {
             newRegistration = this.store.createRecord('draft-registration', {
                 registrationSchema: this.selectedSchema,
                 provider: this.model,

--- a/lib/registries/addon/branded/new/controller.ts
+++ b/lib/registries/addon/branded/new/controller.ts
@@ -6,6 +6,7 @@ import { timeout } from 'ember-concurrency';
 import { task } from 'ember-concurrency-decorators';
 import DS from 'ember-data';
 
+import DraftRegistrationModel from 'ember-osf-web/models/draft-registration';
 import NodeModel from 'ember-osf-web/models/node';
 import { Permission } from 'ember-osf-web/models/osf-model';
 import RegistrationSchemaModel from 'ember-osf-web/models/registration-schema';
@@ -24,19 +25,27 @@ export default class BrandedRegistriesNewSubmissionController extends Controller
     @tracked selectedSchema?: RegistrationSchemaModel;
     @tracked schemaOptions: RegistrationSchemaModel[] = [];
     @tracked projectOptions: NodeModel[] = [];
+    @tracked shouldShowProjectSelect: boolean = false;
 
     get disableCreateDraft(): boolean {
-        return !(this.selectedSchema && this.selectedProject);
+        return this.shouldShowProjectSelect ? !(this.selectedSchema && this.selectedProject) : !this.selectedSchema;
     }
 
     @task({ withTestWaiter: true })
     createNewDraftRegistration = task(function *(this: BrandedRegistriesNewSubmissionController) {
-        const newRegistration = this.store.createRecord('draft-registration',
-            {
+        let newRegistration: DraftRegistrationModel;
+        if (this.shouldShowProjectSelect) {
+            newRegistration = this.store.createRecord('draft-registration', {
                 registrationSchema: this.selectedSchema,
                 provider: this.model,
                 branchedFrom: this.selectedProject,
             });
+        } else {
+            newRegistration = this.store.createRecord('draft-registration', {
+                registrationSchema: this.selectedSchema,
+                provider: this.model,
+            });
+        }
         try {
             yield newRegistration.save();
             this.transitionToRoute('drafts.draft', newRegistration.id);

--- a/lib/registries/addon/branded/new/styles.scss
+++ b/lib/registries/addon/branded/new/styles.scss
@@ -13,6 +13,10 @@
 .selectLabel {
     composes: SchemaBlockDropdown from '../../drafts/draft/metadata/styles.scss';
     display: block;
+
+    div {
+        max-width: 361px;
+    }
 }
 
 .projectHeading {
@@ -25,9 +29,14 @@
     flex-direction: column;
 }
 
-.newProjectHelpText {
-    margin-top: 20px;
-    max-width: 600px;
+.InformationText {
+    margin: 20px 0 30px;
+    text-align: center;
+    font-style: italic;
+
+    &.ComponentHelpText {
+        max-width: 390px;
+    }
 }
 
 .createDraftButton {
@@ -48,4 +57,48 @@
 
 .required {
     color: $brand-danger;
+}
+
+.StepOneContainer {
+    margin-bottom: 30px;
+}
+
+.RadioFieldset {
+    position: relative;
+    text-align: center;
+}
+
+.RadioLegend {
+    border-bottom: 0;
+    font-size: 24px;
+    font-weight: 600;
+}
+
+.RadioElement {
+    width: 80px;
+    height: 40px;
+    margin: 0;
+}
+
+.RadioInput {
+    position: absolute;
+    opacity: 0;
+
+    &:hover {
+        cursor: pointer;
+    } 
+}
+
+.RadioLabel {
+    text-align: center;
+    line-height: 40px;
+    border: 1px solid $color-border-gray;
+    color: $color-text-blue-dark;
+    text-transform: uppercase;
+}
+
+.IsChecked {
+    color: $color-osf-secondary;
+    background-color: $color-bg-gray-blue-light;
+    border: 1px solid $color-bg-gray-blue-light;
 }

--- a/lib/registries/addon/branded/new/template.hbs
+++ b/lib/registries/addon/branded/new/template.hbs
@@ -50,7 +50,7 @@
                             name='no-project'
                             value='no'
                             onclick={{fn (mut this.isBasedOnProject) false}}
-                            checked={{this.isBasedOnProject}}
+                            checked={{not this.isBasedOnProject}}
                         >
                         <label
                             local-class='RadioElement RadioLabel {{unless this.isBasedOnProject 'IsChecked'}}'

--- a/lib/registries/addon/branded/new/template.hbs
+++ b/lib/registries/addon/branded/new/template.hbs
@@ -34,11 +34,11 @@
                             type='radio'
                             name='HasProject'
                             value='yes'
-                            onclick={{fn (mut this.shouldShowProjectSelect) true}}
-                            checked={{if (eq this.shouldShowProjectSelect true) true false}}
+                            onclick={{fn (mut this.isBasedOnProject) true}}
+                            checked={{this.isBasedOnProject}}
                         >
                         <label
-                            local-class='RadioElement RadioLabel {{if this.shouldShowProjectSelect 'IsChecked'}}'
+                            local-class='RadioElement RadioLabel {{if this.isBasedOnProject 'IsChecked'}}'
                             for='HasProject'
                         >
                             {{t 'registries.new.yes'}}
@@ -49,18 +49,18 @@
                             type='radio'
                             name='no-project'
                             value='no'
-                            onclick={{fn (mut this.shouldShowProjectSelect) false}}
-                            checked={{if (eq this.shouldShowProjectSelect false) true false}}
+                            onclick={{fn (mut this.isBasedOnProject) false}}
+                            checked={{this.isBasedOnProject}}
                         >
                         <label
-                            local-class='RadioElement RadioLabel {{unless this.shouldShowProjectSelect 'IsChecked'}}'
+                            local-class='RadioElement RadioLabel {{unless this.isBasedOnProject 'IsChecked'}}'
                             for='NoProject'
                         >
                             {{t 'registries.new.no'}}
                         </label>
                     </fieldset>
                 </label>
-                {{#if this.shouldShowProjectSelect}}
+                {{#if this.isBasedOnProject}}
                     <label data-test-project-select local-class='selectLabel'>
                         <p local-class='stepLabel'>
                             {{t 'registries.new.step_two'}}
@@ -88,7 +88,7 @@
 
                 <label data-test-schema-select local-class='selectLabel'>
                     <p local-class='stepLabel'>
-                        {{#if this.shouldShowProjectSelect}}
+                        {{#if this.isBasedOnProject}}
                             {{t 'registries.new.step_three'}}
                         {{else}}
                             {{t 'registries.new.step_two'}}

--- a/lib/registries/addon/branded/new/template.hbs
+++ b/lib/registries/addon/branded/new/template.hbs
@@ -16,50 +16,83 @@
             </HeroOverlay>
         </layout.heading>
         <layout.main local-class='main'>
+            <p local-class='InformationText'>
+                {{t 'registries.new.provider_info' provider=this.model.name htmlSafe=true}}
+            </p>
             <form data-test-new-registration-form local-class='registrationForm'>
-                <label
-                    data-test-project-select
-                    local-class='selectLabel'
-                >
+                <label local-class='selectLabel StepOneContainer'>
                     <p local-class='stepLabel'>
                         {{t 'registries.new.step_one'}}
                     </p>
-                    <h2
-                        data-test-project-select-title
-                        local-class='projectHeading'
-                    >
-                        {{t 'registries.new.select_project'}}
-                        <span local-class='required' aria-label={{t 'registries.new.required'}}>*</span>
-                    </h2>
-                    <PowerSelect
-                        @ariaLabel={{this.selectedProject.title}}
-                        @placeholder={{t 'registries.new.select_project_placeholder'}}
-                        @options={{this.projectOptions}}
-                        @search={{perform this.projectSearch}}
-                        @selected={{this.selectedProject}}
-                        @onchange={{this.updateSelectedProject}}
-                        as |option|
-                    >
-                        {{option.title}}
-                    </PowerSelect>
+                    <fieldset local-class='RadioFieldset'>
+                        <legend local-class='RadioLegend'>
+                            {{t 'registries.new.step_one_project_heading'}}
+                        </legend>
+                        <input
+                            data-test-has-project-button
+                            local-class='RadioElement RadioInput'
+                            type='radio'
+                            name='HasProject'
+                            value='yes'
+                            onclick={{fn (mut this.shouldShowProjectSelect) true}}
+                            checked={{if (eq this.shouldShowProjectSelect true) true false}}
+                        >
+                        <label
+                            local-class='RadioElement RadioLabel {{if this.shouldShowProjectSelect 'IsChecked'}}'
+                            for='HasProject'
+                        >
+                            {{t 'registries.new.yes'}}
+                        </label>
+                        <input
+                            data-test-no-project-button
+                            local-class='RadioElement RadioInput'
+                            type='radio'
+                            name='no-project'
+                            value='no'
+                            onclick={{fn (mut this.shouldShowProjectSelect) false}}
+                            checked={{if (eq this.shouldShowProjectSelect false) true false}}
+                        >
+                        <label
+                            local-class='RadioElement RadioLabel {{unless this.shouldShowProjectSelect 'IsChecked'}}'
+                            for='NoProject'
+                        >
+                            {{t 'registries.new.no'}}
+                        </label>
+                    </fieldset>
                 </label>
+                {{#if this.shouldShowProjectSelect}}
+                    <label data-test-project-select local-class='selectLabel'>
+                        <p local-class='stepLabel'>
+                            {{t 'registries.new.step_two'}}
+                        </p>
+                        <h3 data-test-project-select-title local-class='projectHeading'>
+                            {{t 'registries.new.select_project'}}
+                            <span local-class='required' aria-label={{t 'registries.new.required'}}>*</span>
+                        </h3>
+                        <PowerSelect
+                            @ariaLabel={{this.selectedProject.title}}
+                            @placeholder={{t 'registries.new.select_project_placeholder'}}
+                            @options={{this.projectOptions}}
+                            @search={{perform this.projectSearch}}
+                            @selected={{this.selectedProject}}
+                            @onchange={{this.updateSelectedProject}}
+                            as |option|
+                        >
+                            {{option.title}}
+                        </PowerSelect>
+                    </label>
+                    <p local-class='InformationText ComponentHelpText'>
+                        {{t 'registries.new.component_help_text'}}
+                    </p>
+                {{/if}}
 
-                <p local-class='newProjectHelpText'>
-                    {{t 'registries.new.new_project_help_fragment1'}}
-                    <OsfLink
-                        @route='dashboard'
-                    >
-                        {{t 'registries.new.go_to_dashboard'}}
-                    </OsfLink>
-                    {{t 'registries.new.new_project_help_fragment2' htmlSafe=true}}
-                </p>
-
-                <label
-                    data-test-schema-select
-                    local-class='selectLabel'
-                >
+                <label data-test-schema-select local-class='selectLabel'>
                     <p local-class='stepLabel'>
-                        {{t 'registries.new.step_two'}}
+                        {{#if this.shouldShowProjectSelect}}
+                            {{t 'registries.new.step_three'}}
+                        {{else}}
+                            {{t 'registries.new.step_two'}}
+                        {{/if}}
                     </p>
                     <h2 data-test-schema-select-title>
                         {{t 'registries.new.select_schema'}}

--- a/lib/registries/addon/drafts/draft/draft-registration-manager.ts
+++ b/lib/registries/addon/drafts/draft/draft-registration-manager.ts
@@ -24,7 +24,7 @@ import buildChangeset from 'ember-osf-web/utils/build-changeset';
 
 type LoadDraftModelTask = TaskInstance<{
     draftRegistration: DraftRegistration,
-    node: NodeModel,
+    node?: NodeModel,
     provider: ProviderModel,
 }>;
 
@@ -52,7 +52,7 @@ export default class DraftRegistrationManager {
     @notEmpty('visitedPages') hasVisitedPages!: boolean;
 
     draftRegistration!: DraftRegistration;
-    node!: NodeModel;
+    node?: NodeModel;
     provider!: ProviderModel;
 
     @computed('pageManagers.{[],@each.pageIsValid}')

--- a/lib/registries/addon/drafts/draft/template.hbs
+++ b/lib/registries/addon/drafts/draft/template.hbs
@@ -16,14 +16,16 @@
                 <layout.heading>
                     <HeroOverlay @align='left' local-class='DraftHeroOverlay'>
                         <div local-class='Title'>
-                            <OsfLink
-                                data-analytics-name='Go to project'
-                                local-class='BreadCrumb'
-                                @route='guid-node'
-                                @models={{array draftManager.node.id}}
-                            >
-                                {{draftManager.node.title}} >
-                            </OsfLink>
+                            {{#if draftManager.node}}
+                                <OsfLink
+                                    data-analytics-name='Go to project'
+                                    local-class='BreadCrumb'
+                                    @route='guid-node'
+                                    @models={{array draftManager.node.id}}
+                                >
+                                    {{draftManager.node.title}} >
+                                </OsfLink>
+                            {{/if}}
                             <h1>
                                 {{t 'registries.drafts.draft.form.new_registration'}}
                             </h1>

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -129,6 +129,7 @@ export default function(this: Server) {
         only: ['index', 'show', 'update'],
         path: '/draft_registrations',
     });
+    this.post('/draft_registrations', createDraftRegistration);
     osfToManyRelationship(this, 'draft-registration', 'subjects');
     osfToManyRelationship(this, 'draft-registration', 'affiliatedInstitutions', {
         only: ['related', 'update', 'add', 'remove'],

--- a/mirage/serializers/draft-registration.ts
+++ b/mirage/serializers/draft-registration.ts
@@ -8,18 +8,6 @@ const { OSF: { apiUrl } } = config;
 export default class DraftRegistrationSerializer extends ApplicationSerializer<DraftRegistration> {
     buildRelationships(model: ModelInstance<DraftRegistration>) {
         const returnValue: SerializedRelationships<DraftRegistration> = {
-            branchedFrom: {
-                data: {
-                    id: model.branchedFrom.id,
-                    type: 'nodes',
-                },
-                links: {
-                    related: {
-                        href: `${apiUrl}/v2/nodes/${model.branchedFrom.id}`,
-                        meta: {},
-                    },
-                },
-            },
             initiator: {
                 data: {
                     id: model.initiator.id,
@@ -81,6 +69,20 @@ export default class DraftRegistrationSerializer extends ApplicationSerializer<D
                 },
             },
         };
+        if (model.branchedFrom) {
+            returnValue.branchedFrom = {
+                data: {
+                    id: model.branchedFrom.id,
+                    type: 'nodes',
+                },
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/nodes/${model.branchedFrom.id}`,
+                        meta: {},
+                    },
+                },
+            };
+        }
         if (model.license) {
             returnValue.license = {
                 data: {

--- a/tests/engines/registries/acceptance/branded/new-test.ts
+++ b/tests/engines/registries/acceptance/branded/new-test.ts
@@ -94,11 +94,6 @@ module('Registries | Acceptance | branded.new', hooks => {
     test('users are prevented from submitting incomplete form no project', async assert => {
         server.loadFixtures('registration-schemas');
         server.loadFixtures('schema-blocks');
-        const currentUser = server.create('user', 'loggedIn');
-        const node = server.create('node', { id: 'decaf', title: 'This is your project' }, 'currentUserAdmin');
-        const nonAdminNode = server.create('node', { id: 'badmin', title: 'User is not admin' });
-        server.create('contributor', { node, users: currentUser });
-        server.create('contributor', { node: nonAdminNode, users: currentUser });
         const brandedProvider = server.create('registration-provider', 'withBrand', 'withSchemas');
         await visit(`/registries/${brandedProvider.id}/new`);
 

--- a/tests/engines/registries/acceptance/branded/new-test.ts
+++ b/tests/engines/registries/acceptance/branded/new-test.ts
@@ -60,7 +60,7 @@ module('Registries | Acceptance | branded.new', hooks => {
         assert.equal(currentRouteName(), 'registries.page-not-found', 'At the correct route: page-not-found');
     });
 
-    test('users are prevented from submitting incomplete form', async assert => {
+    test('users are prevented from submitting incomplete form with project', async assert => {
         server.loadFixtures('registration-schemas');
         server.loadFixtures('schema-blocks');
         const currentUser = server.create('user', 'loggedIn');
@@ -72,7 +72,11 @@ module('Registries | Acceptance | branded.new', hooks => {
         await visit(`/registries/${brandedProvider.id}/new`);
 
         assert.dom('[data-test-start-registration-button]')
-            .isDisabled('Start registration button is disabled on first load');
+            .isNotDisabled('Start registration button is enabled on first load with schema selected');
+        await click('[data-test-has-project-button]');
+        assert.dom('[data-test-project-select]').exists();
+        assert.dom('[data-test-start-registration-button]')
+            .isDisabled('Start button is disabled without project selected');
         await click('[data-test-project-select] .ember-power-select-trigger');
         assert.dom('.ember-power-select-options > li.ember-power-select-option:first-of-type')
             .hasText('This is your project', 'Project dropdown shows project title');
@@ -83,6 +87,26 @@ module('Registries | Acceptance | branded.new', hooks => {
             .hasText('This is a Test Schema', 'Schema dropdown is autopopulated with first schema available');
         assert.dom('[data-test-start-registration-button]')
             .isEnabled('Start registration button is enabled after choosing a project and schema');
+        await click('[data-test-start-registration-button]');
+        assert.equal(currentRouteName(), 'registries.drafts.draft.metadata',
+            'Go to draft registration metadata page on start');
+    });
+    test('users are prevented from submitting incomplete form no project', async assert => {
+        server.loadFixtures('registration-schemas');
+        server.loadFixtures('schema-blocks');
+        const currentUser = server.create('user', 'loggedIn');
+        const node = server.create('node', { id: 'decaf', title: 'This is your project' }, 'currentUserAdmin');
+        const nonAdminNode = server.create('node', { id: 'badmin', title: 'User is not admin' });
+        server.create('contributor', { node, users: currentUser });
+        server.create('contributor', { node: nonAdminNode, users: currentUser });
+        const brandedProvider = server.create('registration-provider', 'withBrand', 'withSchemas');
+        await visit(`/registries/${brandedProvider.id}/new`);
+
+        assert.dom('[data-test-start-registration-button]')
+            .isNotDisabled('Start registration button is enabled on first load with schema selected');
+        assert.dom('[data-test-project-select]').doesNotExist();
+        assert.dom('[data-test-schema-select] .ember-power-select-trigger')
+            .hasText('This is a Test Schema', 'Schema dropdown is autopopulated with first schema available');
         await click('[data-test-start-registration-button]');
         assert.equal(currentRouteName(), 'registries.drafts.draft.metadata',
             'Go to draft registration metadata page on start');

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1025,19 +1025,22 @@ registries:
         overview:
             title: 'Moderated Overview'
     new:
+        provider_info: 'You are submitting to {provider}. <a href="https://help.osf.io/hc/en-us/categories/360001550953-Registrations">Click here</a> to learn more about other hosted registries.'
         required: 'required'
         page_title: 'New Registration'
         page_header: 'Add New Registration'
         step_one: 'Step 1'
         step_two: 'Step 2'
-        select_schema: 'Select registration type'
-        select_project: 'Select project to register'
-        new_project_help: 'If you have not started the project yet, click below to go to your dashboard to create a new project'
-        new_project_help_fragment1: 'A project is required for registration. If you haven’t started the project yet, you can create a new project from'
-        new_project_help_fragment2: 'To learn more about registration, <a href="https://help.osf.io/hc/en-us/articles/360019930893">visit our help docs.</a>'
+        step_three: 'Step 3'
+        step_one_project_heading: 'Do you have content for registration in an existing OSF project?'
+        select_schema: 'Which type of registration would you like to create?'
+        select_project: 'Which project do you want to register?'
+        component_help_text: 'If your project includes components, you can select which components to include or exclude at the end of the registration.'
         go_to_dashboard: 'your dashboard.'
-        start_registration: 'Start registration draft'
+        start_registration: 'Create draft'
         select_project_placeholder: 'Select your project'
+        yes: 'Yes'
+        no: 'No'
     discover:
         page_title: Search
         SHARE: 'About SHARE'


### PR DESCRIPTION
- Ticket: https://openscience.atlassian.net/browse/ENG-2276
- Feature flag: `n/a`

## Purpose

To update the `Add New` page to allow users the chance to start a no-project draft registration.

## Summary of Changes

- Update the `Add New` page to include a radio button to select `yes` or `no` to using a registration
- Add translations
- Update mirage to allow draft-registrations to be created with a project
- Update the draft template/controller to include a conditional for the project link

<img width="1139" alt="Screen Shot 2021-02-07 at 4 44 50 PM" src="https://user-images.githubusercontent.com/19379783/107268769-a1b8ce00-6a16-11eb-9137-eefe6a2b5227.png">

<img width="1142" alt="Screen Shot 2021-02-07 at 4 45 14 PM" src="https://user-images.githubusercontent.com/19379783/107268790-aaa99f80-6a16-11eb-824f-e6bcbeddc4cc.png">


## Side Effects

This touched some styling on the `Add New` page and updated some draft-registration things in mirage.

## QA Notes

This affects two pages. It will add a new option to the `Add New` page and it should also remove the project link on the draft page in the case that the draft-registration doesn't have a project it's related to. The `Create Draft` button is also updated to be disabled if `has project` is checked but a project isn't selected.