### PR TITLE
[ENG-2641] Fix radio button behavior on Add New page and some accessibility updates

### DIFF
--- a/lib/registries/addon/branded/new/styles.scss
+++ b/lib/registries/addon/branded/new/styles.scss
@@ -13,6 +13,7 @@
 .selectLabel {
     composes: SchemaBlockDropdown from '../../drafts/draft/metadata/styles.scss';
     display: block;
+    font-weight: 700;
 
     div {
         max-width: 361px;

--- a/lib/registries/addon/branded/new/template.hbs
+++ b/lib/registries/addon/branded/new/template.hbs
@@ -20,7 +20,7 @@
                 {{t 'registries.new.provider_info' provider=this.model.name htmlSafe=true}}
             </p>
             <form data-test-new-registration-form local-class='registrationForm'>
-                <label local-class='selectLabel StepOneContainer'>
+                <div local-class='selectLabel StepOneContainer'>
                     <p local-class='stepLabel'>
                         {{t 'registries.new.step_one'}}
                     </p>
@@ -29,41 +29,45 @@
                             {{t 'registries.new.step_one_project_heading'}}
                         </legend>
                         <div local-class='RadioButtonAndLabelDiv'>
-                            <input
-                                data-test-has-project-button
-                                local-class='RadioElement RadioInput'
-                                type='radio'
-                                name='HasProject'
-                                value='yes'
-                                onclick={{fn (mut this.isBasedOnProject) true}}
-                                checked={{this.isBasedOnProject}}
-                            >
-                            <label
-                                local-class='RadioElement RadioLabel {{if this.isBasedOnProject 'IsChecked'}}'
-                                for='HasProject'
-                            >
-                                {{t 'registries.new.yes'}}
-                            </label>
+                            {{#let (unique-id) 'has-project' as |hasProjectId|}}
+                                <input
+                                    data-test-has-project-button
+                                    local-class='RadioElement RadioInput'
+                                    id={{hasProjectId}}
+                                    type='radio'
+                                    value='yes'
+                                    onclick={{fn (mut this.isBasedOnProject) true}}
+                                    checked={{this.isBasedOnProject}}
+                                >
+                                <label
+                                    local-class='RadioElement RadioLabel {{if this.isBasedOnProject 'IsChecked'}}'
+                                    for={{hasProjectId}}
+                                >
+                                    {{t 'registries.new.yes'}}
+                                </label>
+                            {{/let}}
                         </div>
                         <div local-class='RadioButtonAndLabelDiv'>
-                            <input
-                                data-test-no-project-button
-                                local-class='RadioElement RadioInput'
-                                type='radio'
-                                name='no-project'
-                                value='no'
-                                onclick={{fn (mut this.isBasedOnProject) false}}
-                                checked={{not this.isBasedOnProject}}
-                            >
-                            <label
-                                local-class='RadioElement RadioLabel {{unless this.isBasedOnProject 'IsChecked'}}'
-                                for='NoProject'
-                            >
-                                {{t 'registries.new.no'}}
-                            </label>
+                            {{#let (unique-id) 'no-project' as |noProjectId|}}
+                                <input
+                                    data-test-no-project-button
+                                    local-class='RadioElement RadioInput'
+                                    id={{noProjectId}}
+                                    type='radio'
+                                    value='no'
+                                    onclick={{fn (mut this.isBasedOnProject) false}}
+                                    checked={{not this.isBasedOnProject}}
+                                >
+                                <label
+                                    local-class='RadioElement RadioLabel {{unless this.isBasedOnProject 'IsChecked'}}'
+                                    for={{noProjectId}}
+                                >
+                                    {{t 'registries.new.no'}}
+                                </label>
+                            {{/let}}
                         </div>
                     </fieldset>
-                </label>
+                </div>
                 {{#if this.isBasedOnProject}}
                     <label data-test-project-select local-class='selectLabel'>
                         <p local-class='stepLabel'>


### PR DESCRIPTION

- Ticket: [ENG-2641]
- Feature flag: n/a

## Purpose
- Remove behavior on Add New page where clicking outside of the Yes/No radio buttons would change the Step 1 radio button to `Yes` (see attached video)
- A little bit of accessibility cleanup

## Summary of Changes
- Removed some errant `<label>` tags, added unique IDs to input elements

## Multimedia

https://user-images.githubusercontent.com/51409893/110848791-7a0a8f00-827c-11eb-9717-c915d8771301.mov



## Side Effects
- NA

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-2641]: https://openscience.atlassian.net/browse/ENG-2641