### PR TITLE
[ENG-3243] Delete button for Revisions and Draft Reg

### DIFF
--- a/app/models/registration.ts
+++ b/app/models/registration.ts
@@ -151,7 +151,7 @@ export default class RegistrationModel extends NodeModel.extend(Validations) {
     originalResponse!: AsyncBelongsTo<SchemaResponseModel> | SchemaResponseModel;
 
     @belongsTo('schema-response', { inverse: null })
-    latestResponse!: AsyncBelongsTo<SchemaResponseModel> | SchemaResponseModel;
+    latestResponse!: AsyncBelongsTo<SchemaResponseModel> | SchemaResponseModel; // Latest accepted response
 
     // Write-only relationships
     @belongsTo('draft-registration', { inverse: null })

--- a/app/packages/registration-schema/validations.ts
+++ b/app/packages/registration-schema/validations.ts
@@ -1,7 +1,7 @@
 import { assert } from '@ember/debug';
 import { set } from '@ember/object';
 import { ValidationObject, ValidatorFunction } from 'ember-changeset-validations';
-import { validateLength, validatePresence } from 'ember-changeset-validations/validators';
+import { validatePresence } from 'ember-changeset-validations/validators';
 import DraftNode from 'ember-osf-web/models/draft-node';
 import LicenseModel from 'ember-osf-web/models/license';
 
@@ -178,11 +178,5 @@ export function buildSchemaResponseValidations() {
         type: 'blank',
     })];
     set(validationObj, 'revisionJustification', notBlank);
-    set(validationObj, 'updatedResponseKeys', [validateLength({
-        min: 1,
-        allowBlank: false,
-        allowNone: false,
-        type: 'no_updated_responses',
-    })]);
     return validationObj;
 }

--- a/lib/registries/addon/drafts/draft/-components/right-nav/styles.scss
+++ b/lib/registries/addon/drafts/draft/-components/right-nav/styles.scss
@@ -1,6 +1,7 @@
 .NextButton,
 .ReviewButton,
-.BackButton {
+.BackButton,
+.DeleteButton {
     button {
         width: 100%;
     }

--- a/lib/registries/addon/drafts/draft/-components/right-nav/template.hbs
+++ b/lib/registries/addon/drafts/draft/-components/right-nav/template.hbs
@@ -79,3 +79,13 @@
         @date={{@draftManager.draftRegistration.datetimeUpdated}}
     />
 </span>
+
+{{#if @draftManager.currentUserIsAdmin}}
+    <DeleteButton
+        local-class='DeleteButton'
+        @delete={{perform @draftManager.deleteDraft}}
+        @modalTitle={{t 'registries.drafts.draft.delete_modal.title'}}
+        @modalBody={{t 'registries.drafts.draft.delete_modal.body'}}
+        @buttonLabel={{t 'registries.drafts.draft.delete_modal.button'}}
+    />
+{{/if}}

--- a/lib/registries/addon/drafts/draft/draft-registration-manager.ts
+++ b/lib/registries/addon/drafts/draft/draft-registration-manager.ts
@@ -203,6 +203,19 @@ export default class DraftRegistrationManager {
         }
     }
 
+    @task
+    @waitFor
+    async deleteDraft() {
+        try {
+            await this.draftRegistration.destroyRecord();
+            this.router.transitionTo('registries.my-registrations');
+        } catch (e) {
+            const errorMessage = this.intl.t('registries.drafts.draft.delete_modal.delete_error');
+            captureException(e, { errorMessage });
+            this.toast.error(getApiErrorMessage(e), errorMessage);
+        }
+    }
+
     @action
     onPageChange(currentPage: number) {
         if (this.hasVisitedPages) {

--- a/lib/registries/addon/edit-revision/-components/right-nav/styles.scss
+++ b/lib/registries/addon/edit-revision/-components/right-nav/styles.scss
@@ -1,6 +1,7 @@
 .NextButton,
 .ReviewButton,
-.BackButton {
+.BackButton,
+.DeleteButton {
     button {
         width: 100%;
     }

--- a/lib/registries/addon/edit-revision/-components/right-nav/template.hbs
+++ b/lib/registries/addon/edit-revision/-components/right-nav/template.hbs
@@ -78,3 +78,13 @@
         @date={{@revisionManager.revision.dateModified}}
     />
 </span>
+
+{{#if @revisionManager.showDeleteButton}}
+    <DeleteButton
+        local-class='DeleteButton'
+        @delete={{perform @onDelete}}
+        @modalTitle={{t 'registries.edit_revision.delete_modal.title'}}
+        @modalBody={{t 'registries.edit_revision.delete_modal.body'}}
+        @buttonLabel={{t 'registries.edit_revision.delete_modal.button'}}
+    />
+{{/if}}

--- a/lib/registries/addon/edit-revision/-components/right-nav/template.hbs
+++ b/lib/registries/addon/edit-revision/-components/right-nav/template.hbs
@@ -82,7 +82,7 @@
 {{#if @revisionManager.showDeleteButton}}
     <DeleteButton
         local-class='DeleteButton'
-        @delete={{perform @onDelete}}
+        @delete={{perform @revisionManager.deleteRevision}}
         @modalTitle={{t 'registries.edit_revision.delete_modal.title'}}
         @modalBody={{t 'registries.edit_revision.delete_modal.body'}}
         @buttonLabel={{t 'registries.edit_revision.delete_modal.button'}}

--- a/lib/registries/addon/edit-revision/controller.ts
+++ b/lib/registries/addon/edit-revision/controller.ts
@@ -1,14 +1,10 @@
 import Controller from '@ember/controller';
-import { assert } from '@ember/debug';
 import { alias, not } from '@ember/object/computed';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
-import { waitFor } from '@ember/test-waiters';
-import { task } from 'ember-concurrency';
 import IntlService from 'ember-intl/services/intl';
 import RegistrationModel from 'ember-osf-web/models/registration';
 import SchemaResponseModel from 'ember-osf-web/models/schema-response';
-import captureException, { getApiErrorMessage } from 'ember-osf-web/utils/capture-exception';
 import Media from 'ember-responsive';
 
 export default class EditRevisionController extends Controller {
@@ -21,19 +17,4 @@ export default class EditRevisionController extends Controller {
 
     @alias('model.revisionManager.revision') revision?: SchemaResponseModel;
     @alias('model.revisionManager.registration') registration?: RegistrationModel;
-
-    @task
-    @waitFor
-    async deleteRevision() {
-        assert('this.revision is required to delete a revision', this.revision);
-        assert('this.registration is required to redirect after deleting a revision', this.registration);
-        try {
-            await this.revision.destroyRecord();
-            this.router.transitionTo('registries.overview.index', this.registration.id);
-        } catch (e) {
-            const errorMessage = this.intl.t('registries.edit_revision.delete_modal.delete_error');
-            captureException(e, { errorMessage });
-            this.toast.error(getApiErrorMessage(e), errorMessage);
-        }
-    }
 }

--- a/lib/registries/addon/edit-revision/justification/styles.scss
+++ b/lib/registries/addon/edit-revision/justification/styles.scss
@@ -21,7 +21,3 @@
 .SchemaBlockLongText {
     composes: SchemaBlockLongText from '../../drafts/draft/metadata/styles.scss';
 }
-
-.RevisedResponses {
-    font-style: italic;
-}

--- a/lib/registries/addon/edit-revision/justification/template.hbs
+++ b/lib/registries/addon/edit-revision/justification/template.hbs
@@ -27,19 +27,6 @@
                         @uniqueID={{reasonFieldId}}
                     />
                 {{/let}}
-                {{#let (unique-id 'questions') as |questionsFieldId|}}
-                    <label for={{questionsFieldId}} id='questions'>
-                        <p local-class='DisplayText'>
-                            {{t 'registries.edit_revision.updatedResponseKeys'}}
-                            <span local-class='Required'>*</span>
-                        </p>
-                    </label>
-                    <Registries::RevisedResponsesList
-                        @revision={{this.revisionManager.revision}}
-                        @schemaBlocks={{this.revisionManager.schemaBlocks}}
-                        local-class='RevisedResponses'
-                    />
-                {{/let}}
             </FormControls>
         </form>
     </main>

--- a/lib/registries/addon/edit-revision/revision-manager.ts
+++ b/lib/registries/addon/edit-revision/revision-manager.ts
@@ -88,6 +88,11 @@ export default class RevisionManager {
         return this.revision?.reviewsState === RevisionReviewStates.RevisionInProgress;
     }
 
+    @computed('currentUserIsAdmin', 'isEditable')
+    get showDeleteButton() {
+        return this.currentUserIsAdmin && this.isEditable;
+    }
+
     @computed('revision.reviewsState')
     get isPendingAdminApproval() {
         return this.revision.reviewsState === RevisionReviewStates.Unapproved;

--- a/lib/registries/addon/edit-revision/route.ts
+++ b/lib/registries/addon/edit-revision/route.ts
@@ -1,3 +1,4 @@
+import { getOwner } from '@ember/application';
 import Store from '@ember-data/store';
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
@@ -53,7 +54,7 @@ export default class EditRevisionRoute extends Route {
     model(params: { revisionId: string }) {
         const { revisionId } = params;
         const loadModelsTask = taskFor(this.loadModels).perform(revisionId) as LoadModelsTask;
-        const revisionManager = new RevisionManager(loadModelsTask, revisionId);
+        const revisionManager = new RevisionManager(getOwner(this), loadModelsTask, revisionId);
         const navigationManager = new RevisionNavigationManager(revisionManager);
         return {
             navigationManager,

--- a/lib/registries/addon/edit-revision/template.hbs
+++ b/lib/registries/addon/edit-revision/template.hbs
@@ -76,18 +76,6 @@
                         @label='{{t 'registries.drafts.draft.review.page_label'}}'
                         @navMode={{leftNav.leftGutterMode}}
                     />
-                    <leftNav.link
-                        @icon='trash-alt'
-                        as |link|
-                    >
-                        <link.icon />
-                        <DeleteButton
-                            @delete={{perform this.deleteRevision}}
-                            @modalTitle={{t 'registries.edit_revision.delete_modal.title'}}
-                            @modalBody={{t 'registries.edit_revision.delete_modal.body'}}
-                            @buttonLabel={{t 'registries.edit_revision.delete_modal.button'}}
-                        />
-                    </leftNav.link>
                 </layout.leftNav>
                 <layout.main local-class='Main'>
                     {{outlet}}
@@ -97,6 +85,7 @@
                         <div local-class='RightWrapper'>
                             <div local-class='RightNavWrapper'>
                                 <EditRevision::-Components::RightNav
+                                    @onDelete={{this.deleteRevision}}
                                     @revisionManager={{revisionManager}}
                                     @navManager={{navManager}}
                                 />

--- a/lib/registries/addon/edit-revision/template.hbs
+++ b/lib/registries/addon/edit-revision/template.hbs
@@ -85,7 +85,6 @@
                         <div local-class='RightWrapper'>
                             <div local-class='RightNavWrapper'>
                                 <EditRevision::-Components::RightNav
-                                    @onDelete={{this.deleteRevision}}
                                     @revisionManager={{revisionManager}}
                                     @navManager={{navManager}}
                                 />

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -136,7 +136,7 @@ export default function(this: Server) {
     });
 
     osfResource(this, 'draft-registration', {
-        only: ['index', 'show', 'update'],
+        only: ['index', 'show', 'update', 'delete'],
         path: '/draft_registrations',
     });
     this.post('/draft_registrations', createDraftRegistration);

--- a/tests/engines/registries/acceptance/draft/draft-test.ts
+++ b/tests/engines/registries/acceptance/draft/draft-test.ts
@@ -184,11 +184,12 @@ module('Registries | Acceptance | draft form', hooks => {
             },
         );
 
-        await visit(`/registries/drafts/${registration.id}/99/`);
+        await visit(`/registries/drafts/${registration.id}/`);
 
-        assert.equal(currentRouteName(), 'registries.page-not-found', 'At page not found');
+        assert.equal(currentRouteName(), 'registries.drafts.draft.metadata', 'On metadata page');
         await click('[data-test-delete-button]');
-        assert.equal(currentRouteName(), 'registries.my-registrations', 'At the expected route');
+        await click('[data-test-confirm-delete]');
+        assert.equal(currentRouteName(), 'registries.my-registrations', 'Reroutes to my-registrations');
     });
 
     test('left nav controls', async function(this: DraftFormTestContext, assert) {

--- a/tests/engines/registries/acceptance/draft/draft-test.ts
+++ b/tests/engines/registries/acceptance/draft/draft-test.ts
@@ -115,6 +115,7 @@ module('Registries | Acceptance | draft form', hooks => {
         assert.dom('[data-test-goto-register]').doesNotExist('RightNav: Register button not shown');
         assert.dom('[data-test-nonadmin-warning-text]').exists('RightNav: Warning non-admins cannot register shown');
         assert.dom('[data-test-goto-previous-page]').doesNotExist('RightNav: Back button not shown');
+        assert.dom('[data-test-delete-button]').doesNotExist('RightNav: Delete button not shown');
 
         // check metadata and form renderer
         assert.dom('[data-test-edit-button]').doesNotExist('MetadataRenderer: Edit button not shown');
@@ -168,6 +169,26 @@ module('Registries | Acceptance | draft form', hooks => {
         await visit(`/registries/drafts/${registration.id}/99/`);
 
         assert.equal(currentRouteName(), 'registries.page-not-found', 'At page not found');
+    });
+
+    test('delete draft', async function(
+        this: DraftFormTestContext, assert,
+    ) {
+        const initiator = server.create('user', 'loggedIn');
+        const registrationSchema = server.schema.registrationSchemas.find('testSchema');
+        const registration = server.create(
+            'draft-registration', {
+                registrationSchema,
+                initiator,
+                branchedFrom: this.branchedFrom,
+            },
+        );
+
+        await visit(`/registries/drafts/${registration.id}/99/`);
+
+        assert.equal(currentRouteName(), 'registries.page-not-found', 'At page not found');
+        await click('[data-test-delete-button]');
+        assert.equal(currentRouteName(), 'registries.my-registrations', 'At the expected route');
     });
 
     test('left nav controls', async function(this: DraftFormTestContext, assert) {

--- a/tests/engines/registries/acceptance/edit-revision/revision-test.ts
+++ b/tests/engines/registries/acceptance/edit-revision/revision-test.ts
@@ -172,6 +172,7 @@ module('Registries | Acceptance | registries revision', hooks => {
         await visit(`/registries/revisions/${revision.id}/`);
         assert.equal(currentRouteName(), 'registries.edit-revision.justification', 'At the expected route');
         await click('[data-test-delete-button]');
+        await click('[data-test-confirm-delete]');
         assert.equal(currentRouteName(), 'registries.overview.index', 'At the expected route');
     });
 
@@ -443,7 +444,6 @@ module('Registries | Acceptance | registries revision', hooks => {
         assert.dom('[data-test-invalid-responses-text]').isVisible('Invalid response text shown');
 
         assert.dom('[data-test-validation-errors="revisionJustification"]').exists('justification invalid');
-        assert.dom('[data-test-validation-errors="updatedResponseKeys"]').exists('revised responses invalid');
         assert.dom(`[data-test-validation-errors="${deserializeResponseKey('page-one_short-text')}"]`)
             .exists('short text invalid');
         assert.dom(`[data-test-validation-errors="${deserializeResponseKey('page-one_long-text')}"]`)
@@ -467,7 +467,6 @@ module('Registries | Acceptance | registries revision', hooks => {
         await click('[data-test-link="justification"]');
         await fillIn('textarea[name="revisionJustification"]', 'Tell the world that ditto is the best');
         assert.dom('[data-test-validation-errors="revisionJustification"]').doesNotExist('justification valid');
-        assert.dom('[data-test-revised-responses-list]').exists({ count: 1 }, 'revised responses list shown');
 
         // check the review page to see if text is valid again
         await click('[data-test-link="review"]');

--- a/tests/engines/registries/acceptance/edit-revision/revision-test.ts
+++ b/tests/engines/registries/acceptance/edit-revision/revision-test.ts
@@ -126,6 +126,7 @@ module('Registries | Acceptance | registries revision', hooks => {
         assert.dom('[data-test-submit-revision]').doesNotExist('RightNav: Register button not shown');
         assert.dom('[data-test-nonadmin-warning-text]').exists('RightNav: Warning non-admins cannot register shown');
         assert.dom('[data-test-goto-previous-page]').doesNotExist('RightNav: Back button not shown');
+        assert.dom('[data-test-delete-button]').doesNotExist('RightNav: Delete button not shown');
 
         // check form renderer
         await percySnapshot('Read-only Revision Review page: Desktop');
@@ -156,6 +157,22 @@ module('Registries | Acceptance | registries revision', hooks => {
         );
         await visit(`/registries/revisions/${revision.id}/`);
         assert.equal(currentRouteName(), 'registries.edit-revision.justification', 'At the expected route');
+    });
+
+    test('delete revision in progress', async function(this: RevisionTestContext, assert) {
+        const initiatedBy = server.create('user', 'loggedIn');
+        const revision = server.create(
+            'schema-response',
+            {
+                initiatedBy,
+                revisionResponses: {},
+                registration: this.registration,
+            },
+        );
+        await visit(`/registries/revisions/${revision.id}/`);
+        assert.equal(currentRouteName(), 'registries.edit-revision.justification', 'At the expected route');
+        await click('[data-test-delete-button]');
+        assert.equal(currentRouteName(), 'registries.overview.index', 'At the expected route');
     });
 
     test('left nav controls', async function(this: RevisionTestContext, assert) {

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1216,9 +1216,9 @@ registries:
             reason: 'What additional changes need to be made and why?'
             submit: 'Submit'
         delete_modal:
-            title: 'Delete this update'
-            body: 'Are you sure to delete this update?'
-            button: 'Cancel update'
+            title: 'Delete this draft update'
+            body: 'Are you sure you want to delete this draft update?'
+            button: 'Delete Draft Update'
             delete_error: 'Unable to delete update'
     index:
         lead: 'The <span class="f-w-lg">open</span> registries network'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1188,6 +1188,11 @@ registries:
             register: Register
             unable_to_fetch_children_count: 'Unable to fetch project''s components'
             submit_error: 'Unable to create a registration.'
+            delete_modal:
+                title: 'Delete this draft registration'
+                body: 'Are you sure you want to delete this draft registration?'
+                button: 'Delete Draft'
+                delete_error: 'Unable to delete draft registration'
     edit_revision:
         revisionJustification: 'Justification for update'
         updatedResponseKeys: 'List of updated registration questions'


### PR DESCRIPTION
-   Ticket: [ENG-3243]
-   Feature flag: n/a

## Purpose
- Move the Delete Revision button in the edit revision workflow
- Remove Updated responses list from the Justification page of the edit-revision workflow
- Add Delete Draft button to the draft registration workflow

## Summary of Changes


## Screenshot(s)
- Draft Registration workflow:
  - ![image](https://user-images.githubusercontent.com/51409893/142509754-0a096e3d-7e98-4079-be45-56d0ac49af09.png)

- Revision workflow:
  - ![image](https://user-images.githubusercontent.com/51409893/142509828-8f2287d8-97c8-4e8b-984b-142b44b04f63.png)


## Side Effects
- None

## QA Notes
- We will no longer validate whether or not responses have been updated on the FE. When submitting an update, the backend should validate that, and if there are no updated responses, the revision shouldn't be able to be submitted

[ENG-3243]: https://openscience.atlassian.net/browse/ENG-3243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ