### PR TITLE
[ENG-3649] Fileslist a11y fixes

### DIFF
--- a/lib/osf-components/addon/components/button/styles.scss
+++ b/lib/osf-components/addon/components/button/styles.scss
@@ -77,6 +77,7 @@
 }
 
 // Composed by ../file-embed-menu/styles.scss
+// Composed by ../file-actions-menu/styles.scss
 .FakeLink {
     background: none;
     border: transparent;

--- a/lib/osf-components/addon/components/file-actions-menu/styles.scss
+++ b/lib/osf-components/addon/components/file-actions-menu/styles.scss
@@ -7,8 +7,14 @@
     flex-direction: column;
     align-items: flex-start;
     border: 1px solid $color-border-gray;
+    padding: 8px;
 
-    button {
-        padding: 8px;
+    div {
+        padding-top: 8px;
     }
+}
+
+.DropdownItem {
+    composes: FakeLink from '../button/styles.scss';
+    margin: 6px 0;
 }

--- a/lib/osf-components/addon/components/file-actions-menu/template.hbs
+++ b/lib/osf-components/addon/components/file-actions-menu/template.hbs
@@ -1,17 +1,15 @@
 <ResponsiveDropdown
     local-class='DownloadShareDropdown'
+    @buttonStyling={{true}}
     @horizontalPosition='right'
     as |dropdown|
 >
     <dropdown.trigger
+        aria-label={{t 'file_actions_menu.actions' filename=@item.name}} 
         data-test-file-download-share-trigger
         data-analytics-name='File actions'
     >
-        <Button
-            aria-label={{t 'file_actions_menu.actions' filename=@item.name}} 
-        >
-            <FaIcon @icon='ellipsis-v' />
-        </Button>
+        <FaIcon @icon='ellipsis-v' />
     </dropdown.trigger>
     <dropdown.content local-class='DropdownList'>
         <OsfLink @href={{@item.links.download}}>

--- a/lib/osf-components/addon/components/file-actions-menu/template.hbs
+++ b/lib/osf-components/addon/components/file-actions-menu/template.hbs
@@ -13,25 +13,18 @@
     </dropdown.trigger>
     <dropdown.content local-class='DropdownList'>
         <OsfLink @href={{@item.links.download}}>
-            <Button
-                @layout='fake-link'
-            >
-                <FaIcon @icon='download' />
-                {{t 'general.download'}}
-            </Button>
+            <FaIcon @icon='download' />
+            {{t 'general.download'}}
         </OsfLink>
         <FileEmbedMenu @file={{@item}} as |dd|>
             <dd.trigger
                 data-test-embed-button
                 data-analytics-name='Expand embed menu'
                 aria-label={{t 'general.embed'}}
+                local-class='DropdownItem'
             >
-                <Button
-                    @layout='fake-link'
-                >
-                    <FaIcon @icon='file-import' />
-                    {{t 'general.embed'}}
-                </Button>
+                <FaIcon @icon='file-import' />
+                {{t 'general.embed'}}
             </dd.trigger>
         </FileEmbedMenu>
         <SharingIcons::Dropdown
@@ -45,13 +38,10 @@
                 data-test-social-sharing-button
                 data-analytics-name='Expand sharing menu'
                 aria-label={{t 'general.share'}}
+                local-class='DropdownItem'
             >
-                <Button
-                    @layout='fake-link'
-                >
-                    <FaIcon @icon='share-alt' />
-                    {{t 'general.share'}}
-                </Button>
+                <FaIcon @icon='share-alt' />
+                {{t 'general.share'}}
             </dd.trigger>
         </SharingIcons::Dropdown>
     </dropdown.content>

--- a/lib/osf-components/addon/components/file-browser/folder-item/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/folder-item/template.hbs
@@ -2,7 +2,6 @@
     data-test-file-list-item
     local-class={{if @manager.parentFolder 'FileList__item Indent' 'FileList__item'}}
 >
-    {{!-- Analytics/test-selector should know if it is a file or folder --}}
     <Button
         data-test-file-list-link
         data-analytics-name='View folder'
@@ -24,18 +23,16 @@
         {{/if}}
         <ResponsiveDropdown
             local-class='DownloadShareDropdown'
+            @buttonStyling={{true}}
             @horizontalPosition='right'
             as |dropdown|
         >
             <dropdown.trigger
+                aria-label={{t 'file_actions_menu.actions' filename=@item.name}}
                 data-test-file-download-share-trigger
                 data-analytics-name='Folder actions'
             >
-                <Button
-                    aria-label={{t 'file_actions_menu.actions' filename=@item.name}}
-                >
-                    <FaIcon @icon='ellipsis-v' />
-                </Button>
+                <FaIcon @icon='ellipsis-v' />
             </dropdown.trigger>
             <dropdown.content local-class='DropdownList'>
                 <OsfLink @href={{@item.links.download}}>

--- a/lib/osf-components/addon/components/file-browser/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/template.hbs
@@ -3,12 +3,13 @@
 <div local-class='OptionBar {{if this.isMobile 'Mobile'}}'>
     <div local-class='OptionBar__left {{if this.isMobile 'Mobile'}}'>
         <Input
+            aria-label={{t 'registries.overview.files.filter_label'}}
             data-test-file-search
             @type='text'
             class='form-control'
             placeholder='{{t 'general.filter'}}'
             @value={{readonly @manager.filter}}
-            {{on 'keyup' this.handleInput}}
+            {{on 'input' this.handleInput}}
         />
 
         <ResponsiveDropdown
@@ -20,16 +21,15 @@
             <dropdown.trigger
                 data-test-file-sort-trigger
                 data-analytics-name='Sort files'
+                local-class='SortDropdown__button {{if this.isMobile 'Mobile'}}'
             >
-                <Button local-class='SortDropdown__button {{if this.isMobile 'Mobile'}}'>
-                    <div>
-                        {{t 'registries.overview.files.sort'}}
-                        <span local-class='SortedBy'>
-                            {{t (concat 'registries.overview.files.sort_by.' @manager.sort)}}
-                        </span>
-                    </div>
-                    <FaIcon @icon='caret-down' />
-                </Button>
+                <div>
+                    {{t 'registries.overview.files.sort'}}
+                    <span local-class='SortedBy'>
+                        {{t (concat 'registries.overview.files.sort_by.' @manager.sort)}}
+                    </span>
+                </div>
+                <FaIcon @icon='caret-down' />
             </dropdown.trigger>
             <dropdown.content
                 local-class='DropdownList'

--- a/lib/osf-components/addon/components/file-browser/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/template.hbs
@@ -13,6 +13,7 @@
 
         <ResponsiveDropdown
             local-class='SortDropdown {{if this.isMobile 'Mobile'}}'
+            @buttonStyling={{true}}
             @horizontalPosition='left'
             as |dropdown|
         >

--- a/lib/osf-components/addon/components/registries/update-dropdown/styles.scss
+++ b/lib/osf-components/addon/components/registries/update-dropdown/styles.scss
@@ -24,12 +24,6 @@
     font-weight: 600;
     padding-left: 10px;
     text-decoration: none;
-
-    &:hover,
-    &:active,
-    &:focus {
-        outline: 0;
-    }
 }
 
 .UpdateContainerText { 

--- a/lib/osf-components/addon/components/responsive-dropdown/styles.scss
+++ b/lib/osf-components/addon/components/responsive-dropdown/styles.scss
@@ -4,8 +4,8 @@
     margin: 0.5rem;
 }
 
-.Trigger {
-    &:focus {
-        outline: 0;
-    }
+.Button {
+    composes: Button from '../button/styles.scss';
+    composes: MediumButton from '../button/styles.scss';
+    composes: SecondaryButton from '../button/styles.scss';
 }

--- a/lib/osf-components/addon/components/responsive-dropdown/template.hbs
+++ b/lib/osf-components/addon/components/responsive-dropdown/template.hbs
@@ -9,7 +9,7 @@
     as |dd|
 >
     {{yield (hash
-        trigger=(component dd.Trigger defaultClass=(local-class 'Trigger'))
+        trigger=(component dd.Trigger defaultClass=(local-class (if @buttonStyling 'Button')))
         isOpen=dd.isOpen
         uniqueId=dd.uniqueId
         open=(action dd.actions.open)

--- a/lib/osf-components/addon/components/side-nav/x-link/styles.scss
+++ b/lib/osf-components/addon/components/side-nav/x-link/styles.scss
@@ -10,7 +10,6 @@ $sidenav-link-height: 40px;
     width: 100%;
     padding: 5px 10px;
     color: $color-text-blue-dark;
-    outline: 0 !important;
 
     h4 {
         color: inherit;

--- a/lib/registries/addon/components/registries-states/styles.scss
+++ b/lib/registries/addon/components/registries-states/styles.scss
@@ -12,12 +12,6 @@
     color: $white;
     font-weight: 600;
     padding-left: 10px;
-
-    &:hover,
-    &:active,
-    &:focus {
-        outline: 0;
-    }
 }
 
 .DescriptionContainer {

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1341,6 +1341,7 @@ registries:
             no_comments: 'No comments.'
         files:
             title: Files
+            filter_label: 'Filter files'
             sort: 'Sort by: '
             sort_by:
                 name: 'Name: A-Z'


### PR DESCRIPTION
-   Ticket: [ENG-3649]
-   Feature flag: n/a

## Purpose
- Fix accessibility issues on registries file list page

## Summary of Changes
- Remove uses of nested interaction elements
  - Add styling for `<ResponsiveDropdown>` to make it look like a `<Button>`
- Remove some uses of `outline: none/0` to let keyboard users know where they are on the page
- Add aria-label to Filter textbox

## Screenshot(s)
NA
## Side Effects
None
## QA Notes
- These changes should fix the existing A11y issues on this page

[ENG-3649]: https://openscience.atlassian.net/browse/ENG-3649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ