### PR TITLE
[ENG-3214] Add aria label to download button

### DIFF
--- a/app/meetings/detail/-components/meeting-submissions-list/template.hbs
+++ b/app/meetings/detail/-components/meeting-submissions-list/template.hbs
@@ -64,6 +64,7 @@
                 <div data-test-submissions-list-item-download>
                     {{#if submission.links.download}}
                         <BsButton
+                            aria-label={{t 'general.download'}}
                             @type='success'
                             class='btn-xs'
                             @onClick={{action this.downloadFile submission}}


### PR DESCRIPTION
-   Ticket: [ENG-3214](https://openscience.atlassian.net/browse/ENG-3214)
-   Feature flag: n/a

## Purpose

Fix a11y problem on the meetings detail page

## Summary of Changes

1. Add aria-label to download button

## Side Effects

Nope

## QA Notes

This shouldn't affect functionality, so just needs accessibility testing.
