### PR TITLE
[No ticket] Hide OSFRegistry in navbar for tablet

### DIFF
--- a/lib/registries/addon/components/registries-navbar/styles.scss
+++ b/lib/registries/addon/components/registries-navbar/styles.scss
@@ -52,6 +52,7 @@
 }
 
 :global(.media-mobile) .HideOnMobile,
+:global(.media-tablet) .HideOnTablet,
 :global(.media-desktop) .OnlyOnMobile,
 :global(.media-tablet) .OnlyOnMobile {
     display: none;

--- a/lib/registries/addon/components/registries-navbar/template.hbs
+++ b/lib/registries/addon/components/registries-navbar/template.hbs
@@ -30,8 +30,8 @@
                     data-analytics-name='Toggle'
                     @classNames={{local-class 'Service Dropdown'}}
                 >
-                    <span local-class='HideOnMobile'>{{t 'general.OSF'}}</span>
-                    <strong local-class='HideOnMobile'>{{t 'general.services.registries'}}</strong>
+                    <span local-class='HideOnMobile HideOnTablet'>{{t 'general.OSF'}}</span>
+                    <strong local-class='HideOnMobile HideOnTablet'>{{t 'general.services.registries'}}</strong>
                     {{nav.icon (if dropdown.isOpen 'caret-up' 'caret-down')}}
                 </dropdown.toggle>
 

--- a/tests/engines/registries/integration/components/registries-navbar/component-test.ts
+++ b/tests/engines/registries/integration/components/registries-navbar/component-test.ts
@@ -158,7 +158,9 @@ module('Registries | Integration | Component | registries-navbar', hooks => {
         await render(hbs`<RegistriesNavbar />`);
         await percySnapshot(assert);
 
-        assert.equal(visibleText('[data-test-service]'), `${t('general.OSF')}${t('general.services.registries')}`);
+        assert.dom('[data-test-service]').doesNotContainText(
+            `${t('general.OSF')}${t('general.services.registries')}`, 'Navbar text hidden on tablet view',
+        );
         assert.dom('[data-test-search-bar-mobile]').isNotVisible('Mobile search bar is not visible on tablet');
 
         assert.dom('a[data-test-help]').isVisible('Help button is visible');


### PR DESCRIPTION
- Ticket: [No ticket]
- Feature flag: n/a

## Purpose
- Hide `OSFRegistry` text in the registries navbar to prevent undesired text-wrapping

## Summary of Changes
- Add a new class to the text in the navbar to hide the title for tablets
<!-- Briefly describe or list your changes. -->

## Screenshots
Old:
![Screen Shot 2021-04-30 at 5 11 48 PM](https://user-images.githubusercontent.com/51409893/116754667-280dfc00-a9d7-11eb-9e58-07213d75b158.png)

New:
![Screen Shot 2021-04-30 at 5 07 01 PM](https://user-images.githubusercontent.com/51409893/116754301-7ec70600-a9d6-11eb-9e5b-b3f151d9f32b.png)

## Side Effects
- None

## QA Notes
- Please verify that logged out users don't get the text-wrapping shown above for tablet view
