### PR TITLE
[ENG-2641] Add analytics to Add New page radio buttons

### DIFF
--- a/lib/registries/addon/branded/new/template.hbs
+++ b/lib/registries/addon/branded/new/template.hbs
@@ -32,6 +32,7 @@
                             {{#let (unique-id) 'has-project' as |hasProjectId|}}
                                 <input
                                     data-test-has-project-button
+                                    data-analytics-name='Toggle to project based registration'
                                     local-class='RadioElement RadioInput'
                                     id={{hasProjectId}}
                                     type='radio'
@@ -51,6 +52,7 @@
                             {{#let (unique-id) 'no-project' as |noProjectId|}}
                                 <input
                                     data-test-no-project-button
+                                    data-analytics-name='Toggle to no project registration'
                                     local-class='RadioElement RadioInput'
                                     id={{noProjectId}}
                                     type='radio'


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-2641]
- Feature flag: n/a

## Purpose
- Add analytics to the Add New page's project-based/no-project registration radio buttons

## Summary of Changes
- Add analytics called `Toggle to project based registration` or `Toggle to no project registration` based on which radio button is selected

## Side Effects
NA
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- Analytics events should be firing when users toggle between project-based and no-project registrations on the Add New page. The Network tab in the developer tools should show an event going to `https://www.google-analytics.com/j/collect` when toggling between these buttons

[ENG-2641]: https://openscience.atlassian.net/browse/ENG-2641