### PR TITLE
[ENG-2791] Fix string for moderator comments

### DIFF
--- a/app/models/review-action.ts
+++ b/app/models/review-action.ts
@@ -35,7 +35,7 @@ export default class ReviewActionModel extends OsfModel {
     @service intl!: Intl;
 
     @attr('string') actionTrigger!: ReviewActionTrigger;
-    @attr('string') comment!: string;
+    @attr('fixstring') comment!: string;
     @attr('string') fromState!: string;
     @attr('string') toState!: string;
     @attr('date') dateCreated!: Date;

--- a/tests/integration/components/registries/review-actions-list/review-action/component-test.ts
+++ b/tests/integration/components/registries/review-actions-list/review-action/component-test.ts
@@ -172,12 +172,18 @@ module('Integration | Component | review-actions', hooks => {
     });
 
     test('Request withdraw action', async function(assert) {
-        const reviewAction = this.get('reviewAction') as ReviewActionModel;
-        reviewAction.setProperties({
+        const mirageRegistration = server.create('registration');
+        const creator = server.create('user', { fullName: 'Superb Mario' });
+        server.create('review-action', {
+            target: mirageRegistration,
+            creator,
             actionTrigger: ReviewActionTrigger.RequestWithdrawal,
-            comment: 'I need my brother Luigi to help me',
+            comment: 'This is a job for Mario &amp; Luigi &gt;_&lt;',
         });
-        const dateString = formattedTimeSince(reviewAction.dateModified);
+        const registration = await this.store.findRecord('registration', mirageRegistration.id) as RegistrationModel;
+        const [action] = await registration.loadAll('reviewActions') as ReviewActionModel[];
+        this.set('reviewAction', action);
+        const dateString = formattedTimeSince(action.dateModified);
         const pastTenseString = t('registries.reviewActions.triggerPastTense.request_withdrawal');
 
         await render(hbs`<Registries::ReviewActionsList::ReviewAction @reviewAction={{this.reviewAction}}/>`);
@@ -190,7 +196,7 @@ module('Integration | Component | review-actions', hooks => {
         assert.dom('[data-test-review-action-wrapper]')
             .doesNotContainText('moderator', 'Review action does not mention moderator');
         assert.dom('[data-test-review-action-comment]')
-            .containsText('I need my brother Luigi to help me', 'Comment shown');
+            .containsText('This is a job for Mario & Luigi >_<', 'Comment shown and characters encoded');
     });
 
     test('Request embargo termination action', async function(assert) {


### PR DESCRIPTION
- Ticket: [ENG-2791] 
- Feature flag: n/a

## Purpose
- Make sure special characters `< > &` display properly for review actions, instead of `&lt; &gt; &amp;`

## Summary of Changes
- Updated review action model to account for these special characters
- Update test
## Screenshots
Before:
<img width="587" alt="Screen Shot 2021-05-04 at 4 26 22 PM" src="https://user-images.githubusercontent.com/51409893/117065408-7a139200-acf5-11eb-86be-73a1e6340eaf.png">
After:
<img width="462" alt="Screen Shot 2021-05-04 at 4 24 11 PM" src="https://user-images.githubusercontent.com/51409893/117065191-2acd6180-acf5-11eb-83bf-79c62e74406d.png">


## Side Effects
- None

## QA Notes
- If a moderator leaves a comment containing these special characters, the review history shown in the Moderation app should show the appropriate characters. 


[ENG-2791]: https://openscience.atlassian.net/browse/ENG-2791