### PR TITLE
[ENG-2641] 21.1.0/read card read only width

### DIFF
--- a/lib/osf-components/addon/components/contributors/card/readonly/styles.scss
+++ b/lib/osf-components/addon/components/contributors/card/readonly/styles.scss
@@ -8,7 +8,7 @@
 
 .CardSection {
     composes: CardSection from '../styles.scss';
-    max-width: 34%;
+    width: 34%;
 }
 
 .CardSectionSmall {

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -180,8 +180,9 @@ function registrationScenario(
         registrationResponses,
         branchedFrom: rootNode,
         license: licenseReqFields,
+        currentUserPermissions: [Permission.Read, Permission.Write],
         provider,
-    });
+    }, 'withContributors');
 
     const clinicalTrials = server.create('external-provider', {
         shareSource: 'ClinicalTrials.gov',


### PR DESCRIPTION
- Ticket: [ENG-2641](https://openscience.atlassian.net/browse/ENG-2641)
- Feature flag: n/a

## Purpose

Make:

<img width="676" alt="Screen Shot 2021-03-12 at 2 47 15 PM" src="https://user-images.githubusercontent.com/6599111/110992565-121f7b80-8344-11eb-9b48-029e96b99e40.png">

Be more like:

<img width="673" alt="Screen Shot 2021-03-12 at 2 46 26 PM" src="https://user-images.githubusercontent.com/6599111/110992588-19468980-8344-11eb-9831-447e622b4444.png">


## Summary of Changes

1. Change `max-width` on read-only contributor card to be `width`
2. Update an existing mirage scenario to make it easy to test things like this

## Side Effects

Nope, should be very isolated

## QA Notes

This is a low-risk change. Will just affect the CSS on that one component.
