### PR TITLE
[ENG-3527] Download provider/current-folder as zip

### DIFF
--- a/app/packages/files/file.ts
+++ b/app/packages/files/file.ts
@@ -33,7 +33,11 @@ export default abstract class File {
     }
 
     get links() {
-        return this.fileModel.links;
+        const links = this.fileModel.links;
+        if (this.isFolder) {
+            links.download = `${links.upload}?zip=`;
+        }
+        return links;
     }
 
     async createFolder(newFolderName: string) {

--- a/lib/osf-components/addon/components/file-browser/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/styles.scss
@@ -21,6 +21,10 @@
     font-weight: bold;
 }
 
+.DownloadAllFromCurrent {
+    margin: 7px;
+}
+
 .DropdownList {
     display: flex;
     flex-direction: column;

--- a/lib/osf-components/addon/components/file-browser/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/template.hbs
@@ -43,15 +43,17 @@
         </ResponsiveDropdown>
     </div>
     <div local-class='OptionBar__right'>
-        {{!-- Add storage provider name to data-analytics-name --}}
-        <Button
-            data-test-download-all
-            data-analytics-name='Download all files'
-            @layout='fake-link'
-        >
-            <FaIcon @icon='download' />
-            {{t 'registries.overview.files.download_all'}}
-        </Button>
+        {{#if @manager.currentFolder}}
+            <OsfLink
+                data-test-download-all
+                data-analytics-name='Download all files from current folder'
+                @href={{@manager.currentFolder.links.download}}
+                local-class='DownloadAllFromCurrent'
+            >
+                <FaIcon @icon='download' />
+                {{t 'registries.overview.files.download_all'}}
+            </OsfLink>
+        {{/if}}
         <Button
             data-test-file-help
             data-analytics-name='Help'

--- a/tests/engines/registries/acceptance/overview/files-test.ts
+++ b/tests/engines/registries/acceptance/overview/files-test.ts
@@ -20,14 +20,19 @@ module('Registries | Acceptance | overview.files', hooks => {
 
         await visit(`/${registration.id}/files`);
         await percySnapshot(assert);
-
+        const rootFolder = registration.files.models[0].rootFolder;
         assert.equal(currentURL(), `/${registration.id}/files`, 'At registration files list URL');
         assert.equal(currentRouteName(), 'registries.overview.files', 'At the expected route');
 
         assert.dom('[data-test-file-search]').exists('File search input exists');
         assert.dom('[data-test-file-sort-trigger]').exists('File sort trigger exists');
-        assert.dom('[data-test-download-all]').exists('Download all button exists');
         assert.dom('[data-test-file-help]').exists('File help button exists');
+
+        assert.dom('[data-test-download-all]').hasAttribute(
+            'href',
+            `http://localhost:8000/wb/files/${rootFolder.id}/upload/?zip=`,
+            'Download all from here button has the right download link',
+        );
 
         // assert.dom('[data-test-file-list-item]').exists({ count: files.length }, 'Files displayed');
         // assert.dom('[data-test-file-list-link]').containsText('Name', 'File name displayed');


### PR DESCRIPTION
-   Ticket: [ENG-3527](https://openscience.atlassian.net/browse/ENG-3527)
-   Feature flag: n/a

## Purpose

Enable the "Download all files" link.

## Summary of Changes

1. Add folder download links to `File.links`
2. Change Download all files from button to link and adjust styling
3. Add href to the Download all files link
4. Test

## Screenshot(s)
<img width="847" alt="Screen Shot 2022-02-03 at 11 07 47 AM" src="https://user-images.githubusercontent.com/6599111/152429438-c7622e0d-b8ab-4338-b96b-e5301f1a5ab2.png">

<img width="1071" alt="Screen Shot 2022-02-03 at 11 07 38 AM" src="https://user-images.githubusercontent.com/6599111/152429443-044e1721-6b5b-494b-8ac6-c3b8930ad1e0.png">


## Side Effects

This gives all folders download links, which will be different links than what Mirage provides, since the OSF API doesn't provide download-as-zip links for folders, while Mirage does.

## QA Notes

Make sure it downloads the right things, mostly.
