### PR TITLE
[ENG-3811] Add data-test selectors for copy/move/delete buttons

### DIFF
--- a/lib/osf-components/addon/components/file-actions-menu/template.hbs
+++ b/lib/osf-components/addon/components/file-actions-menu/template.hbs
@@ -21,7 +21,7 @@
             {{t 'general.download'}}
         </OsfLink>
         {{#if @item.currentUserCanDelete}}
-            <Button @layout='fake-link' local-class='DropdownItem'
+            <Button @layout='fake-link' local-class='DropdownItem' data-test-delete-button
                 {{on 'click' (fn (mut this.isDeleteModalOpen) true)}}
             >
                 <FaIcon @icon='trash-alt' />
@@ -61,6 +61,7 @@
                 <Button
                     @layout='fake-link'
                     local-class='DropdownItem'
+                    data-test-move-button
                     {{on 'click' (queue (action (mut this.useCopyModal) false) (action (mut this.moveModalOpen) true))}}
                 >
                     <FaIcon
@@ -72,6 +73,7 @@
             <Button
                 @layout='fake-link'
                 local-class='DropdownItem'
+                data-test-copy-button
                 {{on 'click' (queue (action (mut this.useCopyModal) true) (action (mut this.moveModalOpen) true))}}
             >
                 <FaIcon

--- a/lib/osf-components/addon/components/file-browser/folder-item/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/folder-item/template.hbs
@@ -68,6 +68,7 @@
                         {{#if @item.currentUserCanDelete}}
                             <Button
                                 @layout='fake-link'
+                                data-test-delete-button
                                 {{on 'click' (queue (action (mut this.useCopyModal) false) (action (mut this.moveModalOpen) true))}}
                             >
                                 <FaIcon
@@ -79,6 +80,7 @@
                         <Button
                             @layout='fake-link'
                             local-class='DropdownItem'
+                            data-test-copy-button
                             {{on 'click' (queue (action (mut this.useCopyModal) true) (action (mut this.moveModalOpen) true))}}
                         >
                             <FaIcon
@@ -87,7 +89,7 @@
                             {{t 'general.copy'}}
                         </Button>
                         {{#if @item.currentUserCanDelete}}
-                            <Button @layout='fake-link' local-class='DropdownItem'
+                            <Button @layout='fake-link' local-class='DropdownItem' data-test-move-button
                                 {{on 'click' (fn (mut this.isDeleteModalOpen) true)}}
                             >
                                 <FaIcon @icon='trash-alt' />


### PR DESCRIPTION
-   Ticket: [ENG-3811]
-   Feature flag: n/a

## Purpose

Allow selenium tests (and ours) to access the move, copy, and delete buttons more easily

## Summary of Changes

1. Add data test selectors to file and folder action menus

## Side Effects

None anticipated

## QA Notes

This should give you the ability to use those buttons easily in your tests.


[ENG-3811]: https://openscience.atlassian.net/browse/ENG-3811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ