### PR TITLE
[ENG-2673] Show Add New button to all registration providers

### DIFF
--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -162,7 +162,6 @@ declare const config: {
         storageI18n: string;
         enableInactiveSchemas: string;
         verifyEmailModals: string;
-        egapAdmins: string;
     };
     gReCaptcha: {
         siteKey: string;

--- a/config/environment.js
+++ b/config/environment.js
@@ -281,7 +281,6 @@ module.exports = function(environment) {
             ABTesting: {
                 homePageHeroTextVersionB: 'ab_testing_home_page_hero_text_version_b',
             },
-            egapAdmins: 'egap_admins',
         },
         gReCaptcha: {
             siteKey: RECAPTCHA_SITE_KEY,

--- a/lib/registries/addon/branded/new/route.ts
+++ b/lib/registries/addon/branded/new/route.ts
@@ -2,18 +2,11 @@ import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import Features from 'ember-feature-flags/services/features';
-import config from 'ember-get-config';
 
 import requireAuth from 'ember-osf-web/decorators/require-auth';
 import RegistrationProviderModel from 'ember-osf-web/models/registration-provider';
 import Analytics from 'ember-osf-web/services/analytics';
 import BrandedRegistriesNewSubmissionController from './controller';
-
-const {
-    featureFlagNames: {
-        egapAdmins,
-    },
-} = config;
 
 @requireAuth()
 export default class BrandedRegistriesNewSubmissionRoute extends Route {
@@ -29,11 +22,6 @@ export default class BrandedRegistriesNewSubmissionRoute extends Route {
         const currentUrl = href.replace(origin, '');
 
         if (!provider.allowSubmissions) {
-            this.transitionTo('page-not-found', currentUrl.slice(1));
-        }
-
-        // TODO: Remove this when moderation is in place
-        if (provider.id === 'egap' && !this.features.isEnabled(egapAdmins)) {
             this.transitionTo('page-not-found', currentUrl.slice(1));
         }
     }

--- a/lib/registries/addon/components/registries-navbar/component.ts
+++ b/lib/registries/addon/components/registries-navbar/component.ts
@@ -3,9 +3,7 @@ import { computed } from '@ember/object';
 import { and } from '@ember/object/computed';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
-import { camelize } from '@ember/string';
 import Features from 'ember-feature-flags/services/features';
-import config from 'ember-get-config';
 
 import { layout } from 'ember-osf-web/decorators/component';
 import RegistrationProviderModel from 'ember-osf-web/models/registration-provider';
@@ -18,11 +16,6 @@ import registriesConfig from 'registries/config/environment';
 import template from './template';
 
 const { externalLinks } = registriesConfig;
-const {
-    featureFlagNames: {
-        egapAdmins,
-    },
-} = config;
 
 @tagName('')
 @layout(template)
@@ -43,10 +36,7 @@ export default class RegistriesNavbar extends AuthBase {
     @computed('provider.{allowSubmissions,id}')
     get showAddRegistrationButton() {
         if (!this.provider) {
-            return false;
-        }
-        if (this.provider.id === 'egap') {
-            return this.features.isEnabled(camelize(egapAdmins));
+            return true;
         }
         return this.provider.allowSubmissions;
     }

--- a/tests/engines/registries/acceptance/branded/new-test.ts
+++ b/tests/engines/registries/acceptance/branded/new-test.ts
@@ -1,7 +1,5 @@
 import { click, currentRouteName } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import Features from 'ember-feature-flags';
-import config from 'ember-get-config';
 import { percySnapshot } from 'ember-percy';
 import { module, test } from 'qunit';
 
@@ -32,31 +30,6 @@ module('Registries | Acceptance | branded.new', hooks => {
         const brandedProvider = server.create('registration-provider',
             'withBrand', 'submissionsNotAllowed');
         await visit(`/registries/${brandedProvider.id}/new`);
-        assert.equal(currentRouteName(), 'registries.page-not-found', 'At the correct route: page-not-found');
-    });
-
-    test('only serves EGAP brand.new if egapAdmins feature flag is enabled', async function(assert) {
-        const brandedProvider = server.create('registration-provider', {
-            id: 'egap',
-            assets: {
-                favicon: 'fakelink',
-            },
-        }, 'withBrand');
-        const { featureFlagNames: { egapAdmins } } = config;
-        const features = this.owner.lookup('service:features') as Features;
-
-        await visit(`/registries/${brandedProvider.id}/new`);
-        assert.equal(currentRouteName(), 'registries.page-not-found', 'At the correct route: page-not-found');
-
-        features.enable(egapAdmins);
-        await visit(`/registries/${brandedProvider.id}/new`);
-        assert.ok(features.isEnabled(egapAdmins), 'egapAdmins flag is enabled');
-        assert.equal(currentRouteName(), 'registries.branded.new', 'At the correct route: EGAP branded.new');
-        assert.ok(document.querySelector('link[rel="icon"][href="fakelink"]'));
-
-        features.disable(egapAdmins);
-        await visit(`/registries/${brandedProvider.id}/new`);
-        assert.notOk(features.isEnabled(egapAdmins), 'egapAdmins flag is disabled');
         assert.equal(currentRouteName(), 'registries.page-not-found', 'At the correct route: page-not-found');
     });
 


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-2673]
- Feature flag: n/a

## Purpose
- Show the Add New button to the navbar for all the registration provider

## Summary of Changes
- Remove checks to remove the Add New button
- Remove test checking if Add New button isn't there for EGAP

## Side Effects
- NA
## QA Notes
- The Add New button should be present for all Registration Providers now (including OSF Registries).
  - `registries/egap/discover` and `registries/discover` should now have the Add New button on the navbar
  - Other registration pages should still have the Add New button on the navbar too

[ENG-2673]: https://openscience.atlassian.net/browse/ENG-2673