### PR TITLE
[ENG-3649] Fix versions feature in VOL

### DIFF
--- a/app/packages/files/file.ts
+++ b/app/packages/files/file.ts
@@ -120,7 +120,12 @@ export default abstract class File {
     @task
     @waitFor
     async getRevisions() {
-        const responseObject = await fetch(`${this.links.upload}?revisions=&`);
+        const revisionsLink = new URL(this.links.upload as string);
+        const params = revisionsLink.searchParams;
+        params.set('revisions', '');
+        revisionsLink.search = params.toString();
+
+        const responseObject = await fetch(revisionsLink.toString());
         const parsedResponse = await responseObject.json();
         this.waterButlerRevisions = parsedResponse.data;
         return this.waterButlerRevisions;


### PR DESCRIPTION
-   Ticket: [ENG-3649]
-   Feature flag: n/a

## Purpose

The versions list wasn't working properly when viewed in a VOL. This changes the way query parameters were appended to the upload link so that it would handle when there was already a query parameter in the URL.

## Summary of Changes

1. Append query parameter properly

## Screenshot(s)

<img width="1513" alt="Screen Shot 2022-03-28 at 4 51 48 PM" src="https://user-images.githubusercontent.com/6599111/160485565-daeb0ca0-f371-4df6-88be-b70a7162e41e.png">


## Side Effects

No, this is isolated to the versions pane

## QA Notes

It should work with and without VOLs now.


[ENG-3649]: https://openscience.atlassian.net/browse/ENG-3649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ