### PR TITLE
[ENG-3449][Hotfix] Account for AVOLs in update dropdown

### DIFF
--- a/lib/osf-components/addon/components/registries/update-dropdown/list-item/component.ts
+++ b/lib/osf-components/addon/components/registries/update-dropdown/list-item/component.ts
@@ -8,17 +8,18 @@ interface Args {
     isModeratorMode: boolean;
     index: number;
     totalRevisions: number;
+    isAnonymous: boolean;
 }
 
 export default class ListItem extends Component<Args> {
     @service intl!: Intl;
 
     get shouldShow() {
-        const { revision, isModeratorMode } = this.args;
+        const { revision, isModeratorMode, isAnonymous} = this.args;
         const visibleStates = [RevisionReviewStates.Approved];
         if (isModeratorMode) {
             visibleStates.push(RevisionReviewStates.RevisionPendingModeration);
         }
-        return revision.isOriginalResponse || visibleStates.includes(revision.reviewsState);
+        return revision.isOriginalResponse || isAnonymous || visibleStates.includes(revision.reviewsState);
     }
 }

--- a/lib/osf-components/addon/components/registries/update-dropdown/template.hbs
+++ b/lib/osf-components/addon/components/registries/update-dropdown/template.hbs
@@ -31,6 +31,7 @@
                         @revision={{revision}}
                         @isModeratorMode={{@isModeratorMode}}
                         @totalRevisions={{this.totalRevisions}}
+                        @isAnonymous={{@registration.isAnonymous}}
                         @index={{index}}
                     />
                 {{/each}}


### PR DESCRIPTION

-   Ticket: [ENG-3449]
-   Feature flag: n/a

## Purpose
- Show all the publicly available updates when viewing a registration through an AVOL

## Summary of Changes
- Updated condition to show a revision in the UpdateDropdown

## Screenshot(s)


## Side Effects
- none, this will only impact AVOLs
## QA Notes
- All public updates will be visible in the Updates dropdown in the overview for AVOLs, not just the original one

[ENG-3449]: https://openscience.atlassian.net/browse/ENG-3449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ