### PR TITLE
[ENG-2641] Remove contributor permissions search

### DIFF
--- a/lib/osf-components/addon/components/contributors/card/editable/template.hbs
+++ b/lib/osf-components/addon/components/contributors/card/editable/template.hbs
@@ -35,6 +35,7 @@
                 @selected={{@contributor.permission}}
                 @options={{this.permissionOptions}}
                 @onchange={{fn @manager.updateContributorPermission @contributor}}
+                @searchEnabled={{false}}
                 as |option|
             >
                 <span data-test-contributor-permission-choice={{option}}>

--- a/lib/osf-components/addon/components/contributors/user-search/card/template.hbs
+++ b/lib/osf-components/addon/components/contributors/user-search/card/template.hbs
@@ -29,6 +29,7 @@
                     @options={{this.permissionOptions}}
                     @onchange={{fn this.updatePermission}}
                     @disabled={{this.isAdded}}
+                    @searchEnabled={{false}}
                     as |option|
                 >
                     <span data-test-user-permission-choice={{option}}>


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-2641]
- Feature flag: n/a

## Purpose
- Remove the search box from the contributor permissions dropdown

## Summary of Changes
- set the `searchEnabled` argument to the power select component invoked to be false
## Screenshots
Before:
![Screen Shot 2021-03-22 at 5 25 06 PM](https://user-images.githubusercontent.com/51409893/112060774-faaa7480-8b33-11eb-86b1-2bd1e51fb376.png)

After:
![Screen Shot 2021-03-22 at 5 25 39 PM](https://user-images.githubusercontent.com/51409893/112060784-ff6f2880-8b33-11eb-8e51-2558aa7c25b2.png)

## Side Effects
- Users now won't be able to search the permissions in the contributor widget, but there's only 3 options, so I don't think it was helping really...

## QA Notes
- When adding/modifying contributor permissions, the dropdown to select the permission should no longer have the search box. 

[ENG-2641]: https://openscience.atlassian.net/browse/ENG-2641