### PR TITLE
[ENG-2641][Demo feedback] Change permission wording in unregistered contributor modal

### DIFF
--- a/lib/osf-components/addon/components/contributors/add-unregistered-modal/template.hbs
+++ b/lib/osf-components/addon/components/contributors/add-unregistered-modal/template.hbs
@@ -42,7 +42,7 @@
                 data-test-select-permission
                 as |permission|
             >
-                {{capitalize permission}}
+                {{t (concat 'osf-components.contributors.permissions.' permission)}}
             </form.select>
             {{#let (unique-id 'citation-checkbox') as |id|}}
                 <label for={{id}}>


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-2641]
- Feature flag: n/a

## Purpose
- Change wording for unregistered user permissions to match contributor list

## Summary of Changes
- see above

## Side Effects
- NA

## QA Notes
- This is only a wording change on the modal to add unregistered contributors. The new wording should be 'Read', 'Read + Write', and 'Administrator'

[ENG-2641]: https://openscience.atlassian.net/browse/ENG-2641