### PR TITLE
[ENG-2898] Fix firefox contributor list

### DIFF
--- a/lib/registries/addon/components/registries-search-result/styles.scss
+++ b/lib/registries/addon/components/registries-search-result/styles.scss
@@ -38,7 +38,7 @@ h3.RegistriesSearchResult__Title {
         padding-right: 5px;
 
         &::after {
-            content: ', ';
+            content: ',';
         }
     }
 


### PR DESCRIPTION
- Ticket: [ENG-2898]
- Feature flag: n/a

## Purpose

Fix registries discover page contributor list appearance on firefox.

![Screenshot from 2021-06-22 04-08-36](https://user-images.githubusercontent.com/1566880/122888583-fe56be80-d30f-11eb-89ac-47f0ecf56f3a.png)


## Summary of Changes

Remove excess space in content of the `::after` pseudo element.


## Side Effects

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-2898]: https://openscience.atlassian.net/browse/ENG-2898