### PR TITLE
[ENG-3811] Leftnav links with differing permissions

### DIFF
--- a/app/guid-node/files/provider/template.hbs
+++ b/app/guid-node/files/provider/template.hbs
@@ -66,43 +66,51 @@
                 @icon='window-maximize'
                 @label={{t 'node.left_nav.wiki'}}
             />
-            <leftNav.link
-                data-test-analytics-link
-                data-analytics-name='Analytics' 
-                @route='guid-node.analytics'
-                @models={{array this.model.node.guid}}
-                @icon='chart-bar'
-                @label={{t 'node.left_nav.analytics'}}
-            />
-            <leftNav.link
-                data-test-registrations-link
-                data-analytics-name='Registrations'
-                @route='guid-node.registrations'
-                @models={{array this.model.node.guid}}
-                @icon='file-alt'
-                @label={{t 'node.left_nav.registrations'}}
-            />
-            <leftNav.link
-                data-test-contributors-link
-                data-analytics-name='Contributors'
-                @href='/{{this.model.node.guid}}/contributors/'
-                @icon='users'
-                @label={{t 'node.left_nav.contributors'}}
-            />
-            <leftNav.link
-                data-test-addons-link
-                data-analytics-name='Add-ons'
-                @href='/{{this.model.node.guid}}/addons/'
-                @icon='database'
-                @label={{t 'node.left_nav.add-ons'}}
-            />
-            <leftNav.link
-                data-test-settings-link
-                data-analytics-name='Settings'
-                @href='/{{this.model.node.guid}}/settings/'
-                @icon='cogs'
-                @label={{t 'node.left_nav.settings'}}
-            />
+            {{#unless this.model.providerTask.value.isViewOnly}}
+                <leftNav.link
+                    data-test-analytics-link
+                    data-analytics-name='Analytics' 
+                    @route='guid-node.analytics'
+                    @models={{array this.model.node.guid}}
+                    @icon='chart-bar'
+                    @label={{t 'node.left_nav.analytics'}}
+                />
+            {{/unless}}
+            {{#unless this.model.providerTask.value.node.isAnonymous}}
+                <leftNav.link
+                    data-test-registrations-link
+                    data-analytics-name='Registrations'
+                    @route='guid-node.registrations'
+                    @models={{array this.model.node.guid}}
+                    @icon='file-alt'
+                    @label={{t 'node.left_nav.registrations'}}
+                />
+            {{/unless}}
+            {{#unless this.model.providerTask.value.isViewOnly}}
+                <leftNav.link
+                    data-test-contributors-link
+                    data-analytics-name='Contributors'
+                    @href='/{{this.model.node.guid}}/contributors/'
+                    @icon='users'
+                    @label={{t 'node.left_nav.contributors'}}
+                />
+                {{#if this.model.providerTask.value.hasWritePermission}}
+                    <leftNav.link
+                        data-test-addons-link
+                        data-analytics-name='Add-ons'
+                        @href='/{{this.model.node.guid}}/addons/'
+                        @icon='database'
+                        @label={{t 'node.left_nav.add-ons'}}
+                    />
+                {{/if}}
+                <leftNav.link
+                    data-test-settings-link
+                    data-analytics-name='Settings'
+                    @href='/{{this.model.node.guid}}/settings/'
+                    @icon='cogs'
+                    @label={{t 'node.left_nav.settings'}}
+                />
+            {{/unless}}
         </layout.leftNavOld>
         <layout.main local-class='OverviewBody'>
             <StorageProviderManager::ProviderMapper

--- a/app/guid-node/files/provider/template.hbs
+++ b/app/guid-node/files/provider/template.hbs
@@ -59,13 +59,15 @@
                     </div>
                 {{/each}}
             </div>
-            <leftNav.link
-                data-test-wiki-link
-                data-analytics-name='Wiki'
-                @href='/{{this.model.node.guid}}/wiki/'
-                @icon='window-maximize'
-                @label={{t 'node.left_nav.wiki'}}
-            />
+            {{#if this.model.providerTask.value.node.wikiEnabled }}
+                <leftNav.link
+                    data-test-wiki-link
+                    data-analytics-name='Wiki'
+                    @href='/{{this.model.node.guid}}/wiki/'
+                    @icon='window-maximize'
+                    @label={{t 'node.left_nav.wiki'}}
+                />
+            {{/if}}
             {{#unless this.model.providerTask.value.isViewOnly}}
                 <leftNav.link
                     data-test-analytics-link

--- a/tests/acceptance/guid-node/files-test.ts
+++ b/tests/acceptance/guid-node/files-test.ts
@@ -9,7 +9,7 @@ module('Acceptance | guid-node/files', hooks => {
     setupOSFApplicationTest(hooks);
     setupMirage(hooks);
 
-    test('leftnav', async function(assert) {
+    test('leftnav for read user', async function(assert) {
         const node = server.create('node', 'withFiles');
         await visit(`/${node.id}/files`);
 
@@ -21,11 +21,11 @@ module('Acceptance | guid-node/files', hooks => {
         assert.dom('[data-test-analytics-link]').exists('Analytics link exists');
         assert.dom('[data-test-registrations-link]').exists('Registrations link exists');
         assert.dom('[data-test-contributors-link]').exists('Contributors link exists');
-        assert.dom('[data-test-addons-link]').exists('Addons link exists');
         assert.dom('[data-test-settings-link]').exists('Settings link exists');
     });
 
     // test no files
     // test selecting files + file actions
     // test switching providers
+    // test links for different user permissions and VOL status
 });

--- a/tests/acceptance/guid-node/files-test.ts
+++ b/tests/acceptance/guid-node/files-test.ts
@@ -17,7 +17,6 @@ module('Acceptance | guid-node/files', hooks => {
         assert.dom('[data-test-overview-link]').exists('Overview link exists');
         assert.dom('[data-test-files-link]').exists('Files link exists');
         // check active tab + file providers
-        assert.dom('[data-test-wiki-link]').exists('Wiki link exists');
         assert.dom('[data-test-analytics-link]').exists('Analytics link exists');
         assert.dom('[data-test-registrations-link]').exists('Registrations link exists');
         assert.dom('[data-test-contributors-link]').exists('Contributors link exists');
@@ -27,5 +26,5 @@ module('Acceptance | guid-node/files', hooks => {
     // test no files
     // test selecting files + file actions
     // test switching providers
-    // test links for different user permissions and VOL status
+    // test links for different user permissions and VOL status and wiki enabled
 });


### PR DESCRIPTION
-   Ticket: [ENG-3811]
-   Feature flag: n/a

## Purpose

Adjust which leftnav links are seen with different permission levels and AVOL/VOLs.

## Summary of Changes

1. Hide Addons for read-only users
2. Hide everything but Overview, Files, Wiki, and Registrations from VOL
3. Hide Registrations for AVOL users

## Screenshot(s)

Write permissions:
<img width="1308" alt="write perms" src="https://user-images.githubusercontent.com/6599111/170725845-1f7cb07a-dc25-43f8-b4ce-b71810ebbe47.png">

Read permissions:
<img width="1308" alt="read perms" src="https://user-images.githubusercontent.com/6599111/170725889-54c21df0-bf78-4a6d-8718-23ca9615b706.png">

Non-anonymous VOL:
<img width="1308" alt="non-anoymous vol" src="https://user-images.githubusercontent.com/6599111/170725950-7a8ed878-be2f-47fd-9332-ddf728823f6f.png">

AVOL:
<img width="1308" alt="avol" src="https://user-images.githubusercontent.com/6599111/170725977-ccf179b9-cec7-4593-803d-9233787bf8c4.png">

Wiki disabled:
<img width="1308" alt="wiki disabled" src="https://user-images.githubusercontent.com/6599111/170766684-a4f92ec3-d6eb-484d-9433-b999930b1652.png">


## Side Effects

No

## QA Notes

Just verify that the current states are as expected.


[ENG-3811]: https://openscience.atlassian.net/browse/ENG-3811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ