### PR TITLE
[ENG-2898] Fix files widget uploads and validation

### DIFF
--- a/lib/osf-components/addon/components/files/menu/template.hbs
+++ b/lib/osf-components/addon/components/files/menu/template.hbs
@@ -1,6 +1,6 @@
 <ResponsiveDropdown
     @disabled={{not this.canEdit}}
-    @onClose={{action this.onCloseMenu @isUploading}}
+    @onClose={{fn this.onCloseMenu @isUploading}}
     as |dropdownMenu|
 >
     <div local-class='actions-menu-trigger'>
@@ -8,40 +8,39 @@
             local-class='trigger-button {{if dropdownMenu.isOpen 'close-button'}}'
             aria-label={{t 'osf-components.files-widget.expand_files_menu'}}
             data-ebd-id='{{dropdownMenu.uniqueId}}-trigger'
-            @onClick={{action dropdownMenu.toggle}}
             @type='success'
+            {{on 'click' dropdownMenu.toggle}}
         >
             <FaIcon @icon='plus' @size='2x' @fixedWidth={{true}} />
         </BsButton>
     </div>
-    <dropdownMenu.content>
-        <div
-            role='menu'
-            local-class='actions-menu-content'
-            {{did-insert (action @setButtonClass this.uploadButtonClass)}}
-            {{will-destroy (action @setButtonClass '')}}
+    <dropdownMenu.content
+        role='menu'
+        local-class='actions-menu-content'
+        @rootEventType='mousedown'
+        {{did-insert (fn @setButtonClass this.uploadButtonClass)}}
+        {{will-destroy (fn @setButtonClass '')}}
+    >
+        <BsButton
+            aria-label={{t 'osf-components.files-widget.upload_file'}}
+            local-class='menu-button'
+            disabled={{@isUploading}}
+            class='{{this.uploadButtonClass}}'
+            @bubble={{true}}
+            @type='link'
         >
-            <BsButton
-                aria-label={{t 'osf-components.files-widget.upload_file'}}
-                local-class='menu-button'
-                disabled={{@isUploading}}
-                class='{{this.uploadButtonClass}}'
-                @type='link'
-                @bubble={{true}}
-            >
-                <FaIcon @icon='upload' @fixedWidth={{true}} />
-                {{t 'osf-components.files-widget.upload_file'}}
-            </BsButton>
-            <BsButton
-                aria-label={{t 'osf-components.files-widget.create_folder'}}
-                local-class='menu-button'
-                @onClick={{action this.openDialog (hash onOpenDialog=dropdownMenu.close)}}
-                @type='link'
-            >
-                <FaIcon @icon='folder' @fixedWidth={{true}} />
-                {{t 'osf-components.files-widget.create_folder'}}
-            </BsButton>
-        </div>
+            <FaIcon @icon='upload' @fixedWidth={{true}} />
+            {{t 'osf-components.files-widget.upload_file'}}
+        </BsButton>
+        <BsButton
+            aria-label={{t 'osf-components.files-widget.create_folder'}}
+            local-class='menu-button'
+            @type='link'
+            {{on 'click' (fn this.openDialog (hash onOpenDialog=dropdownMenu.close))}}
+        >
+            <FaIcon @icon='folder' @fixedWidth={{true}} />
+            {{t 'osf-components.files-widget.create_folder'}}
+        </BsButton>
     </dropdownMenu.content>
 
     {{yield (hash close=dropdownMenu.close)}}
@@ -51,7 +50,7 @@
     @isOpen={{this.newFolderDialogIsOpen}}
     @shouldDisableButtons={{this.shouldDisableButtons}}
     @changeset={{this.changeset}}
-    @closeDialog={{action this.closeDialog}}
+    @closeDialog={{this.closeDialog}}
     @createFolder={{perform this.createFolder}}
 />
 

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/component.ts
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/component.ts
@@ -45,12 +45,4 @@ export default class ReadOnlyFiles extends Component {
     get hasResponses(): boolean {
         return Boolean(this.responses && this.responses.length > 0);
     }
-
-    @computed('changeset.isValid')
-    get isValidating() {
-        if (this.changeset) {
-            return this.changeset.isValidating();
-        }
-        return false;
-    }
 }

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/read-only/files/template.hbs
@@ -30,6 +30,5 @@
         local-class='ValidationErrors'
         @changeset={{@changeset}}
         @key={{@schemaBlock.registrationResponseKey}}
-        @isValidating={{this.isValidating}}
     />
 {{/if}}

--- a/lib/osf-components/addon/components/validation-errors/component.ts
+++ b/lib/osf-components/addon/components/validation-errors/component.ts
@@ -1,6 +1,8 @@
 import { assert } from '@ember/debug';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 import { isEmpty } from '@ember/utils';
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { RawValidationResult } from 'ember-changeset-validations/utils/validation-errors';
 import { BufferedChangeset } from 'ember-changeset/types';
@@ -10,11 +12,12 @@ interface Args {
     changeset?: BufferedChangeset;
     key?: string;
     errors?: string | string[];
-    isValidating?: boolean;
 }
 
 export default class ValidationErrors extends Component<Args> {
     @service intl!: Intl;
+
+    @tracked isValidating?: boolean = false;
 
     constructor(owner: unknown, args: Args) {
         super(owner, args);
@@ -23,11 +26,6 @@ export default class ValidationErrors extends Component<Args> {
         assert('validation-errors - requires (@changeset and @key!) or @errors',
             Boolean(changeset && key) || !isEmpty(errors));
 
-    }
-
-    get isValidating() {
-        const { changeset, key, isValidating } = this.args;
-        return isValidating ?? changeset?.isValidating(key);
     }
 
     get cpValidationErrors() {
@@ -70,5 +68,11 @@ export default class ValidationErrors extends Component<Args> {
     get validatorErrors() {
         const { cpValidationErrors, changesetValidationErrors } = this;
         return isEmpty(cpValidationErrors) ? changesetValidationErrors : cpValidationErrors;
+    }
+
+    @action
+    setIsValidating() {
+        const { changeset, key } = this.args;
+        this.isValidating = changeset?.isValidating(key);
     }
 }

--- a/lib/osf-components/addon/components/validation-errors/template.hbs
+++ b/lib/osf-components/addon/components/validation-errors/template.hbs
@@ -1,5 +1,5 @@
 <div
-    {{did-insert this.setIsValidating @changeset.isValid}}
+    {{did-insert this.setIsValidating}}
     {{did-update this.setIsValidating @changeset.isValid}}
 >
     {{#if this.isValidating}}

--- a/lib/osf-components/addon/components/validation-errors/template.hbs
+++ b/lib/osf-components/addon/components/validation-errors/template.hbs
@@ -1,15 +1,20 @@
-{{#if this.isValidating}}
-    <LoadingIndicator @inline={{true}} @dark={{true}} />
-{{else}}
-    {{#if this.validatorErrors}}
-        <div
-            data-test-validation-errors={{@key}}
-            local-class='Errors'
-            ...attributes
-        >
-            {{#each this.validatorErrors as |error|}}
-                <p>{{~error~}}</p>
-            {{/each}}
-        </div>
+<div
+    {{did-insert this.setIsValidating @changeset.isValid}}
+    {{did-update this.setIsValidating @changeset.isValid}}
+>
+    {{#if this.isValidating}}
+        <LoadingIndicator @inline={{true}} @dark={{true}} />
+    {{else}}
+        {{#if this.validatorErrors}}
+            <div
+                data-test-validation-errors={{@key}}
+                local-class='Errors'
+                ...attributes
+            >
+                {{#each this.validatorErrors as |error|}}
+                    <p>{{~error~}}</p>
+                {{/each}}
+            </div>
+        {{/if}}
     {{/if}}
-{{/if}}
+</div>


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-2898]
- Feature flag: n/a

## Purpose

- Fix broken upload file button
- Fix indefinite validation status loading indicator

## Summary of Changes
- For upload files button
**Fix**: pass `rootEventType='mousedown'` argument to `<BasicDropdown::Content>` component.
**Issue**: with [ember-basic-dropdown v2](https://github.com/cibernox/ember-basic-dropdown/blob/master/CHANGELOG.md#200-alphax), the `rootEventType` default changed to `click` previously `mousedown`.
The `rootEventType` parameter determines what type of event ('click' | 'mousedown') outside the dropdown should result
in closing an open dropdown. With v2, if a user clicks outside the dropdown, the dropdown should close. It turns out, this interferes with how the `Dropzone` upload button works because the `upload` button is rendered in the dropdown. 
A click on the upload button is forwarded to the `Dropzone` hidden input element (as should happen), the event bubbles up all the way up to the ember-basic-dropdown listener on `document` which handles the click by closing the dropdown; Closing the dropdown removes the upload button which in turn removes hidden input element thus breaking the initial upload action because of how the `Dropzone` works. 

Other `<ResponsiveDropdown>` invocations in the app don't need to be updated because this issue is very particular to the use case.

- For indefinite loading indicator:
**Fix**: change `isValidating` parameter to a component's tracked property; update the tracked prop using a combo of `{{did-insert}}, {{did-update}}` modifiers to react to changes in validation status.
**Issue**: Using  a native getter as computed property dependent key (in this case depending on `changeset.isValid`) is a bit broken at the moment, which caused `isValidating` argument of the `<ValidationErrors>` component to not update.

- Remove action helper usage is bonus.

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-2898]: https://openscience.atlassian.net/browse/ENG-2898