### PR TITLE
[ENG-3736] Fix bugs: project link overflow text

### DIFF
--- a/app/guid-file/-components/file-detail-layout/styles.scss
+++ b/app/guid-file/-components/file-detail-layout/styles.scss
@@ -6,6 +6,13 @@
 
 .MainColumn {
     flex-grow: 3;
+
+    h3 {
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+        max-width: 75vw;
+    }
 }
 
 .RightColumn {

--- a/app/guid-file/-components/file-detail-layout/styles.scss
+++ b/app/guid-file/-components/file-detail-layout/styles.scss
@@ -11,7 +11,7 @@
         text-overflow: ellipsis;
         overflow: hidden;
         white-space: nowrap;
-        max-width: 75vw;
+        max-width: 70vw;
     }
 }
 

--- a/app/guid-file/styles.scss
+++ b/app/guid-file/styles.scss
@@ -19,6 +19,13 @@
     padding: 0 20px 20px;
 }
 
+.FlexContainerRow > h2 {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    max-width: 70vw;
+}
+
 .ProjectLink {
     margin: 20px;
 }


### PR DESCRIPTION
-   Ticket: https://openscience.atlassian.net/browse/ENG-3649 , https://openscience.atlassian.net/browse/ENG-3736
-   Feature flag: n/a

## Purpose

The purpose of this ticket is to fix the display of project link and file names which overflow to the next line.

## Summary of Changes

The properties for ellipse text-overflow behavior were added to the CSS file. Additional properties that were added include its white-space set to not wrap, making the element display as an inline block, left aligning the text, and setting a width to ensure the ellipse displays regardless to communicate to the user that there is more text present in the project name.

## Screenshot(s)
<img width="1381" alt="Pasted Graphic 23" src="https://user-images.githubusercontent.com/82047646/164534389-0806eb31-85d9-40e2-8a48-6dd47ddc62b7.png">

## Side Effects

There is a concern that the side divs open oddly on the right when viewport width is added. The solution is not ideal, and should be seen as more of a hotfix until a more complete solution may be reached.

## QA Notes

-Does the project link and file names appear properly?
-Does the text wrap to another line (should not) or appear ellipsed?
-Is the ellipse showing to indicate more text?
-How is the layout for the slide being affected?

