### PR TITLE
[ENG-3184] Darken color of upload placeholder text and icon for a11y

### DIFF
--- a/lib/osf-components/addon/components/files/list/styles.scss
+++ b/lib/osf-components/addon/components/files/list/styles.scss
@@ -5,7 +5,7 @@
     justify-content: center;
 
     height: 420px;
-    color: $color-text-gray-dark;
+    color: $color-black;
 }
 
 .list-container {


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-3184](https://openscience.atlassian.net/browse/ENG-3184)
-   Feature flag: n/a

## Purpose

Fix the accessibility of the file upload widget by making the placeholder text darker.

## Summary of Changes

1. Darken color of file upload placeholder.

## Screenshot(s)

![Screen Shot 2021-09-14 at 12 24 55 PM](https://user-images.githubusercontent.com/6599111/133297008-f1dd9cdc-c9fb-4310-a90f-8429eee08b19.png)


## Side Effects

This should be isolated to this widget

## QA Notes

Should just need running through accessibility testing.
