### PR TITLE
[ENG-2898] Draft registration Help icon hover

### DIFF
--- a/lib/osf-components/addon/components/registries/schema-block-renderer/helper-text-icon/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/helper-text-icon/template.hbs
@@ -1,13 +1,18 @@
 {{#if this.helpText}}
-    <FaIcon
-        local-class='helper-text-icon'
-        tabindex='0'
-        @icon='question-circle'
-        @ariaHidden={{false}}
-        ...attributes
-    >
-        <BsPopover @triggerEvents={{array 'hover' 'focus'}}>
+    {{#let (unique-id 'helper-text-icon') as |id|}}
+        <FaIcon
+            local-class='helper-text-icon'
+            tabindex='0'
+            id={{id}}
+            @icon='question-circle'
+            @ariaHidden={{false}}
+            ...attributes
+        />
+        <BsPopover
+            @triggerEvents={{array 'hover' 'focus'}}
+            @triggerElement={{concat '#' id}}
+        >
             {{this.helpText}}
         </BsPopover>
-    </FaIcon>
+    {{/let}}
 {{/if}}


### PR DESCRIPTION
- Ticket: [ENG-2898]
- Feature flag: n/a

## Purpose
- Fix broken help text icons in the draft-registration workflow

## Summary of Changes
- Moved `BsPopover` outside of `FaIcon` invocation
- Attached `@triggerElement` to the help icon so popover will trigger on hover and focus of help icon

## Side Effects
- NA

## QA Notes
- The `?` icons in the Draft Registration submission process will now properly show help text when you hover or focus into it (whether by tabbing into it, or clicking on it). OSF Preregistration has a lot of these help-texts (especially Sampling Plan page), so that is a good schema to check. Other schemas may not have these help-texts


[ENG-2898]: https://openscience.atlassian.net/browse/ENG-2898