### PR TITLE
[No ticket] Hide link to wiki if wiki is not enabled

### DIFF
--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -62,8 +62,10 @@
                         @models={{array this.registration.id}} @icon='home' @label={{t 'registries.overview.title'}} />
                     <leftNav.link data-analytics-name='Files' @href='/{{this.registration.id}}/files/' @icon='file-alt'
                         @label={{t 'registries.overview.external_links.files'}} />
-                    <leftNav.link data-analytics-name='Wiki' @href='/{{this.registration.id}}/wiki/'
-                        @icon='window-maximize' @label={{t 'registries.overview.external_links.wiki'}} />
+                    {{#if this.registration.wikiEnabled}}
+                        <leftNav.link data-analytics-name='Wiki' data-test-leftNav-wiki @href='/{{this.registration.id}}/wiki/'
+                            @icon='window-maximize' @label={{t 'registries.overview.external_links.wiki'}} />
+                    {{/if}}
                     <leftNav.link data-analytics-name='Components' @route='registries.overview.children'
                         @models={{array this.registration.id}} @icon='puzzle-piece'
                         @label={{t 'registries.overview.components.title'}}

--- a/tests/engines/registries/acceptance/overview/overview-test.ts
+++ b/tests/engines/registries/acceptance/overview/overview-test.ts
@@ -692,4 +692,20 @@ module('Registries | Acceptance | overview.overview', hooks => {
         assert.dom('[data-test-modal-heading]')
             .doesNotExist('claim unregistered user modal gone after canceling claim');
     });
+
+    test('Link to wiki is not shown if wiki is not enabled', async assert => {
+        const openEndedReg = server.schema.registrationSchemas.find('open_ended_registration');
+        const registeredFrom = server.create('node', 'currentUserAdmin');
+
+        const reg = server.create('registration', {
+            registrationSchema: openEndedReg,
+            registeredFrom,
+            wikiEnabled: false,
+        });
+
+        await visit(`/${reg.id}/`);
+
+        assert.dom('[data-test-leftNav-wiki]').doesNotExist('wiki link is not shown');
+    });
+
 });


### PR DESCRIPTION
-   Ticket: [No ticket]
-   Feature flag: n/a

## Purpose
- Hide the link to a Registration's Wiki if wiki is disabled

## Summary of Changes
- wrap logic around the leftnav button for wiki
- add test

## Screenshot(s)
Overview page links for a registration with `wikiEnabled: false`
![Screen Shot 2021-08-16 at 8 43 52 PM](https://user-images.githubusercontent.com/51409893/129646226-398f17bf-1662-4c98-b1f7-dc027e4a5637.png)
Overview page links for a registration with `wikiEnabled: true`
![Screen Shot 2021-08-16 at 8 45 19 PM](https://user-images.githubusercontent.com/51409893/129646311-d06d288b-809f-42a9-8f4c-d077c441d7f1.png)



## Side Effects
- None

## QA Notes
- The LeftNav Link to the Wiki should not be visible if the backing project has its wiki disabled