### PR TITLE
[ENG-3423] Version metadata updates

### DIFF
--- a/lib/osf-components/addon/components/node-card/component.ts
+++ b/lib/osf-components/addon/components/node-card/component.ts
@@ -87,7 +87,7 @@ export default class NodeCard extends Component {
     }
 
     get shouldShowUpdateButton() {
-        if (this.node instanceof RegistrationModel) {
+        if (this.node instanceof RegistrationModel && this.node.userHasAdminPermission) {
             return this.node.revisionState === RevisionReviewStates.Approved &&
                 (
                     this.node.reviewsState === RegistrationReviewStates.Accepted ||

--- a/lib/osf-components/addon/components/registries/overview-form-renderer/component.ts
+++ b/lib/osf-components/addon/components/registries/overview-form-renderer/component.ts
@@ -1,5 +1,6 @@
 import { assert } from '@ember/debug';
 import Store from '@ember-data/store';
+import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
@@ -31,6 +32,11 @@ export default class RegistrationFormViewSchemaBlocks extends Component {
     schemaBlocks?: SchemaBlock[];
     schemaBlockGroups?: SchemaBlockGroup[];
     responses?: { [key: string]: string };
+
+    @computed('registration.latestResponse.isOriginal')
+    get showMetadata() {
+        return !this.registration.latestResponse.get('isOriginalResponse');
+    }
 
     @restartableTask({ on: 'didReceiveAttrs' })
     @waitFor

--- a/lib/osf-components/addon/components/registries/overview-form-renderer/component.ts
+++ b/lib/osf-components/addon/components/registries/overview-form-renderer/component.ts
@@ -1,6 +1,5 @@
 import { assert } from '@ember/debug';
 import Store from '@ember-data/store';
-import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
@@ -33,7 +32,6 @@ export default class RegistrationFormViewSchemaBlocks extends Component {
     schemaBlockGroups?: SchemaBlockGroup[];
     responses?: { [key: string]: string };
 
-    @computed('registration.latestResponse.isOriginal')
     get showMetadata() {
         return !this.registration.latestResponse.get('isOriginalResponse');
     }

--- a/lib/osf-components/addon/components/registries/overview-form-renderer/component.ts
+++ b/lib/osf-components/addon/components/registries/overview-form-renderer/component.ts
@@ -33,7 +33,7 @@ export default class RegistrationFormViewSchemaBlocks extends Component {
     responses?: { [key: string]: string };
 
     get showMetadata() {
-        return !this.registration.latestResponse.get('isOriginalResponse');
+        return this.registration.latestResponse.content && !this.registration.latestResponse.get('isOriginalResponse');
     }
 
     @restartableTask({ on: 'didReceiveAttrs' })

--- a/lib/osf-components/addon/components/registries/overview-form-renderer/template.hbs
+++ b/lib/osf-components/addon/components/registries/overview-form-renderer/template.hbs
@@ -1,7 +1,7 @@
 {{#if this.fetchSchemaBlocks.isRunning}}
     <LoadingIndicator @dark={{true}}/>
 {{else}}
-    {{#if (gt this.registration.schemaResponses.length 1)}}
+    {{#if this.showMetadata}}
         <Registries::VersionMetadata @revision={{@revision}} />
     {{/if}}
     <Registries::RegistrationFormNavigationDropdown

--- a/lib/osf-components/addon/components/registries/registration-list/manager/component.ts
+++ b/lib/osf-components/addon/components/registries/registration-list/manager/component.ts
@@ -21,7 +21,7 @@ export default class RegistrationListManager extends Component {
         }
         if (this.state === RevisionReviewStates.RevisionPendingModeration) {
             filter.revision_state = [RevisionReviewStates.RevisionPendingModeration].toString();
-            filter.reviews_state = undefined;
+            filter.reviews_state = [RegistrationReviewStates.Embargo, RegistrationReviewStates.Accepted].toString();
         }
         const query: Record<string, string | Record<string, string | undefined>> = {
             filter,

--- a/lib/osf-components/addon/components/registries/registration-list/manager/component.ts
+++ b/lib/osf-components/addon/components/registries/registration-list/manager/component.ts
@@ -17,11 +17,11 @@ export default class RegistrationListManager extends Component {
         const filter: Record<string, string | undefined> = { reviews_state: this.state, revision_state: undefined };
         if (this.state === RegistrationReviewStates.Embargo) {
             filter.reviews_state =
-                [RegistrationReviewStates.Embargo, RegistrationReviewStates.PendingEmbargoTermination].toString();
+                [RegistrationReviewStates.Embargo, RegistrationReviewStates.PendingEmbargoTermination].join();
         }
         if (this.state === RevisionReviewStates.RevisionPendingModeration) {
-            filter.revision_state = [RevisionReviewStates.RevisionPendingModeration].toString();
-            filter.reviews_state = [RegistrationReviewStates.Embargo, RegistrationReviewStates.Accepted].toString();
+            filter.revision_state = [RevisionReviewStates.RevisionPendingModeration].join();
+            filter.reviews_state = [RegistrationReviewStates.Embargo, RegistrationReviewStates.Accepted].join();
         }
         const query: Record<string, string | Record<string, string | undefined>> = {
             filter,

--- a/lib/registries/addon/overview/-components/diff-manager/component.ts
+++ b/lib/registries/addon/overview/-components/diff-manager/component.ts
@@ -53,7 +53,6 @@ export default class DiffManager extends Component<Args> {
         } else {
             this.baseRevision = await registration.originalResponse;
         }
-        const revisions = await registration.queryHasMany('schemaResponses');
         if (headRevisionId) {
             let headRevision = this.store.peekRecord('schema-response', headRevisionId);
             if (!headRevision) {
@@ -61,7 +60,7 @@ export default class DiffManager extends Component<Args> {
             }
             this.headRevision = headRevision;
         } else {
-            this.headRevision = revisions.firstObject;
+            this.headRevision = await registration.latestResponse;
         }
         this.getDiff();
     }

--- a/lib/registries/addon/overview/-components/diff-manager/component.ts
+++ b/lib/registries/addon/overview/-components/diff-manager/component.ts
@@ -61,6 +61,9 @@ export default class DiffManager extends Component<Args> {
             this.headRevision = headRevision;
         } else {
             this.headRevision = await registration.latestResponse;
+            if (!this.headRevision) {
+                this.headRevision = await registration.originalResponse;
+            }
         }
         this.getDiff();
     }

--- a/mirage/factories/registration.ts
+++ b/mirage/factories/registration.ts
@@ -153,6 +153,7 @@ export default NodeFactory.extend<MirageRegistration & RegistrationTraits>({
             revisionResponses: newReg.registrationResponses,
         });
         newReg.update({ originalResponse: baseResponse });
+        newReg.update({ latestResponse: baseResponse });
     },
 
     dateRegistered() {

--- a/mirage/serializers/registration.ts
+++ b/mirage/serializers/registration.ts
@@ -274,7 +274,7 @@ export default class RegistrationSerializer extends ApplicationSerializer<Mirage
         }
         if (model.attrs.latestResponseId !== null) {
             const { latestResponseId } = model.attrs;
-            relationships.originalResponse = {
+            relationships.latestResponse = {
                 data: {
                     id: latestResponseId as string,
                     type: 'schema-responses',

--- a/mirage/views/registration.ts
+++ b/mirage/views/registration.ts
@@ -93,6 +93,7 @@ export function createRegistration(this: HandlerContext, schema: Schema) {
         registration: newReg, reviewsState: RevisionReviewStates.Unapproved,
     });
     newReg.update({ originalResponse: baseResponse });
+    newReg.update({ latestResponse: baseResponse });
     return newReg;
 }
 

--- a/tests/integration/components/node-card/component-test.ts
+++ b/tests/integration/components/node-card/component-test.ts
@@ -25,7 +25,7 @@ module('Integration | Component | node-card', hooks => {
             tags: ['a', 'b', 'c'],
             description: 'Through the night',
             revisionState: RevisionReviewStates.Approved,
-        });
+        }, 'currentUserAdmin');
         server.create('contributor', { node: registration, index: 0, bibliographic: true });
         server.create('contributor', { node: registration, index: 1, bibliographic: true });
         server.create('contributor', { node: registration, index: 2, bibliographic: true });

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1608,7 +1608,7 @@ registries:
         modalHeaderNoUpdates: 'Updates not allowed'
         modalBodyFirst: 'Updates to registration responses can be updated by clicking “Next”.<br>Edits to metadata including Description, Category, License, Publication DOI, and Tags are done on the registration by clicking the '
         modalBodySecond: ' icon.'
-        modalBodyNoUpdates: 'The {registryName} does not allow updates for this registration template.<br>Contact their registy if you have any questions.'
+        modalBodyNoUpdates: '{registryName} does not allow updates.<br>Contact their registry if you have any questions.'
         learnMore: 'Click <a href="https://help.osf.io/hc/en-us/articles/360035806634-Edit-Registration-Metadata" target="_blank">here</a>  to learn more.'
         next: Next
         cancel_update: 'Cancel update'


### PR DESCRIPTION
-   Ticket: [ENG-3423]
-   Feature flag: n/a

## Purpose
- Clean up some weirdness around registrations with one approved schemaResponse (the original) and another in-progress
- Hide `Update` button on node-cards on my-registrations page for non-admin contributors
- Hide first time submissions from "pending updates" tab of Registries Moderation app

## Summary of Changes
- Update the diffManager to only get the responses from the latest approved revision when no revisionId is specified
- Update the condition to show the version metadata box, so the box no longer shows up when there is only one approved response and one response in progress (2 or more responses need to be public before the version metadata box appears)
- Change condition for node-card to show update button
- Add filter[reviews_state]=embargo,accepted` when viewing "pending updates" tab

## Screenshot(s)


## Side Effects

## QA Notes
- this is primarily concerned with the case where a registration has only had its original answers approved, and has 1 update in progress.


[ENG-3423]: https://openscience.atlassian.net/browse/ENG-3423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ