### PR TITLE
Prevent dropdown and content from being obscured

### DIFF
--- a/lib/osf-components/addon/components/file-actions-menu/template.hbs
+++ b/lib/osf-components/addon/components/file-actions-menu/template.hbs
@@ -3,6 +3,7 @@
     @renderInPlace={{true}}
     @buttonStyling={{true}}
     @horizontalPosition='right'
+    @verticalPosition='above'
     as |dropdown|
 >
     <dropdown.trigger

--- a/lib/osf-components/addon/components/file-browser/file-item/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/file-item/styles.scss
@@ -42,6 +42,7 @@
 .FileList__item__options {
     display: flex;
     align-items: center;
+    z-index: 1;
 }
 
 .FileList__item__name {

--- a/lib/osf-components/addon/components/file-browser/folder-item/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/folder-item/styles.scss
@@ -59,6 +59,7 @@
 
 .DownloadShareDropdown {
     padding-left: 20px;
+    z-index: 1;
 }
 
 .DropdownList {

--- a/lib/osf-components/addon/components/file-browser/folder-item/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/folder-item/template.hbs
@@ -46,6 +46,7 @@
                     @renderInPlace={{true}}
                     @buttonStyling={{true}}
                     @horizontalPosition='right'
+                    @verticalPosition='above'
                     as |dropdown|
                 >
                     <dropdown.trigger


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [No ticket]
-   Feature flag: n/a

## Purpose
- Allow users to select file actions in mobile view
- Prevent file-dropdown content from being obscured by file-action-menu trigger button of item below

## Summary of Changes
- Add z-index to file action dropdown triggers
- As a consequence of adding z-index to the dropdown trigger, we need to show dropdown above, otherwise it will be obscured by the dropdown trigger in the file item below it

## Screenshot(s)
- File action menu for the bottom file is currently open
<img width="939" alt="Screen Shot 2022-05-26 at 5 03 20 PM" src="https://user-images.githubusercontent.com/51409893/170579846-c50014c2-a3f1-4e40-882e-931ecb7a9fad.png">


## Side Effects
- The menu now shows up above which feels a bit unintuitive
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
