### PR TITLE
[HOTFIX][ENG-2881] Hide registration state for anonymous VOLs

### DIFF
--- a/app/models/registration.ts
+++ b/app/models/registration.ts
@@ -81,7 +81,7 @@ export default class RegistrationModel extends NodeModel.extend(Validations) {
     @attr('fixstring') articleDoi!: string | null;
     @attr('object') registeredMeta!: RegistrationMetadata;
     @attr('registration-responses') registrationResponses!: RegistrationResponse;
-    @attr('fixstring') reviewsState!: RegistrationReviewStates;
+    @attr('fixstring') reviewsState?: RegistrationReviewStates;
     @attr('fixstring') iaUrl?: string;
     @attr('array') providerSpecificMetadata!: ProviderMetadata[];
 

--- a/lib/registries/addon/components/make-decision-dropdown/component.ts
+++ b/lib/registries/addon/components/make-decision-dropdown/component.ts
@@ -49,22 +49,30 @@ export default class MakeDecisionDropdown extends Component<Args> {
     };
 
     get commentTextArea() {
-        if ([RegistrationReviewStates.Pending, RegistrationReviewStates.PendingWithdraw]
-            .includes(this.args.registration.reviewsState)) {
+        if (this.args.registration.reviewsState) {
+            if ([RegistrationReviewStates.Pending, RegistrationReviewStates.PendingWithdraw]
+                .includes(this.args.registration.reviewsState)) {
+                return {
+                    label: this.intl.t('registries.makeDecisionDropdown.additionalComment'),
+                    placeholder: this.intl.t('registries.makeDecisionDropdown.additionalCommentPlaceholder'),
+                };
+            }
+
             return {
-                label: this.intl.t('registries.makeDecisionDropdown.additionalComment'),
-                placeholder: this.intl.t('registries.makeDecisionDropdown.additionalCommentPlaceholder'),
+                label: this.intl.t('registries.makeDecisionDropdown.justificationForWithdrawal'),
+                placeholder: this.intl.t('registries.makeDecisionDropdown.justificationForWithdrawalPlaceholder'),
             };
         }
-
+        // registration is viewed anonymously and this component should not be visible
         return {
-            label: this.intl.t('registries.makeDecisionDropdown.justificationForWithdrawal'),
-            placeholder: this.intl.t('registries.makeDecisionDropdown.justificationForWithdrawalPlaceholder'),
+            label: '',
+            placeholder: '',
         };
     }
 
     get hasModeratorActions() {
-        return ![
+        return this.args.registration.reviewsState
+        && ![
             RegistrationReviewStates.Initial,
             RegistrationReviewStates.Withdrawn,
             RegistrationReviewStates.Rejected,

--- a/lib/registries/addon/components/registries-states/component.ts
+++ b/lib/registries/addon/components/registries-states/component.ts
@@ -47,7 +47,7 @@ export default class RegistriesStates extends Component {
         'isModeratorMode',
     )
     get stateText() {
-        if (!this.registration) {
+        if (!this.registration || !this.registration.reviewsState) {
             return undefined;
         }
         let stateKey;
@@ -73,6 +73,7 @@ export default class RegistriesStates extends Component {
     @computed('registration.{userHasAdminPermission,reviewsState}')
     get shouldOpenDropdownOnLoad() {
         return this.registration.userHasAdminPermission
+        && this.registration.reviewsState
         && ![
             RegistrationReviewStates.Embargo,
             RegistrationReviewStates.Accepted,
@@ -94,6 +95,7 @@ export default class RegistriesStates extends Component {
             !this.registration.isRoot
             || !this.registration.userHasAdminPermission
             || this.isModeratorMode
+            || !this.registration.reviewsState
             || !(
                 [RegistrationReviewStates.Accepted, RegistrationReviewStates.Embargo].includes(
                     this.registration.reviewsState,

--- a/lib/registries/addon/overview/-components/overview-topbar/template.hbs
+++ b/lib/registries/addon/overview/-components/overview-topbar/template.hbs
@@ -1,9 +1,11 @@
-<div data-test-topbar-states>
-    <RegistriesStates
-        @registration={{@registration}}
-        @isModeratorMode={{@isModeratorMode}}
-    />
-</div>
+{{#unless @registration.isAnonymous}}
+    <div data-test-topbar-states>
+        <RegistriesStates
+            @registration={{@registration}}
+            @isModeratorMode={{@isModeratorMode}}
+        />
+    </div>
+{{/unless}}
 {{#if @isModeratorMode}}
     <MakeDecisionDropdown @registration={{@registration}} />
 {{else}}

--- a/lib/registries/addon/overview/-components/overview-topbar/template.hbs
+++ b/lib/registries/addon/overview/-components/overview-topbar/template.hbs
@@ -6,7 +6,7 @@
         />
     </div>
 {{/unless}}
-{{#if @isModeratorMode}}
+{{#if (and @isModeratorMode (not @registration.isAnonymous))}}
     <MakeDecisionDropdown @registration={{@registration}} />
 {{else}}
     <div data-test-topbar-share-bookmark-fork

--- a/mirage/serializers/application.ts
+++ b/mirage/serializers/application.ts
@@ -52,9 +52,9 @@ export default class ApplicationSerializer<T extends DS.Model> extends JSONAPISe
     serialize(model: ModelInstance<T>, request: Request) {
         const json = super.serialize(model, request);
         json.data.links = this.buildNormalLinks(model);
-        json.data.meta = {
+        json.meta = {
             ...this.buildApiMeta(model),
-            ...(json.data.meta || {}),
+            ...(json.meta || {}),
         };
         json.data.relationships = Object
             .entries(this.buildRelationships(model))

--- a/mirage/serializers/registration.ts
+++ b/mirage/serializers/registration.ts
@@ -241,4 +241,11 @@ export default class RegistrationSerializer extends ApplicationSerializer<Mirage
         }
         return relationships;
     }
+
+    buildApiMeta(model: ModelInstance<MirageRegistration>) {
+        return {
+            ...super.buildApiMeta(model),
+            ...(model.attrs._anonymized ? { anonymous: true } : {}),
+        };
+    }
 }

--- a/mirage/views/registration.ts
+++ b/mirage/views/registration.ts
@@ -32,10 +32,13 @@ export function registrationDetail(this: HandlerContext, schema: Schema, request
             errors: [{ detail: 'Not found.' }],
         });
     }
+    const serializedRegistration = this.serialize(registration);
+    const { data } = process(schema, request, this, [serializedRegistration.data]);
 
-    const { data } = process(schema, request, this, [this.serialize(registration).data]);
-
-    return { data: data[0] };
+    return {
+        data: data[0],
+        meta: serializedRegistration.meta,
+    };
 }
 
 export function createNodeFromDraftNode(

--- a/tests/engines/registries/acceptance/overview/topbar-test.ts
+++ b/tests/engines/registries/acceptance/overview/topbar-test.ts
@@ -95,10 +95,8 @@ module('Registries | Acceptance | overview.topbar', hooks => {
 
     test('registration state is not visible in topbar when viewing registrations anonymously', async assert => {
         const anonymousReg = server.create('registration', {
-            isAnonymous: true,
             registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
-        });
-        anonymousReg.attrs.apiMeta = { version: '', anonymous: true };
+        }, 'anonymized');
 
         await visit(`/${anonymousReg.id}/`);
 

--- a/tests/engines/registries/acceptance/overview/topbar-test.ts
+++ b/tests/engines/registries/acceptance/overview/topbar-test.ts
@@ -77,7 +77,7 @@ module('Registries | Acceptance | overview.topbar', hooks => {
         const anonymousReg = server.create('registration', {
             isAnonymous: true,
             registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
-        }, 'isWithdrawn');
+        });
         anonymousReg.attrs.apiMeta = { version: '', anonymous: true };
 
         await visit(`/${anonymousReg.id}/`);

--- a/tests/engines/registries/acceptance/overview/topbar-test.ts
+++ b/tests/engines/registries/acceptance/overview/topbar-test.ts
@@ -64,7 +64,7 @@ module('Registries | Acceptance | overview.topbar', hooks => {
     setupEngineApplicationTest(hooks, 'registries');
     setupMirage(hooks);
 
-    test('topbar is not visible for anonymous, archiving or withdrawn registrations', async assert => {
+    test('topbar is not visible for archiving or withdrawn registrations', async assert => {
         const reg = server.create('registration', {
             registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
             provider: server.create('registration-provider'),
@@ -73,17 +73,6 @@ module('Registries | Acceptance | overview.topbar', hooks => {
 
         assert.dom('[data-test-topbar-share-bookmark-fork]').isVisible();
         assert.dom('[data-test-topbar-states]').isVisible();
-
-        const anonymousReg = server.create('registration', {
-            isAnonymous: true,
-            registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
-        });
-        anonymousReg.attrs.apiMeta = { version: '', anonymous: true };
-
-        await visit(`/${anonymousReg.id}/`);
-
-        assert.dom('[data-test-topbar-share-bookmark-fork]').doesNotExist();
-        assert.dom('[data-test-topbar-states]').doesNotExist();
 
         const withdrawnReg = server.create('registration', {
             registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
@@ -101,6 +90,19 @@ module('Registries | Acceptance | overview.topbar', hooks => {
         await visit(`/${archivingReg.id}/`);
 
         assert.dom('[data-test-topbar-share-bookmark-fork]').doesNotExist();
+        assert.dom('[data-test-topbar-states]').doesNotExist();
+    });
+
+    test('registration state is not visible in topbar when viewing registrations anonymously', async assert => {
+        const anonymousReg = server.create('registration', {
+            isAnonymous: true,
+            registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
+        });
+        anonymousReg.attrs.apiMeta = { version: '', anonymous: true };
+
+        await visit(`/${anonymousReg.id}/`);
+
+        assert.dom('[data-test-topbar-share-bookmark-fork]').exists();
         assert.dom('[data-test-topbar-states]').doesNotExist();
     });
 

--- a/tests/engines/registries/acceptance/overview/topbar-test.ts
+++ b/tests/engines/registries/acceptance/overview/topbar-test.ts
@@ -99,6 +99,7 @@ module('Registries | Acceptance | overview.topbar', hooks => {
         }, 'anonymized');
 
         await visit(`/${anonymousReg.id}/`);
+        await percySnapshot(assert);
 
         assert.dom('[data-test-topbar-share-bookmark-fork]').exists();
         assert.dom('[data-test-topbar-states]').doesNotExist();

--- a/tests/engines/registries/acceptance/overview/topbar-test.ts
+++ b/tests/engines/registries/acceptance/overview/topbar-test.ts
@@ -64,7 +64,7 @@ module('Registries | Acceptance | overview.topbar', hooks => {
     setupEngineApplicationTest(hooks, 'registries');
     setupMirage(hooks);
 
-    test('topbar is not visible for archiving or withdrawn registrations', async assert => {
+    test('topbar is not visible for anonymous, archiving or withdrawn registrations', async assert => {
         const reg = server.create('registration', {
             registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
             provider: server.create('registration-provider'),
@@ -73,6 +73,17 @@ module('Registries | Acceptance | overview.topbar', hooks => {
 
         assert.dom('[data-test-topbar-share-bookmark-fork]').isVisible();
         assert.dom('[data-test-topbar-states]').isVisible();
+
+        const anonymousReg = server.create('registration', {
+            isAnonymous: true,
+            registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
+        }, 'isWithdrawn');
+        anonymousReg.attrs.apiMeta = { version: '', anonymous: true };
+
+        await visit(`/${anonymousReg.id}/`);
+
+        assert.dom('[data-test-topbar-share-bookmark-fork]').doesNotExist();
+        assert.dom('[data-test-topbar-states]').doesNotExist();
 
         const withdrawnReg = server.create('registration', {
             registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),


### PR DESCRIPTION
- Ticket: [ENG-2881]
- Feature flag: n/a

## Purpose
- Fix a bug where anonymous view-only links (AVOLs) will not load properly

## Summary of Changes
- Hide the registration state when registrations are viewed anonymously
- Added test

## Screenshot
- Note: Registration state is not visible on the grey bar below the registration title
![Screen Shot 2021-05-20 at 9 50 04 AM](https://user-images.githubusercontent.com/51409893/118990313-c2b38800-b950-11eb-83aa-8fb5198f3397.png)


## Side Effects
- none

## QA Notes
- This change should only happen when looking at a registration through an anonymous VOL. Any other view should be unchanged

[ENG-2881]: https://openscience.atlassian.net/browse/ENG-2881