### PR TITLE
[ENG-3652] Add tests for file revisions

### DIFF
--- a/lib/osf-components/addon/components/file-version/template.hbs
+++ b/lib/osf-components/addon/components/file-version/template.hbs
@@ -1,6 +1,8 @@
-<li>
+<li data-test-file-version-item={{@version.id}} >
     <span local-class='VersionLabel'>
         <Button
+            data-test-file-version-date
+            data-analytics-name='View file version'
             aria-label={{t 'osf-components.file-version.view_version' date=(moment-format @version.attributes.modified 'YYYY-MM-DD hh:mm A')}}
             @layout='fake-link'
             {{on 'click' (action @changeVersion @version.id)}}
@@ -8,8 +10,9 @@
             {{moment-format @version.attributes.modified 'YYYY-MM-DD hh:mm A'}}
         </Button>
         <Button
+            data-test-file-version-toggle-button
+            data-analytics-name='Toggle file version info'
             aria-label={{if this.dropdownOpen (t 'osf-components.file-version.hide_info') (t 'osf-components.file-version.show_info')}}
-            data-test-detail-trigger-button
             local-class='DropdownTrigger'
             {{on 'click' this.toggleDropdown}}
             @layout='fake-link'
@@ -19,17 +22,24 @@
     </span>
 
     {{#if this.dropdownOpen}}
-        <div local-class='DropdownSection'>
+        <div
+            data-test-file-version-section='user'
+            local-class='DropdownSection'
+        >
             <span>
                 {{t 'general.user'}}:
                 <OsfLink
+                    data-test-file-version-user-link
                     @href={{@version.attributes.extra.user.url}}
                 >
                     {{@version.attributes.extra.user.name}}
                 </OsfLink>
             </span>
         </div>
-        <div local-class='DropdownSection'>
+        <div
+            data-test-file-version-section='md5'
+            local-class='DropdownSection'
+        >
             <CopyButton
                 @clipboardText={{@version.attributes.extra.hashes.md5}}
                 @success={{this.copySuccess}}
@@ -50,7 +60,10 @@
                 </BsTooltip>
             </div>
         </div>
-        <div local-class='DropdownSection'>
+        <div
+            data-test-file-version-section='sha2'
+            local-class='DropdownSection'
+        >
             <CopyButton
                 @clipboardText={{@version.attributes.extra.hashes.sha256}}
                 @success={{this.copySuccess}}
@@ -71,8 +84,12 @@
                 </BsTooltip>
             </div>
         </div>
-        <div local-class='DropdownSection'>
+        <div
+            data-test-file-version-section='download'
+            local-class='DropdownSection'
+        >
             <Button
+                data-analytics-name='Download file version'
                 @layout='fake-link'
                 {{on 'click' (action this.downloadVersion @version.id)}}
             >

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -325,7 +325,6 @@ export default function(this: Server) {
     this.put('/files/:id/upload', uploadToFolder);
     this.get('/files/:id/upload/', wb.fileVersions);
     this.del('/files/:id/delete', wb.deleteFile);
-    this.get('/files/:id/download', wb.fileVersions);
 
     // Private namespace
     this.namespace = '/_';

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -323,6 +323,7 @@ export default function(this: Server) {
     this.post('/files/:id/move', wb.moveFile);
     this.post('/files/:id/upload', wb.renameFile);
     this.put('/files/:id/upload', uploadToFolder);
+    this.get('/files/:id/upload/', wb.fileVersions);
     this.del('/files/:id/delete', wb.deleteFile);
     this.get('/files/:id/download', wb.fileVersions);
 

--- a/tests/acceptance/guid-file/registration-file-detail-test.ts
+++ b/tests/acceptance/guid-file/registration-file-detail-test.ts
@@ -2,26 +2,103 @@ import {
     currentURL,
     visit,
 } from '@ember/test-helpers';
+import { ModelInstance } from 'ember-cli-mirage';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { t } from 'ember-intl/test-support';
 import { percySnapshot } from 'ember-percy';
+import { setBreakpoint } from 'ember-responsive/test-support';
+import { TestContext } from 'ember-test-helpers';
 import { module, test } from 'qunit';
 
-import { setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
+import { click, setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
+import FileModel from 'ember-osf-web/models/file';
+import RegistrationModel from 'ember-osf-web/models/registration';
+
+interface ThisTestContext extends TestContext {
+    registration: ModelInstance<RegistrationModel>;
+    file: ModelInstance<FileModel>;
+}
 
 module('Acceptance | guid file | registration files', hooks => {
     setupOSFApplicationTest(hooks);
     setupMirage(hooks);
 
-    test('works', async assert => {
-        const registration = server.create('registration');
-        const fileOne = server.create('file', { target: registration, name: 'Test File' });
-        await visit(`/--file/${fileOne.id}`);
-        assert.equal(currentURL(), `/--file/${fileOne.guid}`);
+    hooks.beforeEach(function(this: ThisTestContext) {
+        this.registration = server.create('registration');
+        this.file = server.create('file', { target: this.registration, name: 'Test File' });
+    });
+
+    test('Desktop view', async function(this: ThisTestContext, assert) {
+        await visit(`/--file/${this.file.id}`);
+        assert.equal(currentURL(), `/--file/${this.file.guid}`);
         assert.dom('[data-test-filename]')
             .hasText('Test File', 'The correct filename is on the page');
         assert.dom('[data-test-file-renderer] iframe').exists('File renderer is rendering');
         assert.dom('[data-test-project-link]')
-            .hasText(registration.title, 'Link to registration has the title of the registration' );
+            .hasText(this.registration.title, 'Link to registration has the title of the registration' );
+        assert.dom('[data-test-file-download-share-trigger]').exists('File download/share trigger exists');
+        assert.dom('[data-test-file-renderer-button]').doesNotExist('File renderer button does not exist for desktop');
+        assert.dom('[data-test-versions-button]').exists('Versions button exists');
+        assert.dom('[data-test-tags-button]').exists('Tags button exists');
         await percySnapshot(assert);
     });
+
+    test('mobile view', async function(this: ThisTestContext, assert) {
+        setBreakpoint('mobile');
+        await visit(`/--file/${this.file.id}`);
+        assert.equal(currentURL(), `/--file/${this.file.guid}`);
+        assert.dom('[data-test-filename]')
+            .hasText('Test File', 'The correct filename is on the page');
+        assert.dom('[data-test-file-renderer]').exists('File renderer is shown by default');
+        assert.dom('[data-test-project-link]')
+            .hasText(this.registration.title, 'Link to registration has the title of the registration' );
+        assert.dom('[data-test-file-download-share-trigger]').exists('File download/share trigger exists');
+        assert.dom('[data-test-file-renderer-button]').exists('File renderer button exists for mobile');
+        assert.dom('[data-test-versions-button]').exists('Versions button exists');
+        assert.dom('[data-test-tags-button]').exists('Tags button exists');
+        await percySnapshot('Acceptance | guid file | registration files | mobile view | file renderer');
+
+        await click('[data-test-versions-button]');
+        assert.dom('[data-test-revisions-tab]').exists('Revisions shown');
+        assert.dom('[data-test-file-renderer]').doesNotExist('File renderer is hidden');
+        await percySnapshot('Acceptance | guid file | registration files | mobile view | revisions');
+
+        // click tags and verify appropriate panels shown
+
+        await click('[data-test-file-renderer-button]');
+        assert.dom('[data-test-file-renderer]').exists('File renderer is shown again');
+        assert.dom('[data-test-revisions-tab]').doesNotExist('Revisions now hidden');
+    });
+
+    test('view revisions', async function(this: ThisTestContext, assert) {
+        await visit(`/--file/${this.file.id}`);
+        assert.equal(currentURL(), `/--file/${this.file.guid}`);
+
+        assert.dom('[data-test-filename]')
+            .doesNotContainText(t('general.version'), 'Viewed version is not specified on page load');
+        assert.dom('[data-test-revisions-tab]').doesNotExist('Revisions tab closed on page load');
+        assert.dom('[data-test-versions-button]')
+            .hasAria('label', t('file_detail.view_revisions'), 'Versions button has correct label when closed');
+
+        await click('[data-test-versions-button]');
+        assert.dom('[data-test-revisions-tab]').exists('Revisions tab opened');
+        assert.dom('[data-test-versions-button]')
+            .hasAria('label', t('file_detail.close_revisions'), 'Versions button has correct label when open');
+        assert.dom('[data-test-file-version-item]').exists({ count: 2 }, 'Two file versions are shown');
+        await click('[data-test-file-version-toggle-button]');
+        assert.dom('[data-test-file-version-section]').exists({ count: 4 }, 'File version info is shown');
+        await click('[data-test-file-version-date]');
+        assert.dom('[data-test-filename]')
+            .containsText(t('general.version'), 'Viewed version specified after selecting version');
+        await percySnapshot(assert);
+
+        await click('[data-test-versions-button]');
+        assert.dom('[data-test-revisions-tab]').doesNotExist('Revisions tab closes when clicking button again');
+        assert.dom('[data-test-versions-button]')
+            .hasAria('label', t('file_detail.view_revisions'), 'Versions button has correct label when closed');
+    });
+
+    // test for tags
+
+    // test for switching views
 });

--- a/tests/integration/components/file-version/component-test.ts
+++ b/tests/integration/components/file-version/component-test.ts
@@ -1,8 +1,69 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupIntl, t } from 'ember-intl/test-support';
+import { percySnapshot } from 'ember-percy';
 import { setupRenderingTest } from 'ember-qunit';
-import { module } from 'qunit';
+import moment from 'moment';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import { click } from 'ember-osf-web/tests/helpers';
 
 module('Integration | Component | file-version', hooks => {
     setupRenderingTest(hooks);
+    setupIntl(hooks);
 
-    // TODO: Update this test
+    const changeVersionStub = sinon.stub();
+    const downloadUrl = 'https://download.com';
+    const date = '2020-02-02T02:02:02.000Z';
+    test('it renders', async function(assert) {
+        const version = {
+            id: '1',
+            attributes: {
+                extra: {
+                    downloads: 22,
+                    hashes: {
+                        md5: '1234md5',
+                        sha256: '543sha21',
+                    },
+                    user: {
+                        name: 'Larry',
+                        url: '/larry',
+                    },
+                },
+                version: 1,
+                modified: new Date(date),
+                modified_utc: new Date(date),
+                versionIdentifier: 'version',
+            },
+        };
+        this.setProperties({
+            version,
+            changeVersion: changeVersionStub,
+            downloadUrl,
+        });
+
+        await render(hbs`
+        <FileVersion
+            @version={{this.version}} @downloadUrl={{this.downloadUrl}} @changeVersion={{this.changeVersion}}
+        />
+        `);
+        assert.dom('[data-test-file-version-date]').hasText(moment(date).format('YYYY-MM-DD hh:mm A'));
+        assert.dom('[data-test-file-version-toggle-button] .fa-caret-down').exists('toggle button points down');
+        assert.dom('[data-test-file-version-section]').doesNotExist('No sections shown');
+
+        await click('[data-test-file-version-toggle-button]');
+        assert.dom('[data-test-file-version-toggle-button] .fa-caret-up').exists('toggle button points up');
+        assert.dom('[data-test-file-version-section="user"]').hasText(t('general.user')+': Larry');
+        assert.dom('[data-test-file-version-section="user"] a').hasAttribute('href', '/larry', 'user link is correct');
+        assert.dom('[data-test-file-version-section="md5"]')
+            .hasText(t('osf-components.file-version.copy_md5'));
+        assert.dom('[data-test-file-version-section="sha2"]')
+            .hasText(t('osf-components.file-version.copy_sha2'));
+        assert.dom('[data-test-file-version-section="download"]')
+            .containsText(t('general.download'));
+        assert.dom('[data-test-file-version-section="download"]')
+            .containsText('22', 'shows download count');
+        await percySnapshot(assert);
+    });
 });


### PR DESCRIPTION
-   Ticket: [ENG-3652]
-   Feature flag: n/a

## Purpose
- Add tests for file-version component
- Add acceptance tests for file detail page

## Summary of Changes
- component tests and data-test selectors for the file-version component
- add acceptance test for file-detail page
  - View revisions
  - Mobile view
- Add mirage endpoint for waterbutler revisions

## Screenshot(s)
- NA

## Side Effects
- NA

## QA Notes
- NA


[ENG-3652]: https://openscience.atlassian.net/browse/ENG-3652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ