### PR TITLE
[ENG-2919] Add data-test selectors to my-registrations page

### DIFF
--- a/lib/osf-components/addon/components/registries/my-registrations-list/drafts/template.hbs
+++ b/lib/osf-components/addon/components/registries/my-registrations-list/drafts/template.hbs
@@ -24,9 +24,9 @@
                     {{t 'registries.myRegistrationsList.noDrafts'}}
                 </p>
                 <OsfLink
+                    data-test-my-reg-drafts-add-new-button
                     @route='registries.branded.new'
                     @models={{array 'osf'}}
-                    data-test-add-new-button
                 >
                     <Button @type='create'>
                         {{t 'registries.myRegistrationsList.createRegistration'}}

--- a/lib/osf-components/addon/components/registries/my-registrations-list/registrations/template.hbs
+++ b/lib/osf-components/addon/components/registries/my-registrations-list/registrations/template.hbs
@@ -25,9 +25,9 @@
                     {{t 'registries.myRegistrationsList.noRegistrations'}}
                 </p>
                 <OsfLink
+                    data-test-my-reg-registrations-add-new-button
                     @route='registries.branded.new'
                     @models={{array 'osf'}}
-                    data-test-add-new-button
                 >
                     <Button @type='create'>
                         {{t 'registries.myRegistrationsList.createRegistration'}}

--- a/lib/registries/addon/my-registrations/styles.scss
+++ b/lib/registries/addon/my-registrations/styles.scss
@@ -2,7 +2,7 @@
 // stylelint-disable selector-no-qualifying-type
 .ContentBackground {
     composes: ContentBackground from '../overview/styles.scss';
-    
+
     :global(.list-group-item) {
         margin-bottom: 20px;
     }
@@ -25,18 +25,20 @@
         margin-left: 15px;
     }
 
-    :global(a.nav-link) {
+    .NavItem {
         border: none;
         color: #fff;
+        background: none;
+        padding: 10px 15px;
 
         &:hover {
             border: none;
             color: $color-text-gray;
-            background-color: #e4e4e4;    
+            background-color: #e4e4e4;
         }
     }
 
-    :global(a.nav-link.active) {
+    :global(.active) .NavItem {
         border: none;
         color: $color-text-gray;
         background-color: #e4e4e4;
@@ -49,6 +51,14 @@
         &:hover {
             border: none;
             background-color: #e4e4e4;
+        }
+    }
+
+    .TabPane {
+        display: none;
+
+        &:global(.active) {
+            display: block;
         }
     }
 }

--- a/lib/registries/addon/my-registrations/template.hbs
+++ b/lib/registries/addon/my-registrations/template.hbs
@@ -1,6 +1,8 @@
-{{title (t 'registries.my_registrations.header')}}
+{{page-title (t 'registries.my_registrations.header')}}
 
-<RegistriesWrapper>
+<RegistriesWrapper
+    data-analytics-scope='My Registrations page'
+>
     <OsfLayout @backgroundClass={{local-class 'ContentBackground'}} as |layout|>
         <layout.heading>
             <HeroOverlay @align='left'>
@@ -15,22 +17,61 @@
             {{#if this.currentUser.user}}
                 <BsTab
                     local-class='NavTabs'
+                    @customTabs={{true}}
                     @onChange={{this.changeTab}} 
                     @activeId={{this.tab}}
                     as |tab|
                 >
-                    <div local-class='SortDescription'>
+                    <BsNav
+                        @type='tabs'
+                        as |nav|
+                    >
+                        <nav.item
+                            data-test-my-registrations-nav='drafts'
+                            @active={{bs-eq tab.activeId 'drafts'}}
+                        >
+                            <button
+                                data-test-my-registrations-nav-button='drafts'
+                                local-class='NavItem'
+                                type='button'
+                                role='tab'
+                                {{on 'click' (fn this.changeTab 'drafts')}}
+                            >
+                                {{t 'registries.my_registrations.drafts'}}
+                            </button>
+                        </nav.item>
+                        <nav.item
+                            data-test-my-registrations-nav='submitted'
+                            @active={{bs-eq tab.activeId 'submitted'}}
+                        >
+                            <button
+                                data-test-my-registrations-nav-button='submitted'
+                                local-class='NavItem'
+                                type='button'
+                                role='tab'
+                                {{on 'click' (fn this.changeTab 'submitted')}}
+                            >
+                                {{t 'registries.my_registrations.submitted'}}
+                            </button>
+                        </nav.item>
+                    </BsNav>
+                    <div
+                        data-test-my-registrations-sort-description
+                        local-class='SortDescription'
+                    >
                         {{t 'registries.my_registrations.sorted'}}
                     </div>
                     <tab.pane
-                        local-class='Tab'
+                        data-test-my-registrations-pane='drafts'
+                        local-class='TabPane'
                         @title={{t 'registries.my_registrations.drafts'}}
                         @id='drafts'
                     >
                         <Registries::MyRegistrationsList::Drafts />
                     </tab.pane>
                     <tab.pane
-                        local-class='Tab'
+                        data-test-my-registrations-pane='submitted'
+                        local-class='TabPane'
                         @title={{t 'registries.my_registrations.submitted'}}
                         @id='submitted'
                     >

--- a/tests/engines/registries/acceptance/my-registrations-page-test.ts
+++ b/tests/engines/registries/acceptance/my-registrations-page-test.ts
@@ -1,0 +1,48 @@
+import { click, currentURL } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { percySnapshot } from 'ember-percy';
+import { module, test } from 'qunit';
+
+import { visit } from 'ember-osf-web/tests/helpers';
+import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
+import { registerNodeMultiple } from 'ember-osf-web/mirage/helpers';
+
+module('Registries | Acceptance | my-registrations page', hooks => {
+    setupEngineApplicationTest(hooks, 'registries');
+    setupMirage(hooks);
+
+    test('navigation with drafts and registrations', async assert => {
+        const contributorUser = server.create('user', 'loggedIn');
+        const node = server.create('node', 'currentUserAdmin');
+        server.create('contributor', { node, users: contributorUser });
+
+        server.loadFixtures('schema-blocks');
+        server.loadFixtures('registration-schemas');
+        const registrationSchema = server.schema.registrationSchemas.all().models[0];
+        registerNodeMultiple(server, node, 3, { registrationSchema }, 'withArbitraryState');
+
+        server.createList('draft-registration', 2);
+
+        await visit('/registries/my-registrations');
+        assert.dom('[data-test-my-registrations-sort-description]').exists('Sort description shown');
+        assert.notOk(currentURL().includes('tab'), 'Tab query param not visible on submitted');
+        assert.dom('[data-test-my-registrations-nav="submitted"]').hasClass('active', 'Submitted tab is active');
+        assert.dom('[data-test-my-registrations-nav="drafts"]').doesNotHaveClass('active', 'Draft tab is not active');
+        assert.dom('[data-test-my-registrations-pane="submitted"]').isVisible('Submitted pane is shown');
+        assert.dom('[data-test-my-registrations-pane="drafts"]').isNotVisible('Drafts pane is not shown');
+        assert.dom('[data-test-node-card]').exists({ count: 3 }, 'All submitted registrations shown');
+        await percySnapshot(assert);
+
+        await click('[data-test-my-registrations-nav-button="drafts"]');
+        assert.ok(currentURL().includes('tab=drafts'), 'Tab query param visible on drafts');
+        assert.dom('[data-test-my-registrations-nav="drafts"]').hasClass('active', 'Drafts tab is active');
+        assert.dom('[data-test-my-registrations-nav="submitted"]').doesNotHaveClass('active',
+            'Submitted tab is not active');
+        assert.dom('[data-test-my-registrations-pane="drafts"]').isVisible('Drafts pane is shown');
+        assert.dom('[data-test-my-registrations-pane="submitted"]').isNotVisible('Submitted pane is not shown');
+        assert.dom('[data-test-draft-registration-card]').exists({ count: 2 }, 'All drafts shown');
+        await percySnapshot(
+            'Registries | Acceptance | my registrations page | navigation with drafts and registrations | drafts',
+        );
+    });
+});

--- a/tests/integration/components/registries/my-registrations-list/component-test.ts
+++ b/tests/integration/components/registries/my-registrations-list/component-test.ts
@@ -29,7 +29,7 @@ module('Integration | Component | my-registrations-list', hooks => {
             this.intl.t('registries.myRegistrationsList.noDrafts'),
             'Specifc no drafts message exists and correct',
         );
-        assert.dom('[data-test-add-new-button]').exists('Add new button exists');
+        assert.dom('[data-test-my-reg-drafts-add-new-button]').exists('Add new button exists');
     });
 
     test('registration list empty', async function(this: TestContext, assert) {
@@ -50,7 +50,7 @@ module('Integration | Component | my-registrations-list', hooks => {
             this.intl.t('registries.myRegistrationsList.noRegistrations'),
             'Specifc no registrations message exists and correct',
         );
-        assert.dom('[data-test-add-new-button]').exists('Add new button exists');
+        assert.dom('[data-test-my-reg-registrations-add-new-button]').exists('Add new button exists');
     });
 
     test('draft list renders and paginates', async function(this: TestContext, assert) {


### PR DESCRIPTION
- Ticket: [ENG-2919]
- Feature flag: n/a

## Purpose
- Add data-test selectors to the my-registrations page to help with Selenium testing
- Add integration test to the my-registrations page while we're here

## Summary of Changes
- Changed invocation of BsTab to allow us to set data-test selectors on the BsNav.items
  - Add data-test selectors to the tabs, the buttons within the tabs, and to the tab panes
  - Update some CSS to match the existing style
- Update analytics scope to a more appropriate name
- Update data-test selectors on the `Create New Registration` button to be unique for easier selecting in Selenium testing
- Added integration test to My-Registrations page

## Side Effects
- None

## QA Notes
- The My-Registrations page should now be contained under `data-analytics-scope='My Registrations page'`
- Clicking `data-test-my-registrations-nav-button='drafts'` and `data-test-my-registrations-nav-button='submitted'` should toggle between the drafts and the submitted pages respectively
- When there are no drafts and you are on the `Drafts` tab, `data-test-my-reg-drafts-add-new-button` will be the selector for the add new button
- When there are no submitted registrations and you are on the `Submitted` tab, `data-test-my-reg-registrations-add-new-button` will be the selector for the add new button

[ENG-2919]: https://openscience.atlassian.net/browse/ENG-2919