### PR TITLE
[ENG-3516] Files list mobile view

### DIFF
--- a/lib/osf-components/addon/components/file-browser/component.ts
+++ b/lib/osf-components/addon/components/file-browser/component.ts
@@ -1,6 +1,9 @@
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { taskFor } from 'ember-concurrency-ts';
+import Media from 'ember-responsive';
+
 import OsfStorageManager from 'osf-components/components/storage-provider-manager/osf-storage-manager/component';
 
 interface Args {
@@ -8,6 +11,12 @@ interface Args {
 }
 
 export default class FileBrowser extends Component<Args> {
+    @service media!: Media;
+
+    get isMobile() {
+        return this.media.isMobile;
+    }
+
     @action
     handleInput(event: any) {
         taskFor(this.args.manager.changeFilter).perform(event.target.value);

--- a/lib/osf-components/addon/components/file-browser/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/styles.scss
@@ -1,20 +1,45 @@
 .OptionBar {
     display: flex;
     justify-content: space-between;
-    margin-bottom: 24px;
+
+    &.Mobile {
+        flex-direction: column;
+    }
 }
 
 .OptionBar__left {
     display: flex;
+    margin-bottom: 24px;
+
+    &.Mobile {
+        flex-direction: column;
+    }
 }
 
 .OptionBar__right {
     display: flex;
+    justify-content: space-between;
+    margin-bottom: 24px;
 }
 
 .SortDropdown {
     padding-left: 20px;
+
+    &.Mobile {
+        padding-left: 0;
+        padding-top: 18px;
+    }
 }
+
+.SortDropdown__button {
+    display: flex;
+
+    &.Mobile {
+        justify-content: space-between;
+        width: 100%;
+    }
+}
+
 
 .SortedBy {
     padding-right: 58px;

--- a/lib/osf-components/addon/components/file-browser/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/template.hbs
@@ -1,5 +1,5 @@
-<div local-class='OptionBar'>
-    <div local-class='OptionBar__left'>
+<div local-class='OptionBar {{if this.isMobile 'Mobile'}}'>
+    <div local-class='OptionBar__left {{if this.isMobile 'Mobile'}}'>
         <Input
             data-test-file-search
             @type='text'
@@ -10,7 +10,7 @@
         />
 
         <ResponsiveDropdown
-            local-class='SortDropdown'
+            local-class='SortDropdown {{if this.isMobile 'Mobile'}}'
             @horizontalPosition='left'
             as |dropdown|
         >
@@ -18,11 +18,13 @@
                 data-test-file-sort-trigger
                 data-analytics-name='Sort files'
             >
-                <Button>
-                    {{t 'registries.overview.files.sort'}}
-                    <span local-class='SortedBy'>
-                        {{t (concat 'registries.overview.files.sort_by.' @manager.sort)}}
-                    </span>
+                <Button local-class='SortDropdown__button {{if this.isMobile 'Mobile'}}'>
+                    <div>
+                        {{t 'registries.overview.files.sort'}}
+                        <span local-class='SortedBy'>
+                            {{t (concat 'registries.overview.files.sort_by.' @manager.sort)}}
+                        </span>
+                    </div>
                     <FaIcon @icon='caret-down' />
                 </Button>
             </dropdown.trigger>


### PR DESCRIPTION
-   Ticket: [ENG-3516]
-   Feature flag: n/a

## Purpose
- Modify files list view for mobile

## Summary of Changes
- Added media query to file-browser component
- Add `.Mobile` class to elements when in mobile
  - Add styling for `.Mobile`
  - Desktop view _should_ be the same

## Screenshot(s)
- Mobile view
![Screen Shot 2022-02-14 at 11 22 34 AM](https://user-images.githubusercontent.com/51409893/153903736-4cb488d1-2535-4aac-bbe3-8f07ab5148e6.png)


## Side Effects
- There shouldn't be any noticeable changes to the desktop/tablet view of the files list page

## QA Notes


[ENG-3516]: https://openscience.atlassian.net/browse/ENG-3516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ