### PR TITLE
[No ticket] Update styling for draft card button hover

### DIFF
--- a/lib/osf-components/addon/components/draft-registration-card/styles.scss
+++ b/lib/osf-components/addon/components/draft-registration-card/styles.scss
@@ -38,7 +38,8 @@
     }
 }
 
-.DraftRegistrationCard__review {
+// stylelint-disable selector-no-qualifying-type
+a.DraftRegistrationCard__review {
     margin-right: 10px;
 
     &:hover {
@@ -46,6 +47,7 @@
     }
 }
 
+// stylelint-enable selector-no-qualifying-type
 .DraftRegistrationCard__delete {
     button {
         padding: 6px 12px;


### PR DESCRIPTION
- Ticket: []
- Feature flag: n/a

## Purpose
- Correct a style that was supposed to be fixed by earlier PR
- Hovering on the `Review` button will create a small visual bug on Draft Registration cards

## Summary of Changes
- Specify that the `text-underline: none` should apply to `<a>` to override style given by OsfLink
- Added a linting exception to this rule as we are trying to override default OsfLink behavior here

## Side Effects
- None

## QA Notes
