### PR TITLE
[ENG-2641] Don't include registered_from on no-project registration create

### DIFF
--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1105,6 +1105,7 @@ registries:
                 invalid_warning: 'Please address invalid or missing entries to complete registration.'
                 toggle_dropdown: 'Toggle navigation dropdown'
             register: Register
+            unable_to_fetch_children_count: 'Unable to fetch project''s components'
             submit_error: 'Unable to create a registration.'
     index:
         lead: 'The <span class="f-w-lg">open</span> registries network'


### PR DESCRIPTION
- Ticket: [ENG-2641]
- Feature flag: n/a

## Purpose

Omit `registered_from` in the registration create `POST` request for no-project registration.

## Summary of Changes

- Only include `registered_from` if `draftRegistration.hasProject` is `true`
- Add toast and sentry-capture exception

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- Tested as part of the no-project registration release


[ENG-2641]: https://openscience.atlassian.net/browse/ENG-2641