### PR TITLE
[ENG-3414][ENG-3415] Fix a11y with draft registration metadata subjects placeholder

### DIFF
--- a/lib/osf-components/addon/components/subjects/display/styles.scss
+++ b/lib/osf-components/addon/components/subjects/display/styles.scss
@@ -23,7 +23,7 @@
     border: 1px dotted $color-border-gray-light;
     padding: 4px 8px;
     font-style: italic;
-    color: $color-text-gray-dark;
+    color: $color-text-black;
 }
 
 .RemoveButton.RemoveButton {

--- a/lib/osf-components/addon/components/subjects/display/template.hbs
+++ b/lib/osf-components/addon/components/subjects/display/template.hbs
@@ -21,9 +21,9 @@
                 {{/if}}
             </li>
         {{else}}
-            <span data-test-selected-subject-placeholder local-class='Placeholder'>
+            <li data-test-selected-subject-placeholder local-class='Placeholder'>
                 {{t 'osf-components.subjects.display.placeholder'}}
-            </span>
+            </li>
         {{/each}}
     </ul>
 {{/if}}


### PR DESCRIPTION
-   Tickets: 
[ENG-3414](https://openscience.atlassian.net/browse/ENG-3414)
[ENG-3415](https://openscience.atlassian.net/browse/ENG-3415)
-   Feature flag: n/a

## Purpose

Fix accessibility problems with draft registration metadata page's subjects placeholder.

## Summary of Changes

1. Increase contrast
2. Use `li` inside of the `ul`

## Screenshot(s)

<img width="595" alt="Screen Shot 2021-11-22 at 11 24 52 AM" src="https://user-images.githubusercontent.com/6599111/142915702-c542cc2a-6f6d-4147-b19d-ce4a8476bc42.png">


## Side Effects

No

## QA Notes

Should just need accessibility testing