### PR TITLE
[ENG-3609] Filespage/breadcrumbs

### DIFF
--- a/lib/osf-components/addon/components/file-browser/breadcrumbs/crumb/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/breadcrumbs/crumb/template.hbs
@@ -1,0 +1,5 @@
+{{#if @isProvider}}
+    {{t (concat 'registries.overview.files.storage_providers.' @name)}}
+{{else}}
+    {{@name}}
+{{/if}}

--- a/lib/osf-components/addon/components/file-browser/breadcrumbs/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/breadcrumbs/styles.scss
@@ -1,0 +1,7 @@
+.Breadcrumbs {
+    margin-bottom: 20px;
+}
+
+.Divider {
+    color: $color-text-blue-dark;
+}

--- a/lib/osf-components/addon/components/file-browser/breadcrumbs/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/breadcrumbs/styles.scss
@@ -1,7 +1,3 @@
 .Breadcrumbs {
     margin-bottom: 20px;
 }
-
-.Divider {
-    color: $color-text-blue-dark;
-}

--- a/lib/osf-components/addon/components/file-browser/breadcrumbs/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/breadcrumbs/styles.scss
@@ -1,3 +1,28 @@
 .Breadcrumbs {
     margin-bottom: 20px;
 }
+
+.Breadcrumbs {
+    padding: 0.8em 1em;
+}
+  
+.Breadcrumbs ol {
+    margin: 0;
+    padding-left: 0;
+    list-style: none;
+}
+
+.Breadcrumbs li {
+    display: inline;
+    font-size: large;
+    font-weight: 700;
+}
+
+.Breadcrumbs li + li::before {
+    display: inline-block;
+    margin: 0 0.25em;
+    transform: rotate(15deg);
+    border-right: 0.1em solid currentColor;
+    height: 0.8em;
+    content: '';
+}

--- a/lib/osf-components/addon/components/file-browser/breadcrumbs/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/breadcrumbs/styles.scss
@@ -1,11 +1,8 @@
 .Breadcrumbs {
     margin-bottom: 20px;
-}
-
-.Breadcrumbs {
     padding: 0.8em 1em;
 }
-  
+
 .Breadcrumbs ol {
     margin: 0;
     padding-left: 0;

--- a/lib/osf-components/addon/components/file-browser/breadcrumbs/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/breadcrumbs/template.hbs
@@ -1,9 +1,22 @@
 <h3 local-class='Breadcrumbs' data-test-breadcrumbs>
-    {{#each @breadcrumbs as |breadcrumb index| }}
+    {{#each @manager.breadcrumbs as |breadcrumb index| }}
         {{#if (eq index 0)}}
-            {{t (concat 'registries.overview.files.storage_providers.' breadcrumb.name)}}
+            <OsfLink
+                data-test-go-to-folder-{{breadcrumb.name}}
+                @href='#'
+                {{on 'click' (perform @manager.goToFolder breadcrumb)}}
+            >
+                {{t (concat 'registries.overview.files.storage_providers.' breadcrumb.name)}}
+            </OsfLink>
         {{else}}
-            <span local-class='Divider'>></span> {{breadcrumb.name}}
+            >
+            <OsfLink
+                data-test-go-to-folder-{{breadcrumb.name}}
+                @href='#'
+                {{on 'click' (perform @manager.goToFolder breadcrumb)}}
+            >
+                {{breadcrumb.name}}
+            </OsfLink>
         {{/if}}
     {{/each}}
 </h3>

--- a/lib/osf-components/addon/components/file-browser/breadcrumbs/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/breadcrumbs/template.hbs
@@ -2,21 +2,17 @@
     <ol data-test-breadcrumbs>
         {{#each @manager.breadcrumbs as |breadcrumb index| }}
             <li>
-                {{#if (eq index 0)}}
-                    <OsfLink
-                        data-test-go-to-folder={{breadcrumb.name}}
-                        @href='#'
-                        {{on 'click' (perform @manager.goToFolder breadcrumb)}}
-                    >
-                        {{t (concat 'registries.overview.files.storage_providers.' breadcrumb.name)}}
-                    </OsfLink>
+                {{#if (eq breadcrumb @manager.currentFolder)}}
+                    <span data-test-breadcrumb={{breadcrumb.name}}>
+                        <FileBrowser::Breadcrumbs::Crumb @name={{breadcrumb.name}} @isProvider={{eq index 0}} />
+                    </span>
                 {{else}}
                     <OsfLink
-                        data-test-go-to-folder={{breadcrumb.name}}
+                        data-test-breadcrumb={{breadcrumb.name}}
                         @href='#'
                         {{on 'click' (perform @manager.goToFolder breadcrumb)}}
                     >
-                        {{breadcrumb.name}}
+                        <FileBrowser::Breadcrumbs::Crumb @name={{breadcrumb.name}} @isProvider={{eq index 0}} />
                     </OsfLink>
                 {{/if}}
             </li>

--- a/lib/osf-components/addon/components/file-browser/breadcrumbs/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/breadcrumbs/template.hbs
@@ -1,0 +1,9 @@
+<h3 local-class='Breadcrumbs' data-test-breadcrumbs>
+    {{#each @breadcrumbs as |breadcrumb index| }}
+        {{#if (eq index 0)}}
+            {{t (concat 'registries.overview.files.storage_providers.' breadcrumb.name)}}
+        {{else}}
+            <span local-class='Divider'>></span> {{breadcrumb.name}}
+        {{/if}}
+    {{/each}}
+</h3>

--- a/lib/osf-components/addon/components/file-browser/breadcrumbs/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/breadcrumbs/template.hbs
@@ -1,22 +1,25 @@
-<h3 local-class='Breadcrumbs' data-test-breadcrumbs>
-    {{#each @manager.breadcrumbs as |breadcrumb index| }}
-        {{#if (eq index 0)}}
-            <OsfLink
-                data-test-go-to-folder-{{breadcrumb.name}}
-                @href='#'
-                {{on 'click' (perform @manager.goToFolder breadcrumb)}}
-            >
-                {{t (concat 'registries.overview.files.storage_providers.' breadcrumb.name)}}
-            </OsfLink>
-        {{else}}
-            >
-            <OsfLink
-                data-test-go-to-folder-{{breadcrumb.name}}
-                @href='#'
-                {{on 'click' (perform @manager.goToFolder breadcrumb)}}
-            >
-                {{breadcrumb.name}}
-            </OsfLink>
-        {{/if}}
-    {{/each}}
-</h3>
+<nav aria-label={{t 'registries.overview.files.breadcrumbs'}} local-class='Breadcrumbs'>
+    <ol data-test-breadcrumbs>
+        {{#each @manager.breadcrumbs as |breadcrumb index| }}
+            <li>
+                {{#if (eq index 0)}}
+                    <OsfLink
+                        data-test-go-to-folder={{breadcrumb.name}}
+                        @href='#'
+                        {{on 'click' (perform @manager.goToFolder breadcrumb)}}
+                    >
+                        {{t (concat 'registries.overview.files.storage_providers.' breadcrumb.name)}}
+                    </OsfLink>
+                {{else}}
+                    <OsfLink
+                        data-test-go-to-folder={{breadcrumb.name}}
+                        @href='#'
+                        {{on 'click' (perform @manager.goToFolder breadcrumb)}}
+                    >
+                        {{breadcrumb.name}}
+                    </OsfLink>
+                {{/if}}
+            </li>
+        {{/each}}
+    </ol>
+</nav>

--- a/lib/osf-components/addon/components/file-browser/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/template.hbs
@@ -1,4 +1,4 @@
-<FileBrowser::Breadcrumbs @breadcrumbs={{@manager.breadcrumbs}} />
+<FileBrowser::Breadcrumbs @manager={{@manager}} />
 
 <div local-class='OptionBar {{if this.isMobile 'Mobile'}}'>
     <div local-class='OptionBar__left {{if this.isMobile 'Mobile'}}'>

--- a/lib/osf-components/addon/components/file-browser/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/template.hbs
@@ -1,3 +1,5 @@
+<FileBrowser::Breadcrumbs @breadcrumbs={{@manager.breadcrumbs}} />
+
 <div local-class='OptionBar {{if this.isMobile 'Mobile'}}'>
     <div local-class='OptionBar__left {{if this.isMobile 'Mobile'}}'>
         <Input

--- a/lib/osf-components/addon/components/storage-provider-manager/osf-storage-manager/template.hbs
+++ b/lib/osf-components/addon/components/storage-provider-manager/osf-storage-manager/template.hbs
@@ -10,5 +10,6 @@
     changeFilter=this.changeFilter
     changeSort=this.changeSort
     loadMore=this.loadMore
-    goToFolder=this.goToFolder)
+    goToFolder=this.goToFolder
+    breadcrumbs=this.folderLineage)
 }}

--- a/lib/osf-components/app/components/file-browser/breadcrumbs/crumb/template.js
+++ b/lib/osf-components/app/components/file-browser/breadcrumbs/crumb/template.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/file-browser/breadcrumbs/crumb/template';

--- a/lib/osf-components/app/components/file-browser/breadcrumbs/template.js
+++ b/lib/osf-components/app/components/file-browser/breadcrumbs/template.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/file-browser/breadcrumbs/template';

--- a/lib/registries/addon/overview/files/provider/template.hbs
+++ b/lib/registries/addon/overview/files/provider/template.hbs
@@ -1,7 +1,3 @@
-<h3>
-    {{t (concat 'registries.overview.files.storage_providers.' this.model.providerName)}}
-</h3>
-
 {{#unless this.model.overview.taskInstance.isRunning}}
     <StorageProviderManager::ProviderMapper
         as |mapper|

--- a/tests/integration/components/file-browser/breadcrumbs/component-test.ts
+++ b/tests/integration/components/file-browser/breadcrumbs/component-test.ts
@@ -1,0 +1,42 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+
+import { module, test } from 'qunit';
+
+module('Integration | Component | file-browser / breadcrumbs', hooks => {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function(assert) {
+        const breadcrumbsOne = [
+            {name: 'osfstorage'},
+        ];
+        const breadcrumbsTwo = [
+            {name: 'osfstorage'},
+            {name: 'folder one'},
+        ];
+        const breadcrumbsThree = [
+            {name: 'osfstorage'},
+            {name: 'folder one'},
+            {name: 'folder two'},
+        ];
+
+        this.set('breadcrumbs', breadcrumbsOne);
+        await render(hbs`<FileBrowser::Breadcrumbs @breadcrumbs={{this.breadcrumbs}} />`);
+        assert.dom('[data-test-breadcrumbs]')
+            .hasText('OSF Storage', 'Breadcrumbs render properly with just storage provider');
+
+        this.set('breadcrumbs', breadcrumbsTwo);
+        await render(hbs`<FileBrowser::Breadcrumbs @breadcrumbs={{this.breadcrumbs}} />`);
+        assert.dom('[data-test-breadcrumbs]')
+            .hasText('OSF Storage > folder one', 'Breadcrumbs render properly with provider and one folder');
+
+        this.set('breadcrumbs', breadcrumbsThree);
+        await render(hbs`<FileBrowser::Breadcrumbs @breadcrumbs={{this.breadcrumbs}} />`);
+        assert.dom('[data-test-breadcrumbs]')
+            .hasText(
+                'OSF Storage > folder one > folder two',
+                'Breadcrumbs render properly with provider and two folders',
+            );
+    });
+});

--- a/tests/integration/components/file-browser/breadcrumbs/component-test.ts
+++ b/tests/integration/components/file-browser/breadcrumbs/component-test.ts
@@ -9,34 +9,45 @@ module('Integration | Component | file-browser / breadcrumbs', hooks => {
 
     test('it renders', async function(assert) {
         const breadcrumbsOne = [
-            {name: 'osfstorage'},
+            {
+                name: 'osfstorage',
+            },
         ];
         const breadcrumbsTwo = [
             {name: 'osfstorage'},
-            {name: 'folder one'},
+            {name: 'folder_one'},
         ];
         const breadcrumbsThree = [
             {name: 'osfstorage'},
-            {name: 'folder one'},
-            {name: 'folder two'},
+            {name: 'folder_one'},
+            {name: 'folder_two'},
         ];
 
-        this.set('breadcrumbs', breadcrumbsOne);
-        await render(hbs`<FileBrowser::Breadcrumbs @breadcrumbs={{this.breadcrumbs}} />`);
-        assert.dom('[data-test-breadcrumbs]')
-            .hasText('OSF Storage', 'Breadcrumbs render properly with just storage provider');
+        this.set('manager', {breadcrumbs: breadcrumbsOne});
+        await render(hbs`<FileBrowser::Breadcrumbs @manager={{this.manager}} />`);
+        assert.dom('[data-test-go-to-folder="osfstorage"]')
+            .exists();
+        assert.dom('[data-test-go-to-folder="folder_one"]')
+            .doesNotExist();
+        assert.dom('[data-test-go-to-folder="folder_two"]')
+            .doesNotExist();
 
-        this.set('breadcrumbs', breadcrumbsTwo);
-        await render(hbs`<FileBrowser::Breadcrumbs @breadcrumbs={{this.breadcrumbs}} />`);
-        assert.dom('[data-test-breadcrumbs]')
-            .hasText('OSF Storage > folder one', 'Breadcrumbs render properly with provider and one folder');
+        this.set('manager', {breadcrumbs: breadcrumbsTwo});
+        await render(hbs`<FileBrowser::Breadcrumbs @manager={{this.manager}} />`);
+        assert.dom('[data-test-go-to-folder="osfstorage"]')
+            .exists();
+        assert.dom('[data-test-go-to-folder="folder_one"]')
+            .exists();
+        assert.dom('[data-test-go-to-folder="folder_two"]')
+            .doesNotExist();
 
-        this.set('breadcrumbs', breadcrumbsThree);
-        await render(hbs`<FileBrowser::Breadcrumbs @breadcrumbs={{this.breadcrumbs}} />`);
-        assert.dom('[data-test-breadcrumbs]')
-            .hasText(
-                'OSF Storage > folder one > folder two',
-                'Breadcrumbs render properly with provider and two folders',
-            );
+        this.set('manager', {breadcrumbs: breadcrumbsThree});
+        await render(hbs`<FileBrowser::Breadcrumbs @manager={{this.manager}} />`);
+        assert.dom('[data-test-go-to-folder="osfstorage"]')
+            .exists();
+        assert.dom('[data-test-go-to-folder="folder_one"]')
+            .exists();
+        assert.dom('[data-test-go-to-folder="folder_two"]')
+            .exists();
     });
 });

--- a/tests/integration/components/file-browser/breadcrumbs/component-test.ts
+++ b/tests/integration/components/file-browser/breadcrumbs/component-test.ts
@@ -1,53 +1,87 @@
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { TestContext } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 
 import { module, test } from 'qunit';
 
+interface FakeBreadcrumb {
+    name: string;
+}
+
+interface BreadcrumbTestContext extends TestContext {
+    provider: FakeBreadcrumb;
+    folderOne: FakeBreadcrumb;
+    folderTwo: FakeBreadcrumb;
+}
+
 module('Integration | Component | file-browser / breadcrumbs', hooks => {
     setupRenderingTest(hooks);
 
-    test('it renders', async function(assert) {
-        const breadcrumbsOne = [
-            {
-                name: 'osfstorage',
-            },
-        ];
-        const breadcrumbsTwo = [
-            {name: 'osfstorage'},
-            {name: 'folder_one'},
-        ];
-        const breadcrumbsThree = [
-            {name: 'osfstorage'},
-            {name: 'folder_one'},
-            {name: 'folder_two'},
+    hooks.beforeEach(function(this: BreadcrumbTestContext) {
+        this.provider = {name: 'osfstorage'};
+        this.folderOne = {name: 'folder_one'};
+        this.folderTwo = {name: 'folder_two'};
+    });
+
+    test('it renders with one item', async function(this: BreadcrumbTestContext, assert) {
+        const breadcrumbs = [
+            this.provider,
         ];
 
-        this.set('manager', {breadcrumbs: breadcrumbsOne});
+        this.set('manager', {breadcrumbs, currentFolder: this.provider});
         await render(hbs`<FileBrowser::Breadcrumbs @manager={{this.manager}} />`);
-        assert.dom('[data-test-go-to-folder="osfstorage"]')
+        assert.dom('[data-test-breadcrumb="osfstorage"]')
             .exists();
-        assert.dom('[data-test-go-to-folder="folder_one"]')
+        assert.dom('[data-test-breadcrumb="osfstorage"]')
+            .doesNotHaveAttribute('href');
+        assert.dom('[data-test-breadcrumb="folder_one"]')
             .doesNotExist();
-        assert.dom('[data-test-go-to-folder="folder_two"]')
+        assert.dom('[data-test-breadcrumb="folder_two"]')
             .doesNotExist();
+    });
 
-        this.set('manager', {breadcrumbs: breadcrumbsTwo});
-        await render(hbs`<FileBrowser::Breadcrumbs @manager={{this.manager}} />`);
-        assert.dom('[data-test-go-to-folder="osfstorage"]')
-            .exists();
-        assert.dom('[data-test-go-to-folder="folder_one"]')
-            .exists();
-        assert.dom('[data-test-go-to-folder="folder_two"]')
-            .doesNotExist();
+    test('it renders with two items', async function(this: BreadcrumbTestContext, assert) {
+        const breadcrumbs = [
+            this.provider,
+            this.folderOne,
+        ];
 
-        this.set('manager', {breadcrumbs: breadcrumbsThree});
+        this.set('manager', {breadcrumbs, currentFolder: this.folderOne});
         await render(hbs`<FileBrowser::Breadcrumbs @manager={{this.manager}} />`);
-        assert.dom('[data-test-go-to-folder="osfstorage"]')
+        assert.dom('[data-test-breadcrumb="osfstorage"]')
             .exists();
-        assert.dom('[data-test-go-to-folder="folder_one"]')
+        assert.dom('[data-test-breadcrumb="osfstorage"]')
+            .hasAttribute('href');
+        assert.dom('[data-test-breadcrumb="folder_one"]')
             .exists();
-        assert.dom('[data-test-go-to-folder="folder_two"]')
+        assert.dom('[data-test-breadcrumb="folder_one"]')
+            .doesNotHaveAttribute('href');
+        assert.dom('[data-test-breadcrumb="folder_two"]')
+            .doesNotExist();
+    });
+
+
+    test('it renders with more than two items', async function(this: BreadcrumbTestContext, assert) {
+        const breadcrumbs = [
+            this.provider,
+            this.folderOne,
+            this.folderTwo,
+        ];
+
+        this.set('manager', {breadcrumbs, currentFolder: this.folderTwo});
+        await render(hbs`<FileBrowser::Breadcrumbs @manager={{this.manager}} />`);
+        assert.dom('[data-test-breadcrumb="osfstorage"]')
             .exists();
+        assert.dom('[data-test-breadcrumb="osfstorage"]')
+            .hasAttribute('href');
+        assert.dom('[data-test-breadcrumb="folder_one"]')
+            .exists();
+        assert.dom('[data-test-breadcrumb="folder_one"]')
+            .hasAttribute('href');
+        assert.dom('[data-test-breadcrumb="folder_two"]')
+            .exists();
+        assert.dom('[data-test-breadcrumb="folder_two"]')
+            .doesNotHaveAttribute('href');
     });
 });

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -203,7 +203,6 @@ navbar:
     go_home: 'Go home'
     my_projects: 'My Projects'
     my_registrations: 'My Registrations'
-    my_quick_files: 'My Quick Files'
     reviews: 'My Reviewing'
     search: Search
     search_help: 'Search help'
@@ -1336,6 +1335,7 @@ registries:
             storage_providers:
                 osfstorage: 'OSF Storage'
             empty_folder: 'This folder is empty.'
+            breadcrumbs: 'Breadcrumb'
         links:
             title: Links
             linked_nodes: 'Linked projects and components'


### PR DESCRIPTION
-   Ticket: [ENG-3609](https://openscience.atlassian.net/browse/ENG-3609)
-   Feature flag: n/a

## Purpose

Add breadcrumbs to the file browser.

## Summary of Changes

1. Add browser component
2. Export folder lineage from manager
2. Add tests

## Screenshot(s)
<img width="1193" alt="Screen Shot 2022-02-22 at 9 06 21 AM" src="https://user-images.githubusercontent.com/6599111/155155854-d313eff5-08dd-4852-8f12-5b7b10da8792.png">

<img width="425" alt="Screen Shot 2022-02-22 at 9 06 35 AM" src="https://user-images.githubusercontent.com/6599111/155155877-9778463f-6ac6-475b-aaab-ecdafc09cce2.png">


## Side Effects

Long folder structures will push the screen down.

## QA Notes

This should make a segment for each folder that you travel into, including osfstorage, divided by `>`.
