### PR TITLE
[No ticket]Fix metadata panel for registry overview page for tablet view

### DIFF
--- a/lib/osf-components/addon/components/gutters/styles.scss
+++ b/lib/osf-components/addon/components/gutters/styles.scss
@@ -40,7 +40,6 @@
         // Display a box shadow to either side when opened
         &[data-gutter-closed='false'] {
             box-shadow: ($modifier * -5px) 0 5px -4px $color-shadow-dark;
-            overflow: visible;
         }
 
         // Slide off the page when closed


### PR DESCRIPTION

- Ticket: [No ticket]
- Feature flag: n/a

## Purpose
Fix tablet view of the metadata panel for registration overview page

## Summary of Changes
- remove unneeded style
## Screenshots
Before:
![Screen Shot 2021-04-14 at 5 26 32 PM](https://user-images.githubusercontent.com/51409893/114782120-8edcb580-9d47-11eb-82ce-0e88068614ea.png)

After:
![Screen Shot 2021-04-14 at 5 26 42 PM](https://user-images.githubusercontent.com/51409893/114782138-9603c380-9d47-11eb-936b-54fe3dcfd533.png)

## Side Effects
- There should be none... I think this style was added in by mistake to begin with
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- for tablets (or for mobile if the screen is landscape), there should no longer be the weird background-less view for the metadata panel