### PR TITLE
[ENG-3806] Multi file move bugs

### DIFF
--- a/app/packages/files/file.ts
+++ b/app/packages/files/file.ts
@@ -158,10 +158,14 @@ export default abstract class File {
         await this.fileModel.rename(newName, conflict);
     }
 
+    @task
+    @waitFor
     async move(node: NodeModel, path: string, provider: string, options?: { conflict: string }) {
         return await this.fileModel.move(node, path, provider, options);
     }
 
+    @task
+    @waitFor
     async copy(node: NodeModel, path: string, provider: string, options?: { conflict: string }) {
         return await this.fileModel.copy(node, path, provider, options);
     }

--- a/app/packages/files/file.ts
+++ b/app/packages/files/file.ts
@@ -158,14 +158,10 @@ export default abstract class File {
         await this.fileModel.rename(newName, conflict);
     }
 
-    @task
-    @waitFor
     async move(node: NodeModel, path: string, provider: string, options?: { conflict: string }) {
         return await this.fileModel.move(node, path, provider, options);
     }
 
-    @task
-    @waitFor
     async copy(node: NodeModel, path: string, provider: string, options?: { conflict: string }) {
         return await this.fileModel.copy(node, path, provider, options);
     }

--- a/lib/osf-components/addon/components/move-file-modal/component.ts
+++ b/lib/osf-components/addon/components/move-file-modal/component.ts
@@ -307,6 +307,5 @@ export default class MoveFileModalComponent extends Component<MoveFileModalArgs>
     cancelMoves() {
         taskFor(this.moveFile).cancelAll();
         taskFor(this.copyFile).cancelAll();
-        // this.fileActionTasks.forEach(moveOrCopyTask => taskFor(moveOrCopyTask).cancelAll());
     }
 }

--- a/lib/osf-components/addon/components/move-file-modal/component.ts
+++ b/lib/osf-components/addon/components/move-file-modal/component.ts
@@ -45,7 +45,7 @@ export default class MoveFileModalComponent extends Component<MoveFileModalArgs>
     @tracked totalFiles? = 0;
     @tracked breadcrumbs: Array<ProviderFile | File> = [];
 
-    @tracked fileActionTasks: Array<TaskInstance<null>> = [];
+    @tracked fileActionTasks: Array<TaskInstance<void>> = [];
 
     get itemList() {
         return [...this.filesList, ...this.childNodeList];
@@ -205,7 +205,7 @@ export default class MoveFileModalComponent extends Component<MoveFileModalArgs>
         this.totalFiles = 0;
     }
 
-    @task
+    @task({ maxConcurrency: 3, enqueue: true })
     @waitFor
     async moveFile(file: File, destinationNode: NodeModel, path: string, provider: string,
         options?: { conflict: string }) {
@@ -222,12 +222,19 @@ export default class MoveFileModalComponent extends Component<MoveFileModalArgs>
         const provider = breadcrumbs[0];
         try {
             const moveTasks = this.args.filesToMove.map(file =>
-                taskFor(file.move).perform(currentNode, currentFolder.path, provider.name));
+                taskFor(this.moveFile).perform(file, currentNode, currentFolder.path, provider.name));
             this.fileActionTasks = moveTasks;
             await allSettled(moveTasks);
         } catch (e) {
             captureException(e);
         }
+    }
+
+    @task({ maxConcurrency: 3, enqueue: true })
+    @waitFor
+    async copyFile(file: File, destinationNode: NodeModel, path: string, provider: string,
+        options?: { conflict: string }) {
+        await file.copy(destinationNode, path, provider, options);
     }
 
     @task
@@ -240,7 +247,7 @@ export default class MoveFileModalComponent extends Component<MoveFileModalArgs>
         const provider = breadcrumbs[0];
         try {
             const copyTasks = this.args.filesToMove.map(file =>
-                taskFor(file.copy).perform(currentNode, currentFolder.path, provider.name));
+                taskFor(this.copyFile).perform(file, currentNode, currentFolder.path, provider.name));
             this.fileActionTasks = copyTasks;
             await allSettled(copyTasks);
         } catch (e) {
@@ -257,9 +264,9 @@ export default class MoveFileModalComponent extends Component<MoveFileModalArgs>
     @action
     retry(file: File, index: number) {
         const { currentFolder, currentNode, breadcrumbs } = this;
-        const fileActionTask = this.args.preserveOriginal ? file.copy : file.move;
+        const fileActionTask = this.args.preserveOriginal ? this.copyFile : this.moveFile;
         const newTaskInstance = taskFor(fileActionTask).perform(
-            currentNode, currentFolder!.path, breadcrumbs[0].name,
+            file, currentNode, currentFolder!.path, breadcrumbs[0].name,
         );
         this.fileActionTasks[index] = newTaskInstance;
         notifyPropertyChange(this, 'fileActionTasks');
@@ -268,9 +275,9 @@ export default class MoveFileModalComponent extends Component<MoveFileModalArgs>
     @action
     replace(file: File, index: number) {
         const { currentFolder, currentNode, breadcrumbs } = this;
-        const fileActionTask = this.args.preserveOriginal ? file.copy : file.move;
+        const fileActionTask = this.args.preserveOriginal ? this.copyFile : this.moveFile;
         const newTaskInstance = taskFor(fileActionTask).perform(
-            currentNode, currentFolder!.path, breadcrumbs[0].name, { conflict: 'replace' },
+            file, currentNode, currentFolder!.path, breadcrumbs[0].name, { conflict: 'replace' },
         );
         this.fileActionTasks[index] = newTaskInstance;
         notifyPropertyChange(this, 'fileActionTasks');
@@ -290,6 +297,7 @@ export default class MoveFileModalComponent extends Component<MoveFileModalArgs>
     @action
     onClose() {
         if (this.startingFolder && this.fileActionTasks.length > 0) {
+            this.cancelMoves();
             this.args.manager.reload();
         }
         this.args.close();
@@ -297,6 +305,8 @@ export default class MoveFileModalComponent extends Component<MoveFileModalArgs>
 
     @action
     cancelMoves() {
-        this.fileActionTasks.forEach(moveOrCopyTask => moveOrCopyTask.cancel());
+        taskFor(this.moveFile).cancelAll();
+        taskFor(this.copyFile).cancelAll();
+        // this.fileActionTasks.forEach(moveOrCopyTask => taskFor(moveOrCopyTask).cancelAll());
     }
 }

--- a/lib/osf-components/addon/components/move-file-modal/component.ts
+++ b/lib/osf-components/addon/components/move-file-modal/component.ts
@@ -209,7 +209,7 @@ export default class MoveFileModalComponent extends Component<MoveFileModalArgs>
     @waitFor
     async moveFile(file: File, destinationNode: NodeModel, path: string, provider: string,
         options?: { conflict: string }) {
-        await file.move(destinationNode, path, provider, options);
+        await taskFor(file.move).perform(destinationNode, path, provider, options);
     }
 
     @task
@@ -234,7 +234,7 @@ export default class MoveFileModalComponent extends Component<MoveFileModalArgs>
     @waitFor
     async copyFile(file: File, destinationNode: NodeModel, path: string, provider: string,
         options?: { conflict: string }) {
-        await file.copy(destinationNode, path, provider, options);
+        await taskFor(file.copy).perform(destinationNode, path, provider, options);
     }
 
     @task

--- a/lib/osf-components/addon/components/move-file-modal/template.hbs
+++ b/lib/osf-components/addon/components/move-file-modal/template.hbs
@@ -2,6 +2,7 @@
     @isOpen={{@isOpen}}
     @onClose={{this.onClose}}
     @fixedWidth={{true}}
+    @closeOnOutsideClick={{false}}
     as |dialog|
 >
     <dialog.heading data-test-move-modal-heading>
@@ -25,6 +26,8 @@
                             {{#if taskInstance.isRunning}}
                                 {{t (concat 'osf-components.move_file_modal.'(if @preserveOriginal 'copying_file' 'moving_file')) fileName=file.name}}
                                 <FaIcon @icon='spinner' @pulse={{true}} />
+                            {{else if (not taskInstance.hasStarted)}}
+                                {{t (concat 'osf-components.move_file_modal.'(if @preserveOriginal 'awaiting_copy' 'awaiting_move')) fileName=file.name}}
                             {{else if taskInstance.isSuccessful}}
                                 {{t (concat 'osf-components.move_file_modal.'(if @preserveOriginal 'success_copy' 'success_move')) fileName=file.name}}
                                 <FaIcon @icon='check' local-class='success'/>
@@ -123,7 +126,7 @@
         {{else}}
             <Button
                 @type='secondary'
-                {{on 'click' (queue this.cancelMoves this.onClose)}}
+                {{on 'click' this.onClose}}
             >
                 {{t 'general.cancel'}}
             </Button>

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1830,6 +1830,8 @@ osf-components:
         icon_alt: 'Icon for {provider}'
         moving_files: 'Moving...'
         copying_files: 'Copying...'
+        awaiting_move: 'Waiting to move {fileName}'
+        awaiting_copy: 'Waiting to copy {fileName}'
         moving_file: 'Moving {fileName}'
         copying_file: 'Copying {fileName}'
         success_move: 'Successfully moved {fileName}'


### PR DESCRIPTION
-   Ticket: [ENG-3806]
-   Feature flag: n/a

## Purpose
- Limit simultaneous move/copy tasks to 3 at a time to avoid issues with requests getting throttled

## Summary of Changes
- Add `enqueue` and `maxConcurrency: 3` to copy and move tasks
  - Add new message for files waiting to be moved/copied
- Actually cancel move/copy tasks that haven't started when the user closes the modal

## Screenshot(s)
![image](https://user-images.githubusercontent.com/51409893/171468546-faec0e89-5e44-4234-a795-63e58c2b2a56.png)


## Side Effects
- The limit of 3 simultaneous requests was chosen arbitrarily. This may slow down providers that are able to handle more than 3 requests at a time, so it may be worthwhile to adjust the limit higher/lower depending on the provider the users are trying to copy/move to or copy/move from.
  - We could add a property like `maxConcurrentTasks` to the `provider-file` base class and overwrite it with a smaller/larger number for specific providers and reference that in the moveFile/copyFile task.

## QA Notes
- Hopefully by avoiding the scenario where we rapid-fire a lot of requests to storage providers, we no longer see the odd behavior when moving 30+ files between providers.


[ENG-3806]: https://openscience.atlassian.net/browse/ENG-3806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ