### PR TITLE
Mobile: remove excess padding for file sort dropdown

### DIFF
--- a/lib/osf-components/addon/components/file-browser/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/styles.scss
@@ -49,6 +49,10 @@
 .SortedBy {
     padding-right: 58px;
     font-weight: bold;
+
+    &.Mobile {
+        padding-right: 0;
+    }
 }
 
 .DownloadAllFromCurrent {

--- a/lib/osf-components/addon/components/file-browser/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/template.hbs
@@ -28,7 +28,7 @@
                     data-analytics-name='Sort files'
                     local-class='SortDropdown__button {{if this.isMobile 'Mobile'}}'
                 >
-                    <span local-class='SortedBy'>
+                    <span local-class='SortedBy {{if this.isMobile 'Mobile'}}'>
                         {{t (concat 'registries.overview.files.sort_by.' @manager.sort)}}
                     </span>
                     <FaIcon @icon='caret-down' />


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Moible: Fix small visual error when selecting "Last modified" option in file sort dropdown

## Summary of Changes
- Remove padding that is unneeded due to flex-box styling for that dropdown

## Screenshot(s)
Fixes the caret overlapping the very right side of the button seen here
![image](https://user-images.githubusercontent.com/51409893/160871929-7b746cba-d1a7-4685-a53a-bca1990cc03c.png)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- Seen in narrow phones (screenshot from Samsung Galaxy S8+, also seen in Galaxy S21)