### PR TITLE
[ENG-3689][ENG-3688] Make file provider globe icon larger

### DIFF
--- a/lib/osf-components/addon/components/side-nav/component.ts
+++ b/lib/osf-components/addon/components/side-nav/component.ts
@@ -1,7 +1,7 @@
 import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import { action } from '@ember/object';
-import { and, or } from '@ember/object/computed';
+import { and } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Media from 'ember-responsive';
 
@@ -21,8 +21,8 @@ export default class SideNav extends Component {
     // Private properties
     shouldCollapse = false;
 
-    @or('media.{isDesktop,isJumbo}')
-    isCollapseAllowed!: boolean;
+    // remove collapse functionality for now
+    isCollapseAllowed = false;
 
     @and('isCollapseAllowed', 'shouldCollapse')
     isCollapsed!: boolean;

--- a/lib/registries/addon/overview/styles.scss
+++ b/lib/registries/addon/overview/styles.scss
@@ -46,6 +46,10 @@
     margin: 0 18px;
 }
 
+.FileProviderIcon {
+    font-size: 16px;
+}
+
 .Loading {
     height: 100vh;
     display: flex;

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -88,6 +88,7 @@
                                     {{#if (eq provider.name 'osfstorage')}}
                                         <span>
                                             <FaIcon
+                                                local-class='FileProviderIcon'
                                                 @icon='globe'
                                             >
                                             </FaIcon>


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-3689] [ENG-3682]
-   Feature flag: n/a

## Purpose
- Make the globe for file-provider's storage location bigger for mobile users
- Disallow collapse for sidenav on registries overview page

## Summary of Changes
- Increase size of globe icon in left-nav shown when in registration overview's file route
- Disallow collapse for sidenav (done in a way that if we need to revert this, it's not that bad)

## Screenshot(s)
![image](https://user-images.githubusercontent.com/51409893/162308691-7cc7ae55-1094-4833-bea9-8cf84dfdba72.png)


## Side Effects
- Overview sidenav is no longer collapsible, but draft registration and registration revision routes still have collapsible sidenav
## QA Notes
The globe icon should be easier to tap on mobile.
The registration overview sidenav should no longer be collapsible (was only collapsible on desktop)



[ENG-3689]: https://openscience.atlassian.net/browse/ENG-3689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ENG-3682]: https://openscience.atlassian.net/browse/ENG-3682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ