### PR TITLE
[ENG-3516] Create HTML for Registration Files List page

### DIFF
--- a/lib/registries/addon/overview/-components/overview-header/template.hbs
+++ b/lib/registries/addon/overview/-components/overview-header/template.hbs
@@ -22,15 +22,17 @@
                         </nav.buttons.default>
                     </nav.bordered-section>
 
-                    <nav.bordered-section>
-                        <nav.buttons.default
-                            data-analytics-name='Show metadata'
-                            @onclick={{@toggleMetadata}}
-                            local-class={{if @metadataGutterClosed 'NonActive'}}
-                        >
-                            <h4>{{t 'registries.overview.metadata'}}</h4>
-                        </nav.buttons.default>
-                    </nav.bordered-section>
+                    {{#if @showMetadata}}
+                        <nav.bordered-section>
+                            <nav.buttons.default
+                                data-analytics-name='Show metadata'
+                                @onclick={{@toggleMetadata}}
+                                local-class={{if @metadataGutterClosed 'NonActive'}}
+                            >
+                                <h4>{{t 'registries.overview.metadata'}}</h4>
+                            </nav.buttons.default>
+                        </nav.bordered-section>
+                    {{/if}}
                 </Navbar>
             {{/if}}
         {{/if}}

--- a/lib/registries/addon/overview/controller.ts
+++ b/lib/registries/addon/overview/controller.ts
@@ -11,6 +11,7 @@ import { GuidRouteModel } from 'ember-osf-web/resolve-guid/guid-route';
 import pathJoin from 'ember-osf-web/utils/path-join';
 
 import Intl from 'ember-intl/services/intl';
+import RouterService from '@ember/routing/router-service';
 
 const {
     support: {
@@ -23,6 +24,7 @@ const { OSF: { url: baseURL } } = config;
 export default class Overview extends Controller {
     @service store!: Store;
     @service intl!: Intl;
+    @service router!: RouterService;
     model!: GuidRouteModel<Registration>;
 
     queryParams = ['mode', 'revisionId'];
@@ -32,6 +34,14 @@ export default class Overview extends Controller {
     @tracked revisionId = '';
 
     @alias('model.taskInstance.value') registration?: Registration;
+
+    @computed('router.currentRouteName')
+    get showMetadata() {
+        if (this.router.currentRouteName === 'registries.overview.files') {
+            return false;
+        }
+        return true;
+    }
 
     @computed('registration.{reviewsState,archiving}')
     get showTombstone() {

--- a/lib/registries/addon/overview/files/route.ts
+++ b/lib/registries/addon/overview/files/route.ts
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class RegistrationFilesRoute extends Route.extend({}) {
+    model() {
+        return this.modelFor('overview');
+    }
+}

--- a/lib/registries/addon/overview/files/styles.scss
+++ b/lib/registries/addon/overview/files/styles.scss
@@ -1,0 +1,62 @@
+.OptionBar {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 24px;
+}
+
+.OptionBar__left {
+    display: flex;
+}
+
+.OptionBar__right {
+    display: flex;
+}
+
+.SortDropdown {
+    padding-left: 20px;
+}
+
+.SortedBy {
+    padding-right: 58px;
+    font-weight: bold;
+}
+
+.DropdownList {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    border: 1px solid $color-border-gray;
+
+    button {
+        padding: 8px;
+    }
+}
+
+.FileList {
+    list-style-type: none;
+    padding: 0;
+
+    li:last-of-type {
+        border-bottom: solid 1px $color-border-gray;
+    }
+}
+
+.FileList__item {
+    display: flex;
+    justify-content: space-between;
+    padding: 12px 0;
+    border-top: solid 1px $color-border-gray;
+
+    span {
+        margin: 0 6px;
+    }
+}
+
+.FileList__item__options {
+    display: flex;
+    align-items: center;
+}
+
+.DownloadShareDropdown {
+    padding-left: 20px;
+}

--- a/lib/registries/addon/overview/files/template.hbs
+++ b/lib/registries/addon/overview/files/template.hbs
@@ -1,0 +1,145 @@
+{{page-title (t 'registries.overview.files.title')}}
+<h3>
+    {{!-- swap with file provider name --}}
+    {{t 'registries.overview.files.title'}}
+</h3>
+
+<div local-class='OptionBar'>
+    <div local-class='OptionBar__left'>
+        <input type='text' class='form-control' placeholder='{{t 'general.filter'}}' />
+
+        <ResponsiveDropdown
+            local-class='SortDropdown'
+            @horizontalPosition='left'
+            as |dropdown|
+        >
+            <dropdown.trigger
+                data-analytics-name='Sort files'
+            >
+                <Button>
+                    {{t 'registries.overview.files.sort'}}
+                    <span local-class='SortedBy'>
+                        {{t 'registries.overview.files.sort_by.name_ascending'}}
+                    </span>
+                    <FaIcon @icon='caret-down' />
+                </Button>
+            </dropdown.trigger>
+            <dropdown.content
+                local-class='DropdownList'
+            >
+                <Button @layout='fake-link'>
+                    {{t 'registries.overview.files.sort_by.name_ascending'}}
+                </Button>
+                <Button @layout='fake-link'>
+                    {{t 'registries.overview.files.sort_by.name_descending'}}
+                </Button>
+                <Button @layout='fake-link'>
+                    {{t 'registries.overview.files.sort_by.date_ascending'}}
+                </Button>
+                <Button @layout='fake-link'>
+                    {{t 'registries.overview.files.sort_by.date_descending'}}
+                </Button>
+            </dropdown.content>
+        </ResponsiveDropdown>
+    </div>
+    <div local-class='OptionBar__right'>
+        {{!-- Add storage provider name to data-analytics-name --}}
+        <Button @layout='fake-link' data-analytics-name='Download all files'>
+            <FaIcon @icon='download' />
+            {{t 'registries.overview.files.download_all'}}
+        </Button>
+        <Button @layout='fake-link' data-analytics-name='Help' aria-label={{t 'general.help'}}>
+            <FaIcon @icon='question-circle' />
+        </Button>
+    </div>
+</div>
+
+<ul local-class='FileList'>
+    <li local-class='FileList__item'>
+        <Button
+            data-analytics-name='View folder'
+            @layout='fake-link'
+            @route='registries.overview'
+        >
+            <FaIcon
+                @icon='folder' @fixedWidth={{true}}
+            />
+            {{!-- <FaIcon
+                @prefix='far' @icon='file-alt' @fixedWidth={{true}}
+            /> --}}
+            folder
+        </Button>
+        <div local-class='FileList__item__options'>
+            10 Oct 2010 10:10 AM
+            <ResponsiveDropdown
+                local-class='DownloadShareDropdown'
+                @horizontalPosition='right'
+                as |dropdown|
+            >
+                <dropdown.trigger
+                    data-analytics-name='File options'
+                >
+                    <Button
+                        {{!-- use folder/file name for aria-label --}}
+                        aria-label={{t 'general.options'}} 
+                    >
+                        <FaIcon @icon='ellipsis-v' />
+                    </Button>
+                </dropdown.trigger>
+                <dropdown.content local-class='DropdownList'>
+                    <Button
+                        local-class='FileOptionsDropdown__option'
+                        @layout='fake-link'
+                    >
+                        <FaIcon @icon='download' />
+                        {{t 'general.download'}}
+                    </Button>
+
+                    <ResponsiveDropdown
+                        local-class='FileOptionsDropdown__option'
+                        @horizontalPosition='right'
+                        as |dd|
+                    >
+                        <dd.trigger
+                            data-analytics-name='File sharing options'
+                        >
+                            <Button
+                                local-class='FileOptionsDropdown__option'
+                                @layout='fake-link'
+                            >
+                                <FaIcon @icon='share-alt' />
+                                {{t 'general.share'}}
+                            </Button>
+                        </dd.trigger>
+                        <dd.content local-class='DropdownList'>
+                            <Button
+                                @layout='fake-link'
+                            >
+                                <FaIcon @icon='envelope' />
+                                {{t 'social.email'}}
+                            </Button>
+                            <Button
+                                @layout='fake-link'
+                            >
+                                <FaIcon @prefix='fab' @icon='twitter-square' />
+                                {{t 'social.twitter'}}
+                            </Button>
+                            <Button
+                                @layout='fake-link'
+                            >
+                                <FaIcon @prefix='fab' @icon='facebook-square' />
+                                {{t 'social.facebook'}}
+                            </Button>
+                            <Button
+                                @layout='fake-link'
+                            >
+                                <FaIcon @prefix='fab' @icon='linkedin' />
+                                {{t 'social.linkedin'}}
+                            </Button>
+                        </dd.content>
+                    </ResponsiveDropdown>
+                </dropdown.content>
+            </ResponsiveDropdown>
+        </div>
+    </li>
+</ul>

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -62,7 +62,7 @@
                 <layout.leftNavOld as |leftNav|>
                     <leftNav.link data-analytics-name='Overview' @route='registries.overview.index'
                         @models={{array this.registration.id}} @icon='home' @label={{t 'registries.overview.title'}} />
-                    <leftNav.link data-analytics-name='Files' @href='/{{this.registration.id}}/files/' @icon='file-alt'
+                    <leftNav.link data-analytics-name='Files' @route='registries.overview.files' @icon='file-alt'
                         @label={{t 'registries.overview.external_links.files'}} />
                     {{#if this.registration.wikiEnabled}}
                         <leftNav.link

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -52,6 +52,7 @@
                         @registration={{this.registration}}
                         @sidenavGutterClosed={{layout.sidenavGutterClosed}}
                         @toggleSidenav={{layout.toggleSidenav}}
+                        @showMetadata={{this.showMetadata}}
                         @metadataGutterClosed={{layout.metadataGutterClosed}}
                         @toggleMetadata={{layout.toggleMetadata}}
                         @selectedRevisionId={{this.revisionId}}
@@ -91,18 +92,20 @@
                     {{outlet}}
                 </layout.main>
 
-                <layout.right local-class='SideMetadata' as |right|>
-                    {{#if (not-eq right.rightGutterMode 'column')}}
-                        <h3 local-class='MetadataTitle'>
-                            {{t 'registries.overview.metadata'}}
-                            <BsButton data-analytics-name='Close metadata sidebar' aria-label={{t 'general.close'}}
-                                @type='link' @onClick={{right.toggleMetadata}}>
-                                <FaIcon @icon='times' />
-                            </BsButton>
-                        </h3>
-                    {{/if}}
-                    <RegistriesMetadata @registration={{this.registration}} @extendedFields={{true}} />
-                </layout.right>
+                {{#if this.showMetadata}}
+                    <layout.right local-class='SideMetadata' as |right|>
+                        {{#if (not-eq right.rightGutterMode 'column')}}
+                            <h3 local-class='MetadataTitle'>
+                                {{t 'registries.overview.metadata'}}
+                                <BsButton data-analytics-name='Close metadata sidebar' aria-label={{t 'general.close'}}
+                                    @type='link' @onClick={{right.toggleMetadata}}>
+                                    <FaIcon @icon='times' />
+                                </BsButton>
+                            </h3>
+                        {{/if}}
+                        <RegistriesMetadata @registration={{this.registration}} @extendedFields={{true}} />
+                    </layout.right>
+                {{/if}}
             </OsfLayout>
         {{/if}}
     {{/if}}

--- a/lib/registries/addon/routes.ts
+++ b/lib/registries/addon/routes.ts
@@ -39,6 +39,7 @@ export default buildRoutes(function() {
         this.route('analytics');
         this.route('children', { path: '/components' });
         this.route('comments');
+        this.route('files');
         this.route('forks');
         this.route('links');
     });

--- a/tests/engines/registries/acceptance/overview/files-test.ts
+++ b/tests/engines/registries/acceptance/overview/files-test.ts
@@ -1,0 +1,27 @@
+import { currentRouteName } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { percySnapshot } from 'ember-percy';
+import { module, test } from 'qunit';
+
+import { Permission } from 'ember-osf-web/models/osf-model';
+import { currentURL, visit } from 'ember-osf-web/tests/helpers';
+import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
+
+module('Registries | Acceptance | overview.files', hooks => {
+    setupEngineApplicationTest(hooks, 'registries');
+    setupMirage(hooks);
+
+    test('it renders', async assert => {
+        const registration = server.create(
+            'registration',
+            { currentUserPermissions: [Permission.Admin] },
+            'withFiles',
+        );
+
+        await visit(`/${registration.id}/files`);
+        await percySnapshot(assert);
+
+        assert.equal(currentURL(), `/${registration.id}/files`, 'At registration files list URL');
+        assert.equal(currentRouteName(), 'registries.overview.files', 'At the expected route');
+    });
+});

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -654,6 +654,7 @@ paginator:
     previous: 'Previous page'
     page: 'Page {page} of {max}'
 social:
+    email: Email
     twitter: Twitter
     facebook: Facebook
     google_group: 'Google Group'
@@ -1384,6 +1385,15 @@ registries:
             abuse_violence: 'Violence or harmful behavior'
             cannot_retract_report: 'Only the reporter can retract report'
             no_comments: 'No comments.'
+        files:
+            title: Files
+            sort: 'Sort by: '
+            sort_by:
+                name_ascending: 'Name: A-Z'
+                name_descending: 'Name: Z-A'
+                date_ascending: 'Last modified: newest to oldest'
+                date_descending: 'Last modified: oldest to newest'
+            download_all: 'Download all files'
         links:
             title: Links
             linked_nodes: 'Linked projects and components'


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-3516]
-   Feature flag: n/a

## Purpose
- Add a static rendering of the Registration File List view

## Summary of Changes
- Add new route `overview.files` for showing files of a registration
- Add template file for this new route
  - Add translation and styling
- Add placeholder test
- Add logic to show/hide right metadata column

## Screenshot(s)
- http://localhost:4200/decaf/files
![image](https://user-images.githubusercontent.com/51409893/151445309-88dada0c-880a-417b-af21-e5364e401e80.png)
![image](https://user-images.githubusercontent.com/51409893/151445346-ad0549ed-7b55-4433-b1bb-cdda501de09b.png)


## Side Effects
Coming soon

## QA Notes
- This is just the static HTML without any of the functionality of the actual page.
