### PR TITLE
[ENG-2936]Add colors to collection provider description

### DIFF
--- a/lib/collections/addon/components/discover-page/styles.scss
+++ b/lib/collections/addon/components/discover-page/styles.scss
@@ -87,4 +87,99 @@
     position: relative;
     margin: 0 65px;
     padding-top: 10px;
+
+    :global(.ColorBlack) {
+        color: $color-text-black;
+    }
+
+    :global(.ColorPureBlack) {
+        color: $color-black;
+    }
+
+    :global(.ColorBlue) {
+        color: $color-blue;
+    }
+
+    :global(.ColorPureBlue) {
+        color: $color-pure-blue;
+    }
+
+    :global(.ColorGrey) {
+        color: $color-text-gray;
+    }
+
+    :global(.ColorRed) {
+        color: $color-red;
+    }
+
+    :global(.ColorGreen) {
+        color: $color-green;
+    }
+
+    :global(.ColorYellow) {
+        color: $color-yellow;
+    }
+
+    :global(.ColorTurquoise) {
+        color: $color-turquoise;
+    }
+
+    :global(.ColorPurple) {
+        color: $color-purple;
+    }
+
+    :global(.LinkColorBlack) {
+        a {
+            color: $color-link-black;
+        }
+    }
+
+    :global(.LinkColorBlue) {
+        a {
+            color: $color-link-blue;
+        }
+    }
+
+    :global(.LinkColorPureBlue) {
+        a {
+            color: $color-pure-blue;
+        }
+    }
+
+    :global(.LinkColorGrey) {
+        a {
+            color: $color-grey;
+        }
+    }
+
+    :global(.LinkColorRed) {
+        a {
+            color: $color-red;
+        }
+    }
+
+    :global(.LinkColorGreen) {
+        a {
+            color: $color-green;
+        }
+    }
+
+    :global(.LinkColorYellow) {
+        a {
+            color: $color-yellow;
+        }
+    }
+
+    :global(.LinkColorTurquoise) {
+        a {
+            color: $color-turquoise;
+        }
+    }
+
+    :global(.LinkColorPurple) {
+        a {
+            color: $color-purple;
+        }
+    }
+
 }


### PR DESCRIPTION
-   Ticket: [ENG-2936](https://openscience.atlassian.net/browse/ENG-2936)
-   Feature flag: n/a

## Purpose

Enable colors on the collection provider description.

## Summary of Changes

1. Add the color classes into the provider description local-class.

## Screenshot(s)

<img width="1116" alt="Screen Shot 2021-08-23 at 2 49 07 PM" src="https://user-images.githubusercontent.com/6599111/130501335-66cff871-15f0-4e8b-a063-c138c2d777c1.png">

<img width="806" alt="Screen Shot 2021-08-23 at 2 15 57 PM" src="https://user-images.githubusercontent.com/6599111/130497577-fae67006-733e-43d8-b54a-94651c9ba57a.png">


## Side Effects

This is all very isolated.

## QA Notes

Same testing notes as for https://github.com/CenterForOpenScience/ember-osf-web/pull/1181 though wrapping in a span acted weird for me, so you might need to use a p tag instead of a span.
