### PR TITLE
[No ticket] Add guid-file route

### DIFF
--- a/app/guid-file/controller.ts
+++ b/app/guid-file/controller.ts
@@ -1,0 +1,5 @@
+import Controller from '@ember/controller';
+
+export default class GuidFile extends Controller {
+
+}

--- a/app/guid-file/route.ts
+++ b/app/guid-file/route.ts
@@ -9,13 +9,11 @@ import moment from 'moment';
 
 import Institution from 'ember-osf-web/models/institution';
 import Analytics from 'ember-osf-web/services/analytics';
-import CurrentUser from 'ember-osf-web/services/current-user';
 import MetaTags, { HeadTagDef } from 'ember-osf-web/services/meta-tags';
 import Ready from 'ember-osf-web/services/ready';
 
 export default class GuidFile extends Route {
     @service analytics!: Analytics;
-    @service currentUser!: CurrentUser;
     @service('head-tags') headTagsService!: HeadTagsService;
     @service metaTags!: MetaTags;
     @service ready!: Ready;

--- a/app/guid-file/route.ts
+++ b/app/guid-file/route.ts
@@ -1,0 +1,67 @@
+import { action } from '@ember/object';
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { waitFor } from '@ember/test-waiters';
+import HeadTagsService from 'ember-cli-meta-tags/services/head-tags';
+import { task } from 'ember-concurrency';
+import { taskFor } from 'ember-concurrency-ts';
+import moment from 'moment';
+
+import Institution from 'ember-osf-web/models/institution';
+import Analytics from 'ember-osf-web/services/analytics';
+import CurrentUser from 'ember-osf-web/services/current-user';
+import MetaTags, { HeadTagDef } from 'ember-osf-web/services/meta-tags';
+import Ready from 'ember-osf-web/services/ready';
+
+export default class GuidFile extends Route {
+    @service analytics!: Analytics;
+    @service currentUser!: CurrentUser;
+    @service('head-tags') headTagsService!: HeadTagsService;
+    @service metaTags!: MetaTags;
+    @service ready!: Ready;
+
+    headTags?: HeadTagDef[];
+
+    @task
+    @waitFor
+    async setHeadTags(model: any) {
+        const blocker = this.ready.getBlocker();
+        const dateCreated = model.dateCreated;
+        const dateModified = model.dateModified;
+        const institutions = await model.target.get('affiliatedInstitutions');
+        const metaTagsData = {
+            title: model.name,
+            identifier: model.guid,
+            publishedDate: dateCreated ? moment(dateCreated).format('YYYY-MM-DD') : undefined,
+            modifiedDate: dateModified ? moment(dateModified).format('YYYY-MM-DD') : undefined,
+            institution: institutions.map((institution: Institution) => institution.get('name')),
+        };
+        this.set('headTags', this.metaTags.getHeadTags(metaTagsData));
+        this.headTagsService.collectHeadTags();
+        blocker.done();
+    }
+
+    async model(params: { guid: string }) {
+        const { guid } = params;
+        try {
+            let file = this.store.peekAll('file').findBy('guid', guid);
+            if (!file) {
+                file = await this.store.findRecord('file', guid);
+            }
+
+            return file;
+        } catch (error) {
+            this.transitionTo('not-found', guid);
+            throw error;
+        }
+    }
+
+    afterModel(model: any) {
+        taskFor(this.setHeadTags).perform(model);
+    }
+
+    @action
+    didTransition() {
+        this.analytics.trackPage(true, 'files');
+    }
+}

--- a/app/services/meta-tags.ts
+++ b/app/services/meta-tags.ts
@@ -74,10 +74,11 @@ export default class MetaTags extends Service {
      */
     getMetaTags(metaTagsOverrides: MetaTagsData): MetaTagsDefs {
         // Default values.
+        const currentUrl = window.location.href;
         const metaTagsData: MetaTagsData = {
             type: 'article',
             description: this.intl.t('general.hosted_on_the_osf'),
-            url: pathJoin(config.OSF.url, this.router.get('currentURL')),
+            url: pathJoin(config.OSF.url, currentUrl),
             language: this.intl.get('locale'),
             image: pathJoin(config.OSF.url, 'static/img/preprints_assets/osf/sharing.png'),
             imageType: 'image/png',
@@ -153,7 +154,6 @@ export default class MetaTags extends Service {
      */
     getHeadTags(metaTagsData: MetaTagsData): HeadTagDef[] {
         const metaTagsDefs = this.getMetaTags(metaTagsData);
-
         // Morph MetaTagsDefs into an array of MetaTagAttrs.
         const headTagsAttrs: MetaTagAttrs[] = Object.entries(metaTagsDefs)
             .reduce(

--- a/mirage/scenarios/registrations.ts
+++ b/mirage/scenarios/registrations.ts
@@ -66,6 +66,8 @@ export function registrationScenario(
         ],
     });
 
+    server.create('file', {id: 'afile', target: currentUserWrite});
+
     server.create('schema-response', {
         id: 'copyEditWritr1',
         revisionJustification: 'Copy Edit',

--- a/tests/acceptance/resolve-guid-test.ts
+++ b/tests/acceptance/resolve-guid-test.ts
@@ -49,6 +49,14 @@ module('Acceptance | resolve-guid', hooks => {
         sinon.stub(router, '_beforeTransition').returnsArg(0);
     });
 
+    test('File | Index', async assert => {
+        const file = server.create('file', { target: server.create('registration') });
+
+        await visit(`/${file.id}`);
+
+        routingAssertions(assert, '--file', `/${file.id}`, 'guid-file');
+    });
+
     module('Node', mhooks => {
         mhooks.beforeEach(async () => {
             const analyticsEngine = await loadEngine('analytics-page', 'guid-node.analytics');
@@ -130,6 +138,7 @@ module('Acceptance | resolve-guid', hooks => {
 
                 routingAssertions(assert, '--registration', url, 'guid-registration.analytics.index');
             });
+
         });
 
         module('With ember_registries_detail_page', __ => {

--- a/tests/acceptance/resolve-guid-test.ts
+++ b/tests/acceptance/resolve-guid-test.ts
@@ -138,7 +138,6 @@ module('Acceptance | resolve-guid', hooks => {
 
                 routingAssertions(assert, '--registration', url, 'guid-registration.analytics.index');
             });
-
         });
 
         module('With ember_registries_detail_page', __ => {

--- a/tests/unit/guid-file/controller-test.ts
+++ b/tests/unit/guid-file/controller-test.ts
@@ -1,12 +1,12 @@
 import { setupTest } from 'ember-qunit';
-import { module, skip } from 'qunit';
+import { module, test } from 'qunit';
 
 module('Unit | Controller | guid-file', hooks => {
     setupTest(hooks);
 
     // Replace this with your real tests.
 
-    skip('it exists', function(assert) {
+    test('it exists', function(assert) {
         const controller = this.owner.lookup('controller:guid-file');
         assert.ok(controller);
     });


### PR DESCRIPTION
-   Ticket: n/a
-   Feature flag: n/a

## Purpose

Add the route for guid-files so we can do programatic things on the guid-file page.

## Summary of Changes

1. Add route
2. Add minimal controller
3. Add tests
4. Add mirage for a guid-addressable file
5. Fix meta-tags service to use the correct current URL

## Screenshot(s)

<img width="1831" alt="Screen Shot 2022-01-31 at 2 25 38 PM" src="https://user-images.githubusercontent.com/6599111/151859158-c730a2fb-35f1-4cdf-8863-70e19d4cce49.png">


## Side Effects

No, new code.

## QA Notes

This is not testable in isolation. Testable stories coming soon.
