### PR TITLE
[ENG-3242] Add Justification route to registration edit workflow

### DIFF
--- a/app/packages/registration-schema/index.ts
+++ b/app/packages/registration-schema/index.ts
@@ -2,7 +2,7 @@ export { getPages } from './get-pages';
 export { getSchemaBlockGroups } from './get-schema-block-group';
 export { SchemaBlock, SchemaBlockType } from './schema-block';
 export { SchemaBlockGroup } from './schema-block-group';
-export { buildValidation, buildMetadataValidations } from './validations';
+export { buildValidation, buildMetadataValidations, buildSchemaResponseValidations } from './validations';
 export {
     FileReference,
     RegistrationResponse,

--- a/app/packages/registration-schema/validations.ts
+++ b/app/packages/registration-schema/validations.ts
@@ -1,7 +1,7 @@
 import { assert } from '@ember/debug';
 import { set } from '@ember/object';
 import { ValidationObject, ValidatorFunction } from 'ember-changeset-validations';
-import { validatePresence } from 'ember-changeset-validations/validators';
+import { validateLength, validatePresence } from 'ember-changeset-validations/validators';
 import DraftNode from 'ember-osf-web/models/draft-node';
 import LicenseModel from 'ember-osf-web/models/license';
 
@@ -10,6 +10,7 @@ import NodeModel, { NodeLicense } from 'ember-osf-web/models/node';
 import { RegistrationResponse } from 'ember-osf-web/packages/registration-schema';
 import { SchemaBlockGroup } from 'ember-osf-web/packages/registration-schema/schema-block-group';
 import { validateFileList } from 'ember-osf-web/validators/validate-response-format';
+import SchemaResponseModel from 'ember-osf-web/models/schema-response';
 
 export const NodeLicenseFields: Record<keyof NodeLicense, string> = {
     copyrightHolders: 'Copyright Holders',
@@ -164,5 +165,24 @@ export function buildMetadataValidations() {
     set(validationObj, DraftMetadataProperties.Subjects, validateSubjects());
     // TODO: unsure why array of validation functions breaks validations
     set(validationObj, DraftMetadataProperties.NodeLicenseProperty, validateNodeLicense());
+    return validationObj;
+}
+
+export function buildSchemaResponseValidations() {
+    const validationObj: ValidationObject<SchemaResponseModel> = {};
+    const notBlank: ValidatorFunction[] = [validatePresence({
+        presence: true,
+        ignoreBlank: true,
+        allowBlank: false,
+        allowNone: false,
+        type: 'blank',
+    })];
+    set(validationObj, 'revisionJustification', notBlank);
+    set(validationObj, 'revisedResponses', [validateLength({
+        min: 1,
+        allowBlank: false,
+        allowNone: false,
+        type: 'no_updated_responses',
+    })]);
     return validationObj;
 }

--- a/lib/osf-components/addon/components/registries/revised-responses-list/component.ts
+++ b/lib/osf-components/addon/components/registries/revised-responses-list/component.ts
@@ -1,0 +1,38 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import { getSchemaBlockGroups, SchemaBlockGroup } from 'ember-osf-web/packages/registration-schema';
+import SchemaResponseModel from 'ember-osf-web/models/schema-response';
+import SchemaBlockModel from 'ember-osf-web/models/schema-block';
+
+interface Args {
+    revision: SchemaResponseModel;
+    schemaBlocks: SchemaBlockModel[];
+}
+
+export default class RevisedResponsesList extends Component<Args> {
+    @tracked groups?: SchemaBlockGroup[];
+
+    constructor(owner: unknown, args: Args) {
+        super(owner, args);
+        this.groups = getSchemaBlockGroups(this.args.schemaBlocks);
+    }
+
+    get revisedResponses(): string[] {
+        const { revision } = this.args;
+        if (revision.revisedResponses) {
+            const allRevisedLabels = revision.revisedResponses
+                .reduce((labels: string[], revisedResponse: string) => {
+                    const revisedGroup = this.groups?.filter(
+                        (group: SchemaBlockGroup) => group.registrationResponseKey?.includes(revisedResponse),
+                    );
+                    if (revisedResponse) {
+                        labels.push(revisedGroup![0].labelBlock!.displayText!);
+                    }
+                    return labels;
+                }, []);
+            return allRevisedLabels;
+        }
+        return [];
+    }
+}

--- a/lib/osf-components/addon/components/registries/revised-responses-list/template.hbs
+++ b/lib/osf-components/addon/components/registries/revised-responses-list/template.hbs
@@ -1,0 +1,9 @@
+{{~#each this.revisedResponses as |response|~}}
+    <p data-test-revised-responses-list='{{response}}' ...attributes>
+        {{~response~}}
+    </p>
+{{~else}}
+    <p data-test-revised-responses-list-no-update ...attributes>
+        {{~t 'registries.revisedResponsesList.noResponses'~}}
+    </p>
+{{/each}}

--- a/lib/osf-components/addon/components/registries/revision-justification-renderer/label-display/styles.scss
+++ b/lib/osf-components/addon/components/registries/revision-justification-renderer/label-display/styles.scss
@@ -1,0 +1,14 @@
+.ResponseValue {
+    composes: Element from '../../schema-block-renderer/styles.scss';
+    margin: 10px 0 0;
+}
+
+.ValidationErrors {
+    composes: Element from '../../schema-block-renderer/styles.scss';
+}
+
+.DisplayText {
+    font-size: 14px;
+    font-weight: 700;
+    margin: 20px 0 0;
+}

--- a/lib/osf-components/addon/components/registries/revision-justification-renderer/label-display/template.hbs
+++ b/lib/osf-components/addon/components/registries/revision-justification-renderer/label-display/template.hbs
@@ -1,0 +1,32 @@
+{{assert 'Registries::RevisionJustificationRenderer::LabelDisplay requires a revision' @revision}}
+{{assert 'Registries::RevisionJustificationRenderer::LabelDisplay requires a field' @field}}
+{{assert 'Registries::RevisionJustificationRenderer::LabelDisplay requires a changeset' @changeset}}
+<p local-class='DisplayText' data-test-review-label={{@field}} id={{@field}}>
+    {{t (concat 'registries.edit_revision.' @field)}}
+    {{#if @showEditButton}}
+        <OsfLink
+            data-test-edit-button
+            aria-label={{t 'registries.registration_metadata.edit_field' field=(if @fieldText @fieldText @field)}}
+            @route='registries.edit-revision.justification'
+            @models={{array @revision.id }}
+            @fragment={{@field}}
+        >
+            <FaIcon @icon='edit' />
+        </OsfLink>
+    {{/if}}
+</p>
+<p
+    data-test-review-response={{@field}}
+    local-class='ResponseValue'
+    ...attributes
+>
+    {{~yield~}}
+</p>
+{{#unless @hideError}}
+    <ValidationErrors
+        local-class='ValidationErrors'
+        @changeset={{@changeset}}
+        @key={{@field}}
+        @errors={{@errors}}
+    />
+{{/unless}}

--- a/lib/osf-components/addon/components/registries/revision-justification-renderer/styles.scss
+++ b/lib/osf-components/addon/components/registries/revision-justification-renderer/styles.scss
@@ -1,0 +1,12 @@
+.NoResponse,
+.RevisedResponses {
+    font-style: italic;
+}
+
+.TextResponse {
+    white-space: pre-wrap;
+}
+
+.ValidationErrors {
+    composes: Element from '../schema-block-renderer/styles.scss';
+}

--- a/lib/osf-components/addon/components/registries/revision-justification-renderer/template.hbs
+++ b/lib/osf-components/addon/components/registries/revision-justification-renderer/template.hbs
@@ -1,0 +1,25 @@
+{{assert 'Registries::RevisionJustificationRenderer requires a revision' @revision}}
+<h2 id='JustificationPageLabel'>{{t 'registries.edit_revision.justification.page_label'}}</h2>
+
+<Registries::RevisionJustificationRenderer::LabelDisplay
+    @revision={{@revision}}
+    @changeset={{@revisionChangeset}}
+    @showEditButton={{@showEditButton}}
+    @field='revisionJustification'
+    local-class='TextResponse {{unless @revision.revisionJustification 'NoResponse'}}'
+>
+    {{~if @revision.revisionJustification @revision.revisionJustification (t 'registries.edit_revision.review.no_justification')~}}
+</Registries::RevisionJustificationRenderer::LabelDisplay>
+
+<Registries::RevisionJustificationRenderer::LabelDisplay
+    @revision={{@revision}}
+    @changeset={{@revisionChangeset}}
+    @showEditButton={{false}}
+    @field='revisedResponses'
+    local-class='RevisedResponses'
+>
+    <Registries::RevisedResponsesList
+        @revision={{@revision}}
+        @schemaBlocks={{@schemaBlocks}}
+    />
+</Registries::RevisionJustificationRenderer::LabelDisplay>

--- a/lib/osf-components/addon/components/registries/update-dropdown/component.ts
+++ b/lib/osf-components/addon/components/registries/update-dropdown/component.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { waitFor } from '@ember/test-waiters';

--- a/lib/osf-components/app/components/registries/revised-responses-list/component.js
+++ b/lib/osf-components/app/components/registries/revised-responses-list/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/registries/revised-responses-list/component';

--- a/lib/osf-components/app/components/registries/revised-responses-list/template.js
+++ b/lib/osf-components/app/components/registries/revised-responses-list/template.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/registries/revised-responses-list/template';

--- a/lib/osf-components/app/components/registries/revision-justification-renderer/label-display/template.js
+++ b/lib/osf-components/app/components/registries/revision-justification-renderer/label-display/template.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/registries/revision-justification-renderer/label-display/template';

--- a/lib/osf-components/app/components/registries/revision-justification-renderer/template.js
+++ b/lib/osf-components/app/components/registries/revision-justification-renderer/template.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/registries/revision-justification-renderer/template';

--- a/lib/registries/addon/components/page-link/component.ts
+++ b/lib/registries/addon/components/page-link/component.ts
@@ -55,7 +55,7 @@ export default class PageLinkComponent extends Component {
             }
             return PageState.Invalid;
         }
-        if (this.pageName === 'metadata') {
+        if (this.pageName === 'metadata' || this.pageName === 'justification') {
             if (this.metadataIsValid) {
                 return PageState.Valid;
             }

--- a/lib/registries/addon/edit-revision/-components/right-nav/template.hbs
+++ b/lib/registries/addon/edit-revision/-components/right-nav/template.hbs
@@ -51,6 +51,21 @@
         </Button>
     </OsfLink>
 {{/if}}
+{{#if @navManager.isFirstPage}}
+    <OsfLink
+        data-test-goto-justification
+        data-analytics-name='Back to justification'
+        local-class='BackButton'
+        @type='button'
+        @route='registries.edit-revision.justification'
+        @models={{array @revisionManager.revisionId}}
+    >
+        <Button @type='secondary'>
+            <FaIcon @icon='arrow-left' @fixedWidth={{true}} />
+            {{t 'registries.edit_revision.justification.page_label'}}
+        </Button>
+    </OsfLink>
+{{/if}}
 
 {{#if @revisionManager.lastSaveFailed}}
     <span local-class='SaveFailed'>

--- a/lib/registries/addon/edit-revision/-components/top-nav/template.hbs
+++ b/lib/registries/addon/edit-revision/-components/top-nav/template.hbs
@@ -4,7 +4,7 @@
 
 <Navbar local-class='SideBarToggle' ...attributes as |nav|>
     <nav.bordered-section>
-        {{#if (and (not @revisionManager.currentUserIsReadOnly) @revisionManager.isEditable)}}
+        {{#if @navManager.showSidenav}}
             <nav.buttons.default
                 data-test-sidenav-toggle
                 data-analytics-name='Show sidenav'
@@ -19,13 +19,27 @@
         <div data-test-page-label>
             {{#if @navManager.inReview}}
                 {{t 'registries.drafts.draft.review.page_label'}}
+            {{else if @navManager.inJustification}}
+                {{t 'registries.edit_revision.justification.page_label'}}
             {{else}}
                 {{@navManager.currentPageManager.pageHeadingText}}
             {{/if}}
         </div>
     </nav.bordered-section>
     <nav.bordered-section>
-        {{#if (and @navManager.prevPageParam (not @revisionManager.currentUserIsReadOnly) @revisionManager.isEditable)}}
+        {{#if @navManager.isFirstPage}}
+            <nav.links.default
+                data-test-goto-justification
+                data-analytics-name='Topnav back to justification'
+                aria-label={{t 'osf-components.registries-top-nav.justification'}}
+                local-class='MetadataButton'
+                @route='registries.edit-revision.justification'
+                @models={{array @revisionManager.revisionId }}
+            >
+                {{t 'registries.edit_revision.justification.page_label'}}
+            </nav.links.default>
+        {{/if}}
+        {{#if @navManager.showPreviousButton}}
             <nav.links.default
                 data-test-goto-previous-page
                 data-analytics-name='Topnav back'

--- a/lib/registries/addon/edit-revision/index/route.ts
+++ b/lib/registries/addon/edit-revision/index/route.ts
@@ -3,6 +3,6 @@ import Route from '@ember/routing/route';
 export default class EditRevisionIndexRoute extends Route {
     beforeModel() {
         const params: { revisionId?: string } = this.paramsFor('edit-revision');
-        return this.replaceWith('edit-revision.page', params.revisionId, 1);
+        return this.replaceWith('edit-revision.justification', params.revisionId);
     }
 }

--- a/lib/registries/addon/edit-revision/justification/controller.ts
+++ b/lib/registries/addon/edit-revision/justification/controller.ts
@@ -1,0 +1,17 @@
+import Controller from '@ember/controller';
+import { alias, not } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
+import Media from 'ember-responsive';
+
+import RevisionManager from 'registries/edit-revision/revision-manager';
+import SchemaResponseModel from 'ember-osf-web/models/schema-response';
+
+export default class EditRevisionJustification extends Controller {
+    @service media!: Media;
+
+    @alias('model.revisionManager') revisionManager?: RevisionManager;
+    @alias('revisionManager.revision') revision?: SchemaResponseModel;
+
+    @not('revision') loading!: boolean;
+    @not('media.isDesktop') showMobileView!: boolean;
+}

--- a/lib/registries/addon/edit-revision/justification/route.ts
+++ b/lib/registries/addon/edit-revision/justification/route.ts
@@ -7,14 +7,14 @@ import { RevisionRoute } from 'registries/edit-revision/nav-manager';
 
 import { EditRevisionRouteModel } from '../route';
 
-export default class EditRevisionReview extends Route {
+export default class EditRevisionJustification extends Route {
     @service analytics!: Analytics;
 
     model(): EditRevisionRouteModel {
         const editRevisionRouteModel = this.modelFor('edit-revision') as EditRevisionRouteModel;
         const { navigationManager } = editRevisionRouteModel;
 
-        navigationManager.setPageAndRoute(RevisionRoute.Review);
+        navigationManager.setPageAndRoute(RevisionRoute.Justification);
 
         return this.modelFor('edit-revision') as EditRevisionRouteModel;
     }

--- a/lib/registries/addon/edit-revision/justification/styles.scss
+++ b/lib/registries/addon/edit-revision/justification/styles.scss
@@ -1,0 +1,27 @@
+.Metadata {
+    composes: Metadata from '../../drafts/draft/metadata/styles.scss';
+}
+
+.PageHeading {
+    composes: PageHeading from '../../drafts/draft/metadata/styles.scss';
+}
+
+.HeadingParagraph {
+    composes: HeadingParagraph from '../../drafts/draft/metadata/styles.scss';
+}
+
+.Required {
+    composes: Required from '../../drafts/draft/metadata/styles.scss';
+}
+
+.SchemaBlockInput {
+    composes: SchemaBlockInput from '../../drafts/draft/metadata/styles.scss';
+}
+
+.SchemaBlockLongText {
+    composes: SchemaBlockLongText from '../../drafts/draft/metadata/styles.scss';
+}
+
+.RevisedResponses {
+    font-style: italic;
+}

--- a/lib/registries/addon/edit-revision/justification/template.hbs
+++ b/lib/registries/addon/edit-revision/justification/template.hbs
@@ -1,0 +1,46 @@
+{{page-title (t 'registries.drafts.draft.metadata.title')}}
+
+{{#if this.loading}}
+    <LoadingIndicator @dark={{true}} />
+{{else}}
+    <main>
+        <h2 local-class='PageHeading'>
+            {{t 'registries.edit_revision.justification.title'}}
+        </h2>
+        <p local-class='HeadingParagraph'>
+            {{t 'registries.edit_revision.justification.justification_description'}}
+        </p>
+        <hr>
+        <form local-class='Metadata'>
+            <FormControls @changeset={{this.revisionManager.revisionChangeset}} ...attributes as |form|>
+                {{#let (unique-id 'reason') as |reasonFieldId|}}
+                    <label for={{reasonFieldId}} id='justification'>
+                        <p local-class='DisplayText'>
+                            {{t 'registries.edit_revision.justification.justification_label'}}
+                            <span local-class='Required'>*</span>
+                        </p>
+                    </label>
+                    <form.textarea data-test-metadata-description local-class='SchemaBlockLongText'
+                        @valuePath='revisionJustification'
+                        @onKeyUp={{perform this.revisionManager.onJustificationInput}}
+                        @placeholder=' '
+                        @uniqueID={{reasonFieldId}}
+                    />
+                {{/let}}
+                {{#let (unique-id 'questions') as |questionsFieldId|}}
+                    <label for={{questionsFieldId}} id='questions'>
+                        <p local-class='DisplayText'>
+                            {{t 'registries.edit_revision.revisedResponses'}}
+                            <span local-class='Required'>*</span>
+                        </p>
+                    </label>
+                    <Registries::RevisedResponsesList
+                        @revision={{this.revisionManager.revision}}
+                        @schemaBlocks={{this.revisionManager.schemaBlocks}}
+                        local-class='RevisedResponses'
+                    />
+                {{/let}}
+            </FormControls>
+        </form>
+    </main>
+{{/if}}

--- a/lib/registries/addon/edit-revision/page/controller.ts
+++ b/lib/registries/addon/edit-revision/page/controller.ts
@@ -10,7 +10,7 @@ import NavigationManager from 'registries/drafts/draft/navigation-manager';
 import RevisionManager from 'registries/edit-revision/revision-manager';
 import { RevisionPageRouteModel } from './route';
 
-export default class RegistriesDraftPage extends Controller {
+export default class EditRevisionPage extends Controller {
     @service router!: RouterService;
 
     model!: RevisionPageRouteModel;
@@ -29,6 +29,7 @@ export default class RegistriesDraftPage extends Controller {
             this.replaceRoute('edit-revision.page', draftId, pageSlug);
         }
         this.revisionManager.onPageChange(pageIndex);
+        this.revisionManager.revisionChangeset.validate();
     }
 
     @action

--- a/lib/registries/addon/edit-revision/review/template.hbs
+++ b/lib/registries/addon/edit-revision/review/template.hbs
@@ -28,6 +28,12 @@
                 @showMetadata={{true}}
                 @schemaBlocks={{revisionManager.schemaBlocks}}
             />
+            <Registries::RevisionJustificationRenderer
+                @revisionChangeset={{revisionManager.revisionChangeset}}
+                @revision={{revisionManager.revision}}
+                @schemaBlocks={{revisionManager.schemaBlocks}}
+                @showEditButton={{not revisionManager.currentUserIsReadOnly}}
+            />
             <Registries::ReviewFormRenderer
                 @pageManagers={{revisionManager.pageManagers}}
                 @responses={{revisionManager.revision.revisionResponses}}

--- a/lib/registries/addon/edit-revision/template.hbs
+++ b/lib/registries/addon/edit-revision/template.hbs
@@ -45,6 +45,16 @@
                 {{/if}}
                 <layout.leftNav as |leftNav|>
                     {{#if (not (or revisionManager.currentUserIsReadOnly (not revisionManager.isEditable)))}}
+                        <PageLink
+                            @link={{component leftNav.link}}
+                            @draftId={{revisionManager.revisionId}}
+                            @pageName='justification'
+                            @route='registries.edit-revision.justification'
+                            @currentPageName={{navManager.currentRoute}}
+                            @label='{{t 'registries.edit_revision.justification.page_label'}}'
+                            @navMode={{leftNav.leftGutterMode}}
+                            @metadataIsValid={{revisionManager.revisionIsValid}}
+                        />
                         {{#each revisionManager.pageManagers as |pageManager index|}}
                             <PageLink
                                 @link={{component leftNav.link}}

--- a/lib/registries/addon/routes.ts
+++ b/lib/registries/addon/routes.ts
@@ -29,6 +29,7 @@ export default buildRoutes(function() {
     });
 
     this.route('edit-revision', { path: '/registries/revisions/:revisionId' }, function() {
+        this.route('justification');
         this.route('page', { path: '/:page' });
         this.route('review');
     });

--- a/tests/integration/components/registries/revised-responses-list/component-test.ts
+++ b/tests/integration/components/registries/revised-responses-list/component-test.ts
@@ -1,0 +1,57 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupIntl, t, TestContext } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import SchemaBlockModel from 'ember-osf-web/models/schema-block';
+import SchemaResponseModel from 'ember-osf-web/models/schema-response';
+
+interface ThisTestContext extends TestContext {
+    blocks?: SchemaBlockModel[];
+    revision: SchemaResponseModel;
+}
+
+module('Integration | Component | revised-responses-list', hooks => {
+    setupRenderingTest(hooks);
+    setupIntl(hooks);
+    setupMirage(hooks);
+
+    hooks.beforeEach(async function(this: ThisTestContext) {
+        this.store = this.owner.lookup('service:store');
+        server.loadFixtures('schema-blocks');
+        server.loadFixtures('registration-schemas');
+        const registrationSchema = server.schema.registrationSchemas.find('testSchema');
+        const registration = server.create('registration', { registrationSchema });
+        const revisionModel = server.create('schema-response', {
+            registration,
+            registrationSchema,
+        });
+        const revision = await this.store.findRecord('schema-response', revisionModel.id);
+        const schema = await revision.registrationSchema;
+        this.revision = revision;
+        this.blocks = await schema.loadAll('schemaBlocks');
+    });
+
+    test('no revised responses', async function(this: ThisTestContext, assert) {
+        await render(hbs`
+            <Registries::RevisedResponsesList
+                @revision={{this.revision}} @schemaBlocks={{this.blocks}}
+            />`);
+        assert.dom('[data-test-revised-responses-list]').doesNotExist('Updated responses are not shown');
+        assert.dom('[data-test-revised-responses-list-no-update]')
+            .containsText(t('registries.revisedResponsesList.noResponses'), 'No responses updated message shown');
+    });
+
+    test('multiple revised responses', async function(this: ThisTestContext, assert) {
+        this.revision.revisedResponses = ['page-one_single-select', 'page-one_short-text'];
+        await render(hbs`<Registries::RevisedResponsesList
+            @revision={{this.revision}} @schemaBlocks={{this.blocks}}
+        />`);
+        assert.dom('[data-test-revised-responses-list-no-update]')
+            .doesNotExist('No response updated message not shown');
+        assert.dom('[data-test-revised-responses-list]')
+            .exists({ count: 2 }, 'Responsese updated message shown appropriate number of times');
+    });
+});

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -525,6 +525,7 @@ validationErrors:
     onlyProjectOrComponentFiles: 'The {numOfFiles, plural, =1 {file} other {files}} "{missingFilesList}" cannot be found on this {projectOrComponent}.'
     new_folder_name: 'Folder name must not be blank.'
     year_format: 'Please specify a valid year.'
+    no_updated_responses: 'No changes have been made in this update.'
 validated_input_form:
     discard_changes: 'Discard changes'
 node_navbar:
@@ -1112,8 +1113,17 @@ registries:
             unable_to_fetch_children_count: 'Unable to fetch project''s components'
             submit_error: 'Unable to create a registration.'
     edit_revision:
+        revisionJustification: 'Justification for update'
+        revisedResponses: 'List of updated registration questions'
+        justification:
+            page_label: Justification
+            title: 'Justification for Update'
+            justification_label: 'Explain the updates made to this registration and why the changes were necessary. Be thorough in your response.'
+            justification_description: 'Justification will be provided to admins and moderators upon review. Once approved, it will be displayed at the top of the registration.'
         page_title: 'Update registration'
         review:
+            justification_page_label: 'Justification'
+            no_justification: 'No justification provided.'
             submit_changes: 'Submit changes'
             accept_changes: 'Accept changes'
             continue_editing: 'Continue editing'
@@ -1438,6 +1448,8 @@ registries:
         submit: Submit
         back: Back
         datePlaceholder: 'Choose embargo end date'
+    revisedResponsesList:
+        noResponses: 'No responses updated'
     sharingIcons:
         label: 'Share this registration via {mediaType}'
     makeDecisionDropdown:
@@ -1726,6 +1738,7 @@ osf-components:
         collapseSideNav: 'Collapse registration form navigation'
     registries-top-nav:
         showRegistrationNavigation: 'Show registration form navigation'
+        justification: 'Return to justification'
         metadata: 'Return to metadata'
         previousPage: 'Previous page'
         nextPage: 'Next page'


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-3242]
-   Feature flag: n/a

## Purpose
- Add a route where users can enter the reason for update
- Allow users to see which answers have been answered
- make justification and changing a field required

## Summary of Changes
- Add new route `registries.edit-revision.justification` where users can add a reason for their update as well as which fields have been updated
  - Add a new component to see which fields have been updated, given the current schemaResponse object's `revisedResponses` field
  - Add validations so `revisionReason` and `revisedResponses` are required
  - Route users to this new route upon entering the `registries.edit-revision` route
- Add a `RevisionJustificationRenderer` to show on the Review page so users can see the reason they entered as well as the questions changed. This will render validation errors on the screen as well
- Tests

## Screenshot(s)
- Justification route:
![image](https://user-images.githubusercontent.com/51409893/135924332-1d149b9b-629e-47a2-acec-95d15199715a.png)

- Updated Review route:
![image](https://user-images.githubusercontent.com/51409893/135924383-a48e51e9-9eca-48f5-8e6b-6b2add95f929.png)


## Side Effects
- There should be no side-effects

## QA Notes
- We have intentionally silenced the validation message on the Justification page as users cannot directly edit that field and we worried that having the validation message there could lead to confusion.
  - The validation message should show up on the Review page though