### PR TITLE
[ENG-3682] File uploader issue for draft registrations

### DIFF
--- a/lib/osf-components/addon/components/dropzone-widget/component.ts
+++ b/lib/osf-components/addon/components/dropzone-widget/component.ts
@@ -143,6 +143,7 @@ export default class DropzoneWidget extends Component.extend({
             autoQueue: false,
             clickable: this.clickable.length ? this.clickable : '',
             dictDefaultMessage: this.defaultMessage,
+            previewsContainer: false,
             sending(file: any, xhr: XMLHttpRequest) {
                 authorizeXHR(xhr);
 

--- a/lib/osf-components/addon/components/files/manager/component.ts
+++ b/lib/osf-components/addon/components/files/manager/component.ts
@@ -202,7 +202,7 @@ export default class FilesManagerComponent extends Component {
 
         this.lastUploaded.pushObject(file);
 
-        this.toast.success(this.intl.t('file_browser.file_added_toast'));
+        this.toast.success(this.intl.t('osf-components.files-widget.file_add_success'));
         if (this.onAddFile) {
             this.onAddFile(file);
         }

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1813,6 +1813,7 @@ osf-components:
         folder_name_placeholder: 'New folder name'
         create_folder_failed: 'Failed to create folder'
         insufficient_storage_error: 'This file cannot be uploaded to this project/component because it has exceeded the storage limit for OSF Storage.'
+        file_add_success: 'File added successfully'
         delete_failed: 'Failed to delete {filename}'
         delete_success: 'Successfully deleted {filename}'
         delete: Delete


### PR DESCRIPTION
-   Ticket: [ENG-3682]
-   Feature flag: n/a

## Purpose
- Fix broken translation string when user successfully uploads a file to the draft registration
- Remove Dropzone file-previews that are not working correctly

## Summary of Changes
- Add translation for file-upload success toast
- Do not use Dropzone's preview feature

## Screenshot(s)
Removed issues seen in the JIRA ticket
<!-- Attach screenshots if applicable. -->

## Side Effects
None
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- This is for the draft registrations workflow. Dragging/dropping a file onto the widget should no longer show the little file preview with the ✅  and ❌  icons, and the toast message should say something meaningful

[ENG-3682]: https://openscience.atlassian.net/browse/ENG-3682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ