### PR TITLE
[ENG-3241] JBP Collection CSS part 2

### DIFF
--- a/app/styles/_components.scss
+++ b/app/styles/_components.scss
@@ -428,6 +428,7 @@
     padding: 4px 13px;
     margin-top: 3px;
     font-size: 15px;
+    color: #fff;
 }
 
 #navbarScope .btn-top-login {


### PR DESCRIPTION
-   Ticket: [ENG-3241](https://openscience.atlassian.net/browse/ENG-3241)
-   Feature flag: n/a

## Purpose

Apply the white color to the sign up button text so that, when the jbp css is modified, the button will have white text.

## Summary of Changes

1. Apply white color to text of button

## Screenshot(s)

Before:
<img width="361" alt="Screen Shot 2022-01-03 at 3 42 58 PM" src="https://user-images.githubusercontent.com/6599111/147978658-a818a7d2-511b-4fdc-bf10-845af26ba471.png">


After:
<img width="344" alt="Screen Shot 2022-01-03 at 3 42 50 PM" src="https://user-images.githubusercontent.com/6599111/147978673-72364b22-f709-48c1-8e86-95c139d9cee5.png">



## Side Effects

No, this should be isolated.

## QA Notes

Test on https://staging.osf.io/collections/test/discover - it should work with no other changes.
