### PR TITLE
[ENG-1693] Disable registration button for non-admin users

### DIFF
--- a/lib/registries/addon/drafts/draft/-components/register/component.ts
+++ b/lib/registries/addon/drafts/draft/-components/register/component.ts
@@ -26,6 +26,7 @@ export default class Register extends Component {
     @alias('draftManager.hasInvalidResponses') isInvalid?: boolean;
     @alias('draftManager.draftRegistration') draftRegistration!: DraftRegistration;
     @alias('draftManager.node') node?: NodeModel;
+    @alias('draftManager.currentUserIsAdmin') currentUserIsAdmin!: () => boolean;
 
     partialRegDialogIsOpen = false;
     finalizeRegDialogIsOpen = false;

--- a/lib/registries/addon/drafts/draft/-components/register/template.hbs
+++ b/lib/registries/addon/drafts/draft/-components/register/template.hbs
@@ -4,7 +4,7 @@
     local-class='registerButton {{if @showMobileView 'mobileReviewButtonItem'}}'
     @type='success'
     @onClick={{perform this.onClickRegister}}
-    @disabled={{not this.draftManager.registrationResponsesIsValid}}
+    @disabled={{not (and this.draftManager.registrationResponsesIsValid this.currentUserIsAdmin)}}
 >
     {{#if this.onClickRegister.isRunning}}
         <LoadingIndicator @inline={{true}} />

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -169,6 +169,7 @@ function registrationScenario(
         initiator: currentUser,
         branchedFrom: rootNode,
         license: licenseReqFields,
+        currentUserPermissions: [Permission.Read, Permission.Write],
     }, 'withSubjects', 'withAffiliatedInstitutions');
 
     server.create('draft-registration', {

--- a/tests/engines/registries/acceptance/draft/draft-test.ts
+++ b/tests/engines/registries/acceptance/draft/draft-test.ts
@@ -547,6 +547,7 @@ module('Registries | Acceptance | draft form', hooks => {
                 initiator,
                 registrationResponses,
                 branchedFrom: rootNode,
+                currentUserPermissions: Object.values(Permission),
                 license: server.schema.licenses.first(),
             },
         );
@@ -589,6 +590,37 @@ module('Registries | Acceptance | draft form', hooks => {
         await click('[data-test-submit-registration-button]');
 
         assert.equal(currentRouteName(), 'registries.overview.index', 'Redicted to new registration overview page');
+    });
+
+    test('write user cannot register draft', async assert => {
+        const initiator = server.create('user', 'loggedIn');
+        const registrationSchema = server.schema.registrationSchemas.find('testSchema');
+        const rootNode = server.create('node');
+        const registrationResponses = {
+            'page-one_long-text': '',
+            'page-one_multi-select': [],
+            'page-one_multi-select-other': '',
+            'page-one_short-text': 'ditto',
+            'page-one_single-select': 'tuna',
+            'page-one_single-select-two': '',
+        };
+        const registration = server.create(
+            'draft-registration',
+            {
+                registrationSchema,
+                initiator,
+                registrationResponses,
+                branchedFrom: rootNode,
+                currentUserPermissions: [Permission.Read, Permission.Write],
+                license: server.schema.licenses.first(),
+            },
+        );
+        const subjects = [server.create('subject')];
+        registration.update({ subjects });
+        await visit(`/registries/drafts/${registration.id}/review`);
+
+        assert.ok(currentURL().includes(`/registries/drafts/${registration.id}/review`), 'At review page');
+        assert.dom('[data-test-goto-register]').isDisabled('Register button is disabled for write users');
     });
 
     test('validations: marks all pages (visited or unvisited) as visited and validates all in review', async assert => {


### PR DESCRIPTION
- Ticket: [ENG-1693](https://openscience.atlassian.net/browse/ENG-1693)
- Feature flag: n/a

## Purpose

Disable the registration button for non-admin users.

For admins:

<img width="1198" alt="Screen Shot 2021-02-11 at 1 08 05 PM" src="https://user-images.githubusercontent.com/6599111/107684116-64e81380-6c70-11eb-80aa-73e4ac48b1f3.png">

For non-admins:

<img width="1214" alt="Screen Shot 2021-02-11 at 1 08 27 PM" src="https://user-images.githubusercontent.com/6599111/107684138-6b768b00-6c70-11eb-9e0e-5f20fdec07c2.png">


## Summary of Changes

1. Bring currentUserIsAdmin through to the register component
2. Disable the button if the current user is not an admin
3. Tests
4. Make `dcaf` draft registration a current-user write perms for easy testing

## Side Effects

No, this is fairly isolated

## QA Notes

This affects the draft-registration review page. It shouldn't be particularly browser dependent. It's a low-risk change.

