### PR TITLE
[ENG-3728] Show unviewed files as unviewed

### DIFF
--- a/app/models/file.ts
+++ b/app/models/file.ts
@@ -37,6 +37,7 @@ export default class FileModel extends BaseFileItem {
     @attr('object') extra!: any;
     @attr('fixstringarray') tags!: string[];
     @attr('fixstring') checkout!: string;
+    @attr('boolean') currentUserHasViewed!: boolean;
 
     @belongsTo('file', { inverse: 'files' })
     parentFolder!: AsyncBelongsTo<FileModel> & FileModel;

--- a/app/packages/files/file.ts
+++ b/app/packages/files/file.ts
@@ -60,6 +60,10 @@ export default abstract class File {
         return this.fileModel.isFolder;
     }
 
+    get showAsUnviewed() {
+        return !this.fileModel.currentUserHasViewed;
+    }
+
     get currentUserPermission(): string {
         if (this.fileModel.target.get('currentUserPermissions').includes(Permission.Write)) {
             return 'write';

--- a/lib/osf-components/addon/components/file-browser/file-item/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/file-item/styles.scss
@@ -11,6 +11,10 @@
     }
 }
 
+.Unviewed {
+    font-weight: 600;
+}
+
 .Indent {
     margin-left: 30px;
 }

--- a/lib/osf-components/addon/components/file-browser/file-item/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/file-item/template.hbs
@@ -25,7 +25,7 @@
             aria-label={{t 'osf-components.file-browser.view_file' fileName=@item.name}}
             @href={{@item.links.html}}
             @target='_blank'
-            local-class='FileList__item__name'
+            local-class='FileList__item__name {{if @item.showAsUnviewed 'Unviewed'}}'
         >
             <FaIcon
                 @prefix='far' @icon='file-alt' @fixedWidth={{true}}


### PR DESCRIPTION
-   Ticket: [ENG-3728]
-   Feature flag: n/a

## Purpose

When a new version of a file is put up, people who haven't seen it yet should show it as unviewed, which in this case means a bolder font-weight in the file list.

## Summary of Changes

1. Update model
2. Update file object
3. Add style if the version hasn't been viewed 

## Screenshot(s)

<img width="1308" alt="Screen Shot 2022-05-26 at 9 34 21 AM" src="https://user-images.githubusercontent.com/6599111/170502737-91cf0337-2c24-44a8-976b-6e955edfb7a5.png">

<img width="754" alt="Screen Shot 2022-05-26 at 9 35 38 AM" src="https://user-images.githubusercontent.com/6599111/170502753-60797062-a660-4831-a41d-43fad3b933d1.png">

<img width="730" alt="Screen Shot 2022-05-26 at 9 35 57 AM" src="https://user-images.githubusercontent.com/6599111/170502771-90f3e92d-c63d-4151-9c5c-99b54e1b1a8c.png">

## Side Effects

This shouldn't interact with anything

## QA Notes

Viewing a file to clear the flag means rendering it in MFR, so visiting the file detail page should clear it. This is osfstorage-only functionality, so other providers should never show bolded files in the file list, as far as I understand it. If the user isn't logged in or isn't a contributor to the project, it should similarly show as non-bolded. 


[ENG-3728]: https://openscience.atlassian.net/browse/ENG-3728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ