### PR TITLE
[ENG-3649] Better revisions query parameters (take 2)

### DIFF
--- a/app/packages/files/file.ts
+++ b/app/packages/files/file.ts
@@ -121,9 +121,7 @@ export default abstract class File {
     @waitFor
     async getRevisions() {
         const revisionsLink = new URL(this.links.upload as string);
-        const params = revisionsLink.searchParams;
-        params.set('revisions', '');
-        revisionsLink.search = params.toString();
+        revisionsLink.searchParams.set('revisions', '');
 
         const responseObject = await fetch(revisionsLink.toString());
         const parsedResponse = await responseObject.json();

--- a/app/packages/files/file.ts
+++ b/app/packages/files/file.ts
@@ -69,9 +69,7 @@ export default abstract class File {
         const links = this.fileModel.links;
         if (this.isFolder) {
             const uploadLink = new URL(links.upload as string);
-            const params = uploadLink.searchParams;
-            params.set('zip', '');
-            uploadLink.search = params.toString();
+            uploadLink.searchParams.set('zip', '');
 
             links.download = uploadLink.toString();
         }

--- a/app/packages/files/provider-file.ts
+++ b/app/packages/files/provider-file.ts
@@ -28,9 +28,7 @@ export default abstract class ProviderFile {
     get links() {
         const links = this.fileModel.links;
         const uploadLink = new URL(links.upload as string);
-        const params = uploadLink.searchParams;
-        params.set('zip', '');
-        uploadLink.search = params.toString();
+        uploadLink.searchParams.set('zip', '');
 
         links.download = uploadLink.toString();
         return links;


### PR DESCRIPTION
-   Ticket: [ENG-3649]
-   Feature flag: n/a

## Purpose

The versions list wasn't working properly when viewed in a VOL. This changes the way query parameters were appended to the upload link so that it would handle when there was already a query parameter in the URL. Also, I accidentally merged the last version of this before it was done, so there's a new PR here.

## Summary of Changes

1. Append query parameter properly
2. Simplify  query param setting in other locations

## Screenshot(s)

<img width="1513" alt="Screen Shot 2022-03-28 at 4 51 48 PM" src="https://user-images.githubusercontent.com/6599111/160485565-daeb0ca0-f371-4df6-88be-b70a7162e41e.png">


## Side Effects

No, this is isolated to the versions pane

## QA Notes

It should work with and without VOLs now.


[ENG-3649]: https://openscience.atlassian.net/browse/ENG-3649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ