### PR TITLE
[ENG-3524] Add view file link to file-item

### DIFF
--- a/app/models/file.ts
+++ b/app/models/file.ts
@@ -15,6 +15,7 @@ export interface FileLinks extends BaseFileLinks {
     info: Link;
     move: Link;
     delete: Link;
+    html: Link;
 
     // only for files
     download?: Link;

--- a/lib/osf-components/addon/components/file-browser/file-item/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/file-item/template.hbs
@@ -3,16 +3,17 @@
     local-class={{if @manager.parentFolder 'FileList__item Indent' 'FileList__item'}}
 >
     {{!-- Analytics/test-selector should know if it is a file or folder --}}
-    <Button
-        data-test-file-list-link
-        data-analytics-name='View file'
-        @layout='fake-link'
+    <OsfLink
+        data-analytics-name='Open file'
+        @href={{@item.links.html}}
+        @target='_blank'
+        local-class='FileList__item__options'
     >
         <FaIcon
             @prefix='far' @icon='file-alt' @fixedWidth={{true}}
         />
         {{@item.name}}
-    </Button>
+    </OsfLink>
     <div
         data-test-file-list-date
         local-class='FileList__item__options'


### PR DESCRIPTION
-   Ticket: [ENG-3524](https://openscience.atlassian.net/browse/ENG-3524)
-   Feature flags: `ember_registration_files_page` and `ember_registration_file_detail_page`

## Purpose

Allows you to click on a file link to take you to the guid-file page in a new tab.

## Summary of Changes

1. Add html link to file model
2. Replace non-functional button with a link to the page

## Side Effects

Nope

## QA Notes

Without the waffle flags on, this will take you to the legacy registration file detail page (though you have to jump through hoops to get to the file list page with the waffle flags off). With the waffle flag on, it will take you to what is currently a blank page, though that should change soon. 
