### PR TITLE
[ENG-3031] Revisions permissions

### DIFF
--- a/app/models/node.ts
+++ b/app/models/node.ts
@@ -218,6 +218,12 @@ export default class NodeModel extends AbstractNodeModel.extend(Validations, Col
         return Array.isArray(this.currentUserPermissions) && this.currentUserPermissions.includes(Permission.Read);
     }
 
+    @computed('currentUserPermissions.length')
+    get currentUserIsReadOnly() {
+        return Array.isArray(this.currentUserPermissions) && this.currentUserPermissions.includes(Permission.Read)
+            && this.currentUserPermissions.length === 1;
+    }
+
     /**
      * The type of this node.
      */

--- a/app/models/registration.ts
+++ b/app/models/registration.ts
@@ -10,7 +10,6 @@ import CommentModel from './comment';
 import ContributorModel from './contributor';
 import InstitutionModel from './institution';
 import NodeModel from './node';
-import { Permission } from './osf-model';
 import RegistrationProviderModel from './registration-provider';
 import RegistrationSchemaModel, { RegistrationMetadata } from './registration-schema';
 import UserModel from './user';
@@ -130,11 +129,6 @@ export default class RegistrationModel extends NodeModel.extend(Validations) {
     // Write-only relationships
     @belongsTo('draft-registration', { inverse: null })
     draftRegistration!: DraftRegistrationModel;
-
-    get currentUserIsReadOnly() {
-        return Array.isArray(this.currentUserPermissions) && this.currentUserPermissions.includes(Permission.Read)
-            && this.currentUserPermissions.length === 1;
-    }
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/models/registration.ts
+++ b/app/models/registration.ts
@@ -10,6 +10,7 @@ import CommentModel from './comment';
 import ContributorModel from './contributor';
 import InstitutionModel from './institution';
 import NodeModel from './node';
+import { Permission } from './osf-model';
 import RegistrationProviderModel from './registration-provider';
 import RegistrationSchemaModel, { RegistrationMetadata } from './registration-schema';
 import UserModel from './user';
@@ -129,6 +130,11 @@ export default class RegistrationModel extends NodeModel.extend(Validations) {
     // Write-only relationships
     @belongsTo('draft-registration', { inverse: null })
     draftRegistration!: DraftRegistrationModel;
+
+    get currentUserIsReadOnly() {
+        return Array.isArray(this.currentUserPermissions) && this.currentUserPermissions.includes(Permission.Read)
+            && this.currentUserPermissions.length === 1;
+    }
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/lib/registries/addon/drafts/draft/-components/register/template.hbs
+++ b/lib/registries/addon/drafts/draft/-components/register/template.hbs
@@ -1,17 +1,24 @@
-<BsButton
-    data-test-goto-register
-    data-analytics-name='Go to register'
-    local-class='registerButton {{if @showMobileView 'mobileReviewButtonItem'}}'
-    @type='success'
-    @onClick={{perform this.onClickRegister}}
-    disabled={{or (not this.draftManager.registrationResponsesIsValid) (not this.currentUserIsAdmin)}}
->
-    {{#if this.onClickRegister.isRunning}}
-        <LoadingIndicator @inline={{true}} />
-    {{else}}
-        {{t 'registries.drafts.draft.register'}}
-    {{/if}}
-</BsButton>
+{{#if this.currentUserIsAdmin}}
+    <BsButton
+        data-test-goto-register
+        data-analytics-name='Go to register'
+        local-class='registerButton {{if @showMobileView 'mobileReviewButtonItem'}}'
+        @type='success'
+        @onClick={{perform this.onClickRegister}}
+        disabled={{or (not this.draftManager.registrationResponsesIsValid) (not this.currentUserIsAdmin)}}
+    >
+        {{#if this.onClickRegister.isRunning}}
+            <LoadingIndicator @inline={{true}} />
+        {{else}}
+            {{t 'registries.drafts.draft.register'}}
+        {{/if}}
+    </BsButton>
+{{/if}}
+{{#if (and (not this.currentUserIsAdmin) (not @showMobileView))}}
+    <div data-test-nonadmin-warning-text>
+        {{t 'registries.drafts.draft.review.non_admin_warning'}}
+    </div>
+{{/if}}
 {{#if (and this.isInvalid (not @showMobileView))}}
     <div data-test-invalid-responses-text class='text-danger'>
         {{t 'registries.drafts.draft.review.invalid_warning'}}

--- a/lib/registries/addon/drafts/draft/review/template.hbs
+++ b/lib/registries/addon/drafts/draft/review/template.hbs
@@ -7,6 +7,14 @@
         <main
             {{did-insert this.markAndValidatedPages}}
         >
+            {{#if (and (not draftManager.currentUserIsAdmin) this.showMobileView)}}
+                <div
+                    data-test-nonadmin-warning-text
+                    local-class='WarningMessage'
+                >
+                    {{t 'registries.drafts.draft.review.non_admin_warning'}}
+                </div>
+            {{/if}}
             {{#if (and (not draftManager.registrationResponsesIsValid) this.showMobileView)}}
                 <div
                     data-test-invalid-responses-text

--- a/lib/registries/addon/drafts/draft/styles.scss
+++ b/lib/registries/addon/drafts/draft/styles.scss
@@ -117,19 +117,6 @@
     width: 100%;
 }
 
-.MobileNavPageLabelSection {
-    min-width: 0;
-    width: 100%;
-}
-
-.MobileNavPageLabel {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    font-weight: 600;
-    color: $color-text-black;
-}
-
 @media screen and (min-width: 992px) {
     .ContentBackground {
         display: flex;

--- a/lib/registries/addon/edit-revision/-components/right-nav/template.hbs
+++ b/lib/registries/addon/edit-revision/-components/right-nav/template.hbs
@@ -36,7 +36,7 @@
         </Button>
     </OsfLink>
 {{/if}}
-{{#if (and @navManager.prevPageParam (not @currentUserIsReadOnly) @revisionManager.isEditable)}}
+{{#if (and @navManager.prevPageParam (not @revisionManager.currentUserIsReadOnly) @revisionManager.isEditable)}}
     <OsfLink
         data-test-goto-previous-page
         data-analytics-name='Go to previous page'

--- a/lib/registries/addon/edit-revision/-components/submit-and-decide/component.ts
+++ b/lib/registries/addon/edit-revision/-components/submit-and-decide/component.ts
@@ -2,7 +2,7 @@ import Store from '@ember-data/store';
 import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import { assert } from '@ember/debug';
-import { action } from '@ember/object';
+import { action, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { waitFor } from '@ember/test-waiters';
 import { tracked } from '@glimmer/tracking';
@@ -24,6 +24,18 @@ export default class SubmitAndDecide extends Component {
     revisionManager!: RevisionManager;
 
     @tracked continueEditModalOpen = false;
+
+    @computed('revisionManager.{isPendingAdminApproval,currentUserIsAdmin,isPendingModeration}')
+    get pendingStatusString(): string {
+        if (this.revisionManager.isPendingAdminApproval) {
+            return 'registries.edit_revision.review.pending_admin_notice';
+        }
+        if (this.revisionManager.isPendingModeration) {
+            return 'registries.edit_revision.review.pending_moderation_notice';
+        }
+        return 'registries.edit_revision.review.decision_recorded_notice';
+    }
+
 
     @action
     openContinueEditModal() {

--- a/lib/registries/addon/edit-revision/-components/submit-and-decide/styles.scss
+++ b/lib/registries/addon/edit-revision/-components/submit-and-decide/styles.scss
@@ -21,3 +21,8 @@
     border-radius: 0;
     padding: 10px;
 }
+
+.pendingLabel {
+    padding: 10px;
+    color: $color-text-black;
+}

--- a/lib/registries/addon/edit-revision/-components/submit-and-decide/template.hbs
+++ b/lib/registries/addon/edit-revision/-components/submit-and-decide/template.hbs
@@ -1,27 +1,37 @@
 {{assert 'EditRevision::-Components::SubmitAndDecide requires a revisionManager' @revisionManager}}
-{{#if @revisionManager.currentUserIsAdmin}}
-    {{#if @revisionManager.isEditable}}
+{{#if @revisionManager.isEditable}}
+    {{#if @revisionManager.currentUserIsAdmin}}
         <BsButton
             data-test-submit-revision
             data-analytics-name='Submit revision'
             local-class='registerButton {{if @showMobileView 'mobileReviewButtonItem'}}'
             @type='success'
             @onClick={{perform this.submitAction 'submit_revision' ''}}
-            disabled={{@revisionManager.hasInvalidResponses}}
+            disabled={{or @revisionManager.hasInvalidResponses this.submitAction.isRunning}}
         >
-            {{#if this.submicAction.isRunning}}
+            {{#if this.submitAction.isRunning}}
                 <LoadingIndicator @inline={{true}} />
             {{else}}
                 {{t 'registries.edit_revision.review.submit_changes'}}
             {{/if}}
         </BsButton>
-        {{#if (and @revisionManager.hasInvalidResponses (not @showMobileView))}}
-            <div data-test-invalid-responses-text class='text-danger'>
-                {{t 'registries.drafts.draft.review.invalid_warning'}}
-            </div>
-        {{/if}}
     {{/if}}
-    {{#if @revisionManager.isPendingAdminApproval}}
+    {{#if (and (not @revisionManager.currentUserIsAdmin) (not @showMobileView))}}
+        <div
+            data-test-nonadmin-warning-text
+            local-class='WarningMessage'
+        >
+            {{t 'registries.drafts.draft.review.non_admin_warning'}}
+        </div>
+    {{/if}}
+    {{#if (and @revisionManager.hasInvalidResponses (not @showMobileView))}}
+        <div data-test-invalid-responses-text class='text-danger'>
+            {{t 'registries.edit_revision.review.invalid_warning'}}
+        </div>
+    {{/if}}
+{{/if}}
+{{#if @revisionManager.isPendingAdminApproval}}
+    {{#if @revisionManager.currentUserIsAdmin}}
         {{#if @revisionManager.revision.isPendingCurrentUserApproval}}
             <BsButton
                 data-test-accept-changes
@@ -47,10 +57,12 @@
                 @onSubmit={{this.submitAction}}
             />
         {{else}}
-            <p>{{t 'registries.edit_revision.review.decision_recorded_notice'}}</p>
+            <div local-class={{if @showMobileView 'pendingLabel'}}>{{t 'registries.edit_revision.review.decision_recorded_notice'}}</div>
         {{/if}}
+    {{else}}
+        <div local-class={{if @showMobileView 'pendingLabel'}}>{{t 'registries.edit_revision.review.pending_admin_notice'}}</div>
     {{/if}}
-    {{#if @revisionManager.isPendingModeration}}
-        <p>{{t 'registries.edit_revision.review.pending_moderation_notice'}}</p>
-    {{/if}}
+{{/if}}
+{{#if @revisionManager.isPendingModeration}}
+    <div local-class={{if @showMobileView 'pendingLabel'}}>{{t 'registries.edit_revision.review.pending_moderation_notice'}}</div>
 {{/if}}

--- a/lib/registries/addon/edit-revision/-components/submit-and-decide/template.hbs
+++ b/lib/registries/addon/edit-revision/-components/submit-and-decide/template.hbs
@@ -29,31 +29,32 @@
             {{t 'registries.edit_revision.review.invalid_warning'}}
         </div>
     {{/if}}
-{{/if}}
-{{#if @revisionManager.revision.isPendingCurrentUserApproval}}
-    <BsButton
-        data-test-accept-changes
-        data-analytics-name='Admin approve revision'
-        local-class='registerButton {{if @showMobileView 'mobileReviewButtonItem'}}'
-        @type='success'
-        @onClick={{perform this.submitAction 'admin_approve_revision' ''}}
-    >
-        {{t 'registries.edit_revision.review.accept_changes'}}
-    </BsButton>
-    <BsButton
-        data-test-continue-editing
-        data-analytics-name='Admin reject revision'
-        local-class='registerButton {{if @showMobileView 'mobileReviewButtonItem'}}'
-        @type='primary'
-        @onClick={{this.openContinueEditModal}}
-    >
-        {{t 'registries.edit_revision.review.continue_editing'}}
-    </BsButton>
-    <EditRevision::-Components::ContinueEditModal
-        @isOpen={{this.continueEditModalOpen}}
-        @onClose={{this.closeContinueEditModal}}
-        @onSubmit={{this.submitAction}}
-    />
 {{else}}
-    <div data-test-pending-status local-class={{if @showMobileView 'pendingLabel'}}>{{t this.pendingStatusString}}</div>
+    {{#if @revisionManager.revision.isPendingCurrentUserApproval}}
+        <BsButton
+            data-test-accept-changes
+            data-analytics-name='Admin approve revision'
+            local-class='registerButton {{if @showMobileView 'mobileReviewButtonItem'}}'
+            @type='success'
+            @onClick={{perform this.submitAction 'admin_approve_revision' ''}}
+        >
+            {{t 'registries.edit_revision.review.accept_changes'}}
+        </BsButton>
+        <BsButton
+            data-test-continue-editing
+            data-analytics-name='Admin reject revision'
+            local-class='registerButton {{if @showMobileView 'mobileReviewButtonItem'}}'
+            @type='primary'
+            @onClick={{this.openContinueEditModal}}
+        >
+            {{t 'registries.edit_revision.review.continue_editing'}}
+        </BsButton>
+        <EditRevision::-Components::ContinueEditModal
+            @isOpen={{this.continueEditModalOpen}}
+            @onClose={{this.closeContinueEditModal}}
+            @onSubmit={{this.submitAction}}
+        />
+    {{else}}
+        <div data-test-pending-status local-class={{if @showMobileView 'pendingLabel'}}>{{t this.pendingStatusString}}</div>
+    {{/if}}
 {{/if}}

--- a/lib/registries/addon/edit-revision/-components/submit-and-decide/template.hbs
+++ b/lib/registries/addon/edit-revision/-components/submit-and-decide/template.hbs
@@ -30,39 +30,30 @@
         </div>
     {{/if}}
 {{/if}}
-{{#if @revisionManager.isPendingAdminApproval}}
-    {{#if @revisionManager.currentUserIsAdmin}}
-        {{#if @revisionManager.revision.isPendingCurrentUserApproval}}
-            <BsButton
-                data-test-accept-changes
-                data-analytics-name='Admin approve revision'
-                local-class='registerButton {{if @showMobileView 'mobileReviewButtonItem'}}'
-                @type='success'
-                @onClick={{perform this.submitAction 'admin_approve_revision' ''}}
-            >
-                {{t 'registries.edit_revision.review.accept_changes'}}
-            </BsButton>
-            <BsButton
-                data-test-continue-editing
-                data-analytics-name='Admin reject revision'
-                local-class='registerButton {{if @showMobileView 'mobileReviewButtonItem'}}'
-                @type='primary'
-                @onClick={{this.openContinueEditModal}}
-            >
-                {{t 'registries.edit_revision.review.continue_editing'}}
-            </BsButton>
-            <EditRevision::-Components::ContinueEditModal
-                @isOpen={{this.continueEditModalOpen}}
-                @onClose={{this.closeContinueEditModal}}
-                @onSubmit={{this.submitAction}}
-            />
-        {{else}}
-            <div local-class={{if @showMobileView 'pendingLabel'}}>{{t 'registries.edit_revision.review.decision_recorded_notice'}}</div>
-        {{/if}}
-    {{else}}
-        <div local-class={{if @showMobileView 'pendingLabel'}}>{{t 'registries.edit_revision.review.pending_admin_notice'}}</div>
-    {{/if}}
-{{/if}}
-{{#if @revisionManager.isPendingModeration}}
-    <div local-class={{if @showMobileView 'pendingLabel'}}>{{t 'registries.edit_revision.review.pending_moderation_notice'}}</div>
+{{#if @revisionManager.revision.isPendingCurrentUserApproval}}
+    <BsButton
+        data-test-accept-changes
+        data-analytics-name='Admin approve revision'
+        local-class='registerButton {{if @showMobileView 'mobileReviewButtonItem'}}'
+        @type='success'
+        @onClick={{perform this.submitAction 'admin_approve_revision' ''}}
+    >
+        {{t 'registries.edit_revision.review.accept_changes'}}
+    </BsButton>
+    <BsButton
+        data-test-continue-editing
+        data-analytics-name='Admin reject revision'
+        local-class='registerButton {{if @showMobileView 'mobileReviewButtonItem'}}'
+        @type='primary'
+        @onClick={{this.openContinueEditModal}}
+    >
+        {{t 'registries.edit_revision.review.continue_editing'}}
+    </BsButton>
+    <EditRevision::-Components::ContinueEditModal
+        @isOpen={{this.continueEditModalOpen}}
+        @onClose={{this.closeContinueEditModal}}
+        @onSubmit={{this.submitAction}}
+    />
+{{else}}
+    <div data-test-pending-status local-class={{if @showMobileView 'pendingLabel'}}>{{t this.pendingStatusString}}</div>
 {{/if}}

--- a/lib/registries/addon/edit-revision/-components/top-nav/styles.scss
+++ b/lib/registries/addon/edit-revision/-components/top-nav/styles.scss
@@ -4,7 +4,3 @@
     z-index: 1;
     border-bottom: 1px solid $color-border-white;
 }
-
-.MetadataButton {
-    padding: 15px;
-}

--- a/lib/registries/addon/edit-revision/-components/top-nav/template.hbs
+++ b/lib/registries/addon/edit-revision/-components/top-nav/template.hbs
@@ -4,7 +4,7 @@
 
 <Navbar local-class='SideBarToggle' ...attributes as |nav|>
     <nav.bordered-section>
-        {{#unless @currentUserIsReadOnly}}
+        {{#if (and (not @revisionManager.currentUserIsReadOnly) @revisionManager.isEditable)}}
             <nav.buttons.default
                 data-test-sidenav-toggle
                 data-analytics-name='Show sidenav'
@@ -13,10 +13,10 @@
             >
                 <nav.icon @icon={{if @layout.sidenavGutterClosed 'bars' 'times'}} />
             </nav.buttons.default>
-        {{/unless}}
+        {{/if}}
     </nav.bordered-section>
-    <nav.bordered-section local-class='MobileNavPageLabelSection'>
-        <div local-class='MobileNavPageLabel' data-test-page-label>
+    <nav.bordered-section>
+        <div data-test-page-label>
             {{#if @navManager.inReview}}
                 {{t 'registries.drafts.draft.review.page_label'}}
             {{else}}
@@ -25,10 +25,10 @@
         </div>
     </nav.bordered-section>
     <nav.bordered-section>
-        {{#if (and @navManager.prevPageParam (not @currentUserIsReadOnly))}}
+        {{#if (and @navManager.prevPageParam (not @revisionManager.currentUserIsReadOnly) @revisionManager.isEditable)}}
             <nav.links.default
                 data-test-goto-previous-page
-                data-analytics-name='Sidenav back'
+                data-analytics-name='Topnav back'
                 aria-label={{t 'osf-components.registries-top-nav.previousPage'}}
                 @route='registries.edit-revision.page'
                 @models={{array @revisionManager.revisionId @navManager.prevPageParam}}
@@ -39,7 +39,7 @@
         {{#if @navManager.nextPageParam}}
             <nav.links.default
                 data-test-goto-next-page
-                data-analytics-name='Sidenav next'
+                data-analytics-name='Topnav next'
                 aria-label={{t 'osf-components.registries-top-nav.nextPage'}}
                 @route='registries.edit-revision.page'
                 @models={{array @revisionManager.revisionId @navManager.nextPageParam}}
@@ -51,7 +51,7 @@
         {{#if @navManager.isLastPage}}
             <nav.links.default
                 data-test-goto-review
-                data-analytics-name='Sidenav review'
+                data-analytics-name='Topnav review'
                 aria-label={{t 'osf-components.registries-top-nav.reviewRegistration'}}
                 @route='registries.edit-revision.review'
                 @models={{array @revisionManager.revisionId}}

--- a/lib/registries/addon/edit-revision/nav-manager.ts
+++ b/lib/registries/addon/edit-revision/nav-manager.ts
@@ -48,7 +48,7 @@ export default class RevisionNavigationManager {
         return pageManagers.length - 1;
     }
 
-    @computed('currentPage', 'pageManagers.[]', 'inMetadata', 'lastPage')
+    @computed('currentPage', 'pageManagers.[]', 'lastPage')
     get nextPageParam() {
         const {
             pageManagers,

--- a/lib/registries/addon/edit-revision/review/template.hbs
+++ b/lib/registries/addon/edit-revision/review/template.hbs
@@ -7,6 +7,14 @@
         <main
             {{did-insert this.markAndValidatedPages}}
         >
+            {{#if (and (not revisionManager.currentUserIsAdmin) this.showMobileView)}}
+                <div
+                    data-test-nonadmin-warning-text
+                    local-class='WarningMessage'
+                >
+                    {{t 'registries.edit_revision.review.non_admin_warning'}}
+                </div>
+            {{/if}}
             {{#if (and (not revisionManager.registrationResponsesIsValid) this.showMobileView)}}
                 <div
                     data-test-invalid-responses-text

--- a/lib/registries/addon/edit-revision/revision-manager.ts
+++ b/lib/registries/addon/edit-revision/revision-manager.ts
@@ -72,22 +72,22 @@ export default class RevisionManager {
 
     @computed('revision.reviewState')
     get isEditable() {
-        return this.revision.reviewState === RevisionReviewStates.RevisionInProgress;
+        return this.revision && this.revision.reviewState === RevisionReviewStates.RevisionInProgress;
     }
 
     @computed('revision.reviewState')
     get isPendingAdminApproval() {
-        return this.revision.reviewState === RevisionReviewStates.RevisionPendingAdminApproval;
+        return this.revision && this.revision.reviewState === RevisionReviewStates.RevisionPendingAdminApproval;
     }
 
     @computed('revision.reviewState')
     get isPendingModeration() {
-        return this.revision.reviewState === RevisionReviewStates.RevisionPendingModeration;
+        return this.revision && this.revision.reviewState === RevisionReviewStates.RevisionPendingModeration;
     }
 
     @computed('registration.currentUserPermissions')
     get currentUserIsAdmin() {
-        return this.registration.currentUserPermissions.includes(Permission.Admin);
+        return this.registration && this.registration.currentUserPermissions.includes(Permission.Admin);
     }
 
     constructor(loadModelsTask: LoadModelsTask, revisionId: string) {

--- a/lib/registries/addon/edit-revision/revision-manager.ts
+++ b/lib/registries/addon/edit-revision/revision-manager.ts
@@ -1,9 +1,8 @@
 import { action, computed, set } from '@ember/object';
-import { alias, filterBy, not, notEmpty, or } from '@ember/object/computed';
+import { alias, filterBy, not, notEmpty } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import { waitFor } from '@ember/test-waiters';
 import { isEmpty } from '@ember/utils';
-import { BufferedChangeset } from 'ember-changeset/types';
 import { restartableTask, task, TaskInstance, timeout } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 import Intl from 'ember-intl/services/intl';
@@ -41,13 +40,12 @@ export default class RevisionManager {
     revisionResponses!: RegistrationResponse;
 
     pageManagers: PageManager[] = [];
-    metadataChangeset!: BufferedChangeset;
     schemaBlocks!: SchemaBlock[];
 
     @alias('registration.currentUserIsReadOnly') currentUserIsReadOnly!: boolean;
     @alias('provider.reviewsWorkflow') reviewsWorkflow?: string;
-    @or('onPageInput.isRunning', 'onMetadataInput.isRunning') autoSaving!: boolean;
-    @or('initializePageManagers.isRunning', 'initializeMetadataChangeset.isRunning') initializing!: boolean;
+    @alias('onPageInput.isRunning') autoSaving!: boolean;
+    @alias('initializePageManagers.isRunning') initializing!: boolean;
     @not('registrationResponsesIsValid') hasInvalidResponses!: boolean;
     @filterBy('pageManagers', 'isVisited', true) visitedPages!: PageManager[];
     @notEmpty('visitedPages') hasVisitedPages!: boolean;
@@ -58,12 +56,12 @@ export default class RevisionManager {
     node?: NodeModel;
     revisionId!: string;
 
-    @computed('pageManagers.{[],@each.pageIsValid}', 'metadataIsValid')
+    @computed('pageManagers.{[],@each.pageIsValid}')
     get registrationResponsesIsValid() {
         return this.pageManagers.every(pageManager => pageManager.pageIsValid);
     }
 
-    @computed('onPageInput.lastComplete', 'onMetadataInput.lastComplete')
+    @computed('onPageInput.lastComplete')
     get lastSaveFailed() {
         const onPageInputLastComplete = taskFor(this.onPageInput).lastComplete;
         const pageInputFailed = onPageInputLastComplete ? onPageInputLastComplete.isError : false;
@@ -72,22 +70,22 @@ export default class RevisionManager {
 
     @computed('revision.reviewState')
     get isEditable() {
-        return this.revision && this.revision.reviewState === RevisionReviewStates.RevisionInProgress;
+        return this.revision?.reviewState === RevisionReviewStates.RevisionInProgress;
     }
 
     @computed('revision.reviewState')
     get isPendingAdminApproval() {
-        return this.revision && this.revision.reviewState === RevisionReviewStates.RevisionPendingAdminApproval;
+        return this.revision.reviewState === RevisionReviewStates.RevisionPendingAdminApproval;
     }
 
     @computed('revision.reviewState')
     get isPendingModeration() {
-        return this.revision && this.revision.reviewState === RevisionReviewStates.RevisionPendingModeration;
+        return this.revision.reviewState === RevisionReviewStates.RevisionPendingModeration;
     }
 
     @computed('registration.currentUserPermissions')
     get currentUserIsAdmin() {
-        return this.registration && this.registration.currentUserPermissions.includes(Permission.Admin);
+        return this.registration.currentUserPermissions.includes(Permission.Admin);
     }
 
     constructor(loadModelsTask: LoadModelsTask, revisionId: string) {

--- a/lib/registries/addon/edit-revision/route.ts
+++ b/lib/registries/addon/edit-revision/route.ts
@@ -30,8 +30,11 @@ export default class EditRevisionRoute extends Route {
         const revision = await this.store.findRecord('revision', revisionId);
         const registration = await revision.registration;
         const provider = await registration.provider;
-        if (registration.currentUserIsReadOnly || revision.reviewState === RevisionReviewStates.RevisionInProgress) {
+        if (registration.currentUserIsReadOnly && revision.reviewState !== RevisionReviewStates.Approved) {
             this.replaceWith('edit-revision.review', revisionId);
+        }
+        if (revision.reviewState === RevisionReviewStates.Approved) {
+            this.replaceWith('overview', registration.id, { revisionId });
         }
         return {
             revision,

--- a/lib/registries/addon/edit-revision/route.ts
+++ b/lib/registries/addon/edit-revision/route.ts
@@ -8,6 +8,7 @@ import { task } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 
 import requireAuth from 'ember-osf-web/decorators/require-auth';
+import { RevisionReviewStates } from 'ember-osf-web/models/revision';
 import Analytics from 'ember-osf-web/services/analytics';
 import RevisionNavigationManager from 'registries/edit-revision/nav-manager';
 import RevisionManager from 'registries/edit-revision/revision-manager';
@@ -29,6 +30,9 @@ export default class EditRevisionRoute extends Route {
         const revision = await this.store.findRecord('revision', revisionId);
         const registration = await revision.registration;
         const provider = await registration.provider;
+        if (registration.currentUserIsReadOnly || revision.reviewState === RevisionReviewStates.RevisionInProgress) {
+            this.replaceWith('edit-revision.review', revisionId);
+        }
         return {
             revision,
             registration,

--- a/lib/registries/addon/edit-revision/route.ts
+++ b/lib/registries/addon/edit-revision/route.ts
@@ -30,11 +30,9 @@ export default class EditRevisionRoute extends Route {
         const revision = await this.store.findRecord('revision', revisionId);
         const registration = await revision.registration;
         const provider = await registration.provider;
-        if (registration.currentUserIsReadOnly && revision.reviewState !== RevisionReviewStates.Approved) {
+        if ((registration.currentUserIsReadOnly && revision.reviewState !== RevisionReviewStates.Approved) ||
+            (revision.reviewState !== RevisionReviewStates.RevisionInProgress)) {
             this.replaceWith('edit-revision.review', revisionId);
-        }
-        if (revision.reviewState === RevisionReviewStates.Approved) {
-            this.replaceWith('overview', registration.id, { revisionId });
         }
         return {
             revision,

--- a/tests/engines/registries/acceptance/draft/draft-test.ts
+++ b/tests/engines/registries/acceptance/draft/draft-test.ts
@@ -95,7 +95,8 @@ module('Registries | Acceptance | draft form', hooks => {
         assert.ok(reviewNav!.classList.toString().includes('Active'), 'LeftNav: Review is active page');
 
         // check rightnav
-        assert.dom('[data-test-goto-register]').isDisabled('RightNav: Register button disabled');
+        assert.dom('[data-test-goto-register]').doesNotExist('RightNav: Register button not shown');
+        assert.dom('[data-test-nonadmin-warning-text]').exists('RightNav: Warning non-admins cannot register shown');
         assert.dom('[data-test-goto-previous-page]').doesNotExist('RightNav: Back button not shown');
 
         // check metadata and form renderer
@@ -111,7 +112,8 @@ module('Registries | Acceptance | draft form', hooks => {
 
         assert.dom('[data-test-sidenav-toggle]').doesNotExist('Mobile view: sidenav toggle not shown');
         assert.dom('[data-test-goto-previous-page]').doesNotExist('Mobile view: previous page button not shown');
-        assert.dom('[data-test-goto-register]').isDisabled('Mobile view: Register button disabled');
+        assert.dom('[data-test-nonadmin-warning-text]').exists('Mobile view: Warning non-admins cannot register shown');
+        assert.dom('[data-test-goto-register]').doesNotExist('Mobile view: Register button does not exist');
 
         await percySnapshot('Read-only Review page: Mobile');
     });
@@ -309,6 +311,7 @@ module('Registries | Acceptance | draft form', hooks => {
         assert.dom('[data-test-goto-review]').doesNotExist();
 
         assert.dom('[data-test-goto-register]').isVisible();
+        assert.dom('[data-test-nonadmin-warning-text]').doesNotExist('Warning for non-admins not shown to admins');
         assert.dom('[data-test-goto-previous-page]').isVisible();
 
         // Can navigate back to the last page from review page
@@ -367,6 +370,7 @@ module('Registries | Acceptance | draft form', hooks => {
         await percySnapshot('Registries | Acceptance | draft form | mobile navigation | review page');
         assert.dom('[data-test-page-label]').containsText('Review');
         assert.dom('[data-test-goto-next-page]').isNotVisible();
+        assert.dom('[data-test-nonadmin-warning-text]').doesNotExist('Warning for non-admins not shown to admins');
         assert.dom('[data-test-goto-register]').isVisible();
 
         // check that register button is disabled
@@ -404,6 +408,7 @@ module('Registries | Acceptance | draft form', hooks => {
 
         assert.ok(currentURL().includes(`/registries/drafts/${registration.id}/review`), 'At review page');
         assert.dom('[data-test-goto-register]').isDisabled();
+        assert.dom('[data-test-nonadmin-warning-text]').doesNotExist('Warning for non-admins not shown to admins');
         assert.dom('[data-test-invalid-responses-text]').isVisible();
     });
 

--- a/tests/engines/registries/acceptance/draft/draft-test.ts
+++ b/tests/engines/registries/acceptance/draft/draft-test.ts
@@ -22,7 +22,7 @@ import { module, test } from 'qunit';
 
 import NodeModel from 'ember-osf-web/models/node';
 import { Permission } from 'ember-osf-web/models/osf-model';
-import { visit } from 'ember-osf-web/tests/helpers';
+import { getHrefAttribute, visit } from 'ember-osf-web/tests/helpers';
 import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
 import { deserializeResponseKey } from 'ember-osf-web/transforms/registration-response-key';
 import stripHtmlTags from 'ember-osf-web/utils/strip-html-tags';
@@ -30,10 +30,6 @@ import stripHtmlTags from 'ember-osf-web/utils/strip-html-tags';
 const currentUserStub = Service.extend();
 const storeStub = Service.extend();
 const analyticsStub = Service.extend();
-
-function getHrefAttribute(selector: string) {
-    return document.querySelector(selector)!.getAttribute('href');
-}
 
 interface DraftFormTestContext extends TestContext {
     branchedFrom: ModelInstance<NodeModel>;

--- a/tests/engines/registries/acceptance/edit-revision/revision-test.ts
+++ b/tests/engines/registries/acceptance/edit-revision/revision-test.ts
@@ -1,0 +1,360 @@
+import Service from '@ember/service';
+import {
+    click,
+    currentRouteName,
+    currentURL,
+    fillIn,
+    find,
+    // settled,
+    // triggerKeyEvent,
+    // blur,
+    // waitUntil,
+    // findAll,
+} from '@ember/test-helpers';
+import { ModelInstance } from 'ember-cli-mirage';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { TestContext } from 'ember-intl/test-support';
+import { percySnapshot } from 'ember-percy';
+import { setBreakpoint } from 'ember-responsive/test-support';
+import { module, test } from 'qunit';
+
+import { getHrefAttribute, visit } from 'ember-osf-web/tests/helpers';
+import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
+import { Permission } from 'ember-osf-web/models/osf-model';
+import RegistrationModel from 'ember-osf-web/models/registration';
+import RegistrationProviderModel from 'ember-osf-web/models/registration-provider';
+import RegistrationSchemaModel from 'ember-osf-web/models/registration-schema';
+import { deserializeResponseKey } from 'ember-osf-web/transforms/registration-response-key';
+
+const currentUserStub = Service.extend();
+const storeStub = Service.extend();
+
+interface RevisionTestContext extends TestContext {
+    registration: ModelInstance<RegistrationModel>;
+    provider: ModelInstance<RegistrationProviderModel>;
+    registrationSchema: ModelInstance<RegistrationSchemaModel>;
+}
+
+module('Registries | Acceptance | registries revision', hooks => {
+    setupEngineApplicationTest(hooks, 'registries');
+    setupMirage(hooks);
+
+    hooks.beforeEach(function(this: RevisionTestContext) {
+        this.owner.register('service:currentUser', currentUserStub);
+        this.owner.register('service:store', storeStub);
+        this.provider = server.create('registration-provider', {
+            id: 'test',
+            name: 'Test Provider',
+        });
+
+        server.loadFixtures('schema-blocks');
+        server.loadFixtures('registration-schemas');
+        const registrationSchema = server.schema.registrationSchemas.find('testSchema');
+        this.registration = server.create('registration', {
+            currentUserPermissions: Object.values(Permission),
+            provider: this.provider,
+            registrationSchema,
+        });
+    });
+
+    test('it redirects to review page of the update form for read-only users', async function(
+        this: RevisionTestContext, assert,
+    ) {
+        const initiatedBy = server.create('user', 'loggedIn');
+        const registrationSchema = server.schema.registrationSchemas.find('testSchema');
+        this.registration.currentUserPermissions = [Permission.Read];
+        const revision = server.create(
+            'revision',
+            {
+                registrationSchema,
+                initiatedBy,
+                revisionResponses: {},
+                registration: this.registration,
+            },
+        );
+
+        await visit(`/registries/revisions/${revision.id}/`);
+        assert.equal(currentRouteName(), 'registries.edit-revision.review',
+            'Read-only users redirected to review page');
+
+        // check leftnav
+        const reviewNav = find('[data-test-link="review"]');
+        assert.dom('[data-test-link="1-first-page-of-test-schema"]')
+            .doesNotExist('Leftnav: Label for first page is not shown');
+        assert.dom('[data-test-link="review"]').exists('Leftnav: Review label shown');
+        assert.ok(reviewNav!.classList.toString().includes('Active'), 'LeftNav: Review is active page');
+
+        // check rightnav
+        assert.dom('[data-test-submit-revision]').doesNotExist('RightNav: Register button not shown');
+        assert.dom('[data-test-nonadmin-warning-text]').exists('RightNav: Warning non-admins cannot register shown');
+        assert.dom('[data-test-goto-previous-page]').doesNotExist('RightNav: Back button not shown');
+
+        // check form renderer
+        await percySnapshot('Read-only Revision Review page: Desktop');
+
+        // check mobile view
+        setBreakpoint('mobile');
+        await visit(`/registries/revisions/${revision.id}/1-first-page-of-test-schema`);
+        assert.equal(currentRouteName(), 'registries.edit-revision.review',
+            'Read-only users redirected to review page after trying to go to the first page');
+
+        assert.dom('[data-test-sidenav-toggle]').doesNotExist('Mobile view: sidenav toggle not shown');
+        assert.dom('[data-test-goto-previous-page]').doesNotExist('Mobile view: previous page button not shown');
+        assert.dom('[data-test-nonadmin-warning-text]').exists('Mobile view: Warning non-admins cannot register shown');
+        assert.dom('[data-test-submit-revision]').doesNotExist('Mobile view: Register button does not exist');
+
+        await percySnapshot('Read-only Revision Review page: Mobile');
+    });
+
+    test('it redirects to the first page of the revision form 999', async function(this: RevisionTestContext, assert) {
+        const initiatedBy = server.create('user', 'loggedIn');
+        const revision = server.create(
+            'revision',
+            {
+                initiatedBy,
+                revisionResponses: {},
+                registration: this.registration,
+            },
+        );
+        await visit(`/registries/revisions/${revision.id}/`);
+        assert.equal(currentRouteName(), 'registries.edit-revision.page', 'At the expected route');
+    });
+
+    test('left nav controls', async function(this: RevisionTestContext, assert) {
+        const initiatedBy = server.create('user', 'loggedIn');
+        const revision = server.create(
+            'revision', {
+                initiatedBy,
+                revisionResponses: {},
+                registration: this.registration,
+            },
+        );
+
+        await visit(`/registries/revisions/${revision.id}/`);
+        await percySnapshot('Registries | Acceptance | registries revision | left nav controls | first page');
+
+        // first page
+        assert.equal(currentRouteName(), 'registries.edit-revision.page', 'Starts at first page');
+        assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')
+            .hasClass('fa-dot-circle', 'page 1 is current page');
+        assert.dom('[data-test-link="2-this-is-the-second-page"] > [data-test-icon]')
+            .hasClass('fa-circle', 'page 2 is marked unvisited');
+        assert.dom('[data-test-link="review"] > [data-test-icon]')
+            .hasClass('fa-circle', 'review is marked unvisited');
+        assert.dom('[data-test-goto-previous-page]').doesNotExist();
+        assert.dom('[data-test-goto-next-page]').isVisible();
+        assert.dom('[data-test-goto-review]').doesNotExist();
+        assert.dom('[data-test-submit-revision]').doesNotExist();
+
+        // Navigate to second page
+        await click('[data-test-link="2-this-is-the-second-page"]');
+        await percySnapshot('Registries | Acceptance | registries revision | left nav controls | second page');
+        assert.equal(currentRouteName(), 'registries.edit-revision.page', 'Goes to second page');
+        assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')
+            .hasClass('fa-exclamation-circle', 'page 1 is marked visited, invalid');
+        assert.dom('[data-test-link="2-this-is-the-second-page"] > [data-test-icon]')
+            .hasClass('fa-dot-circle', 'page 2 is marked as current page');
+        assert.dom('[data-test-link="review"] > [data-test-icon]')
+            .hasClass('fa-circle', 'review is marked unvisited');
+        assert.dom('[data-test-goto-previous-page]').isVisible();
+        assert.dom('[data-test-goto-next-page]').doesNotExist();
+        assert.dom('[data-test-goto-review]').isVisible();
+        assert.dom('[data-test-submit-revision]').doesNotExist();
+
+        // Navigate to first page
+        await click('[data-test-link="1-first-page-of-test-schema"]');
+        assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')
+            .hasClass('fa-dot-circle', 'page 1 is marked current page');
+        assert.dom('[data-test-link="2-this-is-the-second-page"] > [data-test-icon]')
+            .hasClass('fa-check-circle', 'page 2 is marked visited, valid');
+        assert.dom('[data-test-link="review"] > [data-test-icon]')
+            .hasClass('fa-circle', 'review is marked unvisited');
+        assert.dom('[data-test-goto-previous-page]').doesNotExist();
+        assert.dom('[data-test-goto-next-page]').isVisible();
+        assert.dom('[data-test-goto-review]').doesNotExist();
+        assert.dom('[data-test-submit-revision]').doesNotExist();
+
+        // Navigate to review
+        await click('[data-test-link="review"]');
+        await percySnapshot('Registries | Acceptance | registries revision | left nav controls | review page');
+        assert.equal(currentRouteName(), 'registries.edit-revision.review', 'Goes to review route');
+        assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')
+            .hasClass('fa-exclamation-circle', 'page 1 is marked visited, invalid');
+        assert.dom('[data-test-link="2-this-is-the-second-page"] > [data-test-icon]')
+            .hasClass('fa-check-circle', 'page 2 is marked visited, valid');
+        assert.dom('[data-test-link="review"] > [data-test-icon]')
+            .hasClass('fa-dot-circle', 'review is marked current');
+        assert.dom('[data-test-goto-previous-page]').isVisible();
+        assert.dom('[data-test-goto-next-page]').doesNotExist();
+        assert.dom('[data-test-goto-review]').doesNotExist();
+        assert.dom('[data-test-submit-revision]').isVisible();
+    });
+
+    test('right sidenav controls', async function(this: RevisionTestContext, assert) {
+        const initiatedBy = server.create('user', 'loggedIn');
+        const revision = server.create(
+            'revision',
+            {
+                initiatedBy,
+                revisionResponses: {},
+                registration: this.registration,
+            },
+        );
+
+        await visit(`/registries/revisions/${revision.id}/`);
+
+        // First page of form
+        assert.ok(currentURL().includes(`/registries/revisions/${revision.id}/1-`),
+            'At first schema page');
+        assert.dom('[data-test-submit-revision]').doesNotExist();
+        assert.dom('[data-test-goto-previous-page]').doesNotExist();
+
+        assert.dom('[data-test-goto-next-page]').exists();
+        assert.ok(getHrefAttribute('[data-test-goto-next-page]')!
+            .includes(`/registries/revisions/${revision.id}/2-`));
+
+        await click('[data-test-goto-next-page]');
+
+        // Second page of form
+        assert.ok(currentURL().includes(`/registries/revisions/${revision.id}/2-`),
+            'At second (last) page');
+        assert.ok(getHrefAttribute('[data-test-goto-previous-page]')!
+            .includes(`/registries/revisions/${revision.id}/1-`));
+
+        assert.dom('[data-test-submit-revision]').doesNotExist();
+        assert.dom('[data-test-goto-next-page]').doesNotExist();
+
+        assert.dom('[data-test-goto-review]').isVisible();
+        assert.ok(getHrefAttribute('[data-test-goto-review]')!
+            .includes(`/registries/revisions/${revision.id}/review`));
+
+        await click('[data-test-goto-review]');
+
+        // review page
+        assert.ok(currentURL().includes(`/registries/revisions/${revision.id}/review`), 'At review page');
+        assert.dom('[data-test-read-only-response]').exists();
+
+        assert.dom('data-test-goto-next-page').doesNotExist();
+        assert.dom('[data-test-goto-review]').doesNotExist();
+
+        assert.dom('[data-test-submit-revision]').isVisible();
+        assert.dom('[data-test-nonadmin-warning-text]').doesNotExist('Warning for non-admins not shown to admins');
+        assert.dom('[data-test-goto-previous-page]').isVisible();
+
+        // Can navigate back to the last page from review page
+        await click('[data-test-goto-previous-page]');
+
+        assert.ok(currentURL().includes(`/registries/revisions/${revision.id}/2-`), 'At second (last) page');
+    });
+
+    test('mobile navigation works', async function(this: RevisionTestContext, assert) {
+        const initiatedBy = server.create('user', 'loggedIn');
+        const revision = server.create(
+            'revision', {
+                initiatedBy,
+                revisionResponses: {},
+                registration: this.registration,
+            },
+        );
+
+        await visit(`/registries/revisions/${revision.id}/`);
+
+        setBreakpoint('mobile');
+
+        assert.ok(currentURL().includes(`/registries/revisions/${revision.id}/1-`), 'At first page');
+        await percySnapshot('Registries | Acceptance | registries revisions | mobile navigation | first page');
+
+        // First page
+        assert.dom('[data-test-page-label]').containsText('First page');
+        assert.dom('[data-test-goto-previous-page]').isNotVisible();
+        assert.dom('[data-test-goto-next-page]').isVisible();
+        assert.dom('[data-test-submit-revision]').doesNotExist();
+        await click('[data-test-goto-next-page]');
+
+        await percySnapshot('Registries | Acceptance | registries revisions | mobile navigation | second page');
+        assert.dom('[data-test-page-label]').containsText('This is the second page');
+        assert.dom('[data-test-goto-previous-page]').isVisible();
+        assert.dom('[data-test-goto-next-page]').isNotVisible();
+        assert.dom('[data-test-goto-review]').isVisible();
+        assert.dom('[data-test-submit-revision]').doesNotExist();
+
+        // Review page
+        await click('[data-test-goto-review]');
+
+        await percySnapshot('Registries | Acceptance | registries revisions | mobile navigation | review page');
+        assert.dom('[data-test-page-label]').containsText('Review');
+        assert.dom('[data-test-goto-next-page]').isNotVisible();
+        assert.dom('[data-test-nonadmin-warning-text]').doesNotExist('Warning for non-admins not shown to admins');
+        assert.dom('[data-test-submit-revision]').isVisible();
+
+        // check that register button is disabled
+        assert.dom('[data-test-submit-revision]').isDisabled();
+        assert.dom('[data-test-invalid-responses-text]').isVisible();
+
+        // Check that back button works
+        await click('[data-test-goto-previous-page]');
+
+        assert.dom('[data-test-page-label]').containsText('This is the second page');
+    });
+
+    test('correcting invalid responses', async function(this: RevisionTestContext, assert) {
+        const initiatedBy = server.create('user', 'loggedIn');
+        const revisionResponses = {
+            'page-one_long-text': '',
+            'page-one_multi-select': [],
+            'page-one_multi-select-other': '',
+            'page-one_short-text': null, // Required
+            'page-one_single-select': 'tuna',
+            'page-one_single-select-two': '',
+        };
+        const revision = server.create(
+            'revision',
+            {
+                initiatedBy,
+                revisionResponses,
+                registration: this.registration,
+            },
+        );
+
+        await visit(`/registries/revisions/${revision.id}`);
+
+        // check first page is not invalid
+        assert.ok(currentURL().includes(`/registries/revisions/${revision.id}/1-`),
+            'At first page');
+        assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')
+            .hasClass('fa-dot-circle', 'on page 1');
+        assert.dom(`[data-test-validation-errors="${deserializeResponseKey('page-one_short-text')}"]`)
+            .doesNotExist('No validation messages on initial load');
+
+        await click('[data-test-link="review"]');
+        assert.equal(currentRouteName(), 'registries.edit-revision.review', 'At review page');
+        assert.dom('[data-test-submit-revision]').isDisabled('Submit button disabled');
+        assert.dom('[data-test-nonadmin-warning-text]').doesNotExist('Warning for non-admins not shown to admins');
+        assert.dom('[data-test-invalid-responses-text]').isVisible('Invalid response text shown');
+        assert.dom(`[data-test-validation-errors="${deserializeResponseKey('page-one_short-text')}"]`)
+            .exists('short text invalid');
+        assert.dom(`[data-test-validation-errors="${deserializeResponseKey('page-one_long-text')}"]`)
+            .doesNotExist('long text valid');
+        assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')
+            .hasClass('fa-exclamation-circle', 'first page invalid');
+
+        // check the first page and correct invalid answer
+        await click('[data-test-link="1-first-page-of-test-schema"]');
+        assert.ok(currentURL().includes(`/registries/revisions/${revision.id}/1-`),
+            'At first page');
+        assert.dom(`[data-test-validation-errors="${deserializeResponseKey('page-one_short-text')}"]`)
+            .exists('short text invalid before fixing');
+        await fillIn(`input[name="${deserializeResponseKey('page-one_short-text')}"]`, 'ditto');
+        assert.dom(`[data-test-validation-errors="${deserializeResponseKey('page-one_short-text')}"]`)
+            .doesNotExist('short text valid after being filled');
+
+        // check the review page to see if text is valid again
+        await click('[data-test-link="review"]');
+        assert.dom('[data-test-link="1-first-page-of-test-schema"] > [data-test-icon]')
+            .hasClass('fa-check-circle', 'first page now valid');
+        assert.dom(`[data-test-validation-errors="${deserializeResponseKey('page-one_short-text')}"]`)
+            .exists('short text now valid');
+        assert.dom('[data-test-submit-revision]').isNotDisabled('Submit button no longer disabled');
+    });
+    // TODO: add tests to submit changes, continue edits, resubmit and accept changes
+});

--- a/tests/engines/registries/acceptance/overview/revision-test.ts
+++ b/tests/engines/registries/acceptance/overview/revision-test.ts
@@ -34,4 +34,8 @@ module('Registries | Acceptance | overview.revision', hooks => {
             .exists('version metadata is shown when viewing a specific revision');
         await percySnapshot(assert);
     });
+
+    // TODO: Add tests to create a new revision
+    // TODO: Add tests to check user permissions to create a new revision
+    // TODO: Add tests to check non-contributor view
 });

--- a/tests/helpers/index.ts
+++ b/tests/helpers/index.ts
@@ -62,6 +62,10 @@ export function currentURL() {
     return router.get('location').getURL();
 }
 
+export function getHrefAttribute(selector: string) {
+    return document.querySelector(selector)!.getAttribute('href');
+}
+
 export function setupOSFApplicationTest(hooks: any) {
     setupApplicationTest(hooks);
     hooks.beforeEach(async () => {

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1104,6 +1104,7 @@ registries:
                 page_label: Review
                 start_review: Review
                 invalid_warning: 'Please address invalid or missing entries to complete registration.'
+                non_admin_warning: 'Only admins can submit a registration.'
                 toggle_dropdown: 'Toggle navigation dropdown'
             register: Register
             unable_to_fetch_children_count: 'Unable to fetch project''s components'
@@ -1115,9 +1116,12 @@ registries:
             accept_changes: 'Accept changes'
             continue_editing: 'Continue editing'
             decision_recorded_notice: 'Decision recorded. Pending decisions from other Admin contributors.'
+            pending_admin_notice: 'Pending decisions from admin(s).'
             pending_moderation_notice: 'Pending decisions from moderators.'
             action_submit_success: 'Your decision was recorded'
             action_submit_failed: 'Your decision was not recorded'
+            non_admin_warning: 'Only admins can submit an update.'
+            invalid_warning: 'Please address invalid or missing entries to complete update.'
         continue_edit_modal:
             heading: 'Are you sure this needs more edits?'
             warning: 'This will cancel any approvals from other admin contributors and return the registration back to its draft form for additional changes.'


### PR DESCRIPTION
-   Ticket: [ENG-3031]
-   Feature flag: n/a

## Purpose
- Update `edit-revision` to handle user's permissions appropriately

## Summary of Changes
- Add logic to allow admins to submit update, continue edits
- Add logic to allow write users to edit responses, but not submit update
- Add logic to keep read-only users to the review page
- Add logic to disallow edits when the update is submitted and is pending admin approval or moderator approval
- Add logic to reroute users to the overview page if the update is already accepted by moderators
- Tests

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-3031]: https://openscience.atlassian.net/browse/ENG-3031