### PR TITLE
[ENG-3534] Add tags widget

### DIFF
--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -190,14 +190,11 @@
                     {{t 'general.tags'}}
                 </h2>
                 <hr>
-                <div local-class='container-fluid FileDetail_tags-container'>
-                    <p>
-                        <a href='#'>{{t 'general.science'}}</a>
-                    </p>
-                    <p>
-                        <a href='#'>{{t 'general.engineering'}}</a>
-                    </p>
-                </div>
+                <TagsWidget
+                    @taggable={{this.model}}
+                    @readOnly={{false}}
+                    @inline={{true}}
+                />
             </div>
         </div>
     </div>

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -59,8 +59,8 @@
             <div local-class='RightContainer'>
                 <h2>{{t 'general.tags'}}</h2>
                 <TagsWidget
-                    @taggable={{this.model}}
-                    @readOnly={{false}}
+                    @taggable={{this.model.fileModel}}
+                    @readOnly={{not this.model.userCanEditMetadata}}
                     @inline={{true}}
                 />
             </div>

--- a/app/models/abstract-node.ts
+++ b/app/models/abstract-node.ts
@@ -1,8 +1,10 @@
-import { hasMany, AsyncHasMany } from '@ember-data/model';
+import { hasMany, AsyncHasMany, attr } from '@ember-data/model';
 
 import BaseFileItem from 'ember-osf-web/models/base-file-item';
 import DraftRegistrationModel from 'ember-osf-web/models/draft-registration';
 import FileProviderModel from 'ember-osf-web/models/file-provider';
+
+import { Permission } from './osf-model';
 
 export default class AbstractNodeModel extends BaseFileItem {
     @hasMany('file-provider', { inverse: 'target' })
@@ -10,6 +12,9 @@ export default class AbstractNodeModel extends BaseFileItem {
 
     @hasMany('draft-registration', { inverse: 'branchedFrom' })
     draftRegistrations!: AsyncHasMany<DraftRegistrationModel> & DraftRegistrationModel[];
+
+    @attr('array') currentUserPermissions!: Permission[];
+
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/models/node.ts
+++ b/app/models/node.ts
@@ -87,8 +87,7 @@ export default class NodeModel extends AbstractNodeModel.extend(Validations, Col
     @attr('fixstring') title!: string;
     @attr('fixstring') description!: string;
     @attr('node-category') category!: NodeCategory;
-    @attr('array') currentUserPermissions!: Permission[];
-    @attr('boolean') currentUserIsContributor!: boolean;
+     @attr('boolean') currentUserIsContributor!: boolean;
     @attr('boolean') fork!: boolean;
     @alias('fork') isFork!: boolean;
     @attr('boolean') collection!: boolean;

--- a/app/packages/files/file.ts
+++ b/app/packages/files/file.ts
@@ -4,6 +4,7 @@ import { task } from 'ember-concurrency';
 
 import FileModel from 'ember-osf-web/models/file';
 import NodeModel from 'ember-osf-web/models/node';
+import { Permission } from 'ember-osf-web/models/osf-model';
 
 export enum FileSortKey {
     AscDateModified = 'modified',
@@ -66,6 +67,10 @@ export default abstract class File {
             links.download = `${links.upload}?zip=`;
         }
         return links;
+    }
+
+    get userCanEditMetadata() {
+        return this.fileModel.target.get('currentUserPermissions').includes(Permission.Write);
     }
 
     get dateModified() {


### PR DESCRIPTION
-   Ticket: [ENG-3534]
-   Feature flag: `ember_file_registration_detail_page`

## Purpose

Add the tags widget to the file detail page. 

## Summary of Changes

1. Add tags widget

## Screenshot(s)

<img width="1729" alt="Screen Shot 2022-03-09 at 9 39 55 AM" src="https://user-images.githubusercontent.com/6599111/157464344-eaff1727-f092-458c-b731-99eaa77709ee.png">

## Side Effects

No, this is isolated.

## QA Notes

You will need the current version of `johnetordoff/sunset-quickfiles` in order to test this, as it contains, among other things, the code to make tags writeable.


[ENG-3534]: https://openscience.atlassian.net/browse/ENG-3534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ