### PR TITLE
[No ticket]Rearrange draft-registration-card to prevent visual bug on hover

### DIFF
--- a/lib/osf-components/addon/components/draft-registration-card/styles.scss
+++ b/lib/osf-components/addon/components/draft-registration-card/styles.scss
@@ -40,6 +40,10 @@
 
 .DraftRegistrationCard__review {
     margin-right: 10px;
+
+    a:hover {
+        text-decoration: none;
+    }
 }
 
 .DraftRegistrationCard__delete {

--- a/lib/osf-components/addon/components/draft-registration-card/styles.scss
+++ b/lib/osf-components/addon/components/draft-registration-card/styles.scss
@@ -41,7 +41,7 @@
 .DraftRegistrationCard__review {
     margin-right: 10px;
 
-    a:hover {
+    &:hover {
         text-decoration: none;
     }
 }

--- a/lib/osf-components/addon/components/draft-registration-card/template.hbs
+++ b/lib/osf-components/addon/components/draft-registration-card/template.hbs
@@ -67,17 +67,18 @@
             </dl>
             <div class='row'>
                 <div class='col-md-10'>
-                    <OsfLink
+                    <Button
                         data-test-draft-card-review
                         data-analytics-name='Review'
                         local-class='DraftRegistrationCard__review'
-                        @route='registries.drafts.draft.review'
-                        @models={{array this.draftRegistration.id}}
                     >
-                        <Button>
+                        <OsfLink
+                            @route='registries.drafts.draft.review'
+                            @models={{array this.draftRegistration.id}}
+                        >
                             {{t 'osf-components.draft-registration-card.review'}}
-                        </Button>
-                    </OsfLink>
+                        </OsfLink>
+                    </Button>
                     {{#unless this.draftRegistration.currentUserIsReadOnly}}
                         <OsfLink
                             data-test-draft-card-edit

--- a/lib/osf-components/addon/components/draft-registration-card/template.hbs
+++ b/lib/osf-components/addon/components/draft-registration-card/template.hbs
@@ -74,10 +74,7 @@
                         @route='registries.drafts.draft.review'
                         @models={{array this.draftRegistration.id}}
                     >
-                        <Button
-                            @route='registries.drafts.draft.review'
-                            @models={{array this.draftRegistration.id}}
-                        >
+                        <Button>
                             {{t 'osf-components.draft-registration-card.review'}}
                         </Button>
                     </OsfLink>

--- a/lib/osf-components/addon/components/draft-registration-card/template.hbs
+++ b/lib/osf-components/addon/components/draft-registration-card/template.hbs
@@ -67,18 +67,20 @@
             </dl>
             <div class='row'>
                 <div class='col-md-10'>
-                    <Button
+                    <OsfLink
                         data-test-draft-card-review
                         data-analytics-name='Review'
                         local-class='DraftRegistrationCard__review'
+                        @route='registries.drafts.draft.review'
+                        @models={{array this.draftRegistration.id}}
                     >
-                        <OsfLink
+                        <Button
                             @route='registries.drafts.draft.review'
                             @models={{array this.draftRegistration.id}}
                         >
                             {{t 'osf-components.draft-registration-card.review'}}
-                        </OsfLink>
-                    </Button>
+                        </Button>
+                    </OsfLink>
                     {{#unless this.draftRegistration.currentUserIsReadOnly}}
                         <OsfLink
                             data-test-draft-card-edit


### PR DESCRIPTION
- Ticket: [No ticket]
- Feature flag: n/a

## Purpose
- Remove visual bug caused by excess whitespace when hovering the `Review` button of the Draft Registration Card

## Summary of Changes
- Rearranged `Button` and `OsfLink` component for Review button to prevent the visual bug when hovering Review button
  - I tried using some whitespace trimming techniques (a lot of them listed in [this ember discussion thread](https://discuss.emberjs.com/t/removing-whitespace-with-angle-bracket-syntax/17094/7)) but to no avail, so I decided to just change how the button is invoked in the template
## Screenshots
Old:
![Screen Shot 2021-04-30 at 1 59 04 PM](https://user-images.githubusercontent.com/51409893/116735225-3a2e7100-a9bc-11eb-969b-f57984d52639.png)

New:
![Screen Shot 2021-04-30 at 2 26 25 PM](https://user-images.githubusercontent.com/51409893/116738122-0d7c5880-a9c0-11eb-9015-13a33ca1c5d6.png)

## Side Effects
- No side effects

## QA Notes
- Hovering on the `Review` Button on a draft card should no longer have that weird line poking out behind it
  - This bug only showed up on the `Review` button when the `Edit` button is visible
