### PR TITLE
[No ticket][Hotfix] Update collection header width for desktop

### DIFF
--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -868,7 +868,7 @@ app_components:
         click_to_edit: 'Click to edit'
 collections:
     general:
-        brand: '{name} Collection'
+        brand: '{name}'
     navbar:
         add: 'Add to Collection'
     index:


### PR DESCRIPTION
-   Ticket: [None]
-   Feature flag: n/a

## Purpose
- prevent text  overlap on collections discover page for desktop (993px-1200px)
<!-- Describe the purpose of your changes. -->

## Summary of Changes
- Remove "Collection" at the end of the title on navbar
- I didn't refactor the translation key usage as to leave it refactorable in case future changes are requested. Also it's a little bit more work for this hotfix...
<!-- Briefly describe or list your changes. -->

## Screenshot(s)
- before:
  - ![image](https://user-images.githubusercontent.com/51409893/142915466-ffe9b69a-7382-43d1-8b01-f8723870ebc8.png)
- After:
  - ![image](https://user-images.githubusercontent.com/51409893/142920645-7baf7e4c-c293-4ad8-8852-9b87ea80bd1e.png)


## Side Effects
- forbidden and page not found error pages will no longer contain the trailing "Collection" as well

## QA Notes
This should only effect window sizes between 993px and 1200px.
There is still some overlap that happens for 993px - 1020px or so, but it's a lot less bad?
This is to address the issue found in https://test.osf.io/collections/rpcb/discover