### PR TITLE
Add currentUser service when initializing File instances

### DIFF
--- a/app/guid-file/route.ts
+++ b/app/guid-file/route.ts
@@ -12,12 +12,14 @@ import Analytics from 'ember-osf-web/services/analytics';
 import MetaTags, { HeadTagDef } from 'ember-osf-web/services/meta-tags';
 import Ready from 'ember-osf-web/services/ready';
 import OsfStorageFile from 'ember-osf-web/packages/files/osf-storage-file';
+import CurrentUserService from 'ember-osf-web/services/current-user';
 
 export default class GuidFile extends Route {
     @service analytics!: Analytics;
     @service('head-tags') headTagsService!: HeadTagsService;
     @service metaTags!: MetaTags;
     @service ready!: Ready;
+    @service currentUser!: CurrentUserService;
 
     headTags?: HeadTagDef[];
 
@@ -44,7 +46,7 @@ export default class GuidFile extends Route {
         const { guid } = params;
         try {
             const file = await this.store.findRecord('file', guid);
-            const osfStorageFile = new OsfStorageFile(file);
+            const osfStorageFile = new OsfStorageFile(this.currentUser, file);
             return osfStorageFile;
         } catch (error) {
             this.transitionTo('not-found', guid);

--- a/app/packages/files/osf-storage-file.ts
+++ b/app/packages/files/osf-storage-file.ts
@@ -1,8 +1,9 @@
 import FileModel from 'ember-osf-web/models/file';
 import File from 'ember-osf-web/packages/files/file';
+import CurrentUserService from 'ember-osf-web/services/current-user';
 
 export default class OsfStorageFile extends File {
-    constructor(fileModel: FileModel) {
-        super(fileModel);
+    constructor(currentUser: CurrentUserService,fileModel: FileModel) {
+        super(currentUser, fileModel);
     }
 }

--- a/app/packages/files/osf-storage-provider-file.ts
+++ b/app/packages/files/osf-storage-provider-file.ts
@@ -2,10 +2,11 @@ import { FileSortKey } from 'ember-osf-web/packages/files/file';
 import FileProviderModel from 'ember-osf-web/models/file-provider';
 import OsfStorageFile from 'ember-osf-web/packages/files/osf-storage-file';
 import ProviderFile from 'ember-osf-web/packages/files/provider-file';
+import CurrentUserService from 'ember-osf-web/services/current-user';
 
 export default class OsfStorageProviderFile extends ProviderFile {
-    constructor(providerFileModel: FileProviderModel) {
-        super(providerFileModel);
+    constructor(currentUser: CurrentUserService,providerFileModel: FileProviderModel) {
+        super(currentUser, providerFileModel);
     }
 
     async getFolderItems(page: number, sort: FileSortKey, filter: string ) {
@@ -16,6 +17,6 @@ export default class OsfStorageProviderFile extends ProviderFile {
                 'filter[name]': filter,
             });
         this.totalFileCount = queryResult.meta.total;
-        return queryResult.map(fileModel => new OsfStorageFile(fileModel));
+        return queryResult.map(fileModel => new OsfStorageFile(this.currentUser, fileModel));
     }
 }

--- a/app/packages/files/provider-file.ts
+++ b/app/packages/files/provider-file.ts
@@ -1,11 +1,15 @@
 import { tracked } from '@glimmer/tracking';
 import FileProviderModel from 'ember-osf-web/models/file-provider';
+import CurrentUserService from 'ember-osf-web/services/current-user';
 
 export default abstract class ProviderFile {
     @tracked fileModel: FileProviderModel;
     @tracked totalFileCount = 0;
 
-    constructor(fileModel: FileProviderModel) {
+    currentUser: CurrentUserService;
+
+    constructor(currentUser: CurrentUserService, fileModel: FileProviderModel) {
+        this.currentUser = currentUser;
         this.fileModel = fileModel;
     }
 

--- a/lib/osf-components/addon/components/storage-provider-manager/osf-storage-manager/component.ts
+++ b/lib/osf-components/addon/components/storage-provider-manager/osf-storage-manager/component.ts
@@ -9,6 +9,9 @@ import FileProviderModel from 'ember-osf-web/models/file-provider';
 import { FileSortKey } from 'ember-osf-web/packages/files/file';
 import OsfStorageFile from 'ember-osf-web/packages/files/osf-storage-file';
 import OsfStorageProviderFile from 'ember-osf-web/packages/files/osf-storage-provider-file';
+import { inject as service } from '@ember/service';
+import CurrentUserService from 'ember-osf-web/services/current-user';
+
 
 interface Args {
     provider: FileProviderModel;
@@ -21,6 +24,7 @@ export default class OsfStorageManager extends Component<Args> {
     @tracked filter = '';
     @tracked sort = FileSortKey.AscName;
     @tracked currentPage = 1;
+    @service currentUser!: CurrentUserService;
 
     constructor(owner: unknown, args: Args) {
         super(owner, args);
@@ -59,7 +63,7 @@ export default class OsfStorageManager extends Component<Args> {
     async getRootFolder() {
         if (this.args.provider) {
             this.storageProvider = this.args.provider;
-            this.folderLineage.push(new OsfStorageProviderFile(this.storageProvider));
+            this.folderLineage.push(new OsfStorageProviderFile(this.currentUser, this.storageProvider));
             notifyPropertyChange(this, 'folderLineage');
         }
     }


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose

Fix reivisions list for files whose revisions list view requires permissions.

## Summary of Changes

Add `currentUser` as a class attribute.
Note: can't inject `currentUser` service directly because this is a native JS class.

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
