### PR TITLE
[WIP] [ENG-3720] Rename File Modal

### DIFF
--- a/lib/osf-components/addon/components/file-actions-menu/styles.scss
+++ b/lib/osf-components/addon/components/file-actions-menu/styles.scss
@@ -22,3 +22,8 @@
     composes: FakeLink from '../button/styles.scss';
     margin: 6px 0;
 }
+
+.RenameLink {
+    padding-top: 6px;
+    padding-right: 1px;
+}

--- a/lib/osf-components/addon/components/file-actions-menu/template.hbs
+++ b/lib/osf-components/addon/components/file-actions-menu/template.hbs
@@ -48,5 +48,17 @@
                 {{t 'general.share'}}
             </dd.trigger>
         </SharingIcons::Dropdown>
+        <OsfLink
+            data-test-rename-button
+            data-analytics-name='Rename file'
+            aria-label={{t 'file_actions_menu.rename'}}
+            local-class='RenameLink'
+            value={{t 'file_actions_menu.rename'}}
+            @href='#userInput'
+            {{on 'click' @toggleRenameModal}}
+        >
+            <FaIcon @icon='pencil-alt' />
+            {{t 'file_actions_menu.rename'}}
+        </OsfLink>
     </dropdown.content>
 </ResponsiveDropdown>

--- a/lib/osf-components/addon/components/file-browser/file-item/component.ts
+++ b/lib/osf-components/addon/components/file-browser/file-item/component.ts
@@ -1,0 +1,69 @@
+/* eslint-disable no-console */
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { taskFor } from 'ember-concurrency-ts';
+import FileProviderModel from 'ember-osf-web/models/file-provider';
+import buildChangeset from 'ember-osf-web/utils/build-changeset';
+import { validatePresence } from 'ember-changeset-validations/validators';
+import { ValidationObject } from 'ember-changeset-validations';
+import Media from 'ember-responsive';
+
+import OsfStorageManager from 'osf-components/components/storage-provider-manager/osf-storage-manager/component';
+
+interface Args {
+    manager: OsfStorageManager;
+    provider: FileProviderModel;
+}
+
+interface RenameField {
+    fileName: string;
+}
+
+const RenameFormValidations: ValidationObject<RenameField> = {
+    fileName: validatePresence({
+        presence: true,
+        type: 'empty',
+    }),
+};
+
+export default class FileItem extends Component<Args> {
+    @service media!: Media;
+
+    @tracked renameModalOpen = false;
+
+    constructor(owner: unknown, args: Args) {
+        super(owner, args);
+    }
+
+    fileRenameChangeset =  buildChangeset({
+        fileName: null,
+    }, RenameFormValidations);
+
+    get isMobile() {
+        return this.media.isMobile;
+    }
+
+    @action
+    handleInput(event: any) {
+        taskFor(this.args.manager.changeFilter).perform(event.target.value);
+    }
+
+    @action
+    toggleRenameModal() {
+        this.renameModalOpen = !this.renameModalOpen;
+        console.log('Inside file item - is modal open? T/F', this.renameModalOpen);
+    }
+
+    @action
+    openRenameModal() {
+        this.renameModalOpen = true;
+    }
+
+    @action
+    closeRenameModal() {
+        console.log('Close rename modal in file item ');
+        this.renameModalOpen = false;
+    }
+}

--- a/lib/osf-components/addon/components/file-browser/file-item/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/file-item/template.hbs
@@ -13,7 +13,10 @@
         <FaIcon
             @prefix='far' @icon='file-alt' @fixedWidth={{true}}
         />
-        <span data-test-file-name>
+        <span
+            data-test-file-name
+            id='userInput'
+        >
             {{@item.name}}
         </span>
     </OsfLink>
@@ -26,6 +29,17 @@
                 {{moment-format @item.dateModified 'YYYY-MM-DD hh:mm A'}}
             </span>
         {{/if}}
-        <FileActionsMenu @item={{@item}} />
+        <FileActionsMenu
+            @item={{@item}}
+            @toggleRenameModal={{this.openRenameModal}}
+            local-class='FileActionsButton'
+        />
+        <FileBrowser::FileRenameModal
+            @isOpen={{this.renameModalOpen}}
+            @onClose={{action this.closeRenameModal}}
+            @item={{@item}}
+            @manager={{@manager}}
+            @disabled={{this.disabled}}
+        />
     </div>
 </li>

--- a/lib/osf-components/addon/components/file-browser/file-rename-modal/component.ts
+++ b/lib/osf-components/addon/components/file-browser/file-rename-modal/component.ts
@@ -1,0 +1,135 @@
+/* eslint-disable eqeqeq */
+/* eslint-disable no-console */
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+import RouterService from '@ember/routing/router-service';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+
+import buildChangeset from 'ember-osf-web/utils/build-changeset';
+import { validatePresence } from 'ember-changeset-validations/validators';
+import { ValidationObject } from 'ember-changeset-validations';
+import OsfStorageManager from 'osf-components/components/storage-provider-manager/osf-storage-manager/component';
+import Toast from 'ember-toastr/services/toast';
+import Store from '@ember-data/store';
+import OsfAdapter from 'ember-osf-web/adapters/osf-adapter';
+import CurrentUser from 'ember-osf-web/services/current-user';
+import { restartableTask } from 'ember-concurrency';
+import { waitFor } from '@ember/test-waiters';
+import OsfStorageFile from 'ember-osf-web/packages/files/osf-storage-file';
+import Intl from 'ember-intl/services/intl';
+
+interface Args {
+    manager: OsfStorageManager;
+    item: OsfStorageFile;
+    // validateFileName: (
+        //     fileName: string,
+        // ) => void;
+    }
+
+interface RenameField {
+    fileName: string;
+}
+
+const RenameFormValidations: ValidationObject<RenameField> = {
+    fileName: validatePresence({
+        presence: true,
+        type: 'empty',
+    }),
+};
+
+export default class FileRenameModal extends Component<Args> {
+    @service route!: RouterService;
+    @service toast!: Toast;
+    @service store!: Store;
+    @service osfadapter!: OsfAdapter;
+    @service currentUser!: CurrentUser;
+    @service intl!: Intl;
+
+    @tracked renameModalOpen = false;
+    @tracked disableButtons = false;
+    @tracked newFileName?: string = '';
+    @tracked disabled = true;
+
+    fileRenameChangeset = buildChangeset({
+        fileName: null,
+    }, RenameFormValidations);
+
+    constructor(owner: unknown, args: Args) {
+        super(owner, args);
+        this.newFileName = this.args.item.name;
+        console.log('Manager is:', this.args.manager);
+        console.log('File is:', this.args.item);
+    }
+
+    @restartableTask
+    @waitFor
+    async validateFileName() {
+        const input = document.getElementById('userInput');
+        const newName = this.newFileName;
+        if (input) {
+            const inputValue = this.newFileName;
+            const currentFileName = this.args.item.name;
+            console.log('Input value from newFileName: ', inputValue);
+            console.log('currentFileName: ', currentFileName);
+            if (inputValue) {
+                const noTrailingSpaceInput = inputValue.trim();
+
+                if (inputValue == currentFileName || noTrailingSpaceInput == currentFileName ) {
+                    this.disabled = true;
+                    const errorMessage = this.intl.t('registries.overview.files.file_rename_modal.error_toast');
+                    this.toast.error(errorMessage);
+                    console.log('File name and user input SAME');
+                } else {
+                    this.disabled = false;
+                    console.log('File name and user input DIFFERENT');
+                    console.log('The new filename is:', newName);
+                }
+            }
+            const renameButton = document.getElementById('renameButton');
+            if (renameButton && this.disabled === true) {
+                renameButton.disabled = true;
+            } else if (renameButton) {
+                renameButton.disabled = false;
+            } else {
+                this.toast.error(errorMessage);
+            }
+        }
+    }
+
+    @action
+    clearChangeset() {
+        this.fileRenameChangeset.rollback();
+    }
+
+    @action
+    async updateFileName() {
+        const newName = this.newFileName;
+        console.log('newFileName is:', newName);
+        // this.fileRenameChangeset.validate();
+        // if (this.fileRenameChangeset.isInvalid) {
+        //     return Promise.reject();
+        // }
+        // return Promise.resolve();
+        // return newName;
+        const successMessage = this.intl.t('registries.overview.files.file_rename_modal.success_toast');
+        if (newName) {
+            newName.trim();
+            this.args.item.rename(newName, 'replace');
+        }
+        this.toast.success(successMessage);
+        return newName;
+    }
+
+    @action
+    clearField() {
+        console.log('Inside clear field function.');
+        const input = document.getElementById('userInput');
+        if (input) {
+            console.log(input);
+            input.value = '';
+        }
+    }
+}

--- a/lib/osf-components/addon/components/file-browser/file-rename-modal/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/file-rename-modal/styles.scss
@@ -1,0 +1,32 @@
+.RenameModal {
+    height: 500px;
+    width: 600px;
+}
+
+.RenameInput {
+    margin-bottom: 24px;
+}
+
+.RenameInput > Input {
+    width: 100%;
+    height: 34px;
+    padding: 6px 12px;
+    border: 2px solid #ccc;
+    box-shadow: inset 0 1px 1px #ccc;
+    border-radius: 3px;
+    transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
+
+    &:focus,
+    &:active,
+    &:hover {
+        border: 1px solid #15a5eb;
+        box-shadow: inset 0 1px 1px #66afe9;
+    }
+}
+
+.RenameButton {
+    background-color: rgba(51, 122, 183, 1);
+    margin-left: 25px;
+    color: #fff;
+}
+

--- a/lib/osf-components/addon/components/file-browser/file-rename-modal/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/file-rename-modal/template.hbs
@@ -1,0 +1,71 @@
+<OsfDialog
+    @isOpen={{@isOpen}}
+    @onClose={{@onClose}}
+    @closeOnOutsideClick={{true}}
+    @manger={{@manager}}
+    @buttonStyling={{true}}
+    aria-label={{t 'registries.overview.files.file_rename_modal.dialog_aria'}}
+    local-class='RenameModal'
+    as |dialog|
+>
+    <dialog.heading>
+        {{t 'registries.overview.files.file_rename_modal.heading'}}
+    </dialog.heading>
+    <dialog.main>
+        <div local-class='RenameInput'>
+            <Input
+                aria-label={{t 'registries.overview.files.file_rename_modal.input_aria'}}
+                @value={{this.newFileName}}
+                @type='text'
+                class='form-control'
+                onchange={{perform this.validateFileName}}
+            ></Input>
+        </div>
+    </dialog.main>
+    <dialog.footer>
+        <Button
+            data-test-cancel-rename-button
+            local-class='CancelButton'
+            @type='secondary'
+            aria-label={{t 'registries.overview.files.file_rename_modal.cancel_aria'}}
+            {{on 'click' dialog.close}}
+        >
+            {{t 'registries.overview.files.file_rename_modal.cancel'}}
+        </Button>
+        {{#if this.disabled}}
+            <Button
+                data-test-rename-button-diasabled
+                local-class='RenameButton'
+                id='renameButton'
+                @type='create'
+                disabled={{true}}
+                aria-label={{t 'registries.overview.files.file_rename_modal.save_aria'}}
+                {{on 'click' (
+                    queue
+                    this.updateFileName
+                    dialog.close
+                )
+                }}
+            >
+                {{t 'registries.overview.files.file_rename_modal.save'}}
+            </Button>
+        {{else}}
+            <Button
+                data-test-rename-button-enabled
+                local-class='RenameButton'
+                id='renameButton'
+                @type='create'
+                disabled={{false}}
+                aria-label={{t 'registries.overview.files.file_rename_modal.save_aria'}}
+                {{on 'click' (
+                    queue
+                    this.updateFileName
+                    dialog.close
+                )
+                }}
+            >
+                {{t 'registries.overview.files.file_rename_modal.save'}}
+            </Button>
+        {{/if}}
+    </dialog.footer>
+</OsfDialog>

--- a/lib/osf-components/addon/components/file-browser/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/styles.scss
@@ -45,7 +45,6 @@
     }
 }
 
-
 .SortedBy {
     padding-right: 58px;
     font-weight: bold;

--- a/lib/osf-components/addon/components/file-browser/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/template.hbs
@@ -122,7 +122,7 @@
         {{#if item.isFile}}
             <FileBrowser::FileItem @item={{item}} @manager={{@manager}} />
         {{else}}
-            <FileBrowser::FolderItem @item={{item}} @manager={{@manager}} />            
+            <FileBrowser::FolderItem @item={{item}} @manager={{@manager}} />
         {{/if}}
     </:item>
     <:empty>

--- a/lib/osf-components/app/components/file-browser/file-item/component.js
+++ b/lib/osf-components/app/components/file-browser/file-item/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/file-browser/file-item/component';

--- a/lib/osf-components/app/components/file-browser/file-rename-modal/component.js
+++ b/lib/osf-components/app/components/file-browser/file-rename-modal/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/file-browser/file-rename-modal/component';

--- a/lib/osf-components/app/components/file-browser/file-rename-modal/template.js
+++ b/lib/osf-components/app/components/file-browser/file-rename-modal/template.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/file-browser/file-rename-modal/template';

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -106,6 +106,8 @@ file_actions_menu:
     copy_html: 'Copy static HTML iFrame'
     success_message: 'Copied to clipboard'
     error_message: 'Could not copy to clipboard'
+    rename: 'Rename'
+    rename_aria: 'Open rename link'
 node_categories:
     analysis: Analysis
     communication: Communication
@@ -1370,6 +1372,20 @@ registries:
                 download_file_detail_second: 'to open the dropdown. Click “Download”. From the file list: Click the vertical ellipses'
                 download_file_detail_third: 'of the file to open the dropdown. Click “Download”.'
                 file_actions: 'File actions icon'
+            file_rename_modal:
+                heading: 'Rename file'
+                name_input: 'Please enter a new file name:'
+                cancel: 'Cancel'
+                save: 'Save'
+                rename: 'Rename'
+                label: 'Please enter a new name for the file:'
+                no_input: 'Please enter a name.'
+                dialog_aria: 'Files Rename modal'
+                input_aria: 'User input field for renaming file'
+                cancel_aria: 'Cancel renaming file'
+                save_aria: 'Save renaming file'
+                success_toast: 'File successfully renamed.'
+                error_toast: 'Please rename the file.'
         links:
             title: Links
             linked_nodes: 'Linked projects and components'


### PR DESCRIPTION
-   Ticket: https://openscience.atlassian.net/browse/ENG-3720
-   Feature flag: n/a

## Purpose

The purpose of this ticket was to create a rename modal that allowed the user to rename a file present on the file list view. Changes included adding the 'FileRenameModal' to the 'FileItem' handlebars file, adding the 'Rename' action to the 'File ActionsMenu' as well as adding general styling to the elements. 

When the rename link is clicked the modal opens with the input bar pre-populated with the file's current name. As the user enters text the program verifies that the text is different from the current file name. Current guidance has included to not restrict file extensions as users sometimes create their own. In the upper right of the modal there is a 'X'-style cancel button and the dialog.footer inside the OsfDialog template file includes both 'Cancel' and 'Save' buttons. 

The 'Cancel' button will close the modal, resetting the value of the tracked property of 'renameModalOpen' to 'false'. The 'Save' button will try the rename, returning a 201 upon a successful POST request against the API. 

# When unsuccessful  a 429, 404, and 401 error code will be returned.

## Summary of Changes

        modified: lib/osf-components/addon/components/file-actions-menu/styles.scss
	modified:   lib/osf-components/addon/components/file-actions-menu/template.hbs
	new file:   lib/osf-components/addon/components/file-browser/file-item/component.ts
	modified:   lib/osf-components/addon/components/file-browser/file-item/template.hbs
	new file:   lib/osf-components/addon/components/file-browser/file-rename-modal/component.ts
	new file:   lib/osf-components/addon/components/file-browser/file-rename-modal/styles.scss
	new file:   lib/osf-components/addon/components/file-browser/file-rename-modal/template.hbs
	modified:   lib/osf-components/addon/components/file-browser/styles.scss
	modified:   lib/osf-components/addon/components/file-browser/template.hbs
	new file:   lib/osf-components/app/components/file-browser/file-item/component.js
	new file:   lib/osf-components/app/components/file-browser/file-rename-modal/component.js
	new file:   lib/osf-components/app/components/file-browser/file-rename-modal/template.js
	modified:   translations/en-us.yml

## Screenshot(s)

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/82047646/168912221-e92d5bcd-29b1-4ad9-a739-9d71106c96d3.png">
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/82047646/168912264-81e7a7d5-42e6-49fb-9612-401a2f0d1fcb.png">
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/82047646/168912321-1ea932de-1b6e-46b5-bd3b-86f7a75f73f6.png">
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/82047646/168912396-35ac361f-f7fc-4ae2-9baf-d96b4b691b6e.png">

## Side Effects

If not properly configured, the modal has some breaking consequences for the template view. If 'Args' are not properly passed for instance, the file's currently existing name cannot be resolved and the 'Submit' button will not be able to be disabled. Two cancel buttons ensure the view may be exited if not functioning but should still be accounted for during testing. 

## QA Notes

Please use the screenshot below as reference from the JIRA ticket ENG-3720 when completing your analysis:

<img width="1159" alt="image" src="https://user-images.githubusercontent.com/82047646/168912723-15715398-5797-40e2-9ae3-cf99d8eb47c5.png">

-Does the modal display?
-Do the names make sense?
-Have all necessary/relevant data test links been added?
-Would the modal pass w3 acceptance standards for ARIA?
-Is it well positioned?
-Does it include the text 'Rename file' for the header, 'Cancel' for the cancel button, and 'Save' for the Submit button?
-Does the toast properly display? Was there enough time to rename it?
-Does scroll properly occur for overflow text?
-How does the modal look in mobile?
-Is it legible in dark mode? Is contrast there good?


