### PR TITLE
[ENG-1578] Remove the VOL from the currentUser when stopping view only

### DIFF
--- a/lib/osf-components/addon/components/banners/view-only-link/component.ts
+++ b/lib/osf-components/addon/components/banners/view-only-link/component.ts
@@ -19,6 +19,7 @@ export default class BannersViewOnlyLink extends Component {
 
     @action
     stopViewOnly() {
+        this.currentUser.set('viewOnlyToken', '');
         this.router.transitionTo('home', { queryParams: { view_only: ''}});
     }
 }


### PR DESCRIPTION
-   Ticket: [ENG-1578](https://openscience.atlassian.net/browse/ENG-1578)
-   Feature flag: n/a

## Purpose

The existing functionality of 1578 is only half-fixed. It's removing the VOL from the URL, but leaving it on the currentUser service, so the VOL banner still shows on the dashboard, and transitioning to any other route will put the VOL back on the url. This fixes it so that the VOL is cleared from the currentUser as well.

## Summary of Changes

1. Clear the VOL from the currentUser service.

## Side Effects

Nope.

## QA Notes

This should just be the same test plan you used before for 1578.
