### PR TITLE
[ENG-3357] Make hover state lighter and more contrasty

### DIFF
--- a/lib/registries/addon/components/registries-services-list/styles.scss
+++ b/lib/registries/addon/components/registries-services-list/styles.scss
@@ -20,6 +20,11 @@
     text-decoration: underline;
 }
 
+.ServicesList__ExternalLink:hover {
+    color: $color-text-blue-light;
+    text-decoration: underline;
+}
+
 .ServicesList__ProviderLogo {
     height: 120px;
     background-size: contain;

--- a/lib/registries/addon/components/registries-services-list/template.hbs
+++ b/lib/registries/addon/components/registries-services-list/template.hbs
@@ -28,7 +28,7 @@
                     <a
                         local-class='ServicesList__ExternalLink'
                         href='https://github.com/CenterForOpenScience/ember-osf-registries'
-                        onclick={{action 'click' 'link' 'Index - GitHub Repo' 'https://github.com/CenterForOpenScience/ember-osf-registries'
+                        onclick={{action 'click' 'link' 'Index - GitHub Repo' 'https://github.com/CenterForOpenScience/ember-osf-web'
                             target=this.analytics}}
                     >
                         {{~t 'registries.index.services.bottom.div.linkText1'~}}


### PR DESCRIPTION
-   Ticket: [ENG-3357](https://openscience.atlassian.net/browse/ENG-3357)
-   Feature flag: n/a

## Purpose

The external services links on the registries landing page were too dark compared to their background in the hover state. This lightens up the hover state and increases the contrast.

## Summary of Changes

1. Add hover state css.
2. Fix the link for "open source code" to go to ember-osf-web instead of ember-osf-registries.

## Screenshot(s)

<img width="901" alt="Screen Shot 2021-11-30 at 10 01 44 AM" src="https://user-images.githubusercontent.com/6599111/144073773-7b8e3daf-881f-44d5-8789-514ca0d8f957.png">

## Side Effects

This is isolated to those links and the hover state.

## QA Notes

Just verify that I made the hover state light enough to be properly visible.
