### PR TITLE
[ENG-3406] Fix contrast issues on registries discover page

### DIFF
--- a/lib/registries/addon/components/registries-search-result/styles.scss
+++ b/lib/registries/addon/components/registries-search-result/styles.scss
@@ -2,6 +2,10 @@
 h3.RegistriesSearchResult__Title {
     line-height: inherit;
     margin-top: 10px;
+
+    :global(.label-default) {
+        background-color: $color-bg-gray-darker;
+    }
 }
 
 .RegistriesSearchResult__Sources {

--- a/lib/registries/addon/discover/template.hbs
+++ b/lib/registries/addon/discover/template.hbs
@@ -73,7 +73,7 @@
 
             {{#unless this.totalResults}}
                 <div class='col-sm-8 col-xs-12'>
-                    <div class='text-center text-muted'>
+                    <div class='text-center'>
                         <p data-test-no-results-placeholder class='lead'>
                             {{t 'registries.discover.no_results'}}
                         </p>
@@ -93,7 +93,7 @@
             {{/if}}
         {{else if this.doSearch.isError}}
             <div class='col-sm-8 col-xs-12'>
-                <div class='text-center text-muted'>
+                <div class='text-center'>
                     <p class='lead'>
                         {{t 'registries.discover.error_loading'}}
                     </p>

--- a/mirage/scenarios/registrations.ts
+++ b/mirage/scenarios/registrations.ts
@@ -293,6 +293,7 @@ export function registrationScenario(
     const wdrwn = server.create('registration', {
         id: 'wdrwn',
         title: 'Withdrawn Hermit',
+        withdrawn: true,
         registrationSchema: server.schema.registrationSchemas.find('testSchema'),
         provider: egap,
         reviewsState: RegistrationReviewStates.Withdrawn,


### PR DESCRIPTION
-   Ticket: [ENG-3406](https://openscience.atlassian.net/browse/ENG-3406)
-   Feature flag: n/a

## Purpose

Fix the contrast issues on the registries discover page

## Summary of Changes

1. Fix the mirage scenario for the withdrawn registration to show it as being withdrawn on the search page
2. Darken the 'Withdrawn' tag
3. Un-mute the 'no results found' text (and also the 'cannot load results' text, while I was in there)

## Screenshot(s)

<img width="743" alt="Screen Shot 2021-11-22 at 9 26 42 AM" src="https://user-images.githubusercontent.com/6599111/142879011-7cb8465f-aa7a-4d9c-8bab-b39fbf84b822.png">

<img width="720" alt="Screen Shot 2021-11-22 at 9 27 26 AM" src="https://user-images.githubusercontent.com/6599111/142879031-c7b76b50-a252-4d41-b610-21e9c9508a54.png">

## Side Effects

No

## QA Notes

Just needs accessibility testing
