### PR TITLE
[ENG-3536] Add file-embed-menu to file-actions-menu

### DIFF
--- a/app/models/file.ts
+++ b/app/models/file.ts
@@ -19,6 +19,7 @@ export interface FileLinks extends BaseFileLinks {
 
     // only for files
     download?: Link;
+    render?: Link;
 }
 
 export default class FileModel extends BaseFileItem {

--- a/lib/osf-components/addon/components/button/styles.scss
+++ b/lib/osf-components/addon/components/button/styles.scss
@@ -76,6 +76,7 @@
     }
 }
 
+// Composed by ../file-embed-menu/styles.scss
 .FakeLink {
     background: none;
     border: transparent;

--- a/lib/osf-components/addon/components/file-actions-menu/template.hbs
+++ b/lib/osf-components/addon/components/file-actions-menu/template.hbs
@@ -22,6 +22,20 @@
                 {{t 'general.download'}}
             </Button>
         </OsfLink>
+        <FileEmbedMenu @file={{@item}} as |dd|>
+            <dd.trigger
+                data-test-embed-button
+                data-analytics-name='Expand embed menu'
+                aria-label={{t 'general.embed'}}
+            >
+                <Button
+                    @layout='fake-link'
+                >
+                    <FaIcon @icon='file-import' />
+                    {{t 'general.embed'}}
+                </Button>
+            </dd.trigger>
+        </FileEmbedMenu>
         <SharingIcons::Dropdown
             @title={{@item.name}}
             @description={{@item.name}}

--- a/lib/osf-components/addon/components/file-embed-menu/component.ts
+++ b/lib/osf-components/addon/components/file-embed-menu/component.ts
@@ -1,0 +1,72 @@
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { htmlSafe } from '@ember/template';
+import Component from '@glimmer/component';
+import config from 'ember-get-config';
+import Intl from 'ember-intl/services/intl';
+import Toast from 'ember-toastr/services/toast';
+
+import FileModel from 'ember-osf-web/models/file';
+
+interface Args {
+    file: FileModel;
+}
+
+export default class FileEmbedMenuComponent extends Component<Args>{
+
+    @service toast!: Toast;
+    @service intl!: Intl;
+
+    get shareiFrameDynamic() {
+        const mfrStaticUrl = config.OSF.renderUrl.replace('/render', '/static');
+
+        return htmlSafe(`<style>
+    .embed-responsive {
+        position:relative;
+        height:100%;
+    }
+    .embed-responsive iframe {
+        position:absolute;
+        height:100%;
+    }
+</style>
+<link href="${mfrStaticUrl}/css/mfr.css" media="all" rel="stylesheet">
+<div id="mfrIframe" class="mfr mfr-file"></div>
+<script src="${mfrStaticUrl}/js/mfr.js"></script>
+<script>
+    function renderMfr() {
+        var mfrRender = new mfr.Render("mfrIframe", "${this.args.file.links.render}");
+    }
+    if (window.$) {
+        renderMfr();
+    } else {
+        var jq = document.createElement('script');
+        document.head.appendChild(jq);
+        jq.onload = function() {
+            renderMfr();
+        }
+        jq.src = 'http://code.jquery.com/jquery-1.11.2.min.js';
+    }
+</script>`.trim().replace(/^\s{12}/mg, ''));
+    }
+
+    get shareiFrameDirect() {
+        return htmlSafe(`<iframe src="${this.args.file.links.render}"
+        width="100%"
+        scrolling="yes"
+        height="677px"
+        marginheight="0"
+        frameborder="0"
+        allowfullscreen
+        webkitallowfullscreen
+>`.trim().replace(/^\s{12}/mg, ''));
+    }
+
+    @action successMessage(){
+        this.toast.success(this.intl.t('file_actions_menu.success_message'));
+    }
+
+    @action errorMessage(){
+        this.toast.error(this.intl.t('file_actions_menu.error_message'));
+    }
+}

--- a/lib/osf-components/addon/components/file-embed-menu/component.ts
+++ b/lib/osf-components/addon/components/file-embed-menu/component.ts
@@ -47,19 +47,19 @@ export default class FileEmbedMenuComponent extends Component<Args>{
         }
         jq.src = 'http://code.jquery.com/jquery-1.11.2.min.js';
     }
-</script>`.trim().replace(/^\s{12}/mg, ''));
+</script>`);
     }
 
     get shareiFrameDirect() {
         return htmlSafe(`<iframe src="${this.args.file.links.render}"
-        width="100%"
-        scrolling="yes"
-        height="677px"
-        marginheight="0"
-        frameborder="0"
-        allowfullscreen
-        webkitallowfullscreen
->`.trim().replace(/^\s{12}/mg, ''));
+    width="100%"
+    scrolling="yes"
+    height="677px"
+    marginheight="0"
+    frameborder="0"
+    allowfullscreen
+    webkitallowfullscreen
+>`);
     }
 
     @action successMessage(){

--- a/lib/osf-components/addon/components/file-embed-menu/styles.scss
+++ b/lib/osf-components/addon/components/file-embed-menu/styles.scss
@@ -1,0 +1,45 @@
+.FakeLink {
+    background: none;
+    border: transparent;
+    display: inline;
+    color: $color-link-dark;
+
+    &:hover {
+        color: var(--primary-color);
+        text-decoration: underline;
+    }
+}
+
+.Dropdown__list {
+    background-color: $color-bg-white;
+    padding: 10px 20px;
+    border-radius: 0;
+    box-shadow: 0 1px 2px $primary-box-shadow;
+    border: 1px solid $alto;
+    border-color: transparent;
+    background-size: cover;
+    list-style: none;
+    min-width: 160px;
+    margin: 0;
+
+    a {
+        display: block;
+    }
+}
+
+.Dropdown__option {
+    font-size: 14px;
+    line-height: 2.2;
+
+    svg {
+        padding-right: 6px;
+        font-size: 16px;
+    }
+
+    a:hover,
+    a:focus {
+        text-decoration: none;
+        color: $secondary-blue;
+        outline: 0;
+    }
+}

--- a/lib/osf-components/addon/components/file-embed-menu/styles.scss
+++ b/lib/osf-components/addon/components/file-embed-menu/styles.scss
@@ -1,45 +1,11 @@
 .FakeLink {
-    background: none;
-    border: transparent;
-    display: inline;
-    color: $color-link-dark;
-
-    &:hover {
-        color: var(--primary-color);
-        text-decoration: underline;
-    }
+    composes: FakeLink from '../button/styles.scss';
 }
 
 .Dropdown__list {
-    background-color: $color-bg-white;
-    padding: 10px 20px;
-    border-radius: 0;
-    box-shadow: 0 1px 2px $primary-box-shadow;
-    border: 1px solid $alto;
-    border-color: transparent;
-    background-size: cover;
-    list-style: none;
-    min-width: 160px;
-    margin: 0;
-
-    a {
-        display: block;
-    }
+    composes: Dropdown__list from '../sharing-icons/dropdown/styles.scss';
 }
 
 .Dropdown__option {
-    font-size: 14px;
-    line-height: 2.2;
-
-    svg {
-        padding-right: 6px;
-        font-size: 16px;
-    }
-
-    a:hover,
-    a:focus {
-        text-decoration: none;
-        color: $secondary-blue;
-        outline: 0;
-    }
+    composes: Dropdown__option from '../sharing-icons/dropdown/styles.scss';
 }

--- a/lib/osf-components/addon/components/file-embed-menu/template.hbs
+++ b/lib/osf-components/addon/components/file-embed-menu/template.hbs
@@ -1,0 +1,29 @@
+<ResponsiveDropdown as |dd|>
+    {{yield (hash trigger=dd.trigger isOpen=dd.isOpen)}}
+    <dd.content>
+        <ul data-test-sharing-options local-class='Dropdown__list'>
+            <li>
+                <CopyButton
+                    data-test-copy-js
+                    @clipboardText={{this.shareiFrameDynamic}}
+                    @success={{action this.successMessage}}
+                    @error={{action this.errorMessage}}
+                    local-class='FakeLink Dropdown__option'
+                >
+                    {{t 'file_actions_menu.copy_js'}}
+                </CopyButton>
+            </li>
+            <li>
+                <CopyButton
+                    data-test-copy-html
+                    @clipboardText={{this.shareiFrameDirect}}
+                    @success={{action this.successMessage}}
+                    @error={{action this.errorMessage}}
+                    local-class='FakeLink Dropdown__option'
+                >
+                    {{t 'file_actions_menu.copy_html'}}
+                </CopyButton>
+            </li>
+        </ul>
+    </dd.content>
+</ResponsiveDropdown>

--- a/lib/osf-components/addon/components/sharing-icons/dropdown/styles.scss
+++ b/lib/osf-components/addon/components/sharing-icons/dropdown/styles.scss
@@ -1,3 +1,5 @@
+// Composed by ../../file-embed-menu/styles.scss
+
 .Dropdown__list {
     background-color: $color-bg-white;
     padding: 10px 20px;

--- a/lib/osf-components/app/components/file-embed-menu/component.js
+++ b/lib/osf-components/app/components/file-embed-menu/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/file-embed-menu/component';

--- a/lib/osf-components/app/components/file-embed-menu/template.js
+++ b/lib/osf-components/app/components/file-embed-menu/template.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/file-embed-menu/template';

--- a/tests/integration/components/file-embed-menu/component-test.ts
+++ b/tests/integration/components/file-embed-menu/component-test.ts
@@ -1,11 +1,13 @@
 import { render } from '@ember/test-helpers';
 import click from '@ember/test-helpers/dom/click';
 import { hbs } from 'ember-cli-htmlbars';
+import { setupIntl, t } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Integration | Component | file-embed-menu', hooks => {
     setupRenderingTest(hooks);
+    setupIntl(hooks);
 
     test('it renders', async function(assert) {
         // Set any properties with this.set('myProperty', 'value');
@@ -31,7 +33,8 @@ module('Integration | Component | file-embed-menu', hooks => {
             </dd.trigger>
         </FileEmbedMenu>`);
         await click('[data-test-embed-button]');
-        assert.dom('[data-test-copy-js]').hasText('Copy dynamic JS iFrame');
+        assert.dom('[data-test-copy-js]').hasText(t('file_actions_menu.copy_js'));
+        assert.dom('[data-test-copy-html]').hasText(t('file_actions_menu.copy_html'));
 
     });
 });

--- a/tests/integration/components/file-embed-menu/component-test.ts
+++ b/tests/integration/components/file-embed-menu/component-test.ts
@@ -1,0 +1,37 @@
+import { render } from '@ember/test-helpers';
+import click from '@ember/test-helpers/dom/click';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Component | file-embed-menu', hooks => {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function(assert) {
+        // Set any properties with this.set('myProperty', 'value');
+        // Handle any actions with this.set('myAction', function(val) { ... });
+        this.set('file', {
+            links: {
+                render: 'http://render.url/',
+            },
+        });
+        await render(hbs`
+        <FileEmbedMenu @file={{this.file}} as |dd|>
+            <dd.trigger
+                data-test-embed-button
+                data-analytics-name='Expand embed menu'
+                aria-label={{t 'general.embed'}}
+            >
+                <Button
+                    @layout='fake-link'
+                >
+                    <FaIcon @icon='file-import' />
+                    {{t 'general.embed'}}
+                </Button>
+            </dd.trigger>
+        </FileEmbedMenu>`);
+        await click('[data-test-embed-button]');
+        assert.dom('[data-test-copy-js]').hasText('Copy dynamic JS iFrame');
+
+    });
+});

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -101,6 +101,10 @@ general:
     engineering: 'engineering'
 file_actions_menu:
     actions: '{filename} actions'
+    copy_js: 'Copy dynamic JS iFrame'
+    copy_html: 'Copy static HTML iFrame'
+    success_message: 'Copied to clipboard'
+    error_message: 'Could not copy to clipboard'
 node_categories:
     analysis: Analysis
     communication: Communication


### PR DESCRIPTION
-   Ticket: [ENG-3536](https://openscience.atlassian.net/browse/ENG-3536)
-   Feature flag: `ember_file_registration_detail_page`

## Purpose

Allow users to embed files into their own web pages

## Summary of Changes

1. Create `file-embed-menu` component
2. Add `file-embed-menu` component to `file-actions-menu`
3. Add translation strings
4. Test
5. Add render link to file links

## Screenshot(s)

<img width="642" alt="Screen Shot 2022-03-02 at 2 18 30 PM" src="https://user-images.githubusercontent.com/6599111/156637366-04ff0384-5c1e-435e-8553-8d0c765efcdc.png">

## Side Effects

This will also put the embed on the file list screen.

## QA Notes

This does not fix the accessibility problem with the menu's no-nested-interactive problem, nor any styling issues that may be happening in mobile.
