### PR TITLE
[ENG-3811] Misc files page bugs 1

### DIFF
--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -38,7 +38,7 @@
                 <section data-test-revisions-tab local-class='FileDetail__revisions'>
                     <h2 local-class='FileDetail__right-section-heading'>{{t 'general.revisions'}}</h2>
                     <ol local-class='FileDetail__revision-list' reversed>
-                        <hr>
+                        <hr aria-hidden='true'>
                         {{#if this.model.getRevisions.isRunning}}
                             <LoadingIndicator @dark={{true}} />
                         {{else}}
@@ -48,7 +48,7 @@
                                     @downloadUrl={{this.model.links.download}}
                                     @changeVersion={{this.changeVersion}}
                                 />
-                                <hr>
+                                <hr aria-hidden='true'>
                             {{else}}
                                 {{t 'file_detail.no_revisions'}}
                             {{/each}}

--- a/app/guid-node/files/provider/styles.scss
+++ b/app/guid-node/files/provider/styles.scss
@@ -70,5 +70,5 @@
 }
 
 .FileBrowser {
-    padding-left: 30px;
+    padding: 30px;
 }

--- a/app/guid-node/files/provider/template.hbs
+++ b/app/guid-node/files/provider/template.hbs
@@ -21,8 +21,11 @@
             <leftNav.link
                 data-test-files-link
                 data-analytics-name='Files' 
-                @route='guid-node.files'
-                @models={{array this.model.node.guid}}
+                @route='guid-node.files.provider'
+                @models={{array 
+                    this.model.node.guid
+                    (if this.model.providerTask.value.provider this.model.providerTask.value.provider.name 'osfstorage')
+                }}
                 @icon='file-alt'
                 @label={{t 'node.left_nav.files'}}
             />

--- a/lib/osf-components/addon/components/file-actions-menu/delete-modal/template.hbs
+++ b/lib/osf-components/addon/components/file-actions-menu/delete-modal/template.hbs
@@ -17,6 +17,7 @@
         </Button>
         <Button
             @type='destroy'
+            disabled={{this.confirmDelete.isRunning}}
             {{on 'click' (perform this.confirmDelete)}}
         >
             {{t 'osf-components.file-browser.delete'}}

--- a/lib/osf-components/addon/components/file-renderer/component.ts
+++ b/lib/osf-components/addon/components/file-renderer/component.ts
@@ -74,6 +74,7 @@ export default class FileRenderer extends Component {
 
     didReceiveAttrs(): void {
         if (this.download !== this.lastDownload) {
+            this.isLoading = true;
             this.set('lastDownload', this.download);
         }
     }


### PR DESCRIPTION
-   Ticket: [ENG-3811]
-   Feature flag: n/a

## Purpose

Fix a few bugs on the files page

## Summary of Changes

1. Don't reload files page when clicking files link in sidebar
2. Put padding around whole filebrowser
3. Try to make the pulser work on MFR when changing versions on the file detail page - note that this is hard to test locally because MFR doesn't work, but the theory seems sound.
4. Disable delete button when delete task is running
5. Hide horizontal rules in ordered list from aria



[ENG-3811]: https://openscience.atlassian.net/browse/ENG-3811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ