### PR TITLE
[ENG-2647] Add warning for component contributor management

### DIFF
--- a/lib/osf-components/addon/components/registries/partial-registration-modal/template.hbs
+++ b/lib/osf-components/addon/components/registries/partial-registration-modal/template.hbs
@@ -8,6 +8,9 @@
         {{t 'registries.partialRegistrationModal.title'}}
     </dialog.heading>
     <dialog.main>
+        <div local-class='component-contributor-warning'>
+            {{t 'registries.partialRegistrationModal.componentContributorWarning'}}
+        </div>
         <OsfButton
             @type='link'
             local-class='select-clear-button'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1342,6 +1342,7 @@ registries:
         cancelButton: Cancel
         selectAll: 'Select All'
         clearAll: 'Clear All'
+        componentContributorWarning: 'Contributor changes for included components must be done on the component contributor page before submitting this registration.'
     registrationList:
         pending: 'No registrations pending approval have been found'
         accepted: 'No public registrations have been found'


### PR DESCRIPTION

- Ticket: [ENG-2647](https://openscience.atlassian.net/browse/ENG-2647)
- Feature flag: n/a

## Purpose

Add text to the partial registration component to let people know that they have to manage contributors on components on the components themselves rather than on the draft registration.

Old version:

<img width="338" alt="Screen Shot 2021-03-08 at 9 54 04 AM" src="https://user-images.githubusercontent.com/6599111/110365988-b6878200-8013-11eb-9892-9185178fea12.png">

New version:

<img width="937" alt="Screen Shot 2021-03-08 at 9 34 41 AM" src="https://user-images.githubusercontent.com/6599111/110366017-c30bda80-8013-11eb-8e27-66eb48fdad2d.png">

## Summary of Changes

1. Add text to language file
2. Use text in modal

## Side Effects

No, this is pretty isolated

## QA Notes

This is a low-risk text addition.