### PR TITLE
[ENG-3559] Update wording for a registration's registered_from

### DIFF
--- a/lib/registries/addon/components/registries-metadata/template.hbs
+++ b/lib/registries/addon/components/registries-metadata/template.hbs
@@ -65,7 +65,7 @@
     </div>
 
     <div local-class='Field'>
-        <h4>{{t 'registries.registration_metadata.registered_from'}}</h4>
+        <h4>{{t 'registries.registration_metadata.associated_project'}}</h4>
         <div>
             <OsfLink
                 data-analytics-name='Registered from'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1311,7 +1311,7 @@ registries:
         no_year: 'No year'
         provider_specific_metadata: 'Registry metadata'
         publication_doi: 'Publication DOI'
-        registered_from: 'Registered from'
+        associated_project: 'Associated project'
         registration_doi: 'Registration DOI'
         registration_type: 'Registration type'
         select_license: 'Select license'


### PR DESCRIPTION
-   Ticket: [ENG-3559]
-   Feature flag: n/a

## Purpose
- Update the language for the `registered from` relationship of a registration, since this wording doesn't make much sense now that users can create a registration without a prior project

## Summary of Changes
- Update translation file

## Screenshot(s)
![image](https://user-images.githubusercontent.com/51409893/151588508-3ae12e69-195b-4aeb-94ae-9b604d7694b5.png)

## Side Effects
- None

## QA Notes
- This impacts only the Registration Overview page (osf.io/<registration_guid>), on the right metadata column. It will no longer say `Registered from` but instead say `Associated project`
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-3559]: https://openscience.atlassian.net/browse/ENG-3559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ