### PR TITLE
[No ticket] Align draft buttons for Safari

### DIFF
--- a/lib/osf-components/addon/components/draft-registration-card/styles.scss
+++ b/lib/osf-components/addon/components/draft-registration-card/styles.scss
@@ -48,6 +48,10 @@ a.DraftRegistrationCard__review {
 }
 
 // stylelint-enable selector-no-qualifying-type
+.DraftRegistrationCard__edit {
+    vertical-align: bottom;
+}
+
 .DraftRegistrationCard__delete {
     button {
         padding: 6px 12px;

--- a/lib/osf-components/addon/components/draft-registration-card/template.hbs
+++ b/lib/osf-components/addon/components/draft-registration-card/template.hbs
@@ -89,7 +89,7 @@
                             @route='registries.drafts.draft'
                             @models={{array this.draftRegistration.id}}
                         >
-                            <Button>
+                            <Button local-class='DraftRegistrationCard__edit'>
                                 {{t 'general.edit'}}
                             </Button>
                         </OsfLink>


### PR DESCRIPTION
- Ticket: []
- Feature flag: n/a

## Purpose
- Fix slightly misaligned buttons on Draft Registration Card in Safari

## Summary of Changes
- Realign button using `vertical-align: bottom`

## Screenshots
Before:
![Safari-misaligned bottuns](https://fd-files-production.s3.amazonaws.com/private/401800/97921/uFoebw206sFOzW59F84WQQ?X-Amz-Expires=300&X-Amz-Date=20210505T160001Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIA2QBI5WP5HA3ZEA/20210505/us-east-1/s3/aws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=cdab75633f1b0cc695a9af0dd302d5323b6b414cc1fa502223b42f2256e4622b)
After:
![Screen Shot 2021-05-05 at 12 02 19 PM](https://user-images.githubusercontent.com/51409893/117172360-bf899b00-ad99-11eb-97bf-e2c7d08fced5.png)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- This was only happening for Safari