### PR TITLE
[ENG-3235] Un-mute the collections discover description text for accessibility

### DIFF
--- a/lib/collections/addon/components/collection-search-result/node/template.hbs
+++ b/lib/collections/addon/components/collection-search-result/node/template.hbs
@@ -23,7 +23,7 @@
         <p>
             <div
                 data-test-collection-search-result-node-description
-                class='text-muted m-t-sm'>
+                class='m-t-sm'>
                 {{#if this.showBody}}
                     {{unescape-xml-entities this.item.description}}
                 {{else}}


### PR DESCRIPTION
-   Ticket: [ENG-3235](https://openscience.atlassian.net/browse/ENG-3235)
-   Feature flag: n/a

## Purpose

The description text on the collections discover page was not passing accessibility standards of contrast. This fixes that.

## Summary of Changes

1. Un-mute the text

## Screenshot(s)

<img width="642" alt="Screen Shot 2021-11-04 at 8 46 10 AM" src="https://user-images.githubusercontent.com/6599111/140315802-42a17424-7053-4cba-8023-be3c116d4767.png">

## Side Effects

None

## QA Notes

Just needs to run through accessibility testing.