### PR TITLE
Hide user name from revisions (needed for AVOLs)

### DIFF
--- a/lib/osf-components/addon/components/file-version/template.hbs
+++ b/lib/osf-components/addon/components/file-version/template.hbs
@@ -23,20 +23,6 @@
 
     {{#if this.dropdownOpen}}
         <div
-            data-test-file-version-section='user'
-            local-class='DropdownSection'
-        >
-            <span>
-                {{t 'general.user'}}:
-                <OsfLink
-                    data-test-file-version-user-link
-                    @href={{@version.attributes.extra.user.url}}
-                >
-                    {{@version.attributes.extra.user.name}}
-                </OsfLink>
-            </span>
-        </div>
-        <div
             data-test-file-version-section='md5'
             local-class='DropdownSection'
         >

--- a/tests/acceptance/guid-file/registration-file-detail-test.ts
+++ b/tests/acceptance/guid-file/registration-file-detail-test.ts
@@ -86,7 +86,7 @@ module('Acceptance | guid file | registration files', hooks => {
             .hasAria('label', t('file_detail.close_revisions'), 'Versions button has correct label when open');
         assert.dom('[data-test-file-version-item]').exists({ count: 2 }, 'Two file versions are shown');
         await click('[data-test-file-version-toggle-button]');
-        assert.dom('[data-test-file-version-section]').exists({ count: 4 }, 'File version info is shown');
+        assert.dom('[data-test-file-version-section]').exists({ count: 3 }, 'File version info is shown');
         await click('[data-test-file-version-date]');
         assert.dom('[data-test-filename]')
             .containsText(t('general.version'), 'Viewed version specified after selecting version');

--- a/tests/integration/components/file-version/component-test.ts
+++ b/tests/integration/components/file-version/component-test.ts
@@ -54,8 +54,6 @@ module('Integration | Component | file-version', hooks => {
 
         await click('[data-test-file-version-toggle-button]');
         assert.dom('[data-test-file-version-toggle-button] .fa-caret-up').exists('toggle button points up');
-        assert.dom('[data-test-file-version-section="user"]').hasText(t('general.user')+': Larry');
-        assert.dom('[data-test-file-version-section="user"] a').hasAttribute('href', '/larry', 'user link is correct');
         assert.dom('[data-test-file-version-section="md5"]')
             .hasText(t('osf-components.file-version.copy_md5'));
         assert.dom('[data-test-file-version-section="sha2"]')


### PR DESCRIPTION

-   Ticket: []
-   Feature flag: n/a

## Purpose
- Hide revision creator name due to AVOL issues

## Summary of Changes
- Remove User section from revision item

## Screenshot(s)
This is what got removed
![Screen Shot 2022-03-29 at 5 22 12 PM](https://user-images.githubusercontent.com/51409893/160709409-fb3a05fb-3299-4a63-8cfd-888c27857ccf.png)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
