### PR TITLE
Update styling for file-detail right panel

### DIFF
--- a/app/guid-file/-components/file-detail-layout/styles.scss
+++ b/app/guid-file/-components/file-detail-layout/styles.scss
@@ -11,7 +11,7 @@
 .RightColumn {
     flex-grow: 1;
     border-left: 1px solid #ddd;
-    min-width: 300px;
+    flex-basis: 300px;
 
     &.is-closed {
         display: none;

--- a/app/guid-file/styles.scss
+++ b/app/guid-file/styles.scss
@@ -54,12 +54,12 @@
 }
 
 .FileDetail__right-section-heading {
-    margin-left: 40px;
+    margin-left: 20px;
 }
 
 .FileDetail__revision-list {
     list-style-position: inside;
-    padding-inline-end: 40px;
+    padding-inline: 20px;
 }
 
 .FileDetail__no-revisions {


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Fix issue where tags widget width would increase as more tags are added

## Summary of Changes
- use flex-basis instead of min-width for right panel container div
- make revisions tab and tags tab have same amount of padding/margin

## Screenshot(s)
![image](https://user-images.githubusercontent.com/51409893/160626177-fe6d0b6f-0a52-4e61-921e-9fde1e91f692.png)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
