### PR TITLE
[ENG-3590] Move registration files-list route

### DIFF
--- a/lib/osf-components/addon/components/storage-provider-manager/provider-mapper/template.hbs
+++ b/lib/osf-components/addon/components/storage-provider-manager/provider-mapper/template.hbs
@@ -1,0 +1,3 @@
+{{yield (hash
+    osfstorage=(component 'storage-provider-manager/osf-storage-manager')
+)}}

--- a/lib/osf-components/app/components/storage-provider-manager/provider-mapper/template.js
+++ b/lib/osf-components/app/components/storage-provider-manager/provider-mapper/template.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/storage-provider-manager/provider-mapper/template';

--- a/lib/registries/addon/overview/controller.ts
+++ b/lib/registries/addon/overview/controller.ts
@@ -36,14 +36,14 @@ export default class Overview extends Controller {
     @alias('model.taskInstance.value') registration?: Registration;
 
     get showMetadata() {
-        if (this.router.currentRouteName === 'registries.overview.files') {
+        if (this.router.currentRouteName.includes('registries.overview.files')) {
             return false;
         }
         return true;
     }
 
     get onFilesRoute() {
-        return this.router.currentRouteName === 'registries.overview.files';
+        return this.router.currentRouteName.includes('registries.overview.files');
     }
 
     @computed('registration.{reviewsState,archiving}')

--- a/lib/registries/addon/overview/files/index/route.ts
+++ b/lib/registries/addon/overview/files/index/route.ts
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class FileIndexRoute extends Route.extend({}) {
+    beforeModel() {
+        return this.replaceWith('overview.files.provider', 'osfstorage');
+    }
+}

--- a/lib/registries/addon/overview/files/provider/route.ts
+++ b/lib/registries/addon/overview/files/provider/route.ts
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class RegistrationFilesProviderRoute extends Route.extend({}) {
+    model(params: { providerId: string }) {
+        return { overview: this.modelFor('overview'), providerName: params.providerId };
+    }
+}

--- a/lib/registries/addon/overview/files/provider/template.hbs
+++ b/lib/registries/addon/overview/files/provider/template.hbs
@@ -1,1 +1,15 @@
-{{!-- placeholder --}}
+<h3>
+    {{t (concat 'registries.overview.files.storage_providers.' this.model.providerName)}}
+</h3>
+<StorageProviderManager::ProviderMapper
+    as |mapper|
+>
+    {{#let (get mapper this.model.providerName) as |ProviderManager|}}
+        <ProviderManager
+            @target={{this.model.overview.taskInstance.value}}
+            as |manager|
+        >
+            <FileBrowser @manager={{manager}} />
+        </ProviderManager>
+    {{/let}}
+</StorageProviderManager::ProviderMapper>

--- a/lib/registries/addon/overview/files/provider/template.hbs
+++ b/lib/registries/addon/overview/files/provider/template.hbs
@@ -1,0 +1,1 @@
+{{!-- placeholder --}}

--- a/lib/registries/addon/overview/files/provider/template.hbs
+++ b/lib/registries/addon/overview/files/provider/template.hbs
@@ -1,15 +1,18 @@
 <h3>
     {{t (concat 'registries.overview.files.storage_providers.' this.model.providerName)}}
 </h3>
-<StorageProviderManager::ProviderMapper
-    as |mapper|
->
-    {{#let (get mapper this.model.providerName) as |ProviderManager|}}
-        <ProviderManager
-            @target={{this.model.overview.taskInstance.value}}
-            as |manager|
-        >
-            <FileBrowser @manager={{manager}} />
-        </ProviderManager>
-    {{/let}}
-</StorageProviderManager::ProviderMapper>
+
+{{#unless this.model.overview.taskInstance.isRunning}}
+    <StorageProviderManager::ProviderMapper
+        as |mapper|
+    >
+        {{#let (get mapper this.model.providerName) as |ProviderManager|}}
+            <ProviderManager
+                @target={{this.model.overview.taskInstance.value}}
+                as |manager|
+            >
+                <FileBrowser @manager={{manager}} />
+            </ProviderManager>
+        {{/let}}
+    </StorageProviderManager::ProviderMapper>
+{{/unless}}

--- a/lib/registries/addon/overview/files/template.hbs
+++ b/lib/registries/addon/overview/files/template.hbs
@@ -1,5 +1,3 @@
 {{page-title (t 'registries.overview.files.title')}}
 
-{{#unless this.model.taskInstance.isRunning}}
-    {{outlet}}
-{{/unless}}
+{{outlet}}

--- a/lib/registries/addon/overview/files/template.hbs
+++ b/lib/registries/addon/overview/files/template.hbs
@@ -1,14 +1,5 @@
 {{page-title (t 'registries.overview.files.title')}}
-<h3>
-    {{!-- swap with file provider name --}}
-    {{t 'registries.overview.files.title'}}
-</h3>
 
 {{#unless this.model.taskInstance.isRunning}}
-    <StorageProviderManager::OsfStorageManager
-        @target={{this.model.taskInstance.value}}
-        as |manager|
-    >
-        <FileBrowser @manager={{manager}} />
-    </StorageProviderManager::OsfStorageManager>
+    {{outlet}}
 {{/unless}}

--- a/lib/registries/addon/routes.ts
+++ b/lib/registries/addon/routes.ts
@@ -39,7 +39,9 @@ export default buildRoutes(function() {
         this.route('analytics');
         this.route('children', { path: '/components' });
         this.route('comments');
-        this.route('files');
+        this.route('files', function() {
+            this.route('provider', { path: '/:providerId' });
+        });
         this.route('forks');
         this.route('links');
     });

--- a/tests/engines/registries/acceptance/overview/files-test.ts
+++ b/tests/engines/registries/acceptance/overview/files-test.ts
@@ -23,7 +23,7 @@ module('Registries | Acceptance | overview.files', hooks => {
         await percySnapshot(assert);
         const rootFolder = registration.files.models[0].rootFolder;
         assert.equal(currentURL(), `/${registration.id}/files`, 'At registration files list URL');
-        assert.equal(currentRouteName(), 'registries.overview.files', 'At the expected route');
+        assert.equal(currentRouteName(), 'registries.overview.files.provider', 'At the expected route');
 
         assert.dom('[data-test-file-search]').exists('File search input exists');
         assert.dom('[data-test-file-sort-trigger]').exists('File sort trigger exists');

--- a/tests/engines/registries/acceptance/overview/index-test.ts
+++ b/tests/engines/registries/acceptance/overview/index-test.ts
@@ -71,7 +71,7 @@ module('Registries | Acceptance | overview.index', hooks => {
             url: `/--registries/${this.registration.id}/links`,
         }, {
             name: 'Files',
-            route: 'registries.overview.files',
+            route: 'registries.overview.files.provider',
             url: `/--registries/${this.registration.id}/files`,
         }];
 


### PR DESCRIPTION
-   Ticket: [ENG-3590]
-   Feature flag: n/a

## Purpose
- Move the Registration's file list view into a provider specific route

## Summary of Changes
- Create a new route: `registries.overview.files.provider`
  - Reroute users to default storage provider (OsfStorage) when users enter the overview.files route
  - Expand existing logic for files pages to account for new nested route
- Create new component: `StorageProviderManager::ProviderMapper`
  - Use this new component to grab the appropriate storage manager in the overview.files.provider route
- Show provider name at the top of the files-list

## Screenshot(s)
- provider name shown a the top of the file list
![Screen Shot 2022-02-10 at 4 57 06 PM](https://user-images.githubusercontent.com/51409893/153503446-208a54c8-397d-42d8-be3d-1506e9238ca9.png)


## Side Effects
- None, whatsoever. This is totally harmless with no side effects
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-3590]: https://openscience.atlassian.net/browse/ENG-3590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ