### PR TITLE
Return undefined for empty node license

### DIFF
--- a/app/transforms/node-license.ts
+++ b/app/transforms/node-license.ts
@@ -30,9 +30,9 @@ export default class NodeLicenseTransform extends Transform {
         });
     }
 
-    serialize(value: NodeLicense): SerializedNodeLicense {
-        if (!value) {
-            return {};
+    serialize(value: NodeLicense): SerializedNodeLicense | undefined {
+        if (!value || Object.entries(value).length === 0) {
+            return undefined;
         }
 
         const {

--- a/app/transforms/node-license.ts
+++ b/app/transforms/node-license.ts
@@ -31,7 +31,12 @@ export default class NodeLicenseTransform extends Transform {
     }
 
     serialize(value: NodeLicense): SerializedNodeLicense | undefined {
-        if (!value || Object.entries(value).length === 0) {
+        if (!value) {
+            return {};
+        }
+        // Setting this to undefined will prevent nodelicense from being serialized
+        // in the draft registration metadata workflow if the user has not updated it.
+        if (Object.entries(value).length === 0) {
             return undefined;
         }
 


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: []
- Feature flag: n/a

## Purpose
- the node license would be serialized when updating any field on the metadata page. This PR will make it so it is only sent when the node-license fields have been changed


## Summary of Changes
- Update a condition to check if the node license value is an empty object (previous condition was checking truthiness on an empty object)
- update the return object to be undefined when the node license is an empty

## Side Effects
- None that we know of...

## QA Notes
- This is to help alleviate some of the node license issues that have been occurring on the draft registration's metadata page
- The most important thing to test is that all combinations of modifying the node license work properly, especially clearing out fields.