### PR TITLE
[ENG-2898] Fix warning sticky top

### DIFF
--- a/lib/registries/addon/drafts/draft/styles.scss
+++ b/lib/registries/addon/drafts/draft/styles.scss
@@ -69,7 +69,7 @@
 
 .EditWarning {
     position: sticky;
-    top: 223px; // this is the height of .RightWrapper and its content
+    top: 295px; // this is the height of .RightWrapper and its content
     padding: 30px;
     display: flex;
     flex-direction: column;

--- a/lib/registries/addon/drafts/draft/styles.scss
+++ b/lib/registries/addon/drafts/draft/styles.scss
@@ -52,9 +52,12 @@
 }
 
 .RightWrapper {
-    padding: 30px;
     position: sticky;
     top: 0;
+}
+
+.RightNavWrapper {
+    padding: 30px;
     display: flex;
     flex-direction: column;
     text-align: center;
@@ -68,8 +71,6 @@
 }
 
 .EditWarning {
-    position: sticky;
-    top: 295px; // this is the height of .RightWrapper and its content
     padding: 30px;
     display: flex;
     flex-direction: column;

--- a/lib/registries/addon/drafts/draft/template.hbs
+++ b/lib/registries/addon/drafts/draft/template.hbs
@@ -84,24 +84,26 @@
                 {{#unless this.showMobileView}}
                     <layout.right local-class='Right'>
                         <div local-class='RightWrapper'>
-                            <Drafts::Draft::-Components::RightNav
-                                @navManager={{navManager}}
-                                @draftManager={{draftManager}}
-                                @onSubmitRedirect={{this.onSubmitRedirect}}
-                                @currentUserIsReadOnly={{draftManager.currentUserIsReadOnly}}
-                            />
-                        </div>
-                        <div local-class='EditWarning'>
-                            <strong>
-                                <FaIcon
-                                    @icon='exclamation-circle'
-                                    @fixedWidth={{true}}
+                            <div local-class='RightNavWrapper'>
+                                <Drafts::Draft::-Components::RightNav
+                                    @navManager={{navManager}}
+                                    @draftManager={{draftManager}}
+                                    @onSubmitRedirect={{this.onSubmitRedirect}}
+                                    @currentUserIsReadOnly={{draftManager.currentUserIsReadOnly}}
                                 />
-                                {{t 'general.caution'}}
-                            </strong>
-                            <span>
-                                {{t 'registries.drafts.draft.form.collaborative_edit_warning'}}
-                            </span>
+                            </div>
+                            <div local-class='EditWarning'>
+                                <strong>
+                                    <FaIcon
+                                        @icon='exclamation-circle'
+                                        @fixedWidth={{true}}
+                                    />
+                                    {{t 'general.caution'}}
+                                </strong>
+                                <span>
+                                    {{t 'registries.drafts.draft.form.collaborative_edit_warning'}}
+                                </span>
+                            </div>
                         </div>
                     </layout.right>
                 {{/unless}}


### PR DESCRIPTION
- Ticket: [ENG-2898]
- Feature flag: n/a

## Purpose

Modify the top position of the sticky edit warning div so that it doesn't get clipped on the Review page.

## Summary of Changes

<!-- Briefly describe or list your changes. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-2898]: https://openscience.atlassian.net/browse/ENG-2898