### PR TITLE
[No ticket] Cache providerIsDefault to avoid problem where this.provider is undefined

### DIFF
--- a/lib/registries/addon/components/registries-registration-type-facet/component.ts
+++ b/lib/registries/addon/components/registries-registration-type-facet/component.ts
@@ -42,11 +42,13 @@ export default class RegistriesRegistrationTypeFacet extends Component {
             if (!this.provider){
                 this.provider = await this.store.findRecord('registration-provider', defaultProviderId);
             }
+            const providerIsDefault = this.provider.id === defaultProviderId;
+
             const metaschemas = await this.provider.queryHasMany('schemas', {
                 'page[size]': 100,
             });
             const metaschemaNames = metaschemas.mapBy('name');
-            if (this.provider.id === defaultProviderId) {
+            if (providerIsDefault) {
                 metaschemaNames.push(
                     // Manually add 'Election Research Preacceptance Competition' to the list of possible
                     // facets. Metaschema was removed from the API as a possible registration type

--- a/lib/registries/addon/components/registries-registration-type-facet/component.ts
+++ b/lib/registries/addon/components/registries-registration-type-facet/component.ts
@@ -33,7 +33,7 @@ export default class RegistriesRegistrationTypeFacet extends Component {
 
     registrationTypes: EmberArray<string> = A([]);
 
-    @task({ on: 'init' })
+    @task({ on: 'didReceiveAttrs' })
     @waitFor
     async fetchRegistrationTypes() {
         const { defaultProviderId } = registriesConfig;
@@ -42,13 +42,11 @@ export default class RegistriesRegistrationTypeFacet extends Component {
             if (!this.provider){
                 this.provider = await this.store.findRecord('registration-provider', defaultProviderId);
             }
-            const providerIsDefault = this.provider.id === defaultProviderId;
-
             const metaschemas = await this.provider.queryHasMany('schemas', {
                 'page[size]': 100,
             });
             const metaschemaNames = metaschemas.mapBy('name');
-            if (providerIsDefault) {
+            if (this.provider.id === defaultProviderId) {
                 metaschemaNames.push(
                     // Manually add 'Election Research Preacceptance Competition' to the list of possible
                     // facets. Metaschema was removed from the API as a possible registration type


### PR DESCRIPTION
-   Ticket: n/a
-   Feature flag: n/a

## Purpose

When doing a search from the registries landing page, we would get an error on the discover page that we couldn't load the registration types. This happened because provider was becoming undefined after the await L45 in the diff for this PR was executed.

## Summary of Changes

1. Wait for attrs to load before running task (h/t @aaxelb)

## Screenshot(s)

![Screen Shot 2021-11-03 at 8 00 14 AM](https://user-images.githubusercontent.com/6599111/140069564-919e338a-8ab3-4702-b213-195387ffde32.png)

## Side Effects

This should be pretty isolated

## QA Notes

Original error was when performing a search from the registries landing page, the error above would show on the discover page. This should no longer happen.
