### PR TITLE
[ENG-3649] Sort by date_modified rather than modified

### DIFF
--- a/app/packages/files/file.ts
+++ b/app/packages/files/file.ts
@@ -7,8 +7,8 @@ import NodeModel from 'ember-osf-web/models/node';
 import { Permission } from 'ember-osf-web/models/osf-model';
 
 export enum FileSortKey {
-    AscDateModified = 'modified',
-    DescDateModified = '-modified',
+    AscDateModified = 'date_modified',
+    DescDateModified = '-date_modified',
     AscName = 'name',
     DescName = '-name',
 }


### PR DESCRIPTION
-   Ticket: [ENG-3649]
-   Feature flag: n/a

## Purpose

Use the same field for sorting that we're using to display. Pairs with a back-end PR.

## Summary of Changes

1. Change the sort field to `date_modified`

## Side Effects

This won't work until the back-end piece is in place, but otherwise is isolated.

## QA Notes

This should make the sort match the display field, fixing that bug.
