### PR TITLE
[ENG-3629] Link back to target registration/node

### DIFF
--- a/app/guid-file/route.ts
+++ b/app/guid-file/route.ts
@@ -42,7 +42,7 @@ export default class GuidFile extends Route {
     async model(params: { guid: string }) {
         const { guid } = params;
         try {
-            const file = await this.store.findRecord('file', guid);
+            const file = await this.store.findRecord('file', guid, { include: 'target' });
 
             return file;
         } catch (error) {

--- a/app/guid-file/styles.scss
+++ b/app/guid-file/styles.scss
@@ -180,6 +180,9 @@
     background-color: #337ab7;
 }
 
-// h1 h2 h3 {
-//     font-weight: 900;
-// }
+.FileDetail__registration-link {
+    font-size: larger;
+    font-weight: 400;
+    margin-top: 20px;
+    margin-left: 15px;
+}

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -3,19 +3,14 @@
         <div id='mainPanel' class='col-lg-12' local-class='FileDetail_main'>
             <div class='row'>
                 <div local-class='FileDetail-project-link' class='col-lg-12'>
-                    <BsButton
+                    <OsfLink
                         data-test-project-link
                         data-analytics-name='Linked project'
                         local-class='FileDetail__registration-link'
-                        @bubble={{true}}
-                        @type='link'
-                        @onClick={{'#'}}
+                        @href={{this.model.target.links.html}}
                     >
-                        <h3>
-                            {{t 'file_detail.file_project_placeholder'}}
-                            {{this.file.parentFolder}}
-                        </h3>
-                    </BsButton>
+                        {{this.model.target.title}}
+                    </OsfLink>
                 </div>
             </div>
             <div class='row' local-class='FileDetail_filename-buttons'>

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -7,7 +7,8 @@
                         data-test-project-link
                         data-analytics-name='Linked project'
                         local-class='FileDetail__registration-link'
-                        @href={{this.model.target.links.html}}
+                        @route={{if (eq this.model.target.type 'registrations') 'guid-registration' 'guid-node'}}
+                        @models={{array this.model.target.id}}
                     >
                         {{this.model.target.title}}
                     </OsfLink>

--- a/tests/acceptance/guid-file/registration-file-detail-test.ts
+++ b/tests/acceptance/guid-file/registration-file-detail-test.ts
@@ -20,6 +20,8 @@ module('Acceptance | guid file | registration files', hooks => {
         assert.dom('[data-test-filename]')
             .hasText('Test File', 'The correct filename is on the page');
         assert.dom('[data-test-file-renderer] iframe').exists('File renderer is rendering');
+        assert.dom('[data-test-project-link]')
+            .hasText(registration.title, 'Link to registration has the title of the registration' );
         await percySnapshot(assert);
     });
 });


### PR DESCRIPTION
-   Ticket: [ENG-3629](https://openscience.atlassian.net/browse/ENG-3629)
-   Feature flag: `ember_file_registration_detail_page`

## Purpose

Link the file back to the target node or registration (in this case, registration). 

## Summary of Changes

1. Embed the target in the model request
2. Change button to link
3. Use target info for link
4. Remove h3 for not being semantically correct  

## Screenshot(s)

<img width="1129" alt="Screen Shot 2022-03-01 at 3 57 38 PM" src="https://user-images.githubusercontent.com/6599111/156248307-a692f2e8-0106-418a-89da-7085d787a00c.png">


## Side Effects

The layout is a bit messed up, but I wanted to make minimal changes to layout since there will be some larger-page changes coming soon.

## QA Notes

