### PR TITLE
[ENG-3531] Add file renderer to file detail page

### DIFF
--- a/app/guid-file/route.ts
+++ b/app/guid-file/route.ts
@@ -42,10 +42,7 @@ export default class GuidFile extends Route {
     async model(params: { guid: string }) {
         const { guid } = params;
         try {
-            let file = this.store.peekAll('file').findBy('guid', guid);
-            if (!file) {
-                file = await this.store.findRecord('file', guid);
-            }
+            const file = await this.store.findRecord('file', guid);
 
             return file;
         } catch (error) {

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -21,7 +21,7 @@
             <div class='row' local-class='FileDetail_filename-buttons'>
                 <div class='col-lg-10'>
                     <div local-class='FileDetail_file-name'>
-                        <h2>
+                        <h2 data-test-filename>
                             {{this.model.name}}
                         </h2>
                     </div>
@@ -81,7 +81,7 @@
                 </div>
             </div>
             <div class='row'>
-                <div id='mfrIframeParent' local-class='FileDetail-file-render' class='col-lg-12'>
+                <div data-test-file-renderer id='mfrIframeParent' local-class='FileDetail-file-render' class='col-lg-12'>
                     <FileRenderer @download={{this.model.links.download}} />
                 </div>
             </div>

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -22,8 +22,7 @@
                 <div class='col-lg-10'>
                     <div local-class='FileDetail_file-name'>
                         <h2>
-                            {{t 'file_detail.file_name_placeholder'}}
-                            {{this.file.name}}
+                            {{this.model.name}}
                         </h2>
                     </div>
                 </div>
@@ -83,7 +82,7 @@
             </div>
             <div class='row'>
                 <div id='mfrIframeParent' local-class='FileDetail-file-render' class='col-lg-12'>
-                    <p>{{t 'file_detail.file_viewer_placeholder'}}</p>
+                    <FileRenderer @download={{this.model.links.download}} />
                 </div>
             </div>
         </div>

--- a/tests/acceptance/guid-file/registration-file-detail-test.ts
+++ b/tests/acceptance/guid-file/registration-file-detail-test.ts
@@ -1,0 +1,25 @@
+import {
+    currentURL,
+    visit,
+} from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { percySnapshot } from 'ember-percy';
+import { module, test } from 'qunit';
+
+import { setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
+
+module('Acceptance | guid file | registration files', hooks => {
+    setupOSFApplicationTest(hooks);
+    setupMirage(hooks);
+
+    test('works', async assert => {
+        const registration = server.create('registration');
+        const fileOne = server.create('file', { target: registration, name: 'Test File' });
+        await visit(`/--file/${fileOne.id}`);
+        assert.equal(currentURL(), `/--file/${fileOne.guid}`);
+        assert.dom('[data-test-filename]')
+            .hasText('Test File', 'The correct filename is on the page');
+        assert.dom('[data-test-file-renderer] iframe').exists('File renderer is rendering');
+        await percySnapshot(assert);
+    });
+});

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -128,9 +128,7 @@ file_detail:
     tags: 'Tags:'
     sha2_description: 'SHA-2 is a cryptographic hash function designed by the NSA used to verify data integrity.'
     md5_description: 'MD5 is an algorithm used to verify data integrity.'
-    file_name_placeholder: 'Adjustment of 50 studies to 37 studies.docx'
     file_project_placeholder: 'Decision-making in breast cancer prevention: The ENGAGE study'
-    file_viewer_placeholder: 'File Viewer'
 dashboard:
     page_title: Home
     title: Dashboard


### PR DESCRIPTION
-   Ticket: [ENG-3531](https://openscience.atlassian.net/browse/ENG-3531)
-   Feature flag:`ember_file_registration_detail_page`

## Purpose

Add the file renderer to the file detail page

## Summary of Changes

1. Add file renderer
2. Use file's name above renderer
3. Add tests 
4. Remove unused translation strings

## Screenshot(s)

<img width="1197" alt="Screen Shot 2022-02-28 at 8 51 19 AM" src="https://user-images.githubusercontent.com/6599111/156004248-4e060447-9b74-42e8-bd2d-35e7374c396b.png">

## Side Effects

No.

## QA Notes

I wasn't able to fully test this locally because MFR doesn't like working locally without jumping through a lot of hoops. So when we see it on staging, there may need to be adjustments. The general CSS work I think will also affect the presentation.
