### PR TITLE
[ENG-3811] Text styling for move/copy modal destinations

### DIFF
--- a/lib/osf-components/addon/components/move-file-modal/list-item/styles.scss
+++ b/lib/osf-components/addon/components/move-file-modal/list-item/styles.scss
@@ -19,5 +19,8 @@
 .InvalidDestination {
     color: $color-text-gray;
     font-style: italic;
+}
+
+.FileName {
     padding-left: 6px;
 }

--- a/lib/osf-components/addon/components/move-file-modal/list-item/styles.scss
+++ b/lib/osf-components/addon/components/move-file-modal/list-item/styles.scss
@@ -10,6 +10,12 @@
     width: 100%;
 }
 
+.DestinationName {
+    white-space: normal;
+    text-align: left;
+    padding-right: 12px;
+}
+
 .InvalidDestination {
     color: $color-text-gray;
     font-style: italic;

--- a/lib/osf-components/addon/components/move-file-modal/list-item/template.hbs
+++ b/lib/osf-components/addon/components/move-file-modal/list-item/template.hbs
@@ -43,7 +43,7 @@
             <FaIcon @icon='chevron-right' />
         </Button>
     {{else}}
-        <span local-class='InvalidDestination DestinationName'>
+        <span local-class='InvalidDestination DestinationName FileName'>
             <FaIcon @icon='file' />
             {{@item.name}}
         </span>

--- a/lib/osf-components/addon/components/move-file-modal/list-item/template.hbs
+++ b/lib/osf-components/addon/components/move-file-modal/list-item/template.hbs
@@ -7,7 +7,7 @@
             local-class='NavButton'
             {{on 'click' (fn @onNodeSelect @item)}}
         >
-            <span>
+            <span local-class='DestinationName'>
                 <NodeCard::NodeIcon @category={{@item.category}} />
                 {{@item.title}}
             </span>
@@ -22,7 +22,7 @@
             disabled={{this.shouldDisable}}
             {{on 'click' (fn @onFolderSelect @item)}}
         >
-            <span>
+            <span local-class='DestinationName'>
                 {{#if @isProvider}}
                     <img
                         data-test-provider-icon
@@ -43,7 +43,7 @@
             <FaIcon @icon='chevron-right' />
         </Button>
     {{else}}
-        <span local-class='InvalidDestination'>
+        <span local-class='InvalidDestination DestinationName'>
             <FaIcon @icon='file' />
             {{@item.name}}
         </span>


### PR DESCRIPTION
-   Ticket: [ENG-3811]
-   Feature flag: n/a

## Purpose
- Wrap text for file providers in move/copy file modal
- Fix left-align issue for valid vs invalid move/copy destinations

## Summary of Changes
- Add class to move-file-modal's list-items

## Screenshot(s)
- text wraps for invalid destinations
  - old:
![image](https://user-images.githubusercontent.com/51409893/172470225-4ff79474-d995-415a-be23-d9382b98a555.png)
  - new:
<img width="343" alt="image" src="https://user-images.githubusercontent.com/51409893/172470321-a7efa124-74d9-429f-a41c-c6bfbf462a57.png">



## Side Effects
- NA

## QA Notes
- Text for invalid move/copy destinations now wrap
- Text/icons for valid/invalid move destinations now have the same amount of left-padding


[ENG-3811]: https://openscience.atlassian.net/browse/ENG-3811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ