### PR TITLE
[ENG-2471] Reroute users out of draft route when already submitted

### DIFF
--- a/lib/registries/addon/drafts/draft/route.ts
+++ b/lib/registries/addon/drafts/draft/route.ts
@@ -7,8 +7,6 @@ import { inject as service } from '@ember/service';
 import { waitFor } from '@ember/test-waiters';
 import { task } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
-import Intl from 'ember-intl/services/intl';
-import Toast from 'ember-toastr/services/toast';
 
 import requireAuth from 'ember-osf-web/decorators/require-auth';
 import DraftRegistration from 'ember-osf-web/models/draft-registration';
@@ -27,10 +25,8 @@ export interface DraftRouteModel {
 @requireAuth()
 export default class DraftRegistrationRoute extends Route {
     @service analytics!: Analytics;
-    @service intl!: Intl;
     @service store!: Store;
     @service router!: RouterService;
-    @service toast!: Toast;
 
     @task
     @waitFor
@@ -42,7 +38,6 @@ export default class DraftRegistrationRoute extends Route {
                 { adapterOptions: { include: 'branched_from' } },
             );
             if (draftRegistration.modelName === 'registration') {
-                this.toast.success(this.intl.t('registries.drafts.draft.already_submitted'));
                 this.transitionTo('overview', draftRegistration.id);
             }
             const [subjects, provider]:

--- a/lib/registries/addon/drafts/draft/route.ts
+++ b/lib/registries/addon/drafts/draft/route.ts
@@ -7,6 +7,8 @@ import { inject as service } from '@ember/service';
 import { waitFor } from '@ember/test-waiters';
 import { task } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
+import Intl from 'ember-intl/services/intl';
+import Toast from 'ember-toastr/services/toast';
 
 import requireAuth from 'ember-osf-web/decorators/require-auth';
 import DraftRegistration from 'ember-osf-web/models/draft-registration';
@@ -25,8 +27,10 @@ export interface DraftRouteModel {
 @requireAuth()
 export default class DraftRegistrationRoute extends Route {
     @service analytics!: Analytics;
+    @service intl!: Intl;
     @service store!: Store;
     @service router!: RouterService;
+    @service toast!: Toast;
 
     @task
     @waitFor
@@ -37,6 +41,10 @@ export default class DraftRegistrationRoute extends Route {
                 draftId,
                 { adapterOptions: { include: 'branched_from' } },
             );
+            if (draftRegistration.modelName === 'registration') {
+                this.toast.success(this.intl.t('registries.drafts.draft.already_submitted'));
+                this.transitionTo('overview', draftRegistration.id);
+            }
             const [subjects, provider]:
                 [SubjectModel[], ProviderModel] = await Promise.all([
                     draftRegistration.loadAll('subjects'),

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1188,6 +1188,7 @@ registries:
             register: Register
             unable_to_fetch_children_count: 'Unable to fetch project''s components'
             submit_error: 'Unable to create a registration.'
+            already_submitted: 'This draft has already been submitted.'
             delete_modal:
                 title: 'Delete this draft registration'
                 body: 'Are you sure you want to delete this draft registration?'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1188,7 +1188,6 @@ registries:
             register: Register
             unable_to_fetch_children_count: 'Unable to fetch project''s components'
             submit_error: 'Unable to create a registration.'
-            already_submitted: 'This draft has already been submitted.'
             delete_modal:
                 title: 'Delete this draft registration'
                 body: 'Are you sure you want to delete this draft registration?'


### PR DESCRIPTION
-   Ticket: [ENG-2471]
-   Feature flag: n/a

## Purpose
- Reroute users out of the draft registration edit route to the overview page if a draft has already been submitted

## Summary of Changes
- Add reroute logic and toast message for users accessing a draft that's already submitted
- I looked at changing some of the logic in the osf.io repo, specifically https://github.com/CenterForOpenScience/osf.io/blob/develop/api/nodes/views.py#L225-L226
  - I tried changing this to be something like: `self.headers['location'] = 'localhost:5000/' + draft.registered_node._id` but that didn't seem to work as expected, so I've kept it as is

## Screenshot(s)
NA

## Side Effects
None
## QA Notes
- This should only impact drafts that have already been submitted when going to osf.io/registries/drafts/<draft_that_is_already_submitted>

[ENG-2471]: https://openscience.atlassian.net/browse/ENG-2471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ