### PR TITLE
[ENG-3206] No link if no wiki

### DIFF
--- a/app/models/registration.ts
+++ b/app/models/registration.ts
@@ -82,6 +82,7 @@ export default class RegistrationModel extends NodeModel.extend(Validations) {
     @attr('fixstring') reviewsState?: RegistrationReviewStates;
     @attr('fixstring') iaUrl?: string;
     @attr('array') providerSpecificMetadata!: ProviderMetadata[];
+    @attr('boolean') wikiEnabled!: boolean;
 
     // Write-only attributes
     @attr('array') includedNodeIds?: string[];

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -63,8 +63,13 @@
                     <leftNav.link data-analytics-name='Files' @href='/{{this.registration.id}}/files/' @icon='file-alt'
                         @label={{t 'registries.overview.external_links.files'}} />
                     {{#if this.registration.wikiEnabled}}
-                        <leftNav.link data-analytics-name='Wiki' @href='/{{this.registration.id}}/wiki/'
-                            @icon='window-maximize' @label={{t 'registries.overview.external_links.wiki'}} />
+                        <leftNav.link
+                            data-test-wiki-link
+                            data-analytics-name='Wiki'
+                            @href='/{{this.registration.id}}/wiki/'
+                            @icon='window-maximize'
+                            @label={{t 'registries.overview.external_links.wiki'}}
+                        />
                     {{/if}}
                     <leftNav.link data-analytics-name='Components' @route='registries.overview.children'
                         @models={{array this.registration.id}} @icon='puzzle-piece'

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -62,8 +62,10 @@
                         @models={{array this.registration.id}} @icon='home' @label={{t 'registries.overview.title'}} />
                     <leftNav.link data-analytics-name='Files' @href='/{{this.registration.id}}/files/' @icon='file-alt'
                         @label={{t 'registries.overview.external_links.files'}} />
-                    <leftNav.link data-analytics-name='Wiki' @href='/{{this.registration.id}}/wiki/'
-                        @icon='window-maximize' @label={{t 'registries.overview.external_links.wiki'}} />
+                    {{#if this.registration.wikiEnabled}}
+                        <leftNav.link data-analytics-name='Wiki' @href='/{{this.registration.id}}/wiki/'
+                            @icon='window-maximize' @label={{t 'registries.overview.external_links.wiki'}} />
+                    {{/if}}
                     <leftNav.link data-analytics-name='Components' @route='registries.overview.children'
                         @models={{array this.registration.id}} @icon='puzzle-piece'
                         @label={{t 'registries.overview.components.title'}}

--- a/mirage/factories/registration.ts
+++ b/mirage/factories/registration.ts
@@ -172,6 +172,7 @@ export default NodeFactory.extend<MirageRegistration & RegistrationTraits>({
     registeredFrom: association(),
     registeredBy: association(),
     reviewsState: RegistrationReviewStates.Accepted,
+    wikiEnabled: true,
 
     index(i: number) {
         return i;

--- a/tests/engines/registries/acceptance/overview/index-test.ts
+++ b/tests/engines/registries/acceptance/overview/index-test.ts
@@ -86,7 +86,7 @@ module('Registries | Acceptance | overview.index', hooks => {
             selector: '[data-analytics-name="Files"]',
             href: `/${this.registration.id}/files/`,
         }, {
-            selector: '[data-analytics-name="Wiki"]',
+            selector: '[data-test-wiki-link]',
             href: `/${this.registration.id}/wiki/`,
         }];
 
@@ -95,6 +95,20 @@ module('Registries | Acceptance | overview.index', hooks => {
 
             assert.dom(testCase.selector).hasAttribute('href', testCase.href, 'Non-ember routes have the correct href');
         }
+    });
+
+    test('wiki link hidden if wiki not enabled', async function(this: OverviewTestContext, assert: Assert){
+        this.set('registration', server.create('registration', {
+            archiving: false,
+            withdrawn: false,
+            wikiEnabled: false,
+            registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
+            provider: server.create('registration-provider'),
+        }, 'withContributors', 'currentUserAdmin'));
+
+        await visit(`/${this.registration.id}`);
+
+        assert.dom('[data-test-wiki-link]').doesNotExist('Wiki link hidden because wiki disabled');
     });
 
     test('withdrawn tombstone', async function(this: OverviewTestContext, assert: Assert) {


### PR DESCRIPTION
-   Ticket: [ENG-3206](https://openscience.atlassian.net/browse/ENG-3206)
-   Feature flag: n/a

## Purpose

Hide the wiki link if there's no wiki on a registration so that we don't have a bad link on the page

## Summary of Changes

1. Add wikiEnabled to model and mirage
2. Use wikiEnabled to determine if we should show the wiki link
3. Test

## Screenshot(s)

<img width="233" alt="Screen Shot 2021-09-09 at 3 28 00 PM" src="https://user-images.githubusercontent.com/6599111/132859399-cd464d2b-11a5-4fe2-9a0c-a19a147351c4.png">


## Side Effects

No, this is fairly isolated

## QA Notes

To test, make a project, disable its wiki in the settings, and make a registration of that project. Then visit the registration's page to verify that there's no wiki link. Also verify that registrations with wikis have wiki links.
