### PR TITLE
[ENG-2898] Fix my registrations page infinite reload.

### DIFF
--- a/lib/registries/addon/my-registrations/template.hbs
+++ b/lib/registries/addon/my-registrations/template.hbs
@@ -1,4 +1,4 @@
-{{title (t 'registries.my_registrations.header')}}
+{{page-title (t 'registries.my_registrations.header')}}
 
 <RegistriesWrapper>
     <OsfLayout @backgroundClass={{local-class 'ContentBackground'}} as |layout|>


### PR DESCRIPTION
- Ticket: []
- Feature flag: n/a

## Purpose

Fix my registration page infinite reload.

## Summary of Changes

It seems that my registration page is reloading infinitely because the app cannot find `{{title}}`. Change to `{{page-title}}`.

## Side Effects

None

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
