### PR TITLE
[HOLD] Remove max-width to registries pages

### DIFF
--- a/lib/osf-components/addon/components/container/styles.scss
+++ b/lib/osf-components/addon/components/container/styles.scss
@@ -6,10 +6,6 @@
     margin-right: auto;
     padding: 0 15px;
 
-    &:global(.media-desktop) {
-        max-width: 1140px;
-    }
-
     &:global(.media-tablet) {
         padding: 0 10px;
     }

--- a/lib/registries/addon/drafts/draft/styles.scss
+++ b/lib/registries/addon/drafts/draft/styles.scss
@@ -28,7 +28,6 @@
     justify-content: center;
     min-height: 90px;
     width: 100%;
-    max-width: 1140px;
     margin-left: auto;
     margin-right: auto;
     padding: 1em 2em;

--- a/lib/registries/addon/edit-revision/styles.scss
+++ b/lib/registries/addon/edit-revision/styles.scss
@@ -28,7 +28,6 @@
     justify-content: center;
     min-height: 90px;
     width: 100%;
-    max-width: 1140px;
     margin-left: auto;
     margin-right: auto;
     padding: 1em 2em;

--- a/lib/registries/addon/overview/-components/overview-header/styles.scss
+++ b/lib/registries/addon/overview/-components/overview-header/styles.scss
@@ -39,12 +39,6 @@
     line-height: 37px;
 }
 
-@media(min-width: 992px) {
-    .HeaderContainer {
-        max-width: 1140px;
-    }
-}
-
 @media(max-width: 768px) {
     .Header {
         margin: 20px 15px;


### PR DESCRIPTION
# HOLD FOR PRODUCT+UX FEEDBACK

-   Ticket: []
-   Feature flag: n/a

## Purpose
- Allow registries pages to go full-width

## Summary of Changes
- Remove the max-width of the page content from desktop view for any page using OsfLayout

## TODO: demo with product and designer to see if headers need to be moved for the following pages
- Edit Revision pages
- Registration Overview
- My Registrations
- Registries Moderation
- Add New Registration
- Draft Registration pages

## Screenshot(s)
Coming soon <sup>TM</sup>

## Side Effects
- All registries pages (those listed above) will go full width

## QA Notes
