### PR TITLE
[ENG-3486] Fix language for overview revision metadata

### DIFF
--- a/lib/osf-components/addon/components/registries/overview-form-renderer/template.hbs
+++ b/lib/osf-components/addon/components/registries/overview-form-renderer/template.hbs
@@ -2,7 +2,10 @@
     <LoadingIndicator @dark={{true}}/>
 {{else}}
     {{#if this.showMetadata}}
-        <Registries::VersionMetadata @revision={{@revision}} />
+        <Registries::VersionMetadata
+            @revision={{@revision}}
+            @registration={{@registration}}
+        />
     {{/if}}
     <Registries::RegistrationFormNavigationDropdown
         @showMetadata={{false}}

--- a/lib/osf-components/addon/components/registries/version-metadata/template.hbs
+++ b/lib/osf-components/addon/components/registries/version-metadata/template.hbs
@@ -1,4 +1,5 @@
 {{assert 'Registries::VersionMetadata requires @revision' @revision}}
+{{assert 'Registries::VersionMetadata requires @registration' @registration}}
 <section
     local-class='versionMetadata'
 > 
@@ -14,7 +15,7 @@
     {{!-- TODO: add description for what fields have changed --}}
     <p data-test-version-metadata-date>
         {{if @revision.isOriginalResponse 
-            (t 'registries.overview.versionMetadata.originalDate' date=(moment-format @revision.dateModified 'MMM DD, YYYY'))
+            (t 'registries.overview.versionMetadata.originalDate' date=(moment-format @registration.dateRegistered 'MMM DD, YYYY'))
             (t 'registries.overview.versionMetadata.date' date=(moment-format @revision.dateModified 'MMM DD, YYYY'))
         }}
     </p>

--- a/mirage/factories/registration.ts
+++ b/mirage/factories/registration.ts
@@ -151,6 +151,7 @@ export default NodeFactory.extend<MirageRegistration & RegistrationTraits>({
             registrationSchema: newReg.registrationSchema,
             reviewsState: RevisionReviewStates.Unapproved,
             revisionResponses: newReg.registrationResponses,
+            isOriginalResponse: true,
         });
         newReg.update({ originalResponse: baseResponse });
         newReg.update({ latestResponse: baseResponse });

--- a/tests/engines/registries/acceptance/overview/revision-test.ts
+++ b/tests/engines/registries/acceptance/overview/revision-test.ts
@@ -37,6 +37,7 @@ module('Registries | Acceptance | overview.revision', hooks => {
             revisionResponses: { q1: 'Super Man' },
             registration,
         });
+        registration.update({ latestResponse: revision });
         await visit(`/${registration.id}?revisionId=${revision.id}`);
         assert.dom('[data-test-version-metadata-title]')
             .exists('version metadata is shown when viewing a specific revision');

--- a/tests/integration/components/registries/update-dropdown/component-test.ts
+++ b/tests/integration/components/registries/update-dropdown/component-test.ts
@@ -52,7 +52,7 @@ module('Integration | Component  | update-dropdown', hooks => {
         `);
         assert.dom('[data-test-update-button]').containsText(t('registries.update_dropdown.latest'), 'Latest selected');
         await click('[data-test-update-button]');
-        assert.dom('[data-test-revision-link]').exists({ count: 3 }, '3 revisions shown');
+        assert.dom('[data-test-revision-link]').exists({ count: 4 }, '4 revisions shown');
 
         assert.dom('[data-test-update-dropdown-show-more]').doesNotExist('Show more element not shown');
         assert.dom('[data-test-update-dropdown-create-new-revision]').doesNotExist('New update button not shown');
@@ -86,7 +86,7 @@ module('Integration | Component  | update-dropdown', hooks => {
             .doesNotExist('Link to revision in progress not shown');
     });
 
-    test('update dropdown - 3 revisions, one in progress', async function(this: ComponentTestContext, assert) {
+    test('update dropdown - 3 extra revisions, one in progress', async function(this: ComponentTestContext, assert) {
         const mirageRegistration = server.create('registration', {
             id: 'cobalt',
             title: 'Outcome Reporting Testing',
@@ -114,7 +114,7 @@ module('Integration | Component  | update-dropdown', hooks => {
             <Registries::UpdateDropdown @registration={{this.registration}}/>
         `);
         await click('[data-test-update-button]');
-        assert.dom('[data-test-revision-link]').exists({ count: 2 }, 'revision in progress not listed');
+        assert.dom('[data-test-revision-link]').exists({ count: 3 }, 'revision in progress not listed');
 
         assert.dom('[data-test-update-dropdown-show-more]').doesNotExist('Show more element not shown');
         assert.dom('[data-test-update-dropdown-create-new-revision]').doesNotExist('New update button not shown');


### PR DESCRIPTION
-   Ticket: [ENG-3486]
-   Feature flag: n/a

## Purpose
- Show correct date for when a registration was originally submitted when viewing the original version of a registration

## Summary of Changes
- Pass in `@registration` into the <Registries::VersionMetadata> component and use the registration's dateRegistered property to show when the registration was submitted instead of the SchemaResponse's dateModified
- Tests

## Screenshot(s)
- When viewing the original version of a registration with multiple revisions, these dates should match
![Screen Shot 2021-12-20 at 2 47 17 PM](https://user-images.githubusercontent.com/51409893/146824059-e6bc83be-829d-461a-a25f-f4dc5663c380.png)

## Side Effects
- None

## QA Notes
- There was a mismatch of dates discovered in registrations that were submitted before Registration Updating was released (Dec. 01, 2021). If there is a registration that was submitted before Dec. 01, 2021 that has an update, the dates shown in the righthand metadata bar and the Version metadata infobox were not consistent, but should be fixed now.

[ENG-3486]: https://openscience.atlassian.net/browse/ENG-3486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ