### PR TITLE
[ENG-3741] Fix draft reg reroute logic for read-only users 

### DIFF
--- a/lib/registries/addon/drafts/draft/route.ts
+++ b/lib/registries/addon/drafts/draft/route.ts
@@ -40,6 +40,8 @@ export default class DraftRegistrationRoute extends Route {
             );
             if (draftRegistration.modelName === 'registration') {
                 this.transitionTo('overview', draftRegistration.id);
+            } else if (draftRegistration.currentUserIsReadOnly) {
+                this.replaceWith('drafts.draft.review', draftId);
             }
             const [subjects, provider]:
                 [SubjectModel[], ProviderModel] = await Promise.all([
@@ -48,9 +50,6 @@ export default class DraftRegistrationRoute extends Route {
                 ]);
 
             draftRegistration.setProperties({ subjects });
-            if (draftRegistration.currentUserIsReadOnly) {
-                this.replaceWith('drafts.draft.review', draftId);
-            }
             return { draftRegistration, provider };
         } catch (error) {
             captureException(error);


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- take read-only users to registration overview page if the draft registration is already submitted
## Summary of Changes
- prevent reroute to review page from happening if the draft is already submitted

## Screenshot(s)
- NA
<!-- Attach screenshots if applicable. -->

## Side Effects
- NA
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- This should only impact read-only users on a submitted registration. Read-only users will still be routed to the review page if the draft is still in progress