### PR TITLE
[No ticket] Only show top-level registrations on my-registrations

### DIFF
--- a/lib/osf-components/addon/components/registries/my-registrations-list/registrations/component.ts
+++ b/lib/osf-components/addon/components/registries/my-registrations-list/registrations/component.ts
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+export default class MyRegistrationsListRegistrationsComponent extends Component {
+    filter = { filter: { parent: null } };
+}

--- a/lib/osf-components/addon/components/registries/my-registrations-list/registrations/template.hbs
+++ b/lib/osf-components/addon/components/registries/my-registrations-list/registrations/template.hbs
@@ -3,6 +3,7 @@
         @model={{@user}}
         @relationshipName='registrations'
         @usePlaceholders={{false}}
+        @query={{this.filter}}
         as |list|
     >
         <list.item as |registration|>

--- a/lib/osf-components/app/components/registries/my-registrations-list/registrations/component.js
+++ b/lib/osf-components/app/components/registries/my-registrations-list/registrations/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/registries/my-registrations-list/registrations/component';

--- a/mirage/views/utils/-private.ts
+++ b/mirage/views/utils/-private.ts
@@ -238,13 +238,10 @@ export function compareIds(
 }
 
 export function compare(
-    actualValue: string | boolean | string[] | null,
+    actualValue: string | boolean | string[],
     comparisonValue: string,
     operator: ComparisonOperators,
 ): boolean {
-    if (actualValue === null) {
-        return compareStrings('', comparisonValue, operator);
-    }
     if (typeof actualValue === 'string') {
         return compareStrings(actualValue, comparisonValue, operator);
     }

--- a/mirage/views/utils/-private.ts
+++ b/mirage/views/utils/-private.ts
@@ -238,10 +238,13 @@ export function compareIds(
 }
 
 export function compare(
-    actualValue: string | boolean | string[],
+    actualValue: string | boolean | string[] | null,
     comparisonValue: string,
     operator: ComparisonOperators,
 ): boolean {
+    if (actualValue === null) {
+        return compareStrings('', comparisonValue, operator);
+    }
     if (typeof actualValue === 'string') {
         return compareStrings(actualValue, comparisonValue, operator);
     }

--- a/mirage/views/utils/index.ts
+++ b/mirage/views/utils/index.ts
@@ -43,11 +43,10 @@ export function filter(model: ModelInstance, request: Request) {
                     if (field === 'id') {
                         return compareIds(model.id, val, toOperator(operator));
                     }
-                    if (model[`${field}Ids`] === null || model[`${field}Id`] === null) {
-                        return compareIds('', val, toOperator(operator));
-                    }
-                    if (model[`${field}Ids`] || model[`${field}Id`]) {
-                        return compareIds(model[`${field}Ids`] || model[`${field}Id`], val, toOperator(operator));
+                    if (model[`${field}Ids`] || model[`${field}Id`]
+                        || (model[`${field}Ids`] === null || model[`${field}Id`] === null)
+                    ) {
+                        return compareIds(model[`${field}Ids`] || model[`${field}Id`] || '', val, toOperator(operator));
                     }
                     return compare(model[field], val, toOperator(operator));
                 });

--- a/mirage/views/utils/index.ts
+++ b/mirage/views/utils/index.ts
@@ -43,9 +43,8 @@ export function filter(model: ModelInstance, request: Request) {
                     if (field === 'id') {
                         return compareIds(model.id, val, toOperator(operator));
                     }
-                    if (val === '') {
-                        const actualValue = model[`${field}Ids`] || model[`${field}Id`] || '';
-                        return compareIds(actualValue, val, toOperator(operator));
+                    if (model[`${field}Ids`] === null || model[`${field}Id`] === null) {
+                        return compareIds('', val, toOperator(operator));
                     }
                     if (model[`${field}Ids`] || model[`${field}Id`]) {
                         return compareIds(model[`${field}Ids`] || model[`${field}Id`], val, toOperator(operator));

--- a/mirage/views/utils/index.ts
+++ b/mirage/views/utils/index.ts
@@ -43,6 +43,10 @@ export function filter(model: ModelInstance, request: Request) {
                     if (field === 'id') {
                         return compareIds(model.id, val, toOperator(operator));
                     }
+                    if (val === '') {
+                        const actualValue = model[`${field}Ids`] || model[`${field}Id`] || '';
+                        return compareIds(actualValue, val, toOperator(operator));
+                    }
                     if (model[`${field}Ids`] || model[`${field}Id`]) {
                         return compareIds(model[`${field}Ids`] || model[`${field}Id`], val, toOperator(operator));
                     }


### PR DESCRIPTION
- Ticket: [No ticket]
- Feature flag: n/a

## Purpose
- Filter out component registrations on my-registrations page (e.g. Project A has Component B. I create a registration for Project A and select Component B to be registered as well in the `Almost Done...` modal)
  - Note: this will not filter out registrations of components by themselves (e.g. I create a registration for Component B only)

## Summary of Changes
- Add filter to the paginated list component invocation
- Updated how mirage handles some filtering for `null` 
- Tests

## Side Effects
- If there are other places where we are filtering for null, these may behave differently (only in mirage)?

## QA Notes
- For MyRegistrations page, only registrations of top-level projects should show up (ie: when submitting the draft and a component gets registered with it, that component that was registered should not show up on the my-registrations page)
