### PR TITLE
Add providers list to the leftnav when on registries file route

### DIFF
--- a/app/models/file-provider.ts
+++ b/app/models/file-provider.ts
@@ -1,10 +1,10 @@
 import { attr, belongsTo, AsyncBelongsTo } from '@ember-data/model';
 import { Link } from 'jsonapi-typescript';
 
+import AbstractNodeModel from './abstract-node';
 import BaseFileItem, { BaseFileLinks } from './base-file-item';
 import DraftNodeModel from './draft-node';
 import FileModel from './file';
-import NodeModel from './node';
 
 export interface FileProviderLinks extends BaseFileLinks {
     storage_addons: Link; // eslint-disable-line camelcase
@@ -19,8 +19,9 @@ export default class FileProviderModel extends BaseFileItem {
     @belongsTo('file')
     rootFolder!: AsyncBelongsTo<FileModel> & FileModel;
 
-    @belongsTo('abstract-node', { polymorphic: true })
-    target!: (AsyncBelongsTo<NodeModel> & NodeModel) | (AsyncBelongsTo<DraftNodeModel> & DraftNodeModel);
+    @belongsTo('abstract-node', { inverse: 'files', polymorphic: true })
+    target!: (AsyncBelongsTo<AbstractNodeModel> & AbstractNodeModel) |
+        (AsyncBelongsTo<DraftNodeModel> & DraftNodeModel);
 
     // BaseFileItem override
     isProvider = true;

--- a/app/models/file.ts
+++ b/app/models/file.ts
@@ -5,11 +5,11 @@ import { Link } from 'jsonapi-typescript';
 import { FileReference } from 'ember-osf-web/packages/registration-schema';
 import getHref from 'ember-osf-web/utils/get-href';
 
+import AbstractNodeModel from './abstract-node';
 import BaseFileItem, { BaseFileLinks } from './base-file-item';
 import CommentModel from './comment';
 import DraftNode from './draft-node';
 import FileVersionModel from './file-version';
-import NodeModel from './node';
 
 export interface FileLinks extends BaseFileLinks {
     info: Link;
@@ -50,9 +50,8 @@ export default class FileModel extends BaseFileItem {
     @hasMany('comment', { inverse: null })
     comments!: AsyncHasMany<CommentModel>;
 
-    // TODO: In the future apiv2 may also need to support this pointing at nodes OR registrations
-    @belongsTo('abstract-node', { inverse: 'files', polymorphic: true })
-    target!: (AsyncBelongsTo<NodeModel> & NodeModel) | (AsyncBelongsTo<DraftNode> & DraftNode);
+    @belongsTo('abstract-node', { polymorphic: true })
+    target!: (AsyncBelongsTo<AbstractNodeModel> & AbstractNodeModel) | (AsyncBelongsTo<DraftNode> & DraftNode);
 
     // BaseFileItem override
     isFileModel = true;
@@ -133,7 +132,7 @@ export default class FileModel extends BaseFileItem {
         }).then(() => this.reload());
     }
 
-    move(node: NodeModel): Promise<null> {
+    move(node: AbstractNodeModel): Promise<null> {
         return this.currentUser.authenticatedAJAX({
             url: getHref(this.links.move),
             type: 'POST',

--- a/lib/registries/addon/overview/controller.ts
+++ b/lib/registries/addon/overview/controller.ts
@@ -35,7 +35,6 @@ export default class Overview extends Controller {
 
     @alias('model.taskInstance.value') registration?: Registration;
 
-    @computed('router.currentRouteName')
     get showMetadata() {
         if (this.router.currentRouteName === 'registries.overview.files') {
             return false;
@@ -43,7 +42,6 @@ export default class Overview extends Controller {
         return true;
     }
 
-    @computed('router.currentRouteName')
     get onFilesRoute() {
         return this.router.currentRouteName === 'registries.overview.files';
     }

--- a/lib/registries/addon/overview/controller.ts
+++ b/lib/registries/addon/overview/controller.ts
@@ -43,6 +43,11 @@ export default class Overview extends Controller {
         return true;
     }
 
+    @computed('router.currentRouteName')
+    get onFilesRoute() {
+        return this.router.currentRouteName === 'registries.overview.files';
+    }
+
     @computed('registration.{reviewsState,archiving}')
     get showTombstone() {
         return this.registration && (this.registration.reviewsState === 'withdrawn' || this.registration.archiving);

--- a/lib/registries/addon/overview/route.ts
+++ b/lib/registries/addon/overview/route.ts
@@ -99,7 +99,7 @@ export default class Overview extends GuidRoute {
 
     include() {
         return ['registration_schema', 'bibliographic_contributors', 'identifiers', 'root', 'provider',
-            'schema_responses', 'files'];
+            'schema_responses', 'files', 'region'];
     }
 
     adapterOptions() {

--- a/lib/registries/addon/overview/route.ts
+++ b/lib/registries/addon/overview/route.ts
@@ -99,7 +99,7 @@ export default class Overview extends GuidRoute {
 
     include() {
         return ['registration_schema', 'bibliographic_contributors', 'identifiers', 'root', 'provider',
-            'schema_responses'];
+            'schema_responses', 'files'];
     }
 
     adapterOptions() {

--- a/lib/registries/addon/overview/styles.scss
+++ b/lib/registries/addon/overview/styles.scss
@@ -32,6 +32,20 @@
     }
 }
 
+.FileProviders {
+    display: flex;
+    flex-direction: column;
+}
+
+.FileProvider {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-left: 2px solid $color-border-gray-darker;
+    padding-left: 17px;
+    margin: 0 18px;
+}
+
 .Loading {
     height: 100vh;
     display: flex;

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -62,8 +62,33 @@
                 <layout.leftNavOld as |leftNav|>
                     <leftNav.link data-analytics-name='Overview' @route='registries.overview.index'
                         @models={{array this.registration.id}} @icon='home' @label={{t 'registries.overview.title'}} />
-                    <leftNav.link data-analytics-name='Files' @route='registries.overview.files' @icon='file-alt'
-                        @label={{t 'registries.overview.external_links.files'}} />
+                    <leftNav.link data-analytics-name='Files' @route='registries.overview.files'
+                        @models={{array this.registration.id}} @icon='file-alt'
+                        @label={{t 'registries.overview.files.title'}} />
+                    {{#if this.onFilesRoute}}
+                        <div local-class='FileProvidersList'>
+                            {{#each this.registration.files as |provider|}}
+                                <div local-class='FileProvider'>
+                                    {{provider.name}}
+                                    {{#if (eq provider.name 'osfstorage')}}
+                                        <span>
+                                            <FaIcon
+                                                @icon='globe'
+                                            >
+                                            </FaIcon>
+                                            <BsTooltip
+                                                @placement='right'
+                                                @triggerEvents='hover'
+                                            >
+                                                {{t 'registries.overview.files.storage_location'}}
+                                                {{!-- region here --}}
+                                            </BsTooltip>
+                                        </span>
+                                    {{/if}}
+                                </div>
+                            {{/each}}
+                        </div>
+                    {{/if}}
                     {{#if this.registration.wikiEnabled}}
                         <leftNav.link
                             data-test-wiki-link

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -81,7 +81,7 @@
                                                 @triggerEvents='hover'
                                             >
                                                 {{t 'registries.overview.files.storage_location'}}
-                                                {{!-- region here --}}
+                                                {{this.registration.region.name}}
                                             </BsTooltip>
                                         </span>
                                     {{/if}}

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -66,10 +66,13 @@
                         @models={{array this.registration.id}} @icon='file-alt'
                         @label={{t 'registries.overview.files.title'}} />
                     {{#if this.onFilesRoute}}
-                        <div local-class='FileProvidersList'>
+                        <div
+                            data-test-file-providers-list
+                            local-class='FileProvidersList'
+                        >
                             {{#each this.registration.files as |provider|}}
                                 <div local-class='FileProvider'>
-                                    {{provider.name}}
+                                    {{t (concat 'registries.overview.files.storage_providers.' provider.name)}}
                                     {{#if (eq provider.name 'osfstorage')}}
                                         <span>
                                             <FaIcon

--- a/mirage/factories/file-provider.ts
+++ b/mirage/factories/file-provider.ts
@@ -17,7 +17,10 @@ export default Factory.extend<MirageFileProvider>({
             providerId: `${provider.targetId.id}:${provider.name}`,
         });
 
-        const rootFolder = server.create('file', { target: provider.target }, 'asFolder');
+        const rootFolder = server.create('file', {
+            name: `rootfolder of ${provider.name}`,
+            target: provider.target,
+        }, 'asFolder');
         provider.update({ rootFolder });
     },
 });

--- a/mirage/factories/registration.ts
+++ b/mirage/factories/registration.ts
@@ -184,6 +184,7 @@ export default NodeFactory.extend<MirageRegistration & RegistrationTraits>({
     registeredBy: association(),
     reviewsState: RegistrationReviewStates.Accepted,
     wikiEnabled: true,
+    region: association(),
 
     index(i: number) {
         return i;

--- a/mirage/factories/registration.ts
+++ b/mirage/factories/registration.ts
@@ -155,6 +155,8 @@ export default NodeFactory.extend<MirageRegistration & RegistrationTraits>({
         });
         newReg.update({ originalResponse: baseResponse });
         newReg.update({ latestResponse: baseResponse });
+        const osfstorage = server.create('file-provider', { target: newReg });
+        newReg.update({ files: [osfstorage] });
     },
 
     dateRegistered() {
@@ -276,8 +278,11 @@ export default NodeFactory.extend<MirageRegistration & RegistrationTraits>({
     withFiles: trait<MirageRegistration>({
         afterCreate(registration, server) {
             const count = faker.random.number({ min: 1, max: 5 });
-            const osfstorage = server.create('file-provider', { target: registration });
-            const files = server.createList('file', count, { target: registration });
+            const osfstorage = registration.files.filter(file => file.name === 'osfstorage').models[0];
+            const files = server.createList('file', count, {
+                target: registration,
+                parentFolder: osfstorage.rootFolder,
+            });
             osfstorage.rootFolder.update({ files });
         },
     }),

--- a/mirage/scenarios/registrations.ts
+++ b/mirage/scenarios/registrations.ts
@@ -138,7 +138,7 @@ export function registrationScenario(
             'page-one_long-text': 'aaaaa',
             'page-one_multi-select': ['Crocs'],
         },
-    }, 'withContributors', 'withReviewActions');
+    }, 'withContributors', 'withReviewActions', 'withFiles');
 
     const silicon = server.create('registration', {
         id: 'silicon',

--- a/mirage/serializers/registration.ts
+++ b/mirage/serializers/registration.ts
@@ -14,6 +14,7 @@ interface RegistrationAttrs extends NodeAttrs {
     providerId: ID | null;
     originalResponseId: ID | null;
     latestResponseId: ID | null;
+    regionId: ID | null;
 }
 
 type MirageRegistration = Registration & { attrs: RegistrationAttrs };
@@ -282,6 +283,21 @@ export default class RegistrationSerializer extends ApplicationSerializer<Mirage
                 links: {
                     related: {
                         href: `${apiUrl}/v2/registrations/${model.id}/schema_responses/${latestResponseId}`,
+                        meta: {},
+                    },
+                },
+            };
+        }
+        if (model.attrs.regionId !== null) {
+            const { regionId } = model.attrs;
+            relationships.region = {
+                data: {
+                    id: regionId as string,
+                    type: 'regions',
+                },
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/registrations/${model.id}/regions/${regionId}`,
                         meta: {},
                     },
                 },

--- a/tests/engines/registries/acceptance/overview/files-test.ts
+++ b/tests/engines/registries/acceptance/overview/files-test.ts
@@ -2,6 +2,7 @@ import { currentRouteName } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { percySnapshot } from 'ember-percy';
 import { module, test } from 'qunit';
+import { t } from 'ember-intl/test-support';
 
 import { Permission } from 'ember-osf-web/models/osf-model';
 import { currentURL, visit } from 'ember-osf-web/tests/helpers';
@@ -29,6 +30,9 @@ module('Registries | Acceptance | overview.files', hooks => {
         assert.dom('[data-test-download-all]').exists('Download all button exists');
         assert.dom('[data-test-file-help]').exists('File help button exists');
 
+        assert.dom('[data-test-file-providers-list]').containsText(
+            t('registries.overview.files.storage_providers.osfstorage'),'File providers list contains OSF Storage',
+        );
         // assert.dom('[data-test-file-list-item]').exists({ count: files.length }, 'Files displayed');
         // assert.dom('[data-test-file-list-link]').containsText('Name', 'File name displayed');
         // assert.dom('[data-test-file-list-date]').containsText('Date', 'File date displayed');

--- a/tests/engines/registries/acceptance/overview/index-test.ts
+++ b/tests/engines/registries/acceptance/overview/index-test.ts
@@ -86,6 +86,7 @@ module('Registries | Acceptance | overview.index', hooks => {
         await visit(`/${this.registration.id}/`);
         assert.dom('[data-test-wiki-link]')
             .hasAttribute('href', `/${this.registration.id}/wiki/`, 'Wiki has the correct href');
+        assert.dom('[data-test-file-providers-list]').doesNotExist('File providers list not shown');
     });
 
     test('wiki link hidden if wiki not enabled', async function(this: OverviewTestContext, assert: Assert){

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1332,6 +1332,7 @@ registries:
                 date_ascending: 'Last modified: newest to oldest'
                 date_descending: 'Last modified: oldest to newest'
             download_all: 'Download all files'
+            storage_location: 'Storage location: '
         links:
             title: Links
             linked_nodes: 'Linked projects and components'
@@ -1345,7 +1346,6 @@ registries:
             title: Components
             no_components: 'This registration has no components.'
         external_links:
-            files: Files
             wiki: Wiki
             analytics: Analytics
         form_view:

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1333,6 +1333,8 @@ registries:
                 date_descending: 'Last modified: oldest to newest'
             download_all: 'Download all files'
             storage_location: 'Storage location: '
+            storage_providers:
+                osfstorage: 'OSF Storage'
         links:
             title: Links
             linked_nodes: 'Linked projects and components'


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Show file-providers for registries

## Summary of Changes
- Add element to show a registration's files provider on the registration overview page when you are on the registration's files route
- Change `inverse` for the `target` relationship of the file/file-provider models as this was incorrectly adding files to the `registration.files` relationship

## Screenshot(s)
![image](https://user-images.githubusercontent.com/51409893/152854673-24cf81b2-81be-428f-a28c-c1aa90cc480c.png)

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
