### PR TITLE
[ENG-2940][Hotfix] Update node license validations

### DIFF
--- a/app/packages/registration-schema/validations.ts
+++ b/app/packages/registration-schema/validations.ts
@@ -162,6 +162,7 @@ export function buildMetadataValidations() {
     set(validationObj, DraftMetadataProperties.Description, notBlank);
     set(validationObj, DraftMetadataProperties.License, notBlank);
     set(validationObj, DraftMetadataProperties.Subjects, validateSubjects());
-    set(validationObj, DraftMetadataProperties.NodeLicenseProperty, [validateNodeLicense(), validateNodeLicenseYear()]);
+    // TODO: unsure why array of validation functions breaks validations
+    set(validationObj, DraftMetadataProperties.NodeLicenseProperty, validateNodeLicense());
     return validationObj;
 }

--- a/lib/osf-components/addon/components/validated-input/base-component.ts
+++ b/lib/osf-components/addon/components/validated-input/base-component.ts
@@ -3,6 +3,7 @@
 import Model from '@ember-data/model';
 import Component from '@ember/component';
 import { computed, defineProperty } from '@ember/object';
+import { dependentKeyCompat } from '@ember/object/compat';
 import { alias, oneWay } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
@@ -68,7 +69,12 @@ export default abstract class BaseValidatedInput<M extends Model> extends Compon
         return this.placeholder || this.intl.t(this.isRequired ? 'general.required' : 'general.optional');
     }
 
-    @computed('shouldShowMessages', 'value', 'isInvalid', 'isValidating')
+    @dependentKeyCompat
+    get _isInvalid() {
+        return this.changeset ? Boolean(this.changeset.error[this.valuePath as string]) : this.isInvalid;
+    }
+
+    @computed('shouldShowMessages', 'value', '_isInvalid', 'isInvalid', 'isValidating')
     get validationStatus(): ValidationStatus {
         const {
             shouldShowMessages,
@@ -93,10 +99,6 @@ export default abstract class BaseValidatedInput<M extends Model> extends Compon
 
     get _isValidating() {
         return this.changeset ? this.changeset.isValidating(this.valuePath as string) : this.isValidating;
-    }
-
-    get _isInvalid() {
-        return this.changeset ? Boolean(this.changeset.error[this.valuePath as string]) : this.isInvalid;
     }
 
     init() {

--- a/lib/registries/addon/drafts/draft/-components/managers/license-picker-manager/component.ts
+++ b/lib/registries/addon/drafts/draft/-components/managers/license-picker-manager/component.ts
@@ -73,7 +73,7 @@ export default class LicensePickerManager extends Component implements LicenseMa
         } else {
             this.draftManager.metadataChangeset.set('nodeLicense', null);
         }
-        this.onMetadataInput();
+        taskFor(this.draftManager.updateDraftRegistrationAndSave).perform();
     }
 
     @action

--- a/lib/registries/addon/drafts/draft/draft-registration-manager.ts
+++ b/lib/registries/addon/drafts/draft/draft-registration-manager.ts
@@ -177,8 +177,14 @@ export default class DraftRegistrationManager {
     @restartableTask
     @waitFor
     async onMetadataInput() {
-        await timeout(5000); // debounce
-        this.updateMetadataChangeset();
+        await timeout(3000); // debounce
+        await taskFor(this.updateDraftRegistrationAndSave).perform();
+    }
+
+    @restartableTask
+    @waitFor
+    async updateDraftRegistrationAndSave() {
+        this.copyMetadataChangesToDraft();
         try {
             await this.draftRegistration.save();
         } catch (e) {
@@ -222,7 +228,7 @@ export default class DraftRegistrationManager {
             });
     }
 
-    updateMetadataChangeset() {
+    copyMetadataChangesToDraft() {
         const { metadataChangeset, draftRegistration } = this;
         Object.values(DraftMetadataProperties).forEach(metadataKey => {
             set(

--- a/mirage/factories/registration-provider.ts
+++ b/mirage/factories/registration-provider.ts
@@ -41,7 +41,10 @@ export default Factory.extend<MirageRegistrationProvider & RegistrationProviderT
     afterCreate(provider, server) {
         provider.update({
             licensesAcceptable: [
-                server.create('license', { name: 'MIT License' }),
+                server.create('license', {
+                    name: 'Mozilla Public License 2.0',
+                    requiredFields: [],
+                }),
                 server.create('license', {
                     name: 'No license',
                     requiredFields: [

--- a/tests/acceptance/settings/profile/names-test.ts
+++ b/tests/acceptance/settings/profile/names-test.ts
@@ -1,7 +1,7 @@
 import { currentURL, fillIn, visit } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { percySnapshot } from 'ember-percy';
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 
 import { click, setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
 import { CurrentUserStub } from 'ember-osf-web/tests/helpers/require-auth';
@@ -89,7 +89,7 @@ module('Acceptance | settings | profile | name', hooks => {
     });
 
     // skip: unskip after reworking validated-input after
-    skip('validation works', async assert => {
+    test('validation works', async assert => {
         const givenName = 'Peggy';
         const middleNames = 'Herbert Gavin';
         const familyName = 'Doyle';

--- a/tests/engines/registries/acceptance/draft/draft-test.ts
+++ b/tests/engines/registries/acceptance/draft/draft-test.ts
@@ -7,6 +7,7 @@ import {
     find,
     settled,
     triggerKeyEvent,
+    blur,
     waitUntil,
     findAll,
 } from '@ember/test-helpers';
@@ -877,33 +878,31 @@ module('Registries | Acceptance | draft form', hooks => {
             .hasValue(new Date().getUTCFullYear().toString(), 'License: Year autofills to current year');
         assert.dom('[data-test-required-field="copyrightHolders"]')
             .hasText('', 'License: CopyrightHolders does not autofill');
-        const missingFields = 'Copyright Holders';
-        const validationErrorMsg = t('validationErrors.node_license_missing_fields',
+        let missingFields = 'Copyright Holders';
+        let validationErrorMsg = t('validationErrors.node_license_missing_fields',
             { missingFields, numOfFields: 1 }).toString();
         assert.dom('[data-test-validation-errors="nodeLicense"]')
             .containsText(validationErrorMsg, 'NodeLicense validation error when copyright holder is empty');
 
-        // TODO: Fix node-license validation in test
         // Input invalid Nodelicense fields
-        // await fillIn('[data-test-required-field="year"]', '');
-        // await blur('[data-test-required-field="year"]');
-        // await this.pauseTest();
-        // missingFields = 'Year, Copyright Holders';
-        // validationErrorMsg = t('validationErrors.node_license_missing_fields',
-        //     { missingFields, numOfFields: 2 }).toString();
-        // assert.dom('[data-test-validation-errors="nodeLicense"]')
-        //     .containsText(
-        //           validationErrorMsg,
-        //          'NodeLicense validation error when year and copyrightholder are empty',
-        //      );
-        // await percySnapshot(
-        //      'Registries | Acceptance | draft form | metadata editing | metadata: invalid nodelicense');
+        await fillIn('[data-test-required-field="year"]', '');
+        await blur('[data-test-required-field="year"]');
+        missingFields = 'Year, Copyright Holders';
+        validationErrorMsg = t('validationErrors.node_license_missing_fields',
+            { missingFields, numOfFields: 2 }).toString();
+        assert.dom('[data-test-validation-errors="nodeLicense"]')
+            .containsText(
+                validationErrorMsg,
+                'NodeLicense validation error when year and copyrightholder are empty',
+            );
+        await percySnapshot(
+            'Registries | Acceptance | draft form | metadata editing | metadata: invalid nodelicense',
+        );
 
         // validation errors for nodelicense should show on review page
-        // await click('[data-test-link="review"]');
-        //
-        // assert.dom('[data-test-validation-errors="nodeLicense"]').exists('NodeLicense errors exist on Review page');
-        // await percySnapshot('Registries | Acceptance | draft form | metadata editing | review: invalid nodelicense');
+        await click('[data-test-link="review"]');
+        assert.dom('[data-test-validation-errors="nodeLicense"]').exists('NodeLicense errors exist on Review page');
+        await percySnapshot('Registries | Acceptance | draft form | metadata editing | review: invalid nodelicense');
 
         // Return to metadata page to address empty fields
         await click('[data-test-link="metadata"]');

--- a/tests/engines/registries/acceptance/overview/overview-test.ts
+++ b/tests/engines/registries/acceptance/overview/overview-test.ts
@@ -3,6 +3,7 @@ import { click as untrackedClick, fillIn } from '@ember/test-helpers';
 import { ModelInstance } from 'ember-cli-mirage';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import config from 'ember-get-config';
+import { t } from 'ember-intl/test-support';
 import { percySnapshot } from 'ember-percy';
 import { selectChoose, selectSearch } from 'ember-power-select/test-support';
 import { TestContext } from 'ember-test-helpers';
@@ -562,17 +563,16 @@ module('Registries | Acceptance | overview.overview', hooks => {
         await click('[data-test-edit-button="license"]');
 
         assert.dom('[data-test-license-edit-form]').isVisible();
-        await selectSearch('[data-test-power-select-dropdown]', 'MIT');
-        assert.dom('.ember-power-select-options').hasText('MIT License');
+        await selectSearch('[data-test-power-select-dropdown]', 'Mozilla');
+        assert.dom('.ember-power-select-options').hasText('Mozilla Public License 2.0');
         await selectSearch('[data-test-power-select-dropdown]', 'No');
         assert.dom('.ember-power-select-options').hasText('No license');
         await selectChoose('[data-test-power-select-dropdown]', 'No license');
 
-        // TODO: Fix nodeLicense validation in test
-        // const missingFields = 'Copyright Holders';
-        // const validationErrorMsg = t('validationErrors.node_license_missing_fields',
-        //     { missingFields, numOfFields: 1 }).toString();
-        // assert.dom('.help-block').hasText(validationErrorMsg, 'validation works');
+        const missingFields = 'Copyright Holders';
+        const validationErrorMsg = t('validationErrors.node_license_missing_fields',
+            { missingFields, numOfFields: 1 }).toString();
+        assert.dom('.help-block').hasText(validationErrorMsg, 'validation works');
 
         await fillIn('[data-test-required-field="copyrightHolders"]', 'Jane Doe, John Doe');
         await click('[data-test-save-license]');


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-2940]
- Feature flag: n/a

## Purpose
- update the way node licenses are validated to prevent validation errors from occurring when they should not

## Summary of Changes
- Removed validating year for node license as this was causing odd behavior in the validation (ie: no errors would appear when node license did not have year and/or copyright holder)
- Used the `@dependentKeyCompat` decorator to circumvent troublesome tracking behavior for changeset's error object
- Created a new task that will update the metadata changeset without having to wait for the debounce to circumvent potential state where nodeLicense getting fetched from backing draftRegistration could cause issues
- Decreased debounce time from 5 to 3 seconds
- Reinstated some tests

## Side Effects
- We will no longer validate if the year format is valid. This is due to some unforeseen issues with passing in multiple validator functions to the nodeLicense. I tried incorporating the year formatting validation into the main `validateNodeLicense` function, but it didn't seem to work too great

## QA Notes
- When a user creates a new draft and fills out the metadata page while choosing a license that does not have any required fields (ie: any license that is not `MIT License` or `No License`, and then goes to the Review page, the metadata page should be valid (before it was showing the metadata page to be invalid due to faulty `year` and `copyright holder` validation)
- When a user edits a draft and chooses either `MIT License` or `No License`, the validation status should update as users address or introduce new errors to Year and Copyright Holder fields (you will need to click outside of the text fields for the updated validations to trigger)
- Please change licenses back and forth, between licenses that don't have additional fields and those that do and make sure switching between these doesn't cause unforeseen errors

[ENG-2940]: https://openscience.atlassian.net/browse/ENG-2940