### PR TITLE
[No ticket] Add screenshot section to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,8 +7,8 @@
   Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
 -->
 
-- Ticket: []
-- Feature flag: n/a
+-   Ticket: []
+-   Feature flag: n/a
 
 ## Purpose
 
@@ -17,6 +17,10 @@
 ## Summary of Changes
 
 <!-- Briefly describe or list your changes. -->
+
+## Screenshot(s)
+
+<!-- Attach screenshots if applicable. -->
 
 ## Side Effects
 


### PR DESCRIPTION
- Ticket: None
- Feature flag: n/a

## Purpose
- Add a `Screenshot` section to the PR template cause I keep forgetting to do that

## Summary of Changes
- Update PR template

## Side Effects
- None

## QA Notes
- Just updating the template for these PRs