### PR TITLE
[ENG-3700] Keep currentURL readable when rerouting to page-not-found

### DIFF
--- a/lib/registries/addon/drafts/draft/draft-registration-manager.ts
+++ b/lib/registries/addon/drafts/draft/draft-registration-manager.ts
@@ -2,6 +2,7 @@ import { setOwner } from '@ember/application';
 import { action, computed, set } from '@ember/object';
 import { dependentKeyCompat } from '@ember/object/compat';
 import { alias, filterBy, not, notEmpty, or } from '@ember/object/computed';
+import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 import { waitFor } from '@ember/test-waiters';
 import { isEmpty } from '@ember/utils';
@@ -25,7 +26,7 @@ import {
     RegistrationResponse,
 } from 'ember-osf-web/packages/registration-schema';
 import buildChangeset from 'ember-osf-web/utils/build-changeset';
-import RouterService from '@ember/routing/router-service';
+import { notFoundURL } from 'ember-osf-web/utils/clean-url';
 
 export type LoadDraftModelTask = TaskInstance<{
     draftRegistration: DraftRegistration,
@@ -142,7 +143,7 @@ export default class DraftRegistrationManager {
         set(this, 'draftRegistration', draftRegistration);
         set(this, 'provider', provider);
         if (!draftRegistration || !provider) {
-            return this.router.transitionTo('registries.page-not-found', window.location.href.slice(-1));
+            return this.router.transitionTo('registries.page-not-found', notFoundURL(this.router.currentURL));
         }
         try {
             const node = await this.draftRegistration.branchedFrom;
@@ -175,7 +176,7 @@ export default class DraftRegistrationManager {
     async initializeMetadataChangeset() {
         const { draftRegistration } = await this.draftRegistrationTask;
         if (!draftRegistration) {
-            return this.router.transitionTo('registries.page-not-found', window.location.href.slice(-1));
+            return this.router.transitionTo('registries.page-not-found', notFoundURL(this.router.currentURL));
         }
         const metadataValidations = buildMetadataValidations();
         const metadataChangeset = buildChangeset(draftRegistration, metadataValidations);

--- a/lib/registries/addon/drafts/draft/route.ts
+++ b/lib/registries/addon/drafts/draft/route.ts
@@ -14,6 +14,7 @@ import ProviderModel from 'ember-osf-web/models/provider';
 import SubjectModel from 'ember-osf-web/models/subject';
 import Analytics from 'ember-osf-web/services/analytics';
 import captureException from 'ember-osf-web/utils/capture-exception';
+import { notFoundURL } from 'ember-osf-web/utils/clean-url';
 import DraftRegistrationManager, { LoadDraftModelTask } from 'registries/drafts/draft/draft-registration-manager';
 import NavigationManager from 'registries/drafts/draft/navigation-manager';
 
@@ -53,7 +54,7 @@ export default class DraftRegistrationRoute extends Route {
             return { draftRegistration, provider };
         } catch (error) {
             captureException(error);
-            return this.transitionTo('page-not-found', window.location.href.slice(-1));
+            return this.transitionTo('page-not-found', notFoundURL(this.router.currentURL));
         }
     }
 

--- a/lib/registries/addon/edit-revision/revision-manager.ts
+++ b/lib/registries/addon/edit-revision/revision-manager.ts
@@ -27,6 +27,7 @@ import SchemaResponseModel, { RevisionReviewStates } from 'ember-osf-web/models/
 import NodeModel from 'ember-osf-web/models/node';
 import { Permission } from 'ember-osf-web/models/osf-model';
 import buildChangeset from 'ember-osf-web/utils/build-changeset';
+import { notFoundURL } from 'ember-osf-web/utils/clean-url';
 
 export type LoadModelsTask = TaskInstance<{
     revision: SchemaResponseModel,
@@ -193,7 +194,7 @@ export default class RevisionManager {
     async initializeRevisionChangeset() {
         const { revision } = await this.loadModelsTask;
         if (!revision) {
-            return this.router.transitionTo('registries.page-not-found', window.location.href.slice(-1));
+            return this.router.transitionTo('registries.page-not-found', notFoundURL(this.router.currentURL));
         }
         const revisionValidations = buildSchemaResponseValidations();
         const revisionChangeset = buildChangeset(revision, revisionValidations);

--- a/lib/registries/addon/edit-revision/route.ts
+++ b/lib/registries/addon/edit-revision/route.ts
@@ -12,6 +12,7 @@ import requireAuth from 'ember-osf-web/decorators/require-auth';
 import { RevisionReviewStates } from 'ember-osf-web/models/schema-response';
 import Analytics from 'ember-osf-web/services/analytics';
 import captureException from 'ember-osf-web/utils/capture-exception';
+import { notFoundURL } from 'ember-osf-web/utils/clean-url';
 import RevisionNavigationManager from 'registries/edit-revision/nav-manager';
 import RevisionManager, { LoadModelsTask } from 'registries/edit-revision/revision-manager';
 export interface EditRevisionRouteModel {
@@ -47,7 +48,7 @@ export default class EditRevisionRoute extends Route {
             };
         } catch (error) {
             captureException(error);
-            return this.transitionTo('page-not-found', window.location.href.slice(-1));
+            return this.transitionTo('page-not-found', notFoundURL(this.router.currentURL));
         }
     }
 


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-3700] 
-   Feature flag: n/a

## Purpose
- Keep URL user tried to go to when rerouting them to page-not-found

## Summary of Changes
- Change reroute behavior in draft registration and edit revision pages

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- This changes what is shown in the URL bar when a user goes to an invalid draft registration (osf.io/registries/drafts/invalid/) or an invalid revision (osf.io/registries/revisions/invalid). Before, this would take users to a URL like `osf.io/a`. Now users should see the full URL they tried to go to


[ENG-3700]: https://openscience.atlassian.net/browse/ENG-3700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ