### PR TITLE
[LukewarmFix] Bypass file validation throttle

### DIFF
--- a/app/validators/validate-response-format.ts
+++ b/app/validators/validate-response-format.ts
@@ -4,18 +4,16 @@ import buildMessage from 'ember-changeset-validations/utils/validation-errors';
 import DraftNode from 'ember-osf-web/models/draft-node';
 import File from 'ember-osf-web/models/file';
 import NodeModel from 'ember-osf-web/models/node';
-import { allSettled } from 'rsvp';
 
 export function validateFileList(responseKey: string, node?: NodeModel | DraftNode): ValidatorFunction {
     return async (_: string, newValue: File[]) => {
         if (newValue && node) {
-            const fileReloads: Array<() => Promise<File>> = [];
-            newValue.forEach(file => {
+            for (const file of newValue) {
                 if (file && !file.isError) {
-                    fileReloads.push(file.reload());
+                    // eslint-disable-next-line no-await-in-loop
+                    await file.reload();
                 }
-            });
-            await allSettled(fileReloads);
+            }
 
             const detachedFiles = [];
 


### PR DESCRIPTION
- Ticket: []
- Feature flag: n/a

## Purpose

Execute file validation requests sequentially instead of concurrently.

## Summary of Changes

Instead of `allSettled` the promises, we await each promise sequentially with a for loop.

Note: Assuming that prod has the same throttle of file ops as specified in `local-dist.py`, which is 3/sec for `files-burst`, executing requests sequentially should not break this throttle limit, as each request to staging2 API for file validation takes about 500 ms. However we need to deploy this to staging2 just to make sure. Testing this locally doesn't really help because local test servers are rrrrrreeeeaaaalllllly slow and the problem couldn't be replicated.
 
## Side Effects

File validations on drafts are slower, but better than not validated at all.

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
