### PR TITLE
[ENG-2983] Registries sidebar link hover background

### DIFF
--- a/lib/osf-components/addon/components/osf-layout/registries-side-nav/x-link/styles.scss
+++ b/lib/osf-components/addon/components/osf-layout/registries-side-nav/x-link/styles.scss
@@ -34,7 +34,7 @@
     }
 
     &:hover {
-        background: $color-link-lighter !important; // !important needed to override bootstrap .btn properties
+        background: $color-link-dark !important; // !important needed to override bootstrap .btn properties
         color: $color-text-white !important; // !important needed to override bootstrap .btn properties
         text-decoration: none !important; // !important needed to override bootstrap .btn properties
         width: max-content;


### PR DESCRIPTION
- Ticket: [ENG-2983](https://openscience.atlassian.net/browse/ENG-2983)
- Feature flag: n/a

## Purpose

Stop violating WCAG 2 AA contrast rules on the registries sidebar

Before:

<img width="342" alt="Screen Shot 2021-07-19 at 12 45 31 PM" src="https://user-images.githubusercontent.com/6599111/126208928-9fc6bfd1-bfc2-4f91-b583-01e4e54d4864.png">

After:

<img width="287" alt="Screen Shot 2021-07-19 at 12 51 13 PM" src="https://user-images.githubusercontent.com/6599111/126208951-3c035002-5d4b-486d-b731-13f8e1fd8bd4.png">

## Summary of Changes

1. Change hover color to darker color

## Side Effects

This should be isolated to the sidenav in registries.

## QA Notes

This is just a css change, and an isolated one at that, so shouldn't require much QA.
