### PR TITLE
[ENG-2969] A11y fixes for registries discover page

### DIFF
--- a/lib/registries/addon/components/registries-discover-results-header/template.hbs
+++ b/lib/registries/addon/components/registries-discover-results-header/template.hbs
@@ -12,7 +12,7 @@
                 local-class='DropdownTrigger'
             >
                 {{t 'registries.discover.sort_by'}}: {{t @searchOptions.order.display}}
-                <span aria-label='{{t 'registries.discover.sort_by'}}' class='caret'></span>
+                <span role='button' aria-label='{{t 'registries.discover.sort_by'}}' class='caret'></span>
             </dd.trigger>
             <dd.content local-class='DropdownContent'>
                 {{#each @sortOptions as |option index|}}

--- a/lib/registries/addon/components/registries-header/template.hbs
+++ b/lib/registries/addon/components/registries-header/template.hbs
@@ -33,6 +33,7 @@
                 <label local-class='SearchForm__HiddenLabel' for='search'>{{t 'registries.header.search_label'}}</label>
                 <Input
                     data-test-search-box={{true}}
+                    aria-label={{t 'registries.header.search_label'}}
                     id='search'
                     @value={{this.value}}
                     @class='form-control'

--- a/lib/registries/addon/components/registries-navbar/template.hbs
+++ b/lib/registries/addon/components/registries-navbar/template.hbs
@@ -168,6 +168,7 @@
                 <dropdown.toggle
                     data-analytics-name='Toggle'
                     local-class='Dropdown'
+                    aria-label={{t 'auth_dropdown.toggle_auth_dropdown'}}
                 >
                     {{#if this.session.isAuthenticated}}
                         <img


### PR DESCRIPTION
-   Ticket: [https://openscience.atlassian.net/browse/ENG-2969]
-   Feature flag: n/a

## Purpose

Fixes for accessibility issues on the registries discover page, including the navbar.

## Summary of Changes

1. Navbar auth-dropdown gets an aria-label
2. Sort dropdown gets a role
3. Search bar gets an aria-label


## QA Notes

Just needs to be run through the selenium tests for accessibility again.