### PR TITLE
[ENG-2982] Draft metadata page a11y fixes

### DIFF
--- a/lib/app-components/addon/components/project-metadata/template.hbs
+++ b/lib/app-components/addon/components/project-metadata/template.hbs
@@ -42,7 +42,8 @@
                     @removeTagAtIndex={{action this.removeTagAtIndex}}
                     @allowSpacesInTags={{true}}
                     @placeholder={{t 'osf-components.tags-widget.add_tag'}}
-                    @aria_label={{t 'file_detail.tags'}}
+                    @ariaLabel={{t 'osf-components.tags-widget.add_tag'}}
+                    aria-label={{t 'file_detail.tags'}}
                     @readOnly={{false}}
                     local-class='tagInput'
                     as |tag|

--- a/lib/osf-components/addon/components/contributors/card/editable/styles.scss
+++ b/lib/osf-components/addon/components/contributors/card/editable/styles.scss
@@ -23,6 +23,7 @@
 .Handle {
     padding-right: 10px;
     color: var(--primary-color);
+    font-size: 20pt;
 }
 
 .DropdownSection {

--- a/lib/osf-components/addon/components/contributors/card/editable/template.hbs
+++ b/lib/osf-components/addon/components/contributors/card/editable/template.hbs
@@ -3,11 +3,10 @@
     <div data-test-contributor-card-main local-class='MainSection'>
         <span local-class='CardSection'>
             <span local-class='Handle'>
-                {{#@item.handle}}
-                    <FaIcon
-                        @icon='sort'
-                        data-test-sortable-handle={{@contributor.id}}
-                    />
+                {{#@item.handle aria-label='Sort contributor'}}
+                    <span data-test-sortable-handle={{@contributor.id}}>
+                        {{t 'osf-components.contributors.reorderContributor.dragHandle'}}
+                    </span>
                 {{/@item.handle}}
             </span>
             <img
@@ -47,6 +46,7 @@
             <Input
                 @type='checkbox'
                 @checked={{readonly @contributor.bibliographic}}
+                aria-label={{t 'app_components.project_contributors.list.citation'}}
                 data-test-contributor-citation-checkbox
                 data-analytics-name='Toogle isBibliographic'
                 {{on 'click' (fn @manager.toggleContributorIsBibliographic @contributor)}}

--- a/lib/osf-components/addon/components/tags-widget/template.hbs
+++ b/lib/osf-components/addon/components/tags-widget/template.hbs
@@ -12,6 +12,7 @@
     @removeTagAtIndex={{action this._removeTag}}
     @allowSpacesInTags={{true}}
     @placeholder={{t 'osf-components.tags-widget.add_tag'}}
+    @ariaLabel={{t 'osf-components.tags-widget.add_tag'}}
     @readOnly={{this.readOnly}}
     @maxlength={{1024}}
     as |tag|

--- a/lib/registries/addon/components/registries-tags-widget/template.hbs
+++ b/lib/registries/addon/components/registries-tags-widget/template.hbs
@@ -22,6 +22,7 @@
     {{#unless this.readOnly}}
         <BsButton
             local-class='RemoveButton'
+            aria-label={{t 'osf-components.tags-widget.remove_tag'}}
             data-analytics-name='Remove Tag'
             data-analytics-extra={{tag}}
             @type='link'

--- a/lib/registries/addon/components/registries-tags-widget/template.hbs
+++ b/lib/registries/addon/components/registries-tags-widget/template.hbs
@@ -6,6 +6,7 @@
     @addTag={{action this.addTag}}
     @allowSpacesInTags={{true}}
     @placeholder={{t 'osf-components.tags-widget.add_tag'}}
+    @ariaLabel={{t 'osf-components.tags-widget.add_tag'}}
     @readOnly={{this.readOnly}}
     @maxlength={{1024}}
     @showRemoveButtons={{false}}

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     "ember-sinon-qunit": "^5.0.0",
     "ember-sortable": "2.2",
     "ember-source": "~3.26.1",
-    "ember-tag-input": "^1.2.2",
+    "ember-tag-input": "^2.0.3",
     "ember-template-compiler": "^1.9.0-alpha",
     "ember-template-lint": "^3.2.0",
     "ember-toastr": "^1.7.2",

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1575,6 +1575,7 @@ osf-components:
         tags: Tags
         add_tag: 'Add a tag to enhance discoverability'
         no_tags: 'No tags'
+        remove_tag: 'Remove tag'
     institutions-list:
         no_affiliated_institution:
             project: 'This project has no affiliated institutions'
@@ -1680,6 +1681,7 @@ osf-components:
             error: 'Error updating contributor bibliographic status.'
         reorderContributor:
             success: 'Contributor order updated.'
+            dragHandle: '⇕'
         noEducation: 'No education history to show'
         noEmployment: 'No employment history to show'
         addContributor:

--- a/yarn.lock
+++ b/yarn.lock
@@ -9868,13 +9868,13 @@ ember-style-modifier@^0.6.0:
     ember-cli-babel "^7.21.0"
     ember-modifier "^2.1.0"
 
-ember-tag-input@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/ember-tag-input/-/ember-tag-input-1.2.2.tgz#a730065b08cbcc472c73d19790d9abda21f654ae"
-  integrity sha512-pmlRRVEQfEfJrMDBofXzGoLkMSi+xSFuCxZwvN1yDl3BlPONsdLBpqfFhm50Ml5sNj/6pXin+oX+/3SXXQ5Q4A==
+ember-tag-input@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/ember-tag-input/-/ember-tag-input-2.0.3.tgz#6e22bb340b6f3e413e56421bf86409954f68e740"
+  integrity sha512-4JbUOID9b8EOEhtudywEsAoOUmiwuAE5WtKCO3jwRrZUi+HcNNn4vCx5tlHffGnGExa/iM+TwhZr1WEvarOOqQ==
   dependencies:
-    ember-cli-babel "^6.7.1"
-    ember-cli-htmlbars "^2.0.3"
+    ember-cli-babel "^7.13.2"
+    ember-cli-htmlbars "^4.2.0"
 
 ember-template-compiler@^1.9.0-alpha:
   version "1.9.0-alpha"


### PR DESCRIPTION
- Ticket: [ENG-2982](https://openscience.atlassian.net/browse/ENG-2982)
- Feature flag: n/a

## Purpose

Reduce the accessibility problems on the Draft Metadata page, especially around third party components.

## Summary of Changes

1. Use unicode text instead of an icon as a drag handle for contributors
![Screen Shot 2021-07-27 at 10 18 08 AM](https://user-images.githubusercontent.com/6599111/127693424-5fc134f5-5378-4c1e-81c0-4187818323a0.png)


2. Use fixed version of ember-tag-input
3. Use new ariaLabel parameter wherever we use the ember-tag-input
4. Add an aria-label to the 'citation' checkbox for contributors
5. Add an aria-label to the 'remove tag' button 

## Side Effects

This will also fix other instances of ember-tag-input, such as Quickfiles

## QA Notes

This is mostly on the draft metadata page, but Quickfiles detail page will have better tags as well.
