### PR TITLE
[ENG-3523] Filespage/filter file list

### DIFF
--- a/app/packages/files/file.ts
+++ b/app/packages/files/file.ts
@@ -48,7 +48,7 @@ export default abstract class File {
                 {
                     page,
                     sort,
-                    filter,
+                    'filter[name]': filter,
                 });
             return queryResult.map(fileModel => Reflect.construct(this.constructor, [fileModel]));
         }

--- a/lib/osf-components/addon/components/file-browser/component.ts
+++ b/lib/osf-components/addon/components/file-browser/component.ts
@@ -1,5 +1,5 @@
-import { action } from '@ember/object';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import OsfStorageManager from 'osf-components/components/storage-provider-manager/osf-storage-manager/component';
 
 interface Args {
@@ -7,8 +7,6 @@ interface Args {
 }
 
 export default class FileBrowser extends Component<Args> {
-    @action
-    noop() {
-        // Nothing to see here.
-    }
+
+    @tracked filter = '';
 }

--- a/lib/osf-components/addon/components/file-browser/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/template.hbs
@@ -5,6 +5,7 @@
             type='text'
             class='form-control'
             placeholder='{{t 'general.filter'}}'
+            oninput={{perform @manager.changeFilter value='target.value'}}
         />
 
         <ResponsiveDropdown

--- a/lib/osf-components/addon/components/file-browser/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/template.hbs
@@ -1,11 +1,12 @@
 <div local-class='OptionBar'>
     <div local-class='OptionBar__left'>
-        <input
+        <Input
             data-test-file-search
-            type='text'
+            @type='text'
             class='form-control'
             placeholder='{{t 'general.filter'}}'
-            oninput={{perform @manager.changeFilter value='target.value'}}
+            @value={{this.filter}}
+            {{on 'keyup' (perform @manager.changeFilter this.filter)}}
         />
 
         <ResponsiveDropdown

--- a/lib/osf-components/addon/components/storage-provider-manager/osf-storage-manager/component.ts
+++ b/lib/osf-components/addon/components/storage-provider-manager/osf-storage-manager/component.ts
@@ -3,7 +3,7 @@ import { action, notifyPropertyChange } from '@ember/object';
 import { waitFor } from '@ember/test-waiters';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { restartableTask, task } from 'ember-concurrency';
+import { restartableTask, task, timeout } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 import FileProviderModel from 'ember-osf-web/models/file-provider';
 import NodeModel from 'ember-osf-web/models/node';
@@ -51,6 +51,9 @@ export default class OsfStorageManager extends Component<Args> {
     @waitFor
     async getCurrentFolderItems() {
         if (this.currentFolder) {
+            if(this.currentPage === 1){
+                this.displayItems = [];
+            }
             const items = await this.currentFolder.getFolderItems(this.currentPage, this.sort, this.filter);
             this.displayItems.push(...items);
             notifyPropertyChange(this, 'displayItems');
@@ -74,8 +77,10 @@ export default class OsfStorageManager extends Component<Args> {
         }
     }
 
-    @action
-    changeFilter(filter: string) {
+    @restartableTask
+    @waitFor
+    async changeFilter(filter: string) {
+        await timeout(500);
         this.filter = filter;
         this.currentPage = 1;
     }

--- a/mirage/views/file.ts
+++ b/mirage/views/file.ts
@@ -4,7 +4,7 @@ import DraftNode from 'ember-osf-web/models/draft-node';
 import faker from 'faker';
 
 import { guid } from '../factories/utils';
-import { process } from './utils';
+import { filter, process } from './utils';
 
 export function uploadToFolder(this: HandlerContext, schema: Schema) {
     const uploadAttrs = this.request.requestBody;
@@ -83,7 +83,14 @@ export function uploadToRoot(this: HandlerContext, schema: Schema) {
 export function folderFilesList(this: HandlerContext, schema: Schema) {
     const { folderId } = this.request.params;
     const folder = schema.files.find(folderId);
-    return process(schema, this.request, this, folder.files.models.map(file => this.serialize(file).data));
+    const files = folder.files.models;
+    const filteredFiles = [];
+    for (const file of files) {
+        if (filter(file, this.request)){
+            filteredFiles.push(file);
+        }
+    }
+    return process(schema, this.request, this, filteredFiles.map(file => this.serialize(file).data));
 }
 
 export function nodeFilesListForProvider(this: HandlerContext, schema: Schema) {


### PR DESCRIPTION
-   Ticket: [ENG-3523](https://openscience.atlassian.net/browse/ENG-3523)
-   Feature flag: n/a

## Purpose

Enable filtering for Files page. Note that this does not yet include tests, because I'm waiting on a change to mirage that @futa-ikeda is working on that will affect how tests are setup.

## Summary of Changes

1. Change filter query parameter to filter on filename
2. Have input box perform filter update
3. Add debouncing to filtering
4. Clear out the current results if currentPage=1
5. Fix file view in mirage so that it filters

## Screenshot(s)
<img width="1075" alt="Screen Shot 2022-02-04 at 11 04 40 AM" src="https://user-images.githubusercontent.com/6599111/152561944-198ccb43-daae-4ab0-b107-e9e557cdbd6f.png">

<img width="1073" alt="Screen Shot 2022-02-04 at 11 04 53 AM" src="https://user-images.githubusercontent.com/6599111/152561953-bd2fb5a0-4b3e-41f9-a38d-7e2d7c6d8f1f.png">


## Side Effects

No

## QA Notes

Filtering should work on file name after this.
