### PR TITLE
[ENG-3811] Firefox multi file select

### DIFF
--- a/lib/osf-components/addon/components/file-browser/file-item/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/file-item/template.hbs
@@ -10,13 +10,13 @@
                 data-analytics-category='checkbox'
                 data-test-select-file={{@item.id}}
                 aria-label={{t 'osf-components.file-browser.select_file' fileName=@item.name}}
+                {{on 'click' (action @manager.selectFile @item)}}
                 local-class='Label'
             >
                 <Input
                     local-class='Checkbox'
                     @type='checkbox'
                     @checked={{isSelected}}
-                    {{on 'click' (action @manager.selectFile @item)}}
                 />
             </label>
         {{/if}}

--- a/lib/osf-components/addon/components/file-browser/folder-item/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/folder-item/template.hbs
@@ -10,13 +10,13 @@
                 data-analytics-category='checkbox'
                 data-test-select-folder={{@item.id}}
                 aria-label={{t 'osf-components.file-browser.select_folder' folderName=@item.name}}
+                {{on 'click' (action @manager.selectFile @item)}}
                 local-class='Label'
             >
                 <Input
                     local-class='Checkbox'
                     @type='checkbox'
                     @checked={{isSelected}}
-                    {{on 'click' (action @manager.selectFile @item)}}
                 />
             </label>
         {{/if}}

--- a/lib/osf-components/addon/components/storage-provider-manager/storage-manager/component.ts
+++ b/lib/osf-components/addon/components/storage-provider-manager/storage-manager/component.ts
@@ -225,7 +225,8 @@ export default class StorageManager extends Component<Args> {
     @action
     selectFile(file: File, event: PointerEvent) {
         const target = event.target as HTMLElement;
-        // prevent click event from being forwarded to associated <input>
+        // prevent browser from programatically triggering another click event on the <label>'s associated <input>,
+        // while still allowing for keyboard users to toggle checkbox
         if (target?.tagName.toLowerCase() === 'label') {
             event.preventDefault();
         }

--- a/lib/osf-components/addon/components/storage-provider-manager/storage-manager/component.ts
+++ b/lib/osf-components/addon/components/storage-provider-manager/storage-manager/component.ts
@@ -224,12 +224,8 @@ export default class StorageManager extends Component<Args> {
 
     @action
     selectFile(file: File, event: PointerEvent) {
-        const target = event.target as HTMLElement;
         // prevent browser from programatically triggering another click event on the <label>'s associated <input>,
-        // while still allowing for keyboard users to toggle checkbox
-        if (target?.tagName.toLowerCase() === 'label') {
-            event.preventDefault();
-        }
+        event.preventDefault();
         if (document.getSelection()) {
             document.getSelection()!.removeAllRanges();
         }

--- a/lib/osf-components/addon/components/storage-provider-manager/storage-manager/component.ts
+++ b/lib/osf-components/addon/components/storage-provider-manager/storage-manager/component.ts
@@ -224,6 +224,11 @@ export default class StorageManager extends Component<Args> {
 
     @action
     selectFile(file: File, event: PointerEvent) {
+        const target = event.target as HTMLElement;
+        // prevent click event from being forwarded to associated <input>
+        if (target?.tagName.toLowerCase() === 'label') {
+            event.preventDefault();
+        }
         if (document.getSelection()) {
             document.getSelection()!.removeAllRanges();
         }


### PR DESCRIPTION
-   Ticket: [ENG-3811]
-   Feature flag: n/a

## Purpose
- Allow users to shift-click files/folders and select a range in firefox

## Summary of Changes
- Move the click event handler from the `<input>` to the `<label>` element
  - preventDefault for the click event if the event is started from the label to prevent the `selectFile` action from firing twice (once from the label, another from the input)
  - Some interesting discussion about this bug here: https://bugzilla.mozilla.org/show_bug.cgi?id=559506 and some indication that this behavior may be by-design (to allow users to select text in a `<label>` element)

## Screenshot(s)
- NA

## Side Effects
- Not really a side-effect, but for whatever reason, Firefox doesn't believe that the shiftKey is pressed when you "click" a checkbox using the spacebar, so other browsers will allow users to select a range of files using the shift-spacebar, but Firefox does not.

## QA Notes
- Users should now be able to select a range of files/folders using the shift-key and clicking in Firefox as well, but not when using the shift+space combo. The shift+space seems like a weirder issue to address and my thought is, that it will be sufficiently edge-case enough

[ENG-3811]: https://openscience.atlassian.net/browse/ENG-3811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ