### PR TITLE
[ENG-3806] Move files bugs

### DIFF
--- a/lib/osf-components/addon/components/move-file-modal/component.ts
+++ b/lib/osf-components/addon/components/move-file-modal/component.ts
@@ -126,6 +126,7 @@ export default class MoveFileModalComponent extends Component<MoveFileModalArgs>
         if (!this.currentFolder) {
             fileList = await this.currentNode!.queryHasMany('files', {
                 page: this.folderPage,
+                'page[size]': 20,
             });
             fileList = fileList.map(
                 fileProviderModel => getStorageProviderFile(this.currentUser, fileProviderModel),

--- a/lib/osf-components/addon/components/move-file-modal/list-item/component.ts
+++ b/lib/osf-components/addon/components/move-file-modal/list-item/component.ts
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import Intl from 'ember-intl/services/intl';
 import Toast from 'ember-toastr/services/toast';
+import config from 'ember-get-config';
 
 import NodeModel from 'ember-osf-web/models/node';
 import File from 'ember-osf-web/packages/files/file';
@@ -48,5 +49,9 @@ export default class ListItemComponent extends Component<ListItemArgs> {
             return this.intl.t('osf-components.move_file_modal.no_write_permission');
         }
         return this.intl.t('osf-components.move_file_modal.select_provider');
+    }
+
+    get assetPrefix() {
+        return config.assetsPrefix;
     }
 }

--- a/lib/osf-components/addon/components/move-file-modal/list-item/template.hbs
+++ b/lib/osf-components/addon/components/move-file-modal/list-item/template.hbs
@@ -26,7 +26,7 @@
                 {{#if @isProvider}}
                     <img
                         data-test-provider-icon
-                        src={{concat '/assets/images/addons/icons/' @item.name '.png'}}
+                        src={{concat this.assetPrefix 'assets/images/addons/icons/' @item.name '.png'}}
                         alt={{t 'osf-components.move_file_modal.icon_alt' provider=(t (concat 'osf-components.file-browser.storage_providers.' @item.name))}}
                     >
                     {{t (concat 'osf-components.file-browser.storage_providers.' @item.name)}}


### PR DESCRIPTION
-   Ticket: [ENG-3806]
-   Feature flag: n/a

## Purpose
- Address bugs found for move files/folders capabilities

## Summary of Changes
- Load all file-providers when fetching a node's file providers
- Show provider icons properly

## Screenshot(s)
- Issue where only 10 providers load as seen here fixed and should now show icons
![Untitled](https://user-images.githubusercontent.com/51409893/171413891-904dc390-b98a-4cf0-ab06-aa1cdc26c856.png)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-3806]: https://openscience.atlassian.net/browse/ENG-3806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ