### PR TITLE
[ENG-2648] Make data analytics name dependent on isBasedOnProject

### DIFF
--- a/lib/registries/addon/branded/new/template.hbs
+++ b/lib/registries/addon/branded/new/template.hbs
@@ -112,7 +112,7 @@
 
                 <Button
                     data-test-start-registration-button
-                    data-analytics-name='Create new draft registration'
+                    data-analytics-name={{if this.isBasedOnProject 'Create new draft registration' 'Create new no-project draft registration'}}
                     local-class='createDraftButton'
                     disabled={{this.disableCreateDraft}}
                     @type='primary'


### PR DESCRIPTION
- Ticket: [ENG-2648](https://openscience.atlassian.net/browse/ENG-2648)
- Feature flag: n/a

## Purpose

Make data analytics name for creating a new draft registration dependent on isBasedOnProject. I left the original response as was, and just added "no-project" to the no-project case, so all of the historical clicks of the button would match with the future clicks of the button meaning that it was based on a project.

## Summary of Changes

1. Add an if to the data-analytics-name element

## Side Effects

No

## QA Notes

Just check the first `collect` network request in each case to make sure if it says "no-project" or not. 
