### PR TITLE
[ENG-3241] Prepare for jbp collection provider style changes

### DIFF
--- a/lib/app-components/addon/components/branded-navbar/styles.scss
+++ b/lib/app-components/addon/components/branded-navbar/styles.scss
@@ -10,6 +10,19 @@
     :global(.navbar-collapse) {
         border-top-color: transparent;
     }
+    /* stylelint-disable */
+    #navbarScope {
+        :global(.secondary-nav-dropdown) {
+            a {
+                color: $color-text-white;
+            }
+        }
+
+        :global(.btn-success) {
+            color: $color-text-white;
+        }
+    }
+    /* stylelint-enable */
 }
 
 .navbar-image {


### PR DESCRIPTION

-   Ticket: [ENG-3241](https://openscience.atlassian.net/browse/ENG-3241)
-   Feature flag: n/a

## Purpose

The collection provider branded css uses `!important` tags to override styles, which is causing some trouble. In the case of a logged-out user, the sign-up button text is overridden. In the case of a logged in user, the secondary nav in the navbar is overridden, which in the case of jbp collection, causes it to look like:

<img width="232" alt="Screen Shot 2021-11-30 at 2 42 55 PM" src="https://user-images.githubusercontent.com/6599111/144126137-831e5bc2-6eb5-4b11-8154-32d57d88421e.png">

This is the set of changes necessary to allow the jbp.css provider css to be changed in order to override the menu links but not the secondary nav nor the sign-in button. It will have no visible effect before the provider css is changed.

I had to do things that our stylelint doesn't like, so I've disabled linting for my new rules. It's better than using the `!important` tag in css, though, which is entirely non-overrideable.

## Summary of Changes

1. Add in some CSS for specific selectors

## Side Effects

This is limited to the branded navbar, and the way most of the branded stylesheets are written, shouldn't have any effect at all on its own.

## QA Notes

This won't be testable until the jbp.css stylesheet is modified by Product.
