### PR TITLE
[ENG-3690] Set file-renderer url params properly

### DIFF
--- a/lib/osf-components/addon/components/file-renderer/component.ts
+++ b/lib/osf-components/addon/components/file-renderer/component.ts
@@ -57,7 +57,9 @@ export default class FileRenderer extends Component {
         const downloadLink = new URL(download);
         downloadLink.searchParams.set('direct', params.direct || '');
         downloadLink.searchParams.set('mode', params.mode);
-        downloadLink.searchParams.set('version', version?.toString() || '');
+        if (version) {
+            downloadLink.searchParams.set('version', version.toString());
+        }
         return downloadLink.toString();
     }
 

--- a/lib/osf-components/addon/components/file-renderer/component.ts
+++ b/lib/osf-components/addon/components/file-renderer/component.ts
@@ -66,7 +66,7 @@ export default class FileRenderer extends Component {
         // Waiting until the iframe is loaded then changing the URL avoids a race condition in the MFR iframe
         // This is most apparent in 3D files
         const urlWithParams = new URL(renderUrl);
-        urlWithParams.searchParams.set('url', encodeURIComponent(this.downloadUrl));
+        urlWithParams.searchParams.set('url', this.downloadUrl);
         return this.isLoading ? '' : urlWithParams.toString();
     }
 

--- a/lib/osf-components/addon/components/file-renderer/component.ts
+++ b/lib/osf-components/addon/components/file-renderer/component.ts
@@ -3,7 +3,6 @@ import Component from '@ember/component';
 import { action, computed } from '@ember/object';
 import { next } from '@ember/runloop';
 import config from 'ember-get-config';
-import $ from 'jquery';
 
 import { layout } from 'ember-osf-web/decorators/component';
 
@@ -52,15 +51,23 @@ export default class FileRenderer extends Component {
     @computed('download', 'params', 'version')
     get downloadUrl(): string {
         const { download, params, version } = this;
-
-        return `${download}?${$.param({ ...params, ...(version ? { version } : {}) })}`;
+        if (!download) {
+            return '';
+        }
+        const downloadLink = new URL(download);
+        downloadLink.searchParams.set('direct', params.direct || '');
+        downloadLink.searchParams.set('mode', params.mode);
+        downloadLink.searchParams.set('version', version?.toString() || '');
+        return downloadLink.toString();
     }
 
     @computed('downloadUrl', 'isLoading')
     get mfrUrl(): string {
         // Waiting until the iframe is loaded then changing the URL avoids a race condition in the MFR iframe
         // This is most apparent in 3D files
-        return this.isLoading ? '' : `${renderUrl}?url=${encodeURIComponent(this.downloadUrl)}`;
+        const urlWithParams = new URL(renderUrl);
+        urlWithParams.searchParams.set('url', encodeURIComponent(this.downloadUrl));
+        return this.isLoading ? '' : urlWithParams.toString();
     }
 
     didReceiveAttrs(): void {

--- a/tests/integration/components/file-renderer/component-test.ts
+++ b/tests/integration/components/file-renderer/component-test.ts
@@ -10,7 +10,7 @@ module('Integration | Component | file-renderer', hooks => {
     setupRenderingTest(hooks);
 
     test('file rendering defaults', async function(assert) {
-        const download = this.set('download', 'someTruthyValue');
+        const download = this.set('download', 'http://cos.io/');
 
         await render(hbs`
             {{file-renderer download=download}}
@@ -26,7 +26,7 @@ module('Integration | Component | file-renderer', hooks => {
         assert.equal(iframe.getAttribute('width'), '100%');
         assert.equal(
             iframe.getAttribute('src'),
-            `${renderUrl}?url=${encodeURIComponent(`${download}?direct=&mode=render`)}`,
+            `${renderUrl}?url=${encodeURIComponent(`${download}?direct=&mode=render&version=`)}`,
         );
     });
 
@@ -51,7 +51,7 @@ module('Integration | Component | file-renderer', hooks => {
         assert.equal(iframe.getAttribute('width'), '500');
         assert.equal(
             iframe.getAttribute('src'),
-            `${renderUrl}?url=${encodeURIComponent('http://cos.io/?direct=&mode=render')}`,
+            `${renderUrl}?url=${encodeURIComponent('http://cos.io/?direct=&mode=render&version=')}`,
         );
     });
 });

--- a/tests/integration/components/file-renderer/component-test.ts
+++ b/tests/integration/components/file-renderer/component-test.ts
@@ -26,7 +26,7 @@ module('Integration | Component | file-renderer', hooks => {
         assert.equal(iframe.getAttribute('width'), '100%');
         assert.equal(
             iframe.getAttribute('src'),
-            `${renderUrl}?url=${encodeURIComponent(`${download}?direct=&mode=render&version=`)}`,
+            `${renderUrl}?url=${encodeURIComponent(`${download}?direct=&mode=render`)}`,
         );
     });
 
@@ -51,7 +51,7 @@ module('Integration | Component | file-renderer', hooks => {
         assert.equal(iframe.getAttribute('width'), '500');
         assert.equal(
             iframe.getAttribute('src'),
-            `${renderUrl}?url=${encodeURIComponent('http://cos.io/?direct=&mode=render&version=')}`,
+            `${renderUrl}?url=${encodeURIComponent('http://cos.io/?direct=&mode=render')}`,
         );
     });
 });


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-3690]
-   Feature flag: n/a

## Purpose
- Fix broken file-renderer when viewing a file through an anonymized view-only-link

## Summary of Changes
- Use actual queryparam manipulation in JS instead of treating them like glorified strings

## Screenshot(s)
- prevents views like this:
![image](https://user-images.githubusercontent.com/51409893/162467697-f942efd7-6efa-4a5c-b640-bab090234172.png)


## Side Effects
- None

## QA Notes
should prevent `UNAUTHORIZED` message in MFR iframe in URLs like: https://staging2.osf.io/sx8g4?view_only=b1a940b7abd84d9f892275437b65e730


[ENG-3690]: https://openscience.atlassian.net/browse/ENG-3690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ