### PR TITLE
[ENG-3561] Show metadata infobox for moderators on first update

### DIFF
--- a/lib/osf-components/addon/components/registries/overview-form-renderer/component.ts
+++ b/lib/osf-components/addon/components/registries/overview-form-renderer/component.ts
@@ -3,14 +3,20 @@ import Store from '@ember-data/store';
 import { inject as service } from '@ember/service';
 import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 import { waitFor } from '@ember/test-waiters';
-import { restartableTask } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
+import { restartableTask, task } from 'ember-concurrency';
+import { taskFor } from 'ember-concurrency-ts';
+import Intl from 'ember-intl/services/intl';
 import Toast from 'ember-toastr/services/toast';
 
 import { layout } from 'ember-osf-web/decorators/component';
+import ModeratorModel from 'ember-osf-web/models/moderator';
 import Registration from 'ember-osf-web/models/registration';
 import SchemaResponseModel from 'ember-osf-web/models/schema-response';
 import { getSchemaBlockGroups, SchemaBlock, SchemaBlockGroup } from 'ember-osf-web/packages/registration-schema';
+import CurrentUserService from 'ember-osf-web/services/current-user';
 import captureException, { getApiErrorMessage } from 'ember-osf-web/utils/capture-exception';
 
 import template from './template';
@@ -20,20 +26,27 @@ import template from './template';
 export default class RegistrationFormViewSchemaBlocks extends Component {
     @service store!: Store;
     @service toast!: Toast;
+    @service currentUser!: CurrentUserService;
+    @service intl!: Intl;
     // Required parameter
     registration!: Registration;
     revision!: SchemaResponseModel;
 
     // Optional parameters
     updatedResponseIds?: string[];
+    mode?: string;
 
     // Private properties
     schemaBlocks?: SchemaBlock[];
     schemaBlockGroups?: SchemaBlockGroup[];
     responses?: { [key: string]: string };
 
+    @tracked currentModerator?: ModeratorModel;
+
+    @computed('currentModerator', 'registration.{latestResponse.content,schemaResponses.length}')
     get showMetadata() {
-        return this.registration.latestResponse.content && !this.registration.latestResponse.get('isOriginalResponse');
+        return this.registration.latestResponse.content && !this.registration.latestResponse.get('isOriginalResponse')
+            || (Boolean(this.currentModerator) && this.registration.schemaResponses.length > 1);
     }
 
     @restartableTask({ on: 'didReceiveAttrs' })
@@ -55,7 +68,26 @@ export default class RegistrationFormViewSchemaBlocks extends Component {
         }
     }
 
+    @task
+    @waitFor
+    async loadCurrentModerator() {
+        try {
+            this.currentModerator = await this.store.findRecord('moderator', this.currentUser.currentUserId!,
+                {
+                    adapterOptions: {
+                        providerId: this.registration.provider.get('id'),
+                    },
+                });
+        } catch (e) {
+            captureException(e);
+            this.toast.error(this.intl.t('registries.overviewHeader.needModeratorPermission'));
+        }
+    }
+
     didReceiveAttrs() {
-        assert('OverviewFormRenderer needs a registration',Boolean(this.registration));
+        assert('OverviewFormRenderer needs a registration', Boolean(this.registration));
+        if (this.mode === 'moderator') {
+            taskFor(this.loadCurrentModerator).perform();
+        }
     }
 }

--- a/lib/registries/addon/overview/index/template.hbs
+++ b/lib/registries/addon/overview/index/template.hbs
@@ -17,6 +17,7 @@
     as |diffManager|>
         {{#if diffManager.headRevision}}
             <Registries::OverviewFormRenderer
+                @mode={{this.overview.mode}}
                 @registration={{this.registration}}
                 @revision={{diffManager.headRevision}}
                 @updatedResponseIds={{diffManager.updatedKeys}}


### PR DESCRIPTION
-   Ticket: [ENG-3561]
-   Feature flag: n/a

## Purpose
- show update metadata infobox for Registrations that are having their first update moderated

## Summary of Changes
- Update the condition to show the version metadata info
  - check if the user is a moderator in moderator mode and show the metadata infobox if this is not the original submission being moderated

## Screenshot(s)
- This is a registration that was submitted to a moderated community-operated registry and it has an update that is pending moderation.
![image](https://user-images.githubusercontent.com/51409893/152410916-255dee77-bec6-422c-9abd-142758c1abe6.png)
![image](https://user-images.githubusercontent.com/51409893/152410959-51682e7b-d414-4c9e-b232-0d9baa2f459f.png)


## Side Effects
- There should be none

## QA Notes
This change fixes an issue where moderators could not see the update-justification for a registration on its first update. The orange infobox should be visible in the following scenarios:
1) All users if there are 2 or more public responses (original version + 1 update that is admin + moderator approved), or 
2) when you are a moderator viewing a registration that is pending update (non-original submission)