### PR TITLE
[ENG-3198][ENG-3199] A11y fixes for submitted registration page

### DIFF
--- a/lib/osf-components/addon/components/registries/registration-form-navigation-dropdown/styles.scss
+++ b/lib/osf-components/addon/components/registries/registration-form-navigation-dropdown/styles.scss
@@ -42,7 +42,7 @@
     line-height: 2.8;
 }
 
-.ToggleNav__button:global(.btn.btn-link) {
+.ToggleNav__button {
     float: right;
     color: $color-text-blue-dark;
     padding: 3px 8px;

--- a/lib/osf-components/addon/components/registries/registration-form-navigation-dropdown/template.hbs
+++ b/lib/osf-components/addon/components/registries/registration-form-navigation-dropdown/template.hbs
@@ -1,15 +1,14 @@
 {{assert 'Registries::RegistrationFormNavigationDropdown requires schemablocks' @schemaBlocks}}
 <ResponsiveDropdown local-class='Dropdown' @renderInPlace={{true}} as |dd|>
-    <dd.trigger local-class='MenuTrigger'>
-        <BsButton
-            data-analytics-name='Expand'
-            data-test-toggle-anchor-nav-button
-            local-class='ToggleNav__button'
-            aria-label={{t 'registries.drafts.draft.review.toggle_dropdown'}}
-            @type='link'
-        >
+    <dd.trigger
+        local-class='MenuTrigger'
+        data-test-toggle-anchor-nav-button
+        data-analytics-name='Expand'
+        aria-label={{t 'registries.drafts.draft.review.toggle_dropdown'}}
+    >
+        <div local-class='ToggleNav__button'>
             <FaIcon @icon='bars' />
-        </BsButton>
+        </div>
     </dd.trigger>
     <dd.content>
         <nav

--- a/lib/osf-components/addon/components/side-nav/x-link/styles.scss
+++ b/lib/osf-components/addon/components/side-nav/x-link/styles.scss
@@ -59,7 +59,7 @@ $sidenav-link-height: 40px;
 }
 
 .Count {
-    color: $color-text-slate-gray;
+    color: $color-text-gray;
     font-weight: 700;
 }
 

--- a/lib/registries/addon/overview/-components/overview-topbar/template.hbs
+++ b/lib/registries/addon/overview/-components/overview-topbar/template.hbs
@@ -15,6 +15,7 @@
         <ResponsiveDropdown as |dd|>
             <dd.trigger
                 data-test-forks-dropdown-button
+                aria-label={{t 'registries.overview.tooltips.fork'}}
                 data-analytics-name='Expand fork dropdown'
                 local-class='Action'
             >
@@ -61,6 +62,11 @@
             @type='link'
             @onClick={{action (perform this.bookmark)}}
             local-class='ActionButton'
+            aria-label={{if
+                this.isBookmarked
+                (t 'registries.overview.tooltips.remove_bookmark')
+                (t 'registries.overview.tooltips.bookmark')
+            }}
         >
             <FaIcon
                 local-class='Icon'
@@ -91,6 +97,7 @@
                 data-test-social-sharing-button
                 data-analytics-name='Expand sharing menu'
                 local-class='Action'
+                aria-label={{t 'registries.overview.tooltips.share'}}
             >
                 <FaIcon
                     local-class='Icon'

--- a/tests/engines/registries/acceptance/overview/overview-test.ts
+++ b/tests/engines/registries/acceptance/overview/overview-test.ts
@@ -249,7 +249,7 @@ module('Registries | Acceptance | overview.overview', hooks => {
         ) && displayText);
         await visit(`/${reg.id}/`);
 
-        assert.dom('[data-test-toggle-anchor-nav-button]').isVisible();
+        assert.dom('[data-test-toggle-anchor-nav-button] div').isVisible();
         assert.dom('[data-test-page-anchor]').isNotVisible();
 
         await click('[data-test-toggle-anchor-nav-button]');


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Tickets: 
[ENG-3198](https://openscience.atlassian.net/browse/ENG-3198)
[ENG-3199](https://openscience.atlassian.net/browse/ENG-3199)
-   Feature flag: n/a

## Purpose

Fix the accessibility problems on the submitted registration page.

## Summary of Changes

1. Add aria-labels to the forks, bookmarks, and sharing icons on the top-right
2. Increase the contrast of the counts on the left sidebar links
3. This was not in the tickets, but was found by my accessibility checker, so I fixed it here: don't nest interactive controls. There was a dropdown control with a role='button' and a button was nested inside of that. So I changed the nested button to a div, moved the interaction markers (data-test selector and data-analytics), and did a little fixing of the css and tests. This was for the hamburger menu next to the summary in the center section (see second screenshot below)

## Screenshot(s)

<img width="220" alt="Screen Shot 2021-09-17 at 9 34 39 AM" src="https://user-images.githubusercontent.com/6599111/133815188-d558ad81-4c4d-4a67-8d5c-58d29ebc0175.png">

<img width="509" alt="Screen Shot 2021-09-17 at 9 43 46 AM" src="https://user-images.githubusercontent.com/6599111/133814805-ff78a4d2-ef1d-44c2-95e5-a61e25710331.png">

## Side Effects

Shouldn't be. 

## QA Notes

Just needs checking on the accessibility.
