### PR TITLE
[ENG-2982] Correct typo in citation

### DIFF
--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -740,7 +740,7 @@ app_components:
             permissions: Permissions
             permissions_popover_title: 'Permission Information'
             permissions_popover: "\n                    <dl>\n                        <dt>Read</dt>\n                        <dd>\n                            <ul>\n                                <li>View project</li>\n                            </ul>\n                        </dd>\n                        <dt>Read + Write</dt>\n                        <dd>\n                            <ul>\n                                <li>Read privileges</li>\n                                <li>Add and configure project</li>\n                                <li>Add and edit content</li>\n                            </ul>\n                        </dd>\n                        <dt>Administrator</dt>\n                        <dd>\n                            <ul>\n                                <li>Read and write privileges</li>\n                                <li>Manage contributors</li>\n                                <li>Public-private settings</li>\n                            </ul>\n                        </dd>\n                    </dl>\n                "
-            citation: Citiation
+            citation: Citation
             citation_popover_title: 'Citation Information'
             citation_popover: 'Only checked contributors will be included in project citations. Contributors not in the citation can read and modify the project as normal.'
             remove_contributor_success: 'Project contributor removed!'


### PR DESCRIPTION
-   Ticket: [ENG-2982]
-   Feature flag: n/a

## Purpose

We had a translation string that should have been 'citation' but was 'citiation'. This corrects that typo.

## Summary of Changes

1. Fix translation string


[ENG-2982]: https://openscience.atlassian.net/browse/ENG-2982