### PR TITLE
Fix FaIcon size parameters

### DIFF
--- a/lib/app-components/addon/components/project-contributors/search/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/search/template.hbs
@@ -47,7 +47,7 @@
     </h3>
     {{#if this.search.isRunning}}
         <div class='text-center'>
-            <FaIcon @icon='spinner' @pulse={{true}} @size={{2}} />
+            <FaIcon @icon='spinner' @pulse={{true}} @size='2x' />
         </div>
     {{else if this.results.length}}
         <table class='table'>

--- a/lib/collections/addon/components/collections-submission/template.hbs
+++ b/lib/collections/addon/components/collections-submission/template.hbs
@@ -61,7 +61,7 @@
                         <FaIcon
                             @icon='spinner'
                             @pulse={{true}}
-                            @size={{2}}
+                            @size='2x'
                         />
                     </div>
                 {{/if}}

--- a/lib/collections/addon/components/discover-page/template.hbs
+++ b/lib/collections/addon/components/discover-page/template.hbs
@@ -169,7 +169,7 @@
                         class='text-center p-v-md'
                         aria-label={{t 'collections.discover_page.searchLoading'}}
                     >
-                        <FaIcon @icon='spinner' @pulse={{true}} @size={{3}} />
+                        <FaIcon @icon='spinner' @pulse={{true}} @size='3x' />
                     </div>
                 {{else}}
                     {{#if this.numberOfResults}}

--- a/lib/osf-components/addon/components/file-browser/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/template.hbs
@@ -441,7 +441,7 @@
     <div class='file-browser-list' local-class='file-browser-list'>
         <div local-class='shade {{unless this.dropping 'transparent'}}'>
             <div local-class='upload-drop'>
-                <div local-class='upload-text'>{{fa-icon 'upload' size=5}}</div>
+                <div local-class='upload-text'>{{fa-icon 'upload' size='5x'}}</div>
                 <div local-class='upload-text'>{{t 'file_browser.drop_reminder'}}</div>
             </div>
         </div>
@@ -480,7 +480,7 @@
             <div local-class='file-placeholder'>
                 {{#if this.canEdit}}
                     <div local-class='file-placeholder-content'>
-                        <div>{{fa-icon 'upload' size=5}}</div>
+                        <div>{{fa-icon 'upload' size='5x'}}</div>
                         <div local-class='file-placeholder-text'>{{t 'file_browser.drop_placeholder'}}</div>
                     </div>
                 {{else}}

--- a/lib/osf-components/addon/components/files/list/template.hbs
+++ b/lib/osf-components/addon/components/files/list/template.hbs
@@ -8,7 +8,7 @@
     {{else}}
         {{#if @filesManager.canEdit}}
             <div data-test-no-files-placeholder local-class='placeholder'>
-                <FaIcon @icon='upload' @size='4' />
+                <FaIcon @icon='upload' @size='4x' />
                 {{t 'osf-components.files-widget.drag_drop_files'}}
             </div>
         {{/if}}

--- a/lib/osf-components/addon/components/files/menu/template.hbs
+++ b/lib/osf-components/addon/components/files/menu/template.hbs
@@ -11,7 +11,7 @@
             @onClick={{action dropdownMenu.toggle}}
             @type='success'
         >
-            <FaIcon @icon='plus' @size='2' @fixedWidth={{true}} />
+            <FaIcon @icon='plus' @size='2x' @fixedWidth={{true}} />
         </OsfButton>
     </div>
     <dropdownMenu.content>

--- a/lib/osf-components/addon/components/node-doi-create/template.hbs
+++ b/lib/osf-components/addon/components/node-doi-create/template.hbs
@@ -1,5 +1,5 @@
 <div local-class='CreateMessage'>
-    <FaIcon @icon='info-circle' @size='4' @fixedWidth={{true}} />
+    <FaIcon @icon='info-circle' @size='4x' @fixedWidth={{true}} />
     <div>
         <p>{{t 'registries.registration_metadata.mint_doi.header'}}</p>
         <p>{{t 'registries.registration_metadata.mint_doi.text'}}</p>

--- a/lib/osf-components/addon/components/registries/registration-list/card/template.hbs
+++ b/lib/osf-components/addon/components/registries/registration-list/card/template.hbs
@@ -6,7 +6,7 @@
     <FaIcon
         data-test-registration-list-card-icon='{{@state}}'
         @icon={{this.icon}}
-        @size={{2}}
+        @size='2x'
         local-class='filterIcon {{@state}}'
     />
     <div local-class='cardInfo'>

--- a/lib/registries/addon/components/registries-states/template.hbs
+++ b/lib/registries/addon/components/registries-states/template.hbs
@@ -16,7 +16,7 @@
     >
         {{#if this.stateText}}
             <div local-class='DescriptionContainer'>
-                <FaIcon data-test-state-icon @icon={{this.stateIcon}} @size='4' />
+                <FaIcon data-test-state-icon @icon={{this.stateIcon}} @size='4x' />
                 <div local-class='DescriptionText'>
                     <h4 data-test-state-description-short>{{this.stateText.short}}</h4>
                     <p


### PR DESCRIPTION
## Purpose

Fix all the cases of the size parameter being mis-used in the new Font Awesome icons.

## Summary of Changes

All places in the code where `size='[0-9]'` or `size={{[0-9]}}`

1. Project contributors search spinner (do we still even use a spinner?)
2. Collections submission spinner (apparently)
3. Collections discover page spinner (seriously?)
4. Quickfiles no-file state upload icon
5. Files list upload icon
6. Files menu plus icon
7. Node-doi create info icon (I think this isn't used anymore, or won't be soon)
8. Registration card state icons

## QA Notes

This should be limited to just the places above.