### PR TITLE
[ENG-3243][ENG-3417] Revisions bugfixes

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -31,7 +31,7 @@ $brand-warning: #f0ad4e !default;
 $brand-danger: #d9534f;
 
 /* overrides with darkened colors for a11y contrast */
-$brand-success: darken($brand-success, 10%);
+$brand-success: darken($brand-success, 20%);
 $brand-info: darken($brand-info, 15%);
 // no override needed for brand-warning (will use dark text instead)
 $brand-danger: darken($brand-danger, 15%);

--- a/lib/osf-components/addon/components/delete-button/template.hbs
+++ b/lib/osf-components/addon/components/delete-button/template.hbs
@@ -43,11 +43,11 @@
         @onHide={{action this._cancel}}
         as |modal|
     >
-        <modal.header>
+        <modal.header data-test-delete-modal-header>
             <h3 local-class='Modal__title'>{{this.modalTitle}}</h3>
         </modal.header>
 
-        <modal.body data-analytics-scope='Delete button modal'>
+        <modal.body data-test-delete-modal-body data-analytics-scope='Delete button modal'>
             {{#if (has-block)}}
                 {{yield}}
             {{else}}
@@ -68,7 +68,7 @@
             {{/if}}
         </modal.body>
 
-        <modal.footer data-analytics-scope='Delete button modal footer'>
+        <modal.footer data-test-delete-modal-footer data-analytics-scope='Delete button modal footer'>
             <BsButton
                 data-analytics-name='Hard confirm cancel'
                 data-test-cancel-delete

--- a/lib/osf-components/addon/components/node-card/template.hbs
+++ b/lib/osf-components/addon/components/node-card/template.hbs
@@ -42,7 +42,7 @@
                 {{else if (eq @node.revisionState 'in_progress')}}
                     <span class='label label-info'>{{t 'node_card.registration.statuses.revision_in_progress'}}</span> |
                 {{else if (eq @node.revisionState 'pending_moderation')}}
-                    {{#if (not-eq @node.reviewsState 'pending_moderation')}}
+                    {{#if (not-eq @node.reviewsState 'pending')}}
                         <span class='label label-info'>{{t 'node_card.registration.statuses.revision_pending_moderation'}}</span> |
                     {{/if}}
                 {{/if}}

--- a/lib/osf-components/addon/components/registries/update-dropdown/component.ts
+++ b/lib/osf-components/addon/components/registries/update-dropdown/component.ts
@@ -93,6 +93,13 @@ export default class UpdateDropdown extends Component<Args> {
         this.showModal = false;
     }
 
+    @action
+    onRevisionSelect(callback: () => void) {
+        this.router.on('routeDidChange', () => {
+            callback();
+        });
+    }
+
     @task
     @waitFor
     async getRevisionList() {

--- a/lib/osf-components/addon/components/registries/update-dropdown/list-item/template.hbs
+++ b/lib/osf-components/addon/components/registries/update-dropdown/list-item/template.hbs
@@ -1,7 +1,12 @@
 {{#if this.shouldShow}}
     <div data-test-revision-link={{@index}} local-class='UpdateContainer'>
         {{!-- Using LinkTo instead of OsfLink due to how queryParams are buggy for setting active state --}}
-        <LinkTo @route='overview.index' @query={{hash revisionId=@revision.id}} local-class='UpdateLink'>
+        <LinkTo
+            local-class='UpdateLink'
+            {{on 'click' @onRevisionSelect}}
+            @route='overview.index'
+            @query={{hash revisionId=@revision.id}}
+        >
             <Registries::UpdateDropdown::UpdateLabel
                 @totalRevisions={{@totalRevisions}}
                 @index={{@index}}

--- a/lib/osf-components/addon/components/registries/update-dropdown/template.hbs
+++ b/lib/osf-components/addon/components/registries/update-dropdown/template.hbs
@@ -27,6 +27,7 @@
             {{#if this.revisions}}
                 {{#each this.revisions as |revision index|}}
                     <Registries::UpdateDropdown::ListItem
+                        @onRevisionSelect={{action this.onRevisionSelect dd.close}}
                         @revision={{revision}}
                         @isModeratorMode={{@isModeratorMode}}
                         @totalRevisions={{this.totalRevisions}}

--- a/tests/integration/components/delete-button/component-test.ts
+++ b/tests/integration/components/delete-button/component-test.ts
@@ -1,0 +1,27 @@
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Component | delete-button', hooks => {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function(assert) {
+        await render(hbs`
+        <DeleteButton
+            @buttonLabel='Button here!'
+            @modalTitle='Head'
+            @modalBody='Shoulders'
+            @cancelButtonText='Knees'
+            @confirmButtonText='Toes'
+        />
+        `);
+        assert.dom('[data-test-delete-button]').hasText('Button here!');
+        await click('[data-test-delete-button]');
+        assert.dom('[data-test-delete-modal-header]').containsText('Head');
+        assert.dom('[data-test-delete-modal-body]').hasText('Shoulders');
+        assert.dom('[data-test-cancel-delete]').hasText('Knees');
+        assert.dom('[data-test-confirm-delete]').hasText('Toes');
+        await click('[data-test-confirm-delete]');
+    });
+});

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -601,7 +601,7 @@ node_card:
     options: Options
     view_button: 'View'
     update_button: 'Update'
-    view_changes_button: 'View changes'
+    view_changes_button: 'Continue update'
     schema_response_error: 'Updates irretreivable.'
     
 forks:
@@ -1608,7 +1608,7 @@ registries:
         modalBodyFirst: 'Updates to registration responses can be updated by clicking “Next”.<br>Edits to metadata including Description, Category, License, Publication DOI, and Tags are done on the registration by clicking the '
         modalBodySecond: ' icon.'
         modalBodyNoUpdates: 'The {registryName} does not allow updates for this registration template.<br>Contact their registy if you have any questions.'
-        learnMore: 'Click <a href="https://help.osf.io/hc/en-us/articles/360035806634-Edit-Registration-Metadata" target="_blank">here</a>  to learn more'
+        learnMore: 'Click <a href="https://help.osf.io/hc/en-us/articles/360035806634-Edit-Registration-Metadata" target="_blank">here</a>  to learn more.'
         next: Next
         cancel_update: 'Cancel update'
 meetings:

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -581,7 +581,7 @@ node_card:
         statuses:
             revision_pending_moderation: 'Update pending moderation'
             revision_in_progress: 'Update in progress'
-            revision_unapproved: 'Update pending unapproved'
+            revision_unapproved: 'Update pending approval'
             pending_registration_approval: 'Pending registration approval'
             pending_embargo_approval: 'Pending embargo'
             pending: 'Pending moderation'


### PR DESCRIPTION
-   Ticket: [ENG-3243] [ENG-3417]
-   Feature flag: n/a

## Purpose
- Address various bugs found in Revisions workflow

## Summary of Changes
- Darken color contrast for create buttons (3.41 -> 5.33 : 1, passes AA)
- Small wording changes
- Auto-close the dropdown when selecting a revision on the overview page
- Add data-test selectors to delete button modal for automated testing

## Screenshot(s)

## Side Effects
- All create buttons will have better color contrast!

## QA Notes


[ENG-3243]: https://openscience.atlassian.net/browse/ENG-3243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ENG-3417]: https://openscience.atlassian.net/browse/ENG-3417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ