### PR TITLE
Tab-navigable dropdown

### DIFF
--- a/lib/osf-components/addon/components/file-actions-menu/styles.scss
+++ b/lib/osf-components/addon/components/file-actions-menu/styles.scss
@@ -8,7 +8,10 @@
     align-items: flex-start;
     border: 1px solid $color-border-gray;
     padding: 8px;
-    width: max-content !important; // override width: auto from ember-basic-dropdown
+
+    &.DropdownList {
+        width: max-content; // override width: auto from ember-basic-dropdown
+    }
 
     > div {
         padding-top: 8px;

--- a/lib/osf-components/addon/components/file-actions-menu/styles.scss
+++ b/lib/osf-components/addon/components/file-actions-menu/styles.scss
@@ -8,8 +8,9 @@
     align-items: flex-start;
     border: 1px solid $color-border-gray;
     padding: 8px;
+    width: max-content !important; // override width: auto from ember-basic-dropdown
 
-    div {
+    > div {
         padding-top: 8px;
     }
 }

--- a/lib/osf-components/addon/components/file-actions-menu/template.hbs
+++ b/lib/osf-components/addon/components/file-actions-menu/template.hbs
@@ -1,5 +1,6 @@
 <ResponsiveDropdown
     local-class='DownloadShareDropdown'
+    @renderInPlace={{true}}
     @buttonStyling={{true}}
     @horizontalPosition='right'
     as |dropdown|

--- a/lib/osf-components/addon/components/file-browser/folder-item/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/folder-item/styles.scss
@@ -39,6 +39,7 @@
     align-items: flex-start;
     padding: 8px;
     border: 1px solid $color-border-gray;
+    width: max-content !important; // override width: auto from ember-basic-dropdown
 
     button {
         padding: 8px;

--- a/lib/osf-components/addon/components/file-browser/folder-item/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/folder-item/styles.scss
@@ -39,7 +39,10 @@
     align-items: flex-start;
     padding: 8px;
     border: 1px solid $color-border-gray;
-    width: max-content !important; // override width: auto from ember-basic-dropdown
+
+    &.DropdownList {
+        width: max-content; // override width: auto from ember-basic-dropdown
+    }
 
     button {
         padding: 8px;

--- a/lib/osf-components/addon/components/file-browser/folder-item/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/folder-item/template.hbs
@@ -23,6 +23,7 @@
     >
         <ResponsiveDropdown
             local-class='DownloadShareDropdown'
+            @renderInPlace={{true}}
             @buttonStyling={{true}}
             @horizontalPosition='right'
             as |dropdown|

--- a/lib/osf-components/addon/components/file-browser/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/styles.scss
@@ -71,7 +71,7 @@
     list-style-type: none;
     padding: 0;
 
-    li:last-of-type {
+    > li:last-of-type {
         border-bottom: solid 1px $color-border-gray;
     }
 }

--- a/lib/osf-components/addon/components/file-browser/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/template.hbs
@@ -16,6 +16,7 @@
 
         <ResponsiveDropdown
             local-class='SortDropdown {{if this.isMobile 'Mobile'}}'
+            @renderInPlace={{true}}
             @buttonStyling={{true}}
             @horizontalPosition='left'
             as |dropdown|

--- a/lib/osf-components/addon/components/file-embed-menu/styles.scss
+++ b/lib/osf-components/addon/components/file-embed-menu/styles.scss
@@ -3,6 +3,7 @@
 }
 
 .Dropdown__list {
+    width: max-content;
     composes: Dropdown__list from '../sharing-icons/dropdown/styles.scss';
 }
 

--- a/lib/osf-components/addon/components/file-embed-menu/template.hbs
+++ b/lib/osf-components/addon/components/file-embed-menu/template.hbs
@@ -1,4 +1,4 @@
-<ResponsiveDropdown as |dd|>
+<ResponsiveDropdown @renderInPlace={{true}} as |dd|>
     {{yield (hash trigger=dd.trigger isOpen=dd.isOpen)}}
     <dd.content>
         <ul data-test-sharing-options local-class='Dropdown__list'>

--- a/lib/osf-components/addon/components/sharing-icons/dropdown/template.hbs
+++ b/lib/osf-components/addon/components/sharing-icons/dropdown/template.hbs
@@ -1,4 +1,4 @@
-<ResponsiveDropdown as |dd|>
+<ResponsiveDropdown @renderInPlace={{true}} as |dd|>
     {{yield (hash trigger=dd.trigger isOpen=dd.isOpen)}}
     <dd.content>
         <SharingIcons

--- a/lib/registries/addon/components/hero-overlay/styles.scss
+++ b/lib/registries/addon/components/hero-overlay/styles.scss
@@ -3,7 +3,6 @@
 .HeroOverlay {
     display: flex;
     flex-direction: column;
-    overflow: hidden;
     width: 100%;
     height: 100%;
     min-width: 100%;


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Make files page related dropdowns tab-navigable

## Summary of Changes
- Use `renderInPlace` option for dropdowns in file page
- Add style change needed to prevent text wrap
- restrict some loose CSS rules to not apply to newly nested dropdown content

## Screenshot(s)
- No visible changes

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- Haven't updated the social media sharing icons yet as applying the same fix as I have done for the other dropdowns makes it so the "Share this registration" button does not show dropdown properly
![Screen Shot 2022-03-29 at 5 05 37 PM](https://user-images.githubusercontent.com/51409893/160707082-8ddda03e-c9c0-45f2-8ccb-c83fe67c9ad4.png)
- EDIT: There was a `overflow: hidden` on the `HeroOverlay` component that was hiding the dropdown content. I've removed that rule, and it shows the dropdown. I've checked other places where this HeroOverlay component is used (branded registries moderation, add new registration, registries discover page, draft registration, registration revision pages, registries overview) to verify the `overflow: hidden` isn't needed and I don't see any issues in desktop or mobile. I suspect this rule was unneeded and left over?
 