### PR TITLE
[ENG-2604][ENG-2273] Show registration provider description

### DIFF
--- a/app/models/registration-provider.ts
+++ b/app/models/registration-provider.ts
@@ -1,3 +1,4 @@
+import { htmlSafe } from '@ember/string';
 import DS from 'ember-data';
 import ReviewActionModel from 'ember-osf-web/models/review-action';
 
@@ -41,6 +42,14 @@ export default class RegistrationProviderModel extends ProviderModel {
             return this.permissions.includes(ReviewPermissions.ViewSubmissions);
         }
         return false;
+    }
+
+    @computed('description')
+    get htmlSafeDescription() {
+        if (this.description) {
+            return htmlSafe(this.description);
+        }
+        return '';
     }
 }
 

--- a/lib/registries/addon/components/registries-header/styles.scss
+++ b/lib/registries/addon/components/registries-header/styles.scss
@@ -2,6 +2,12 @@
     padding: 30px 0;
 }
 
+.ProviderDescription {
+    position: relative;
+    margin: 0 65px;
+    padding-top: 10px;
+}
+
 .RegistriesHeader {
     color: #fff;
 

--- a/lib/registries/addon/components/registries-header/template.hbs
+++ b/lib/registries/addon/components/registries-header/template.hbs
@@ -54,7 +54,10 @@
     </div>
     {{#if @providerModel.htmlSafeDescription}}
         <div  local-class='ProviderDescription' class='row m-t-md m-b-lg'>
-            <div class='col-xs-12 col-sm-8 col-sm-offset-2'>
+            <div
+                data-test-provider-description
+                class='col-xs-12 col-sm-8 col-sm-offset-2'
+            >
                 {{@providerModel.htmlSafeDescription}}
             </div>
         </div>

--- a/lib/registries/addon/components/registries-header/template.hbs
+++ b/lib/registries/addon/components/registries-header/template.hbs
@@ -52,7 +52,13 @@
             </form>
         </div>
     </div>
-
+    {{#if @providerModel.htmlSafeDescription}}
+        <div  local-class='ProviderDescription' class='row m-t-md m-b-lg'>
+            <div class='col-xs-12 col-sm-8 col-sm-offset-2'>
+                {{@providerModel.htmlSafeDescription}}
+            </div>
+        </div>
+    {{/if}}
     <div class='row p-v-sm'>
         {{yield (hash row=(element ''))}}
     </div>

--- a/lib/registries/addon/discover/styles.scss
+++ b/lib/registries/addon/discover/styles.scss
@@ -1,13 +1,3 @@
-.ShareLogo {
-    background-size: contain !important;
-    background-repeat: no-repeat !important;
-    background: url('img/share-logo-white.png');
-    display: inline-block;
-    height: 33px;
-    vertical-align: middle;
-    width: 69px;
-}
-
 .ResultsHeader {
     padding: 0 0 15px;
 

--- a/lib/registries/addon/discover/template.hbs
+++ b/lib/registries/addon/discover/template.hbs
@@ -6,14 +6,13 @@
     data-analytics-scope='Registries Discover page'
 >
     <HeroOverlay local-class='DiscoverHero'>
-        {{#registries-header
+        {{registries-header
             providerModel=this.providerModel
             showHelp=true
             value=(mut this.query)
             onSearch=(action 'onSearch')
             searchable=this.searchable
         }}
-        {{/registries-header}}
     </HeroOverlay>
     {{#registries-discover-search
         results=this.results

--- a/lib/registries/addon/discover/template.hbs
+++ b/lib/registries/addon/discover/template.hbs
@@ -12,18 +12,7 @@
             value=(mut this.query)
             onSearch=(action 'onSearch')
             searchable=this.searchable
-        as |header|}}
-            {{#header.lead}}
-                {{t 'registries.discover.powered_by' }}
-                <a
-                    data-test-share-logo
-                    href='https://share.osf.io/'
-                    local-class='ShareLogo'
-                    title={{t 'registries.discover.SHARE'}}
-                    aria-label={{t 'registries.discover.go_to_SHARE'}}
-                    data-analytics-name='SHARE Logo'
-                ></a>
-            {{/header.lead}}
+        }}
         {{/registries-header}}
     </HeroOverlay>
     {{#registries-discover-search

--- a/mirage/factories/registration-provider.ts
+++ b/mirage/factories/registration-provider.ts
@@ -29,7 +29,7 @@ export default Factory.extend<MirageRegistrationProvider & RegistrationProviderT
         return `provider-${i}`;
     },
     description() {
-        return faker.lorem.sentence();
+        return `${faker.lorem.paragraph()} Find out <a href="https://help.osf.io/">more</a>.`;
     },
     allowSubmissions: true,
     brandedDiscoveryPage: true,

--- a/tests/engines/registries/acceptance/branded/discover-test.ts
+++ b/tests/engines/registries/acceptance/branded/discover-test.ts
@@ -37,6 +37,8 @@ module('Registries | Acceptance | branded.discover', hooks => {
         assert.dom('[data-test-source-filter-id]').isChecked('Provider facet checkbox is checked');
         assert.dom('[data-test-source-filter-id]').isDisabled('Provider facet checkbox is disabled');
         assert.dom('[data-test-link-other-registries]').exists('Link to other registries is shown');
+        assert.dom('[data-test-provider-description]').containsText('Find out more', 'Provider description exists');
+        assert.dom('[data-test-provider-description] a').exists('There is a link in the provider description');
         assert.ok(document.querySelector('link[rel="icon"][href="fakelink"]'));
     });
 

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1049,7 +1049,6 @@ registries:
         go_to_SHARE: 'Go to SHARE'
         registration_count: '{count, plural, =1 {# Registration} other {# Registrations}}'
         sort_by: 'Sort by'
-        powered_by: 'powered by'
         no_results: 'No results found.'
         try_broadening: 'Try broadening your search terms'
         error_loading: 'There was an error loading registrations'


### PR DESCRIPTION
- Ticket: [ENG-2604](https://openscience.atlassian.net/browse/ENG-2604)
- Ticket: [ENG-2273](https://openscience.atlassian.net/browse/ENG-2273)

## Purpose

Show the description from the registration provider on the discover page, including html. Also, while we're here, remove the 'Powered by SHARE' logo.

<img width="793" alt="Screen Shot 2021-03-26 at 2 19 12 PM" src="https://user-images.githubusercontent.com/6599111/112676019-4e6fd300-8e3e-11eb-9ec1-6aa7e2a9bb82.png">
<img width="951" alt="Screen Shot 2021-03-26 at 2 19 05 PM" src="https://user-images.githubusercontent.com/6599111/112676020-4e6fd300-8e3e-11eb-8829-a02c51e881ed.png">
<img width="1503" alt="Screen Shot 2021-03-26 at 2 18 57 PM" src="https://user-images.githubusercontent.com/6599111/112676022-4e6fd300-8e3e-11eb-8e66-e9ff03cb86da.png">
<img width="1970" alt="Screen Shot 2021-03-26 at 1 00 36 PM" src="https://user-images.githubusercontent.com/6599111/112676023-4e6fd300-8e3e-11eb-9643-7e84e43c9235.png">


## Summary of Changes

1. Make an HTML Safe computed on the provider model for the description
2. Change the mirage factory for registration provider to provide better data for this case
3. [Remove the 'Powered by SHARE' logo](https://openscience.atlassian.net/browse/ENG-2273)
4. Show the registry provider description on the discover page

## Side Effects

Should be pretty localized.

## QA Notes

The registry discover pages should be tested. It will need the provider's description to be set in the admin app. HTML should work fine in this widget.
