### PR TITLE
[ENG-2789] Add description to how drafts and registrations are sorted

### DIFF
--- a/lib/registries/addon/my-registrations/styles.scss
+++ b/lib/registries/addon/my-registrations/styles.scss
@@ -55,5 +55,6 @@
 
 .SortDescription {
     text-align: right;
+    margin-top: 10px;
     margin-right: 15px;
 }

--- a/lib/registries/addon/my-registrations/styles.scss
+++ b/lib/registries/addon/my-registrations/styles.scss
@@ -52,3 +52,8 @@
         }
     }
 }
+
+.SortDescription {
+    text-align: right;
+    margin-right: 15px;
+}

--- a/lib/registries/addon/my-registrations/template.hbs
+++ b/lib/registries/addon/my-registrations/template.hbs
@@ -19,6 +19,9 @@
                     @activeId={{this.tab}}
                     as |tab|
                 >
+                    <div local-class='SortDescription'>
+                        {{t 'registries.my_registrations.sorted'}}
+                    </div>
                     <tab.pane
                         local-class='Tab'
                         @title={{t 'registries.my_registrations.drafts'}}

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1138,6 +1138,7 @@ registries:
         header: 'My Registrations'
         drafts: 'Drafts'
         submitted: 'Submitted'
+        sorted: 'Sorted by date modified'
     registration_metadata:
         add_description: 'Add description'
         add_contributors:

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1138,7 +1138,7 @@ registries:
         header: 'My Registrations'
         drafts: 'Drafts'
         submitted: 'Submitted'
-        sorted: 'Sorted by date modified'
+        sorted: 'Sorted by last updated'
     registration_metadata:
         add_description: 'Add description'
         add_contributors:


### PR DESCRIPTION
- Ticket: [ENG-2789]
- Feature flag: n/a

## Purpose
- Let users know that registrations and drafts are sorted by date modified

<img width="1145" alt="Screen Shot 2021-05-17 at 1 23 25 PM" src="https://user-images.githubusercontent.com/51409893/118530794-10db4800-b713-11eb-9441-a64e3d38a5be.png">

![image](https://user-images.githubusercontent.com/51409893/118530902-323c3400-b713-11eb-865c-ab8c18c0a168.png)


## Summary of Changes
- Add a div with explanation to my-registrations page template

## Side Effects
- Should be none.

## QA Notes
- There should be a little bit of text on the my registrations page that says how drafts and registrations are submitted. The text is the same for both tabs


[ENG-2789]: https://openscience.atlassian.net/browse/ENG-2789