### PR TITLE
[ENG-2751] Allow provider descriptions to have color options

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -120,6 +120,12 @@ $color-alt: #c7ffc7;
 $color-select: #337ab7;
 $color-grey: #333;
 $color-filter-bg: #a4b3bd;
+$color-red: #f00;
+$color-green: #090;
+$color-yellow: #ff0;
+$color-turquoise: rgb(64, 224, 211);
+$color-purple: rgb(154, 0, 192);
+$color-black: #000;
 
 .bg-color-blue {
     background-color: $color-blue;

--- a/lib/registries/addon/components/registries-header/styles.scss
+++ b/lib/registries/addon/components/registries-header/styles.scss
@@ -6,6 +6,100 @@
     position: relative;
     margin: 0 65px;
     padding-top: 10px;
+
+    :global(.ColorBlack) {
+        color: $color-text-black;
+    }
+
+    :global(.ColorPureBlack) {
+        color: $color-black;
+    }
+
+    :global(.ColorBlue) {
+        color: $color-blue;
+    }
+
+    :global(.ColorPureBlue) {
+        color: $color-pure-blue;
+    }
+
+    :global(.ColorGrey) {
+        color: $color-text-gray;
+    }
+
+    :global(.ColorRed) {
+        color: $color-red;
+    }
+
+    :global(.ColorGreen) {
+        color: $color-green;
+    }
+
+    :global(.ColorYellow) {
+        color: $color-yellow;
+    }
+
+    :global(.ColorTurquoise) {
+        color: $color-turquoise;
+    }
+
+    :global(.ColorPurple) {
+        color: $color-purple;
+    }
+
+    :global(.LinkColorBlack) {
+        a {
+            color: $color-link-black;
+        }
+    }
+
+    :global(.LinkColorBlue) {
+        a {
+            color: $color-link-blue;
+        }
+    }
+
+    :global(.LinkColorPureBlue) {
+        a {
+            color: $color-pure-blue;
+        }
+    }
+
+    :global(.LinkColorGrey) {
+        a {
+            color: $color-grey;
+        }
+    }
+
+    :global(.LinkColorRed) {
+        a {
+            color: $color-red;
+        }
+    }
+
+    :global(.LinkColorGreen) {
+        a {
+            color: $color-green;
+        }
+    }
+
+    :global(.LinkColorYellow) {
+        a {
+            color: $color-yellow;
+        }
+    }
+
+    :global(.LinkColorTurquoise) {
+        a {
+            color: $color-turquoise;
+        }
+    }
+
+    :global(.LinkColorPurple) {
+        a {
+            color: $color-purple;
+        }
+    }
 }
 
 .RegistriesHeader {
@@ -72,3 +166,4 @@
         color: var(--secondary-color);
     }
 }
+


### PR DESCRIPTION
- Ticket: [ENG-2751](https://openscience.atlassian.net/browse/ENG-2751)
- Feature flag: n/a

## Purpose

Give product the ability to do limited changes of the color of the Provider Description text and links. One would use it by wrapping the description in a span with the appropriate classes. For example, `<span class="ColorBlack LinkColorPurple">This is the provider description <a href="https://osf.io/">with a link</a>.</span>`. I added the following CSS classes for use by Product:

For text: 

- ColorBlack
- ColorPureBlack
- ColorBlue
- ColorPureBlue
- ColorGrey
- ColorRed
- ColorGreen
- ColorYellow
- ColorTurquoise
- ColorPurple

For links:

- LinkColorBlack
- LinkColorBlue
- LinkColorPureBlue
- LinkColorGrey
- LinkColorRed
- LinkColorGreen
- LinkColorYellow
- LinkColorTurquoise
- LinkColorPurple

Original could only look like:
<img width="1117" alt="Screen Shot 2021-04-12 at 1 32 54 PM" src="https://user-images.githubusercontent.com/6599111/114436673-9d826b80-9b93-11eb-81c6-762b6e66ada0.png">

Now can look like:
<img width="1135" alt="Screen Shot 2021-04-12 at 10 42 35 AM" src="https://user-images.githubusercontent.com/6599111/114436583-804d9d00-9b93-11eb-96bb-f84071b2d1d6.png">


## Summary of Changes

1. Add some colors to the _variables.scss
2. Add global classes, restricted to the local scope, that will change the color of the text and links of the provider description.

## Side Effects

Shouldn't be. The tooling that our admin app provides will strip out inline css, so we had to provide classes that would be usable from a dynamic text field in order to make color changes to the text and links. This meant using global classes, but I kept those classes only active within the ProviderDescription local class namespace. So everything should be restricted.

## QA Notes

This will only affect the discover page of a branded provider that's using the Provider Description option from the admin app. Instructions for use are at the top of this PR in the Description section.