### PR TITLE
[ENG-3183] Use more contrasty color for active element

### DIFF
--- a/lib/registries/addon/branded/new/styles.scss
+++ b/lib/registries/addon/branded/new/styles.scss
@@ -103,7 +103,7 @@
 }
 
 .IsChecked {
-    color: $color-osf-secondary;
+    color: #2e6ea3;
     background-color: $color-bg-gray-blue-light;
     border: 1px solid $color-bg-gray-blue-light;
 }


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-3183](https://openscience.atlassian.net/browse/ENG-3183)
-   Feature flag: n/a

## Purpose

Make Add New Registration page more accessible by making the highlighted color more contrasty.

## Summary of Changes

1. Make the text color darker

## Screenshot(s)

![Screen Shot 2021-09-14 at 10 41 54 AM](https://user-images.githubusercontent.com/6599111/133279301-b20b3354-c2d1-47f0-940f-22addb36f0be.png)


## Side Effects

No, this is isolated to this component.

## QA Notes

Should just need a11y testing.
