### PR TITLE
Additional tweaks for Revision workflow

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -31,7 +31,7 @@ $brand-warning: #f0ad4e !default;
 $brand-danger: #d9534f;
 
 /* overrides with darkened colors for a11y contrast */
-$brand-success: darken($brand-success, 20%);
+$brand-success: darken($brand-success, 10%);
 $brand-info: darken($brand-info, 15%);
 // no override needed for brand-warning (will use dark text instead)
 $brand-danger: darken($brand-danger, 15%);

--- a/lib/osf-components/addon/components/button/styles.scss
+++ b/lib/osf-components/addon/components/button/styles.scss
@@ -59,11 +59,11 @@
 }
 
 .CreateButton {
-    background-color: $brand-success;
+    background-color: darken($brand-success, 10%);
     color: $color-text-white;
 
     &:hover:not([disabled]) {
-        background-color: darken($brand-success, 15%);
+        background-color: darken($brand-success, 25%);
     }
 }
 

--- a/lib/registries/addon/edit-revision/-components/submit-and-decide/component.ts
+++ b/lib/registries/addon/edit-revision/-components/submit-and-decide/component.ts
@@ -58,7 +58,11 @@ export default class SubmitAndDecide extends Component {
             });
             await schemaResponseAction.save();
             await this.revisionManager.revision.reload();
-            this.toast.success(this.intl.t('registries.edit_revision.review.action_submit_success'));
+            let successMessage = this.intl.t('registries.edit_revision.review.action_submit_success');
+            if (actionTrigger === SchemaResponseActionTrigger.SubmitRevision) {
+                successMessage = this.intl.t('registries.edit_revision.review.submit_success');
+            }
+            this.toast.success(successMessage);
         } catch (e) {
             const errorMessage = this.intl.t('registries.edit_revision.review.action_submit_failed');
             captureException(e, { errorMessage });

--- a/tests/engines/registries/acceptance/edit-revision/revision-test.ts
+++ b/tests/engines/registries/acceptance/edit-revision/revision-test.ts
@@ -499,7 +499,7 @@ module('Registries | Acceptance | registries revision', hooks => {
         await visit(`/registries/revisions/${revision.id}/review`);
         await click('[data-test-submit-revision]');
         assert.dom('#toast-container', document as any).hasTextContaining(t(
-            'registries.edit_revision.review.action_submit_success',
+            'registries.edit_revision.review.submit_success',
         ), 'Toast message shown after initial submit');
         assert.dom('[data-test-submit-revision]').doesNotExist('Submit button no longer shown');
         assert.dom('[data-test-goto-previous-page]').doesNotExist('There is no turning back from this');

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1211,6 +1211,7 @@ registries:
             decision_recorded_notice: 'Decision recorded. Pending decisions from other Admin contributors.'
             pending_admin_notice: 'Pending decisions from admin(s).'
             pending_moderation_notice: 'Pending decisions from moderators.'
+            submit_success: 'Submitted for Admin approval'
             action_submit_success: 'Your decision was recorded'
             action_submit_failed: 'Your decision was not recorded'
             non_admin_warning: 'Only admins can submit an update.'


### PR DESCRIPTION
-   Ticket: [ENG-3243]
-   Feature flag: n/a

## Purpose
- Redo accessiblity fix for color contrast that was darkening <BsButtons> unexpectedly
- wording change

## Summary of Changes
- Undo change in _variables.scss that was changing `<BsButton @type='success'>`
- wording change for revisions being submitted for admin review

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-3243]: https://openscience.atlassian.net/browse/ENG-3243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ