### PR TITLE
[ENG-3649] Fix bugs: decrease breadcrumb font weight

### DIFF
--- a/lib/osf-components/addon/components/file-browser/breadcrumbs/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/breadcrumbs/styles.scss
@@ -11,8 +11,8 @@
 
 .Breadcrumbs li {
     display: inline;
-    font-size: large;
-    font-weight: 700;
+    font-size: x-large;
+    font-weight: 500;
 }
 
 .Breadcrumbs li + li::before {


### PR DESCRIPTION
-   Ticket: https://openscience.atlassian.net/browse/ENG-3649
-   Feature flag: n/a

## Purpose

The purpose of this change was to decrease the font weight present on the file list view and it increase its font size.

## Summary of Changes

I have updated the font weight to be 500 from 700 and increased the font-size from large to x-large in the File Browser's breadcrumb scss file here: lib/osf-components/addon/components/file-browser/breadcrumbs/styles.scss

## Screenshot(s)

<img width="1328" alt="image" src="https://user-images.githubusercontent.com/82047646/159550520-d04ab9ea-0436-421c-b70b-0da2dc48b198.png">
Figure 1: File List view prior to font-weight change
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/82047646/159550401-fa629bb9-6759-4782-be3e-7ac0bd7fe2e2.png">
Figure 2: File List view after font-weight change

## Side Effects

This will change how the font for the breadcrumb will display. UA testing should ensure this looks right.

## QA Notes

-Does the breadcrumb title display? Is it aesthetically pleasing with the rest of the page?

