### PR TITLE
[ENG-3761] LeftNav links and page styling

### DIFF
--- a/app/guid-node/files/provider/route.ts
+++ b/app/guid-node/files/provider/route.ts
@@ -19,7 +19,7 @@ export default class GuidNodeFilesProviderRoute extends Route.extend({}) {
             },
         );
         const provider = fileProviders.findBy('id', fileProviderId) as FileProviderModel;
-        return provider;
+        return {provider, fileProviders, node};
     }
 
     model(params: { providerId: string }) {

--- a/app/guid-node/files/provider/styles.scss
+++ b/app/guid-node/files/provider/styles.scss
@@ -68,3 +68,7 @@
 .FileProviderIcon {
     font-size: 16px;
 }
+
+.FileBrowser {
+    padding-left: 30px;
+}

--- a/app/guid-node/files/provider/styles.scss
+++ b/app/guid-node/files/provider/styles.scss
@@ -55,6 +55,7 @@
     border-left: 2px solid $color-border-gray-darker;
     padding-left: 17px;
     margin: 0 18px;
+    padding-top: 2px;
 
     :global(.active) {
         border-left: 4px solid $color-black;

--- a/app/guid-node/files/provider/styles.scss
+++ b/app/guid-node/files/provider/styles.scss
@@ -18,3 +18,52 @@
         filter: grayscale(1);
     }
 }
+
+.Hero {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    min-width: 100%;
+    min-height: 100%;
+    position: relative;
+    background: url('images/default-brand/bg-dark.jpg');
+    background-size: cover;
+    display: block;
+    align-items: center;
+
+
+    h1 {
+        color: $color-text-white;
+        font-size: large;
+        font-weight: 600;
+        margin-top: 0;
+        margin-bottom: 0;
+        padding: 20px;
+    }
+}
+
+.FileProviders {
+    display: flex;
+    flex-direction: column;
+}
+
+.FileProvider {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-left: 2px solid $color-border-gray-darker;
+    padding-left: 17px;
+    margin: 0 18px;
+
+    :global(.active) {
+        border-left: 4px solid $color-black;
+        font-weight: 700;
+        padding-left: 16px;
+        margin-left: -20px;
+    }
+}
+
+.FileProviderIcon {
+    font-size: 16px;
+}

--- a/app/guid-node/files/provider/template.hbs
+++ b/app/guid-node/files/provider/template.hbs
@@ -7,8 +7,8 @@
         @backgroundClass='{{local-class 'ContentBackground'}}'
         as |layout|
     >
-        <layout.heading>
-            {{!-- Placeholder for header --}}
+        <layout.heading local-class='Hero'>
+            <h1>{{this.model.providerTask.value.node.title}}</h1>
         </layout.heading>
         <layout.leftNavOld as |leftNav|>
             <leftNav.link
@@ -26,6 +26,39 @@
                 @icon='file-alt'
                 @label={{t 'node.left_nav.files'}}
             />
+            <div
+                data-test-file-providers-list
+                local-class='FileProvidersList'
+            >
+                {{#each this.model.providerTask.value.fileProviders as |provider|}}
+                    <div local-class='FileProvider'>
+                        <OsfLink
+                            data-test-files-provider-link={{provider.name}}
+                            data-analytics-name={{concat 'Files - ' provider.name}} 
+                            @route='guid-node.files.provider'
+                            @models={{array this.model.node.guid provider.name}}
+                        >
+                            {{t (concat 'osf-components.file-browser.storage_providers.' provider.name)}}
+                        </OsfLink>
+                        {{#if (eq provider.name 'osfstorage')}}
+                            <span>
+                                <FaIcon
+                                    local-class='FileProviderIcon'
+                                    @icon='globe'
+                                >
+                                </FaIcon>
+                                <BsTooltip
+                                    @placement='right'
+                                    @triggerEvents='hover'
+                                >
+                                    {{t 'osf-components.file-browser.storage_location'}}
+                                    {{this.model.providerTask.value.node.region.name}}
+                                </BsTooltip>
+                            </span>
+                        {{/if}}
+                    </div>
+                {{/each}}
+            </div>
             <leftNav.link
                 data-test-wiki-link
                 data-analytics-name='Wiki'
@@ -77,7 +110,7 @@
             >
                 {{#let (get mapper this.model.providerName) as |ProviderManager|}}
                     <ProviderManager
-                        @provider={{this.model.providerTask.value}}
+                        @provider={{this.model.providerTask.value.provider}}
                         as |manager|
                     >
                         <FileBrowser @manager={{manager}} @selectable={{true}} @enableUpload={{true}} />

--- a/app/guid-node/files/provider/template.hbs
+++ b/app/guid-node/files/provider/template.hbs
@@ -113,7 +113,9 @@
                         @provider={{this.model.providerTask.value.provider}}
                         as |manager|
                     >
-                        <FileBrowser @manager={{manager}} @selectable={{true}} @enableUpload={{true}} />
+                        <div local-class='FileBrowser'>
+                            <FileBrowser @manager={{manager}} @selectable={{true}} @enableUpload={{true}} />
+                        </div>
                     </ProviderManager>
                 {{/let}}
             </StorageProviderManager::ProviderMapper>

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -96,7 +96,7 @@
                                                 @placement='right'
                                                 @triggerEvents='hover'
                                             >
-                                                {{t 'registries.overview.files.storage_location'}}
+                                                {{t 'osf-components.file-browser.storage_location'}}
                                                 {{this.registration.region.name}}
                                             </BsTooltip>
                                         </span>


### PR DESCRIPTION
-   Ticket: [ENG-3761]
-   Feature flag: n/a

## Purpose

Add the provider links to the leftnav and style the outer portions of the page

## Summary of Changes

1. Add hero banner
2. Add provider links to leftnav
3. Fix broken translation


## Screenshot(s)

<img width="1466" alt="Screen Shot 2022-05-19 at 4 16 51 PM" src="https://user-images.githubusercontent.com/6599111/169397223-1d36d94f-6074-44e6-8073-1ef5985371e7.png">

## Side Effects

Nah

## QA Notes

It should only show providers that are linked to the current project, and you should be able to navigate to each of the providers.


[ENG-3761]: https://openscience.atlassian.net/browse/ENG-3761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ