### PR TITLE
[ENG-2943] Separate session invalidate and redirect from logout

### DIFF
--- a/app/services/current-user.ts
+++ b/app/services/current-user.ts
@@ -79,7 +79,7 @@ export default class CurrentUserService extends Service {
 
     constructor(...args: any[]) {
         super(...args);
-        this.session.on('invalidationSucceeded', this, this.logout);
+        this.session.on('invalidationSucceeded', this, this._authRedirect.bind(this, AuthRoute.Logout));
     }
 
     /**
@@ -92,14 +92,12 @@ export default class CurrentUserService extends Service {
     }
 
     /**
-     * Invalidate the current session and cookie, then redirect to the given URL (or back to the current page).
-     * Returns a promise that never resolves.
+     * Invalidate the current session and cookie
      */
-    async logout(nextUrl?: string) {
+    async logout() {
         if (this.session.isAuthenticated) {
             await this.session.invalidate();
         }
-        return this._authRedirect(AuthRoute.Logout, nextUrl);
     }
 
     _authRedirect(authRoute: AuthRoute, nextUrl?: string) {

--- a/lib/app-components/addon/components/branded-navbar/template.hbs
+++ b/lib/app-components/addon/components/branded-navbar/template.hbs
@@ -66,7 +66,6 @@
                     <OsfNavbar::AuthDropdown
                         @signupUrl={{@signupUrl}}
                         @loginAction={{@loginAction}}
-                        @redirectUrl={{@redirectUrl}}
                         @onLinkClicked={{action (mut this.showNavLinks) false}}
                         @headline={{t 'app_components.branded_navbar.on_the_osf'}}
                         @externalLink={{true}}

--- a/lib/osf-components/addon/components/osf-navbar/auth-dropdown/component.ts
+++ b/lib/osf-components/addon/components/osf-navbar/auth-dropdown/component.ts
@@ -34,11 +34,6 @@ export class AuthBase extends Component {
      */
     loginAction?: () => void;
 
-    /**
-     * The URL to redirect to after logout
-     */
-    redirectUrl = '/goodbye';
-
     campaign?: string;
 
     profileURL = pathJoin(baseUrl, 'profile');
@@ -71,11 +66,6 @@ export class AuthBase extends Component {
     @action
     login() {
         this.currentUser.login();
-    }
-
-    @action
-    logout() {
-        this.currentUser.logout(this.redirectUrl);
     }
 }
 

--- a/lib/osf-components/addon/components/osf-navbar/auth-dropdown/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/auth-dropdown/template.hbs
@@ -61,7 +61,7 @@
                     data-analytics-name='Logout'
                     class='logoutLink'
                     @type='link'
-                    @onClick={{action 'logout'}}
+                    @onClick={{action this.currentUser.logout}}
                 >
                     <FaIcon @icon='sign-out-alt' class='fa-lg p-r-xs' />
                     {{t 'auth_dropdown.log_out'}}

--- a/lib/registries/addon/components/registries-navbar/template.hbs
+++ b/lib/registries/addon/components/registries-navbar/template.hbs
@@ -275,7 +275,7 @@
                                 data-test-ad-logout
                                 data-analytics-name='Logout'
                                 @type='link'
-                                @onClick={{action 'logout'}}
+                                @onClick={{action this.currentUser.logout}}
                             >
                                 <FaIcon @icon='sign-out-alt' @fixedWidth={{true}} />
                                 {{t 'auth_dropdown.log_out'}}

--- a/tests/engines/registries/integration/components/registries-navbar/component-test.ts
+++ b/tests/engines/registries/integration/components/registries-navbar/component-test.ts
@@ -42,6 +42,7 @@ const currentUserStub = Service.extend({
     },
 
     async checkShowTosConsentBanner() { /* stub */ },
+    async logout() { /* stub */ },
 });
 
 const featuresStub = Service.extend({


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

- Ticket: [ENG-2943]
- Feature flag: n/a

## Purpose
- Make users actually log out when using the logout button

## Summary of Changes
- Separate invalidating session and redirect logic from the `CurrentUser.logout` function

## Side Effects
- none

## QA Notes
- Users should now actually be logged out when clicking the logout button. This effect should have been happening on any emberized page when a user logs out. Unsure why it was happening primarily when logging out of the Registries app though 🤔 

[ENG-2943]: https://openscience.atlassian.net/browse/ENG-2943