### PR TITLE
[No ticket] Fix sorting by date

### DIFF
--- a/app/packages/files/file.ts
+++ b/app/packages/files/file.ts
@@ -7,8 +7,8 @@ import { Permission } from 'ember-osf-web/models/osf-model';
 import CurrentUserService from 'ember-osf-web/services/current-user';
 
 export enum FileSortKey {
-    AscDateModified = 'modified',
-    DescDateModified = '-modified',
+    AscDateModified = 'date_modified',
+    DescDateModified = '-date_modified',
     AscName = 'name',
     DescName = '-name',
 }

--- a/lib/osf-components/addon/components/file-browser/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/template.hbs
@@ -73,15 +73,15 @@
                         </Button>
                         <Button
                             @layout='fake-link'
-                            {{on 'click' (fn  @manager.changeSort 'modified')}}
+                            {{on 'click' (fn  @manager.changeSort 'date_modified')}}
                         >
-                            {{t 'osf-components.file-browser.sort_by.modified'}}
+                            {{t 'osf-components.file-browser.sort_by.date_modified'}}
                         </Button>
                         <Button
                             @layout='fake-link'
-                            {{on 'click' (fn  @manager.changeSort '-modified')}}
+                            {{on 'click' (fn  @manager.changeSort '-date_modified')}}
                         >
-                            {{t 'osf-components.file-browser.sort_by.-modified'}}
+                            {{t 'osf-components.file-browser.sort_by.-date_modified'}}
                         </Button>
                     </dropdown.content>
                 </ResponsiveDropdown>

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1849,8 +1849,8 @@ osf-components:
         sort_by:
             name: 'Name: A-Z'
             -name: 'Name: Z-A'
-            modified: 'Last modified: newest to oldest'
-            -modified: 'Last modified: oldest to newest'
+            -date_modified: 'Last modified: newest to oldest'
+            date_modified: 'Last modified: oldest to newest'
         download_all: 'Download this folder'
         storage_location: 'Storage location: '
         storage_providers:


### PR DESCRIPTION
## Purpose

Fix sorting by date modified

## Summary of Changes

1. Use date_modified instead of modified for sorting to match the recently fixed backend.

## Side Effects

Will also affect the registries files page

## QA Notes

Sorting should work properly now.
