### PR TITLE
[ENG-3649] Route withdrawn file to registration overview page for tombstone

### DIFF
--- a/app/guid-file/route.ts
+++ b/app/guid-file/route.ts
@@ -12,6 +12,7 @@ import Analytics from 'ember-osf-web/services/analytics';
 import MetaTags, { HeadTagDef } from 'ember-osf-web/services/meta-tags';
 import Ready from 'ember-osf-web/services/ready';
 import OsfStorageFile from 'ember-osf-web/packages/files/osf-storage-file';
+import RegistrationModel from 'ember-osf-web/models/registration';
 
 export default class GuidFile extends Route {
     @service analytics!: Analytics;
@@ -43,7 +44,11 @@ export default class GuidFile extends Route {
     async model(params: { guid: string }) {
         const { guid } = params;
         try {
-            const file = await this.store.findRecord('file', guid);
+            const file = await this.store.findRecord('file', guid, {include: 'target'});
+            const target = file.target as unknown as RegistrationModel;
+            if (target.get('withdrawn') === true) {
+                this.transitionTo('guid-registration', target.get('id'));
+            }
             const osfStorageFile = new OsfStorageFile(file);
             return osfStorageFile;
         } catch (error) {

--- a/app/guid-file/route.ts
+++ b/app/guid-file/route.ts
@@ -47,9 +47,9 @@ export default class GuidFile extends Route {
         const { guid } = params;
         try {
             const file = await this.store.findRecord('file', guid, {include: 'target'});
-            const target = file.target as unknown as RegistrationModel;
-            if (target.get('withdrawn') === true) {
-                this.transitionTo('guid-registration', target.get('id'));
+            const target = await file.target as unknown as RegistrationModel;
+            if (target.withdrawn === true) {
+                this.transitionTo('guid-registration', target.id);
             }
             const osfStorageFile = new OsfStorageFile(this.currentUser, file);
             return osfStorageFile;


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-3649]
-   Feature flag: n/a

## Purpose

If a file belongs to a withdrawn registration, this will take direct access of that file to the registration's tombstone page rather than showing the file.

## Summary of Changes

1. Route withdrawn file request to registration tombstone page.

## Screenshot(s)

<img width="1322" alt="Screen Shot 2022-03-30 at 9 49 33 AM" src="https://user-images.githubusercontent.com/6599111/160851099-3e273afe-b163-42d0-8e43-bb7190bb4798.png">

## Side Effects

Shouldn't be. 

## QA Notes

Should just need quick testing with regular and withdrawn registration files.


[ENG-3649]: https://openscience.atlassian.net/browse/ENG-3649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ