### PR TITLE
[No ticket] Files page a11y fixes

### DIFF
--- a/lib/osf-components/addon/components/file-browser/add-new/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/add-new/template.hbs
@@ -5,6 +5,7 @@
         as |dropdown|
     >
         <Button
+            aria-label={{t 'osf-components.file-browser.add_button_aria'}}
             local-class='TriggerButton {{if dropdown.isOpen 'CloseButton'}}'
             @type='create'
             {{on 'click' dropdown.toggle}}

--- a/lib/osf-components/addon/components/file-browser/help-modal/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/help-modal/template.hbs
@@ -7,7 +7,7 @@
     <dialog.heading>
         {{t 'osf-components.file-browser.help_modal.heading'}}
     </dialog.heading>
-    <dialog.main local-class='FileHelpModal__main'>
+    <dialog.main local-class='FileHelpModal__main' tabindex='0'>
         <h3>{{t 'osf-components.file-browser.help_modal.download_all'}}</h3>
         <p>{{t 'osf-components.file-browser.help_modal.download_all_detail'}}</p>
         <h3>{{t 'osf-components.file-browser.help_modal.download_folder'}}</h3>

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1855,6 +1855,7 @@ osf-components:
             s3: 'Amazon S3'
         empty_folder: 'This folder is empty.'
         breadcrumbs: 'Breadcrumb'
+        add_button_aria: 'Add files or folders here'
         create_folder: 'Create folder'
         upload_file: 'Upload file'
         new_folder_name: 'New folder name'


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [No ticket]
-   Feature flag: n/a

## Purpose
- Better accessibility for files page stuff

## Summary of Changes
- Add tab index to modal body to allow scrolling with keyboard
- Add aria-label to files widget omni-button

## Screenshot(s)
NA

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- These fixes should be covered by automated testing:
  - Green omni button to add folder and files should have aria-label
  - Files widget help modal should be scrollable