### PR TITLE
[ENG-3410] Add main landmark to project.registrations page

### DIFF
--- a/app/guid-node/template.hbs
+++ b/app/guid-node/template.hbs
@@ -3,7 +3,7 @@
         @node={{this.model.taskInstance.value}}
     />
 {{/unless}}
-<div data-analytics-scope='Node'>
+<div data-analytics-scope='Node' role='main'>
     {{outlet}}
 </div>
 <JoinOsfBanner />


### PR DESCRIPTION
-   Ticket: [ENG-3410](https://openscience.atlassian.net/browse/ENG-3410)
-   Feature flag: n/a

## Purpose

Add a 'main' landmark to the project.registrations page

## Summary of Changes

1. Add the main landmark

## Side Effects

No, unless there's somehow already a main landmark in there under some circumstances.

## QA Notes

My A11y tool did not pick up on the lack of a main landmark. Also, I couldn't find one even if there were a registration card on the page. So I don't think I broke anything with this, but I can't verify for sure. As near as I can tell, there's only one main landmark, so it shooould be fine.
