### PR TITLE
[ENG-2713] Use provider's schemas relationship to get registration schemas

### DIFF
--- a/app/guid-node/registrations/controller.ts
+++ b/app/guid-node/registrations/controller.ts
@@ -5,8 +5,10 @@ import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency-decorators';
 import DS from 'ember-data';
+import config from 'ember-get-config';
 
 import Node from 'ember-osf-web/models/node';
+import RegistrationProviderModel from 'ember-osf-web/models/registration-provider';
 import RegistrationSchema from 'ember-osf-web/models/registration-schema';
 import Analytics from 'ember-osf-web/services/analytics';
 
@@ -37,11 +39,12 @@ export default class GuidNodeRegistrations extends Controller {
 
     @task({ withTestWaiter: true })
     getRegistrationSchemas = task(function *(this: GuidNodeRegistrations) {
-        let schemas = yield this.store.query('registration-schema',
-            {
-                'filter[active]': true,
-                'page[size]': 100,
-            });
+        const { defaultProvider } = config;
+        const provider: RegistrationProviderModel = yield this.store.findRecord(
+            'registration-provider',
+            defaultProvider,
+        );
+        let schemas: RegistrationSchema[] = yield provider.loadAll('schemas');
         schemas = schemas.toArray();
         schemas.sort((a: RegistrationSchema, b: RegistrationSchema) => a.name.length - b.name.length);
         this.set('defaultSchema', schemas.firstObject);

--- a/mirage/factories/registration-provider.ts
+++ b/mirage/factories/registration-provider.ts
@@ -18,6 +18,7 @@ export interface MirageRegistrationProvider extends RegistrationProvider {
 
 export interface RegistrationProviderTraits {
     withBrand: Trait;
+    withAllSchemas: Trait;
     withSchemas: Trait;
     submissionsNotAllowed: Trait;
     withModerators: Trait;
@@ -64,6 +65,27 @@ export default Factory.extend<MirageRegistrationProvider & RegistrationProviderT
     withSchemas: trait<RegistrationProvider>({
         afterCreate(provider, server) {
             provider.update({ schemas: [server.schema.registrationSchemas.find('testSchema')] });
+        },
+    }),
+    withAllSchemas: trait<RegistrationProvider>({
+        afterCreate(provider, server) {
+            provider.update(
+                {
+                    schemas: [
+                        server.schema.registrationSchemas.find('testSchema'),
+                        server.schema.registrationSchemas.find('testSchemaTwo'),
+                        server.schema.registrationSchemas.find('testSchemaThree'),
+                        server.schema.registrationSchemas.find('prereg_challenge'),
+                        server.schema.registrationSchemas.find('open_ended_registration'),
+                        server.schema.registrationSchemas.find('as_predicted_preregsitration'),
+                        server.schema.registrationSchemas.find('registered_report_protocol_preregistration.'),
+                        server.schema.registrationSchemas.find('osf_standard_pre_data_collection_registration'),
+                        server.schema.registrationSchemas.find('replication_recipe_post_completion'),
+                        server.schema.registrationSchemas.find('replication_recipe_pre_registration'),
+                        server.schema.registrationSchemas.find('pre_registration_in_social_psychology'),
+                    ],
+                },
+            );
         },
     }),
     submissionsNotAllowed: trait<RegistrationProvider>({

--- a/mirage/factories/registration-provider.ts
+++ b/mirage/factories/registration-provider.ts
@@ -69,23 +69,8 @@ export default Factory.extend<MirageRegistrationProvider & RegistrationProviderT
     }),
     withAllSchemas: trait<RegistrationProvider>({
         afterCreate(provider, server) {
-            provider.update(
-                {
-                    schemas: [
-                        server.schema.registrationSchemas.find('testSchema'),
-                        server.schema.registrationSchemas.find('testSchemaTwo'),
-                        server.schema.registrationSchemas.find('testSchemaThree'),
-                        server.schema.registrationSchemas.find('prereg_challenge'),
-                        server.schema.registrationSchemas.find('open_ended_registration'),
-                        server.schema.registrationSchemas.find('as_predicted_preregsitration'),
-                        server.schema.registrationSchemas.find('registered_report_protocol_preregistration.'),
-                        server.schema.registrationSchemas.find('osf_standard_pre_data_collection_registration'),
-                        server.schema.registrationSchemas.find('replication_recipe_post_completion'),
-                        server.schema.registrationSchemas.find('replication_recipe_pre_registration'),
-                        server.schema.registrationSchemas.find('pre_registration_in_social_psychology'),
-                    ],
-                },
-            );
+            const schemas = server.schema.registrationSchemas.all().models;
+            provider.update({ schemas });
         },
     }),
     submissionsNotAllowed: trait<RegistrationProvider>({

--- a/mirage/fixtures/registration-schemas.ts
+++ b/mirage/fixtures/registration-schemas.ts
@@ -40,6 +40,30 @@ const testSchema = {
     },
 };
 
+const testSchemaTwo = {
+    id: 'testSchemaTwo',
+    active: true,
+    name: 'This is a second Test Schema',
+    schemaVersion: 801,
+    schemaBlockIds: ids,
+    schemaNoConflict: {
+        title: 'Fake title for testing',
+        pages: [],
+    },
+};
+
+const testSchemaThree = {
+    id: 'testSchemaThree',
+    active: true,
+    name: 'This is a third Test Schema',
+    schemaVersion: 801,
+    schemaBlockIds: ids,
+    schemaNoConflict: {
+        title: 'Fake title for testing',
+        pages: [],
+    },
+};
+
 export default [
     prereg_challenge,
     open_ended_registration,
@@ -50,6 +74,8 @@ export default [
     replication_recipe_pre_registration,
     pre_registration_in_social_psychology,
     testSchema,
+    testSchemaTwo,
+    testSchemaThree,
 ] as MirageRegistrationSchema[];
 
 /* eslint-enable camelcase */

--- a/mirage/scenarios/registrations.ts
+++ b/mirage/scenarios/registrations.ts
@@ -1,4 +1,5 @@
 import { ModelInstance, Server } from 'ember-cli-mirage';
+import config from 'ember-get-config';
 
 import { StorageStatus } from 'ember-osf-web/models/node-storage';
 import { Permission } from 'ember-osf-web/models/osf-model';
@@ -41,7 +42,14 @@ export function registrationScenario(
     server: Server,
     currentUser: ModelInstance<User>,
 ) {
+    const { defaultProvider } = config;
     server.loadFixtures('citation-styles');
+
+    server.create('registration-provider', {
+        id: defaultProvider,
+        shareSource: 'OSF Registries',
+        name: 'OSF Registries',
+    }, 'withAllSchemas');
 
     server.create('registration', { id: 'beefs' });
 
@@ -66,6 +74,7 @@ export function registrationScenario(
     };
 
     const rootNode = server.create('node', {
+        id: 'anode',
         public: false,
         contributors: server.createList('contributor', 10),
         currentUserPermissions: [Permission.Admin],

--- a/tests/acceptance/guid-node/registrations-test.ts
+++ b/tests/acceptance/guid-node/registrations-test.ts
@@ -1,5 +1,6 @@
 import { click as untrackedClick, currentRouteName } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import config from 'ember-get-config';
 import { percySnapshot } from 'ember-percy';
 import { module, test } from 'qunit';
 
@@ -13,11 +14,18 @@ import { click, currentURL, setupOSFApplicationTest, visit } from 'ember-osf-web
 
 import { Permission } from 'ember-osf-web/models/osf-model';
 
+const { defaultProvider } = config;
+
 module('Acceptance | guid-node/registrations', hooks => {
     setupOSFApplicationTest(hooks);
     setupMirage(hooks);
 
     test('logged out, no registrations', async assert => {
+        server.create('registration-provider', {
+            id: defaultProvider,
+            shareSource: 'OSF Registries',
+            name: 'OSF Registries',
+        });
         const node = server.create('node', { id: 'decaf', currentUserPermissions: [] });
 
         const url = `/${node.id}/registrations`;
@@ -148,7 +156,11 @@ module('Acceptance | guid-node/registrations', hooks => {
 
     test('logged in admin, no registrations', async assert => {
         server.create('user', 'loggedIn');
-
+        server.create('registration-provider', {
+            id: defaultProvider,
+            shareSource: 'OSF Registries',
+            name: 'OSF Registries',
+        });
         const node = server.create('node', { id: 'decaf' }, 'currentUserAdmin');
 
         const url = `/${node.id}/registrations`;
@@ -177,7 +189,11 @@ module('Acceptance | guid-node/registrations', hooks => {
 
     test('logged in admin, 1 registration', async assert => {
         const contributorUser = server.create('user', 'loggedIn');
-
+        server.create('registration-provider', {
+            id: defaultProvider,
+            shareSource: 'OSF Registries',
+            name: 'OSF Registries',
+        });
         const node = server.create('node', {
             id: 'decaf',
             title: 'Test Title',
@@ -362,6 +378,11 @@ module('Acceptance | guid-node/registrations', hooks => {
 
         server.loadFixtures('schema-blocks');
         server.loadFixtures('registration-schemas');
+        server.create('registration-provider', {
+            id: defaultProvider,
+            shareSource: 'OSF Registries',
+            name: 'OSF Registries',
+        }, 'withAllSchemas');
 
         const url = `/${node.id}/registrations`;
 
@@ -391,11 +412,15 @@ module('Acceptance | guid-node/registrations', hooks => {
 
     test('logged in admin, prereg challenge modal', async assert => {
         server.create('user', 'loggedIn');
-
         const node = server.create('node', { id: 'decaf' }, 'currentUserAdmin');
 
         server.loadFixtures('schema-blocks');
         server.loadFixtures('registration-schemas');
+        server.create('registration-provider', {
+            id: defaultProvider,
+            shareSource: 'OSF Registries',
+            name: 'OSF Registries',
+        }, 'withAllSchemas');
 
         const url = `/${node.id}/registrations`;
 

--- a/tests/acceptance/resolve-guid-test.ts
+++ b/tests/acceptance/resolve-guid-test.ts
@@ -3,6 +3,7 @@ import Service from '@ember/service';
 import { currentRouteName, currentURL, settled } from '@ember/test-helpers';
 import { getContext } from '@ember/test-helpers/setup-context';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import config from 'ember-get-config';
 import { setupApplicationTest } from 'ember-qunit';
 import { TestContext } from 'ember-test-helpers';
 import { module, test } from 'qunit';
@@ -93,6 +94,13 @@ module('Acceptance | resolve-guid', hooks => {
         });
 
         test('Registrations', async assert => {
+            const { defaultProvider } = config;
+
+            server.create('registration-provider', {
+                id: defaultProvider,
+                shareSource: 'OSF Registries',
+                name: 'OSF Registries',
+            });
             const node = server.create('node');
 
             await visit(`/${node.id}/registrations`);


### PR DESCRIPTION
- Ticket: [ENG-2713](https://openscience.atlassian.net/browse/ENG-2713)
- Feature flag: n/a

## Purpose

On the guid-node/registrations page, stop using the top-level schemas endpoint and instead use the default provider's schema relationship.

## Summary of Changes

1. Grab the default provider and that provider's schemas for the guid-node/registrations page's list of schemas
2. Fix tests
3. Add a 'withAllSchemas' trait to the registrationProvider factory
4. Add a couple more test schemas to the total number of schemas so we have more than 10
5. Make a couple of small mirage scenario changes to support the change and make testing easier

## Side Effects

Shouldn't be.

## QA Notes

This is the older workflow's (i.e. with project, through the project page) create registration list of schemas. It should work the same as it did before, I'm just grabbing the schemas from the same place that the new workflow (using the Add New button in registries) does, to keep that consistent. Also this endpoint should be a little more performant. It's a fairly low-risk change.
