### PR TITLE
[ENG-2898] Fix notice for metadata failed autosave

### DIFF
--- a/lib/registries/addon/drafts/draft/-components/right-nav/styles.scss
+++ b/lib/registries/addon/drafts/draft/-components/right-nav/styles.scss
@@ -5,3 +5,7 @@
         width: 100%;
     }
 }
+
+.SaveFailed {
+    color: $brand-danger;
+}

--- a/lib/registries/addon/drafts/draft/draft-registration-manager.ts
+++ b/lib/registries/addon/drafts/draft/draft-registration-manager.ts
@@ -71,12 +71,13 @@ export default class DraftRegistrationManager {
         return this.metadataChangeset.isValid;
     }
 
-    @computed('onPageInput.lastComplete')
+    @computed('onPageInput.lastComplete', 'onMetadataInput.lastComplete')
     get lastSaveFailed() {
         const onPageInputLastComplete = taskFor(this.onPageInput).lastComplete;
+        const metadataInputLastComplete = taskFor(this.onMetadataInput).lastComplete;
         const pageInputFailed = onPageInputLastComplete ? onPageInputLastComplete.isError : false;
-        const metadataInputFailed = onPageInputLastComplete
-            ? onPageInputLastComplete.isError : false;
+        const metadataInputFailed = metadataInputLastComplete
+            ? metadataInputLastComplete.isError : false;
         return pageInputFailed || metadataInputFailed;
     }
 

--- a/lib/registries/addon/drafts/draft/styles.scss
+++ b/lib/registries/addon/drafts/draft/styles.scss
@@ -113,10 +113,6 @@
     display: inline-block;
 }
 
-.SaveFailed {
-    color: $primary-red;
-}
-
 .SideBarToggle {
     width: 100%;
 }


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-2898]
- Feature flag: n/a

## Purpose

When autosave fails on the draft-registration metadata, the notice in the right sidebar is not showing up.

## Summary of Changes

- Update `DraftRegistrationManager.lastSaveFailed` computed property to update on status of `onMetadataInput` task.
- Make notice red (actually have rules in the notice existing local class)

## Side Effects

N/A

## QA Notes

- On a draft-registration metadata page, currently, one way to cause an auto-save error is by deleting the autofilled `year`
on a license with required fields (for example `No License`, `MIT License`); you should see an error toast then in the right sidebar; a notice similar to the one below should show.

<img width="1140" alt="Screen Shot 2021-06-25 at 9 58 46 AM" src="https://user-images.githubusercontent.com/4511563/123444320-c4eab100-d5a4-11eb-9e2d-d0b75ff9ebf6.png">




[ENG-2898]: https://openscience.atlassian.net/browse/ENG-2898