### PR TITLE
[ENG-3649] Remove LinkedIn from sharing icons

### DIFF
--- a/lib/osf-components/addon/components/sharing-icons/component.ts
+++ b/lib/osf-components/addon/components/sharing-icons/component.ts
@@ -41,14 +41,6 @@ export default class SharingIcons extends Component {
         return `https://www.facebook.com/dialog/share?${param(queryParams)}`;
     }
 
-    // https://developer.linkedin.com/docs/share-on-linkedin
-    @computed('hyperlink', 'description')
-    get linkedinHref(): string {
-        const url = encodeURIComponent(this.hyperlink || '').slice(0, 1024);
-        // Linkedin uses the head meta tags regardless of the share url params
-        return `https://www.linkedin.com/shareArticle?url=${url}`;
-    }
-
     @computed('hyperlink', 'title')
     get emailHref(): string {
         const queryParams = {

--- a/lib/osf-components/addon/components/sharing-icons/dropdown/template.hbs
+++ b/lib/osf-components/addon/components/sharing-icons/dropdown/template.hbs
@@ -20,9 +20,6 @@
                 <li local-class='Dropdown__option'>
                     {{links.facebook}}
                 </li>
-                <li local-class='Dropdown__option'>
-                    {{links.linkedin}}
-                </li>
             </ul>
         </SharingIcons>
     </dd.content>

--- a/lib/osf-components/addon/components/sharing-icons/template.hbs
+++ b/lib/osf-components/addon/components/sharing-icons/template.hbs
@@ -6,13 +6,6 @@
         icon='twitter-square'
         showText=@showText
     )
-    linkedin=(component 'sharing-icons/sharing-anchor'
-        href=this.linkedinHref
-        medium='Linkedin'
-        analyticsName='Share - linkedin'
-        icon='linkedin'
-        showText=@showText
-    )
     facebook=(component 'sharing-icons/sharing-anchor'
         href=this.facebookHref
         medium='Facebook'
@@ -31,7 +24,6 @@
         {{yield links}}
     {{else}}
         {{links.twitter}}
-        {{links.linkedin}}
         {{links.facebook}}
         {{links.email}}
     {{/if}}

--- a/tests/engines/registries/acceptance/overview/topbar-test.ts
+++ b/tests/engines/registries/acceptance/overview/topbar-test.ts
@@ -191,7 +191,7 @@ module('Registries | Acceptance | overview.topbar', hooks => {
         await click('[data-test-social-sharing-button]');
         assert.dom('[data-test-sharing-options]').isVisible();
 
-        ['Email', 'Linkedin', 'Twitter', 'Facebook'].forEach(
+        ['Email', 'Twitter', 'Facebook'].forEach(
             medium => assert.dom(`[data-test-share-registration="${medium}"]`).isVisible(),
         );
     });

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -613,7 +613,6 @@ social:
     facebook: Facebook
     google_group: 'Google Group'
     github: GitHub
-    linkedin: LinkedIn
 institutions:
     description: 'OSF Institutions enhances transparency and increases the visibility of research outputs, accelerating discovery and reuse. Institutional members focus on generating and sharing research, and let OSF Institutions handle the infrastructure.'
     read_more: 'Read more'


### PR DESCRIPTION
## Purpose

Remove LinkedIn from the sharing icons. The functionality is rarely used and has been broken for an indeterminate amount of time. There is a ticket to add it back if we decide to do that.

## Summary of Changes

1. Remove LinkedIn from Sharing Icons
2. Remove LinkedIn test case
3. Remove from translations file

## Screenshot(s)
<img width="255" alt="Screen Shot 2022-03-28 at 10 53 31 AM" src="https://user-images.githubusercontent.com/6599111/160445062-9b171ed3-cf99-4560-88d6-8241bdc89e1c.png">



## Side Effects

Should be pretty isolated.

## QA Notes

You'll know it works if you can't find LinkedIn to share with any more.
