### PR TITLE
[ENG-3585] Filespage/fix download provider

### DIFF
--- a/app/models/base-file-item.ts
+++ b/app/models/base-file-item.ts
@@ -15,6 +15,7 @@ enum FileItemKinds {
 
 export interface BaseFileLinks extends OsfLinks {
     upload: Link;
+    download?: Link;
     // only for folders
     new_folder?: Link; // eslint-disable-line camelcase
 }

--- a/app/models/file-provider.ts
+++ b/app/models/file-provider.ts
@@ -1,4 +1,4 @@
-import { attr, belongsTo, AsyncBelongsTo } from '@ember-data/model';
+import { attr, belongsTo, AsyncBelongsTo, hasMany, AsyncHasMany } from '@ember-data/model';
 import { Link } from 'jsonapi-typescript';
 
 import AbstractNodeModel from './abstract-node';
@@ -8,6 +8,7 @@ import FileModel from './file';
 
 export interface FileProviderLinks extends BaseFileLinks {
     storage_addons: Link; // eslint-disable-line camelcase
+    download?: Link;
 }
 
 export default class FileProviderModel extends BaseFileItem {
@@ -18,6 +19,9 @@ export default class FileProviderModel extends BaseFileItem {
 
     @belongsTo('file')
     rootFolder!: AsyncBelongsTo<FileModel> & FileModel;
+
+    @hasMany('file', { inverse: 'parentFolder' })
+    files!: AsyncHasMany<FileModel>;
 
     @belongsTo('abstract-node', { inverse: 'files', polymorphic: true })
     target!: (AsyncBelongsTo<AbstractNodeModel> & AbstractNodeModel) |

--- a/app/models/file-provider.ts
+++ b/app/models/file-provider.ts
@@ -8,7 +8,6 @@ import FileModel from './file';
 
 export interface FileProviderLinks extends BaseFileLinks {
     storage_addons: Link; // eslint-disable-line camelcase
-    download?: Link;
 }
 
 export default class FileProviderModel extends BaseFileItem {

--- a/app/packages/files/osf-storage-provider-file.ts
+++ b/app/packages/files/osf-storage-provider-file.ts
@@ -1,13 +1,7 @@
+import { FileSortKey } from 'ember-osf-web/packages/files/file';
 import FileProviderModel from 'ember-osf-web/models/file-provider';
 import OsfStorageFile from 'ember-osf-web/packages/files/osf-storage-file';
 import ProviderFile from 'ember-osf-web/packages/files/provider-file';
-
-export enum FileSortKey {
-    AscDateModified = 'date_modified',
-    DescDateModified = '-date_modified',
-    AscName = 'name',
-    DescName = 'name',
-}
 
 export default class OsfStorageProviderFile extends ProviderFile {
     constructor(providerFileModel: FileProviderModel) {

--- a/app/packages/files/osf-storage-provider-file.ts
+++ b/app/packages/files/osf-storage-provider-file.ts
@@ -1,0 +1,26 @@
+import FileProviderModel from 'ember-osf-web/models/file-provider';
+import OsfStorageFile from 'ember-osf-web/packages/files/osf-storage-file';
+import ProviderFile from 'ember-osf-web/packages/files/provider-file';
+
+export enum FileSortKey {
+    AscDateModified = 'date_modified',
+    DescDateModified = '-date_modified',
+    AscName = 'name',
+    DescName = 'name',
+}
+
+export default class OsfStorageProviderFile extends ProviderFile {
+    constructor(providerFileModel: FileProviderModel) {
+        super(providerFileModel);
+    }
+
+    async getFolderItems(page: number, sort: FileSortKey, filter: string ) {
+        const queryResult = await this.fileModel.queryHasMany('files',
+            {
+                page,
+                sort,
+                'filter[name]': filter,
+            });
+        return queryResult.map(fileModel => new OsfStorageFile(fileModel));
+    }
+}

--- a/app/packages/files/osf-storage-provider-file.ts
+++ b/app/packages/files/osf-storage-provider-file.ts
@@ -21,6 +21,7 @@ export default class OsfStorageProviderFile extends ProviderFile {
                 sort,
                 'filter[name]': filter,
             });
+        this.totalFileCount = queryResult.meta.total;
         return queryResult.map(fileModel => new OsfStorageFile(fileModel));
     }
 }

--- a/app/packages/files/provider-file.ts
+++ b/app/packages/files/provider-file.ts
@@ -1,7 +1,7 @@
 import { tracked } from '@glimmer/tracking';
 import FileProviderModel from 'ember-osf-web/models/file-provider';
 
-export default abstract class File {
+export default abstract class ProviderFile {
     @tracked fileModel: FileProviderModel;
     @tracked totalFileCount = 0;
 

--- a/app/packages/files/provider-file.ts
+++ b/app/packages/files/provider-file.ts
@@ -3,6 +3,7 @@ import FileProviderModel from 'ember-osf-web/models/file-provider';
 
 export default abstract class File {
     @tracked fileModel: FileProviderModel;
+    @tracked totalFileCount = 0;
 
     constructor(fileModel: FileProviderModel) {
         this.fileModel = fileModel;

--- a/app/packages/files/provider-file.ts
+++ b/app/packages/files/provider-file.ts
@@ -1,0 +1,36 @@
+import { tracked } from '@glimmer/tracking';
+import FileProviderModel from 'ember-osf-web/models/file-provider';
+
+export default abstract class File {
+    @tracked fileModel: FileProviderModel;
+
+    constructor(fileModel: FileProviderModel) {
+        this.fileModel = fileModel;
+    }
+
+    get isFile() {
+        return false;
+    }
+
+    get isFolder() {
+        return true;
+    }
+
+    get currentUserPermission() {
+        return 'read';
+    }
+
+    get name() {
+        return this.fileModel.name;
+    }
+
+    get links() {
+        const links = this.fileModel.links;
+        links.download = `${links.upload}?zip=`;
+        return links;
+    }
+
+    async createFolder(newFolderName: string) {
+        await this.fileModel.createFolder(newFolderName);
+    }
+}

--- a/lib/osf-components/addon/components/storage-provider-manager/osf-storage-manager/component.ts
+++ b/lib/osf-components/addon/components/storage-provider-manager/osf-storage-manager/component.ts
@@ -9,6 +9,7 @@ import FileProviderModel from 'ember-osf-web/models/file-provider';
 import NodeModel from 'ember-osf-web/models/node';
 import { FileSortKey } from 'ember-osf-web/packages/files/file';
 import OsfStorageFile from 'ember-osf-web/packages/files/osf-storage-file';
+import OsfStorageProviderFile from 'ember-osf-web/packages/files/osf-storage-provider-file';
 
 interface Args {
     target: NodeModel;
@@ -16,7 +17,7 @@ interface Args {
 
 export default class OsfStorageManager extends Component<Args> {
     @tracked storageProvider?: FileProviderModel;
-    @tracked folderLineage: OsfStorageFile[] = [];
+    @tracked folderLineage: Array<OsfStorageFile | OsfStorageProviderFile> = [];
     @tracked displayItems: OsfStorageFile[] = [];
     @tracked filter = '';
     @tracked sort = FileSortKey.AscName;
@@ -54,7 +55,7 @@ export default class OsfStorageManager extends Component<Args> {
         if (this.args.target) {
             const fileProviders = await this.args.target.files;
             this.storageProvider = fileProviders.findBy('name', 'osfstorage') as FileProviderModel;
-            this.folderLineage.push(new OsfStorageFile(await this.storageProvider.rootFolder));
+            this.folderLineage.push(new OsfStorageProviderFile(this.storageProvider));
             notifyPropertyChange(this, 'folderLineage');
         }
     }

--- a/lib/registries/addon/overview/route.ts
+++ b/lib/registries/addon/overview/route.ts
@@ -99,7 +99,7 @@ export default class Overview extends GuidRoute {
 
     include() {
         return ['registration_schema', 'bibliographic_contributors', 'identifiers', 'root', 'provider',
-            'schema_responses', 'files', 'region'];
+            'schema_responses', 'files'];
     }
 
     adapterOptions() {

--- a/mirage/factories/file-provider.ts
+++ b/mirage/factories/file-provider.ts
@@ -6,6 +6,7 @@ import { PolymorphicTargetRelationship } from '../factories/file';
 export interface MirageFileProvider extends FileProviderModel {
     providerId: string;
     targetId: PolymorphicTargetRelationship;
+    files: FileProviderModel[];
 }
 
 export default Factory.extend<MirageFileProvider>({

--- a/mirage/factories/file-provider.ts
+++ b/mirage/factories/file-provider.ts
@@ -6,7 +6,6 @@ import { PolymorphicTargetRelationship } from '../factories/file';
 export interface MirageFileProvider extends FileProviderModel {
     providerId: string;
     targetId: PolymorphicTargetRelationship;
-    files: FileProviderModel[];
 }
 
 export default Factory.extend<MirageFileProvider>({

--- a/mirage/serializers/file-provider.ts
+++ b/mirage/serializers/file-provider.ts
@@ -11,6 +11,15 @@ const { OSF: { apiUrl } } = config;
 export default class FileSerializer extends ApplicationSerializer<MirageFileProvider> {
     buildRelationships(model: ModelInstance<MirageFileProvider>) {
         const relationships: SerializedRelationships<MirageFileProvider> = {};
+        const pathName = pluralize(underscore(model.targetId.type));
+        relationships.files = {
+            links: {
+                related: {
+                    href:`${apiUrl}/v2/${pathName}/${model.targetId.id}/files/${model.name}/`,
+                    meta:{},
+                },
+            },
+        };
         if (model.rootFolder) {
             relationships.rootFolder = {
                 data: {

--- a/tests/engines/registries/acceptance/overview/files-test.ts
+++ b/tests/engines/registries/acceptance/overview/files-test.ts
@@ -21,7 +21,6 @@ module('Registries | Acceptance | overview.files', hooks => {
 
         await visit(`/${registration.id}/files`);
         await percySnapshot(assert);
-        const rootFolder = registration.files.models[0].rootFolder;
         assert.equal(currentURL(), `/${registration.id}/files`, 'At registration files list URL');
         assert.equal(currentRouteName(), 'registries.overview.files', 'At the expected route');
 
@@ -35,7 +34,7 @@ module('Registries | Acceptance | overview.files', hooks => {
 
         assert.dom('[data-test-download-all]').hasAttribute(
             'href',
-            `http://localhost:8000/wb/files/${rootFolder.id}/upload/?zip=`,
+            `http://localhost:8000/v2/registrations/${registration.id}/files/osfstorage/upload?zip=`,
             'Download all from here button has the right download link',
         );
 


### PR DESCRIPTION
-   Ticket: [ENG-3585](https://openscience.atlassian.net/browse/ENG-3585)
-   Feature flag: n/a

## Purpose

Root folders are incomplete and buggy in the OSF API. For OSF Storage, they provide a url that is incompatible with waterbutler. For other storage providers, it's not implemented. So, instead of using the root folder, this PR uses the storage provider's files relationship, which provides the same info in a way that's complete and functional across providers. This should also allow the download provider as zip functionality to work.

## Summary of Changes

1. Add mirage for provider files relationship
2. Add provider files relationship to model
3. Create provider-file and osfstorage-provider-file
4. Make osfstorage manager use the osfstorage-provider-file when appropriate
5. Fix download as zip test
6. Don't embed region, because the osf api *hates* it

## Screenshot(s)

<img width="1059" alt="Screen Shot 2022-02-14 at 3 45 02 PM" src="https://user-images.githubusercontent.com/6599111/153945041-e7ebf383-42d9-4330-9d63-90cd9543a983.png">

## Side Effects

Shouldn't be side effects. This should function just as it did before, just better. 

## QA Notes

Nothing different from what should have been happening all along.
