### PR TITLE
[ENG-3688] Remove leftnav collapse button from registration draft and update pages

### DIFF
--- a/lib/osf-components/addon/components/osf-layout/registries-side-nav/component.ts
+++ b/lib/osf-components/addon/components/osf-layout/registries-side-nav/component.ts
@@ -1,7 +1,7 @@
 import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import { action } from '@ember/object';
-import { and, or } from '@ember/object/computed';
+import { and } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Media from 'ember-responsive';
 
@@ -21,8 +21,8 @@ export default class RegistriesSideNav extends Component {
     // Private properties
     shouldCollapse = false;
 
-    @or('media.{isDesktop,isJumbo}')
-    isCollapseAllowed!: boolean;
+    // remove collapse capability for now
+    isCollapseAllowed!: false;
 
     @and('isCollapseAllowed', 'shouldCollapse')
     isCollapsed!: boolean;


### PR DESCRIPTION
-   Ticket: [ENG-3688]
-   Feature flag: n/a

## Purpose
- Remove collapse leftnav button from the draft registration and update registration pages to make them more consistent with overview page

## Summary of Changes
- Temporarily change `isCollapseAllowed` to always return false
- If removing permanently, we should remove `shouldCollapse`, `isCollapsed`, `isCollapseAllowed` and other properties pertaining to collapsibility

## Screenshot(s)
- Draft registration page
![image](https://user-images.githubusercontent.com/51409893/163415067-e10a9172-53f6-40cc-8273-88c8208c569f.png)

- Registration update page
![image](https://user-images.githubusercontent.com/51409893/163415291-feef9b9f-25b6-4232-8880-21c52fcd79eb.png)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-3688]: https://openscience.atlassian.net/browse/ENG-3688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ