### PR TITLE
[ENG-3649] Fix DAZ for VOLs

### DIFF
--- a/app/packages/files/file.ts
+++ b/app/packages/files/file.ts
@@ -68,7 +68,12 @@ export default abstract class File {
     get links() {
         const links = this.fileModel.links;
         if (this.isFolder) {
-            links.download = `${links.upload}?zip=`;
+            const uploadLink = new URL(links.upload as string);
+            const params = uploadLink.searchParams;
+            params.set('zip', '');
+            uploadLink.search = params.toString();
+
+            links.download = uploadLink.toString();
         }
         return links;
     }

--- a/app/packages/files/provider-file.ts
+++ b/app/packages/files/provider-file.ts
@@ -27,7 +27,12 @@ export default abstract class ProviderFile {
 
     get links() {
         const links = this.fileModel.links;
-        links.download = `${links.upload}?zip=`;
+        const uploadLink = new URL(links.upload as string);
+        const params = uploadLink.searchParams;
+        params.set('zip', '');
+        uploadLink.search = params.toString();
+
+        links.download = uploadLink.toString();
         return links;
     }
 


### PR DESCRIPTION
-   Ticket: [ENG-3649]
-   Feature flag: n/a

## Purpose

Fix Download As Zip links for when people are using View Only Links.

## Summary of Changes

1. Don't just append `?zip=` to the URL. Actually properly manipulate the query parameters.

## Side Effects

This is isolated to uses of the DAZ link functionality

## QA Notes

Should work properly now in the case of View Only Links.

[ENG-3649]: https://openscience.atlassian.net/browse/ENG-3649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ