### PR TITLE
[ENG-3245] Update broken help guide link

### DIFF
--- a/app/guid-node/registrations/template.hbs
+++ b/app/guid-node/registrations/template.hbs
@@ -37,7 +37,7 @@
                                 {{/if}}
                                 <p>
                                     {{t 'node.registrations.learn_more'
-                                        learnMoreLink='https://openscience.zendesk.com/hc/en-us/articles/360019930893'
+                                        learnMoreLink='https://help.osf.io/hc/en-us/categories/360001550953-Registrations'
                                         htmlSafe=true
                                     }}
                                 </p>
@@ -74,7 +74,7 @@
                                     {{/if}}
                                     <p>
                                         {{t 'node.registrations.learn_more'
-                                          learnMoreLink='https://openscience.zendesk.com/hc/en-us/articles/360019930893'
+                                          learnMoreLink='https://help.osf.io/hc/en-us/categories/360001550953-Registrations'
                                           htmlSafe=true
                                         }}
                                     </p>


### PR DESCRIPTION
-   Ticket: [ENG-3245](https://openscience.atlassian.net/browse/ENG-3245)
-   Feature flag: n/a

## Purpose

Update the help guide link on the project registrations page to one that is not broken.

## Summary of Changes

1. Update the link in both places it's used.

## Side Effects

Nope

## QA Notes

Make sure the new link goes to a help page for registrations.