### PR TITLE
[ENG-2673] Show Add New for button for OSFRegistries

### DIFF
--- a/lib/registries/addon/components/registries-navbar/component.ts
+++ b/lib/registries/addon/components/registries-navbar/component.ts
@@ -32,6 +32,7 @@ export default class RegistriesNavbar extends AuthBase {
     @service features!: Features;
 
     provider?: RegistrationProviderModel;
+    defaultProviderId: string = 'osf';
 
     @and('media.isMobile', 'searchDropdownOpen') showSearchDropdown!: boolean;
 
@@ -42,6 +43,7 @@ export default class RegistriesNavbar extends AuthBase {
 
     @computed('provider.{allowSubmissions,id}')
     get showAddRegistrationButton() {
+        // Check if this is OSF Registries
         if (!this.provider) {
             return true;
         }

--- a/lib/registries/addon/components/registries-navbar/component.ts
+++ b/lib/registries/addon/components/registries-navbar/component.ts
@@ -17,7 +17,7 @@ import registriesConfig from 'registries/config/environment';
 
 import template from './template';
 
-const { externalLinks } = registriesConfig;
+const { externalLinks, defaultProviderId } = registriesConfig;
 const {
     featureFlagNames: {
         egapAdmins,
@@ -32,9 +32,13 @@ export default class RegistriesNavbar extends AuthBase {
     @service features!: Features;
 
     provider?: RegistrationProviderModel;
-    defaultProviderId: string = 'osf';
 
     @and('media.isMobile', 'searchDropdownOpen') showSearchDropdown!: boolean;
+
+    @computed('provider')
+    get providerId() {
+        return this.provider ? this.provider.id : defaultProviderId;
+    }
 
     @computed('media.isMobile', 'provider.brand')
     get shouldShowProviderName() {

--- a/lib/registries/addon/components/registries-navbar/component.ts
+++ b/lib/registries/addon/components/registries-navbar/component.ts
@@ -43,7 +43,7 @@ export default class RegistriesNavbar extends AuthBase {
     @computed('provider.{allowSubmissions,id}')
     get showAddRegistrationButton() {
         if (!this.provider) {
-            return false;
+            return true;
         }
         if (this.provider.id === 'egap') {
             return this.features.isEnabled(camelize(egapAdmins));

--- a/lib/registries/addon/components/registries-navbar/template.hbs
+++ b/lib/registries/addon/components/registries-navbar/template.hbs
@@ -75,7 +75,7 @@
                     data-analytics-name='Create new registration'
                     local-class='SecondaryNavLinkButton'
                     @route='registries.branded.new'
-                    @models={{if this.provider (array this.provider.id) (array 'osf')}}
+                    @models={{if this.provider (array this.provider.id) (array this.defaultProviderId)}}
                 >
                     {{t 'navbar.add_registration'}}
                 </nav.links.secondary>

--- a/lib/registries/addon/components/registries-navbar/template.hbs
+++ b/lib/registries/addon/components/registries-navbar/template.hbs
@@ -75,7 +75,7 @@
                     data-analytics-name='Create new registration'
                     local-class='SecondaryNavLinkButton'
                     @route='registries.branded.new'
-                    @models={{if this.provider (array this.provider.id) (array this.defaultProviderId)}}
+                    @models={{array this.providerId}}
                 >
                     {{t 'navbar.add_registration'}}
                 </nav.links.secondary>

--- a/lib/registries/addon/components/registries-navbar/template.hbs
+++ b/lib/registries/addon/components/registries-navbar/template.hbs
@@ -75,7 +75,7 @@
                     data-analytics-name='Create new registration'
                     local-class='SecondaryNavLinkButton'
                     @route='registries.branded.new'
-                    @models={{array this.provider.id}}
+                    @models={{if this.provider (array this.provider.id) (array 'osf')}}
                 >
                     {{t 'navbar.add_registration'}}
                 </nav.links.secondary>

--- a/lib/registries/config/environment.d.ts
+++ b/lib/registries/config/environment.d.ts
@@ -15,6 +15,7 @@ declare const config: {
         help: string;
         donate: string;
     };
+    defaultProviderId: string;
 };
 
 export default config;

--- a/lib/registries/config/environment.js
+++ b/lib/registries/config/environment.js
@@ -46,6 +46,7 @@ module.exports = function(environment) {
             help: 'https://openscience.zendesk.com/hc/en-us/categories/360001550953',
             donate: 'https://cos.io/donate',
         },
+        defaultProviderId: 'osf',
     };
 
     if (environment === 'test') {


### PR DESCRIPTION
- Ticket: [ENG-2673]
- Feature flag: n/a

## Purpose
- Allow users to create a draft registration to OSF Registries by using the Add New button

## Summary of Changes
- Show Add New button when looking at OSF Registries

## Side Effects
- NA

## QA Notes
- Add New button will be visible on `osf.io/registries/discover` route. This button will take users to `osf.io/registries/osf/new` and users should be able to submit to OSF registries from there

[ENG-2673]: https://openscience.atlassian.net/browse/ENG-2673