### PR TITLE
[ENG-3657] Link users to new helpscout guides

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -197,7 +197,7 @@ module.exports = function(environment) {
         support: {
             preregUrl: 'https://cos.io/prereg/',
             statusPageUrl: 'https://status.cos.io',
-            faqPageUrl: 'https://openscience.zendesk.com/hc/en-us/articles/360019737894',
+            faqPageUrl: 'https://osf-support.helpscoutdocs.com/',
             supportEmail: 'support@osf.io',
             contactEmail: 'contact@osf.io',
             consultationUrl: 'https://cos.io/stats_consulting/',

--- a/config/environment.js
+++ b/config/environment.js
@@ -197,7 +197,7 @@ module.exports = function(environment) {
         support: {
             preregUrl: 'https://cos.io/prereg/',
             statusPageUrl: 'https://status.cos.io',
-            faqPageUrl: 'https://osf-support.helpscoutdocs.com/',
+            faqPageUrl: 'https://help.osf.io',
             supportEmail: 'support@osf.io',
             contactEmail: 'contact@osf.io',
             consultationUrl: 'https://cos.io/stats_consulting/',

--- a/lib/osf-components/addon/components/osf-navbar/x-links/component.ts
+++ b/lib/osf-components/addon/components/osf-navbar/x-links/component.ts
@@ -1,12 +1,10 @@
 import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
-import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import config from 'ember-get-config';
 import Session from 'ember-simple-auth/services/session';
 
 import { layout } from 'ember-osf-web/decorators/component';
-import CurrentUser from 'ember-osf-web/services/current-user';
 
 import template from './template';
 
@@ -15,22 +13,11 @@ const osfURL = config.OSF.url;
 @layout(template)
 @tagName('') // Don't wrap this component in a div
 export default class XLinks extends Component {
-    @service router!: any;
     @service session!: Session;
-    @service currentUser!: CurrentUser;
 
     searchURL = `${osfURL}search/`;
     myProjectsURL = `${osfURL}myprojects/`;
     myRegistrationsURL = `${osfURL}myprojects/#registrations`;
+    supportURL = `${config.support.faqPageUrl}`;
     onLinkClicked: () => void = () => null;
-
-    @computed('onInstitutions', 'router.currentRouteName')
-    get supportURL() {
-        return this.onInstitutions ? 'https://openscience.zendesk.com/hc/en-us/categories/360001550913' : 'support';
-    }
-
-    @computed('router.currentRouteName')
-    get onInstitutions() {
-        return this.router.currentRouteName === 'institutions';
-    }
 }

--- a/lib/registries/config/environment.js
+++ b/lib/registries/config/environment.js
@@ -43,7 +43,7 @@ module.exports = function(environment) {
             urlRegex: '^https?://.*researchregistry\\.com.*$',
         }],
         externalLinks: {
-            help: 'https://openscience.zendesk.com/hc/en-us/categories/360001550953',
+            help: 'https://osf-support.helpscoutdocs.com/',
             donate: 'https://cos.io/donate',
         },
         defaultProviderId: 'osf',

--- a/lib/registries/config/environment.js
+++ b/lib/registries/config/environment.js
@@ -43,7 +43,7 @@ module.exports = function(environment) {
             urlRegex: '^https?://.*researchregistry\\.com.*$',
         }],
         externalLinks: {
-            help: 'https://osf-support.helpscoutdocs.com/',
+            help: 'https://help.osf.io',
             donate: 'https://cos.io/donate',
         },
         defaultProviderId: 'osf',


### PR DESCRIPTION

-   Ticket: [ENG-3657]
-   Feature flag: n/a

## Purpose
- Update navbar links to go to the new helpscout guides

## Summary of Changes
- Update general OSF navbar to go to helpscout
- Update registries navbar to go to helpscout

## Screenshot(s)
NA

## Side Effects
- We will no longer be taking users to the support route (osf.io/support) via the navbar links

## QA Notes
This is to just change the link in the navbar. Other links going to the old help guides can stay for now, and will be revisited in the future

[ENG-3657]: https://openscience.atlassian.net/browse/ENG-3657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ