### PR TITLE
[ENG-3243] Refactor node and draft reg cards for better CSS

### DIFF
--- a/lib/osf-components/addon/components/draft-registration-card/styles.scss
+++ b/lib/osf-components/addon/components/draft-registration-card/styles.scss
@@ -38,18 +38,14 @@
     }
 }
 
-// stylelint-disable selector-no-qualifying-type
-a.DraftRegistrationCard__review {
-    margin-right: 10px;
+.DraftRegistrationCard__review {
+    composes: Button from '../button/styles.scss';
+    composes: SecondaryButton from '../button/styles.scss';
+    composes: MediumButton from '../button/styles.scss';
 
     &:hover {
-        text-decoration: none;
+        text-decoration: none !important; /* override OsfLink hover style */
     }
-}
-
-// stylelint-enable selector-no-qualifying-type
-.DraftRegistrationCard__edit {
-    vertical-align: bottom;
 }
 
 .DraftRegistrationCard__delete {

--- a/lib/osf-components/addon/components/draft-registration-card/template.hbs
+++ b/lib/osf-components/addon/components/draft-registration-card/template.hbs
@@ -78,20 +78,17 @@
                         @route='registries.drafts.draft.review'
                         @models={{array this.draftRegistration.id}}
                     >
-                        <Button>
-                            {{t 'osf-components.draft-registration-card.review'}}
-                        </Button>
+                        {{t 'osf-components.draft-registration-card.review'}}
                     </OsfLink>
                     {{#unless this.draftRegistration.currentUserIsReadOnly}}
                         <OsfLink
                             data-test-draft-card-edit
+                            local-class='DraftRegistrationCard__review'
                             data-analytics-name='Edit'
                             @route='registries.drafts.draft'
                             @models={{array this.draftRegistration.id}}
                         >
-                            <Button local-class='DraftRegistrationCard__edit'>
-                                {{t 'general.edit'}}
-                            </Button>
+                            {{t 'general.edit'}}
                         </OsfLink>
                     {{/unless}}
                 </div>

--- a/lib/osf-components/addon/components/node-card/styles.scss
+++ b/lib/osf-components/addon/components/node-card/styles.scss
@@ -87,3 +87,13 @@
     overflow: hidden;
     white-space: nowrap;
 }
+
+.NodeCard__link {
+    composes: Button from '../button/styles.scss';
+    composes: SecondaryButton from '../button/styles.scss';
+    composes: MediumButton from '../button/styles.scss';
+
+    &:hover {
+        text-decoration: none !important; /* override OsfLink hover style */
+    }
+}

--- a/lib/osf-components/addon/components/node-card/template.hbs
+++ b/lib/osf-components/addon/components/node-card/template.hbs
@@ -168,30 +168,24 @@
             </dl>
             <div local-class='MyRegistrationsButtons'>
                 <OsfLink
+                    local-class='NodeCard__link'
                     data-analytics-name='View registration'
                     data-test-view-button='{{@node.id}}'
                     @route='resolve-guid'
                     @models={{array @node.id}}
                 >
-                    <Button
-                        local-class='RegistrationCard_view'
-                    >
-                        {{t 'node_card.view_button'}}
-                    </Button>
+                    {{t 'node_card.view_button'}}
                 </OsfLink>
                 {{#if this.latestSchemaResponse}}
                     {{#if this.shouldShowViewChangesButton}}
                         <OsfLink
+                            local-class='NodeCard__link'
                             data-analytics-name='View changes'
                             data-test-view-changes-button={{@node.id}}
                             @route='registries.edit-revision.review'
                             @models={{array this.latestSchemaResponse.id}}
                         >
-                            <Button
-                                {{!-- local-class='RegistrationCard_update' --}}
-                            >
-                                {{t 'node_card.view_changes_button'}}
-                            </Button>
+                            {{t 'node_card.view_changes_button'}}
                         </OsfLink>
                     {{/if}}
                 {{/if}}


### PR DESCRIPTION
-   Ticket: [ENG-3243]
-   Feature flag: n/a

## Purpose
- Simplify the HTML that is rendered for draft-registration card and node-cards to prevent weird artifacts when hovering, and also better tab-navigation UX

## Summary of Changes
- Un-nested some html that was causing issues when hovering these buttons/links, as well as causing tab-focus on these buttons/links to be caught twice
- style these links to look like `<Button>`s

## Screenshot(s)
Node Cards:
- This should no longer have a little line poking out of the right-side of the button when hovering the View button
- Before
  - ![image](https://user-images.githubusercontent.com/51409893/142290578-cfab385d-1913-4832-b8f3-255a1677bb34.png)

- After
  - ![image](https://user-images.githubusercontent.com/51409893/142289942-fce4606e-5b5d-45d8-be2f-95f93cfd2491.png)

Draft Registration Cards:
- This should look the exact same for mouse and keyboard, but should no longer focus in a weird way when users tab into focus
- Before
  - ![image](https://user-images.githubusercontent.com/51409893/142290801-34f0daa0-dcc5-4cd5-872a-de16b94d11d0.png)

- After
  - ![image](https://user-images.githubusercontent.com/51409893/142290006-3fa88676-0c7b-49fb-9d8a-2a9d26713ad0.png)



## Side Effects
- none
## QA Notes
- This should eliminate the little bit that pokes out on the `View` button of the node cards on the `Submitted` tab of MyRegistrations and `Registrations` tab of Project Registrations page
- This should also eliminate an extra tab-keypress that would happen for the `Review` and `Edit` buttons of the draft-registration cards on the `Drafts`/`Draft Registrations` tab


[ENG-3243]: https://openscience.atlassian.net/browse/ENG-3243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ