### PR TITLE
Align download button to center

### DIFF
--- a/lib/osf-components/addon/components/file-browser/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/styles.scss
@@ -19,6 +19,7 @@
 .OptionBar__right {
     display: flex;
     justify-content: space-between;
+    align-items: center;
     margin-bottom: 24px;
 }
 


### PR DESCRIPTION

-   Ticket: []
-   Feature flag: n/a

## Purpose
- Align 'Download this folder button' to center
## Summary of Changes
- Ditto
## Screenshot(s)
![image](https://user-images.githubusercontent.com/51409893/160439309-c1ee7cc1-7271-47bf-af9f-cb34de675a12.png)
![image](https://user-images.githubusercontent.com/51409893/160439347-ce256abd-0c9a-4bc4-a8e3-65f7af6e9882.png)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
