### PR TITLE
[ENG-3214] Add aria label to search box on meetings detail page

### DIFF
--- a/app/meetings/detail/-components/meeting-submissions-list/template.hbs
+++ b/app/meetings/detail/-components/meeting-submissions-list/template.hbs
@@ -4,6 +4,7 @@
             @type='text'
             @placeholder={{t 'meetings.index.meetings-list.search'}}
             @key-up={{perform this.searchSubmissions}}
+            aria-label={{t 'meetings.index.meetings-list.search'}}
         />
     </div>
 </div>


### PR DESCRIPTION
-   Ticket: [https://openscience.atlassian.net/browse/ENG-3214]
-   Feature flag: n/a

## Purpose

Add an aria label to the search box on the meetings detail page. Apparently last time I got the meeting list page, but not the detail page's search box.

## Summary of Changes

1. Add aria label

## Side Effects

No

## QA Notes

Just needs a11y testing.
