### PR TITLE
[ENG-2636] Get all registration schemas on discover page

### DIFF
--- a/app/guid-node/registrations/controller.ts
+++ b/app/guid-node/registrations/controller.ts
@@ -40,6 +40,7 @@ export default class GuidNodeRegistrations extends Controller {
         let schemas = yield this.store.query('registration-schema',
             {
                 'filter[active]': true,
+                'page[size]': 100,
             });
         schemas = schemas.toArray();
         schemas.sort((a: RegistrationSchema, b: RegistrationSchema) => a.name.length - b.name.length);

--- a/lib/registries/addon/components/registries-registration-type-facet/component.ts
+++ b/lib/registries/addon/components/registries-registration-type-facet/component.ts
@@ -43,8 +43,9 @@ export default class RegistriesRegistrationTypeFacet extends Component {
     @task({ withTestWaiter: true, on: 'init' })
     fetchRegistrationTypes = task(function *(this: RegistriesRegistrationTypeFacet): any {
         try {
-            const metaschemas: RegistrationSchema[] = yield this.store.findAll('registration-schema');
-
+            const metaschemas: RegistrationSchema[] = yield this.store.query('registration-schema', {
+                'page[size]': 100,
+            });
             const metaschemaNames = metaschemas.mapBy('name');
             if (!this.features.isEnabled(enableInactiveSchemas)) {
                 metaschemaNames.push(

--- a/lib/registries/addon/discover/controller.ts
+++ b/lib/registries/addon/discover/controller.ts
@@ -212,8 +212,8 @@ export default class Discover extends Controller.extend(discoverQueryParams.Mixi
             ]),
         }));
 
-        const osfProviders: RegistrationProviderModel[] = yield this.store.findAll('registration-provider', {
-            adapterOptions: { queryParams: { 'page[size]': 100 } },
+        const osfProviders: RegistrationProviderModel[] = yield this.store.query('registration-provider', {
+            'page[size]': 100,
         });
 
         // Setting osfProviders on the share-search service


### PR DESCRIPTION
- Ticket: [ENG-2636](https://openscience.atlassian.net/browse/ENG-2636)
- Feature flag: n/a

## Purpose

Use the page[size] query parameter to get all of the registration schemas for faceting on the registries discover page.

## Summary of Changes

1. Change instances of `findAll` where we want to use `page[size]` to `query`
2. Add `page[size]` query parameter to the registration-type-facet for the registries discover page.
3. Add `page[size]` query parameter to the guid-nodes/registration page

## Side Effects

None anticipated

## QA Notes

- There should be more than 10 registration types on the registration discovery page 'registration types' facet when limiting the provider to OSF Registries (if there are more than 10 registration types in that environment)
- There should be more than 10 registration providers in the 'provider' facet on the registries discover page (if there are more than 10 providers in that environment)
