### PR TITLE
[ENG-3649] Fix bugs: add mfr iframe translation

### DIFF
--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -129,6 +129,7 @@ file_detail:
     view_tags: 'View tags'
     close_tags: 'Close tags'
     tags: 'Tags:'
+    mfr_iframe_title: 'Rendering of document'
 dashboard:
     page_title: Home
     title: Dashboard


### PR DESCRIPTION
Ticket: https://openscience.atlassian.net/browse/ENG-3649
Feature flag: n/a

## Purpose
The purpose of this change is to provide a translation string for the mfr iframe on the File Renderer component.

## Summary of Changes
-The en-us.yml translation file was updated to include file_detail.mfr_iframe_title : 'File Detail View: '
-A paragraph tag including the title was added to the iframe element

## Screenshot(s)
Screenshots will need to be updated with Docker enabled.

## Side Effects
When missing, the error message produced would throw off the UI. It is suggested that there be a font property added to the error message that renders it smaller and the same size as the current/ no larger than the parent element.

## QA Notes
-Does the string render properly?
-Is proper styling added to the string?