### PR TITLE
[ENG-2898] Fix missing save/cancel buttons

### DIFF
--- a/lib/registries/addon/components/registries-license-picker/template.hbs
+++ b/lib/registries/addon/components/registries-license-picker/template.hbs
@@ -70,23 +70,23 @@
             {{#if this.showText}}
                 <LicenseText @node={{@manager.registration}} />
             {{/if}}
+        {{/if}}
 
-            {{#if this.shouldShowButtons}}
-                <div local-class='Controls'>
-                    <BsButton @type='default' {{on 'click' @manager.cancel}}>
-                        {{t 'general.cancel'}}
-                    </BsButton>
-                    <BsButton
-                        data-analytics-name='Save license'
-                        data-test-save-license
-                        disabled={{@manager.changeset.isInvalid}}
-                        @type='primary'
-                        {{on 'click' @manager.save}}
-                    >
-                        {{t 'general.save'}}
-                    </BsButton>
-                </div>
-            {{/if}}
+        {{#if this.shouldShowButtons}}
+            <div local-class='Controls'>
+                <BsButton @type='default' {{on 'click' @manager.cancel}}>
+                    {{t 'general.cancel'}}
+                </BsButton>
+                <BsButton
+                    data-analytics-name='Save license'
+                    data-test-save-license
+                    disabled={{@manager.changeset.isInvalid}}
+                    @type='primary'
+                    {{on 'click' @manager.save}}
+                >
+                    {{t 'general.save'}}
+                </BsButton>
+            </div>
         {{/if}}
     </div>
 </FormControls>


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-2898]
- Feature flag: n/a

## Purpose

Fix missing save/cancel buttons on the registration's license/node-license editable field.
Currently, only licenses with `requiredFields` can be saved.

## Summary of Changes
- Make it so control buttons show regardless of whether or not the selected license has required fields. 

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
You should be able to edit and save a registration's license (with or w/o required fields) or cancel the edit.
Try 'MIT License' or 'No License' (have requiredFields) to make sure you still see the editable field control buttons.
Try a difference license and make sure the control buttons are visible and usable.


[ENG-2898]: https://openscience.atlassian.net/browse/ENG-2898