### PR TITLE
[ENG-3649] Fix bugs: add mfr iframe translation

### DIFF
--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -23,7 +23,7 @@
     </:header>
     <:body>
         <div data-test-file-renderer id='mfrIframeParent' local-class='FileRenderer'>
-            <FileRenderer @download={{this.model.links.download}} />
+            <FileRenderer @download={{this.model.links.download}} @name={{this.model.name}}/>
         </div>
     </:body>
     <:right>

--- a/lib/osf-components/addon/components/file-renderer/component.ts
+++ b/lib/osf-components/addon/components/file-renderer/component.ts
@@ -1,8 +1,11 @@
 import Component from '@ember/component';
 import { action, computed } from '@ember/object';
+import { inject as service } from '@ember/service';
 import { next } from '@ember/runloop';
 import config from 'ember-get-config';
 import $ from 'jquery';
+import Media from 'ember-responsive';
+import File from 'ember-osf-web/models/file';
 
 import { layout } from 'ember-osf-web/decorators/component';
 
@@ -34,6 +37,12 @@ interface Params {
  */
 @layout(template)
 export default class FileRenderer extends Component {
+    @service media!: Media;
+
+    get isMobile() {
+        return this.media.isMobile;
+    }
+
     params: Params = {
         direct: '',
         mode: 'render',
@@ -46,6 +55,11 @@ export default class FileRenderer extends Component {
     allowfullscreen = true;
     version?: number;
     isLoading = true;
+    file?: File;
+
+    getFileName(): string {
+        return this.file!.name;
+    }
 
     @computed('download', 'params', 'version')
     get downloadUrl(): string {

--- a/lib/osf-components/addon/components/file-renderer/template.hbs
+++ b/lib/osf-components/addon/components/file-renderer/template.hbs
@@ -6,7 +6,7 @@
     <iframe
         src={{this.mfrUrl}}
         width={{this.width}}
-        title={{t 'file_detail.mfr_iframe_title'}}
+        name={{this.file.name}}
         height={{this.height}}
         scrolling='yes'
         marginheight='0'

--- a/lib/osf-components/addon/components/file-renderer/template.hbs
+++ b/lib/osf-components/addon/components/file-renderer/template.hbs
@@ -2,6 +2,7 @@
     {{#if this.isLoading}}
         <LoadingIndicator @dark={{true}}/>
     {{/if}}
+    <p>{{t 'file_detail.mfr_iframe_title'}}</p>
     <iframe
         src={{this.mfrUrl}}
         width={{this.width}}

--- a/lib/osf-components/addon/components/file-renderer/template.hbs
+++ b/lib/osf-components/addon/components/file-renderer/template.hbs
@@ -2,17 +2,19 @@
     {{#if this.isLoading}}
         <LoadingIndicator @dark={{true}}/>
     {{/if}}
-    <p>{{t 'file_detail.mfr_iframe_title'}}</p>
+
     <iframe
         src={{this.mfrUrl}}
         width={{this.width}}
-        name={{this.file.name}}
         height={{this.height}}
+        name={{@item.name}}
         scrolling='yes'
         marginheight='0'
         frameborder='0'
         allowfullscreen={{this.allowfullscreen}}
         hidden={{this.isLoading}}
         onload={{action this.loaded}}
-    ></iframe>
+    >
+        <p>{{t 'file_detail.mfr_iframe_title'}} {{this.name}}</p>
+    </iframe>
 {{/if}}

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -118,6 +118,7 @@ maintenance:
     line2: 'Thank you for your patience.'
     title: 'Notice:'
 file_detail:
+    mfr_iframe_title: 'File Detail View: {name}'
     version:
         id: 'Version ID'
         title: '(Version: {versionNumber})'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -118,7 +118,7 @@ maintenance:
     line2: 'Thank you for your patience.'
     title: 'Notice:'
 file_detail:
-    mfr_iframe_title: 'File Detail View: {name}'
+    mfr_iframe_title: 'File Detail View: '
     version:
         id: 'Version ID'
         title: '(Version: {versionNumber})'


### PR DESCRIPTION


-   Ticket: https://openscience.atlassian.net/browse/ENG-3649
-   Feature flag: n/a

## Purpose

The purpose of this change is to provide a translation string for the mfr iframe on the File Renderer component.

## Summary of Changes

-The en-us.yml translation file was updated to include file_detail.mfr_iframe_title : 'File Detail View: '
-A paragraph tag including the title was added to the iframe element

## Screenshot(s)

Screenshots will need to be updated with Docker enabled.

## Side Effects

When missing, the error message produced would throw off the UI. It is suggested that there be a font property added to the error message that renders it smaller and the same size as the current/ no larger than the parent element.

## QA Notes

-Does the string render properly?
-Is proper styling added to the string?