### PR TITLE
[ENG-3822] Update file help modal

### DIFF
--- a/lib/osf-components/addon/components/file-browser/help-modal/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/help-modal/styles.scss
@@ -4,6 +4,15 @@
     }
 }
 
+.FileHelpModal__upload-icon.FileHelpModal__upload-icon {
+    background-color: darken($brand-success, 10%);
+    padding: 3px;
+    border-radius: 50%;
+    outline: none;
+    color: $color-text-white;
+    width: 1em;
+}
+
 .FileHelpModal__actions-icon {
     color: var(--primary-color);
 }

--- a/lib/osf-components/addon/components/file-browser/help-modal/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/help-modal/template.hbs
@@ -8,6 +8,31 @@
         {{t 'osf-components.file-browser.help_modal.heading'}}
     </dialog.heading>
     <dialog.main local-class='FileHelpModal__main' tabindex='0'>
+        <h3>{{t 'osf-components.file-browser.help_modal.providers'}}</h3>
+        <p>{{t 'osf-components.file-browser.help_modal.providers_detail'}}</p>
+        {{#if @selectable}}
+            <h3>{{t 'osf-components.file-browser.help_modal.select'}}</h3>
+            <p>{{t 'osf-components.file-browser.help_modal.select_detail'}}</p>
+            <h3>{{t 'osf-components.file-browser.help_modal.move'}}</h3>
+            <p>{{t 'osf-components.file-browser.help_modal.move_detail'}}</p>
+            <h3>{{t 'osf-components.file-browser.help_modal.copy'}}</h3>
+            <p>{{t 'osf-components.file-browser.help_modal.copy_detail'}}</p>
+        {{/if}}
+        {{#if @enableUpload}}
+            <h3>{{t 'osf-components.file-browser.help_modal.upload'}}</h3>
+            <p>
+                {{t 'osf-components.file-browser.help_modal.upload_detail_first'}}
+                <FaIcon
+                    aria-hidden='false'
+                    aria-label={{t 'osf-components.file-browser.help_modal.upload_icon'}}
+                    local-class='FileHelpModal__upload-icon'
+                    @size='2x'
+                    @fixedWidth={{true}}
+                    @icon='plus'
+                />
+                {{t 'osf-components.file-browser.help_modal.upload_detail_second'}}
+            </p>
+        {{/if}}
         <h3>{{t 'osf-components.file-browser.help_modal.download_all'}}</h3>
         <p>{{t 'osf-components.file-browser.help_modal.download_all_detail'}}</p>
         <h3>{{t 'osf-components.file-browser.help_modal.download_folder'}}</h3>
@@ -15,7 +40,7 @@
             {{t 'osf-components.file-browser.help_modal.download_folder_detail_first'}}
             <FaIcon
                 aria-hidden='false'
-                aria-label={{t 'osf-components.file-browser.help_modal.file_actions'}}
+                aria-label={{t 'osf-components.file-browser.help_modal.file_actions_icon'}}
                 local-class='FileHelpModal__actions-icon'
                 @icon='ellipsis-v'
             />
@@ -28,14 +53,14 @@
             {{t 'osf-components.file-browser.help_modal.download_file_detail_first'}}
             <FaIcon
                 aria-hidden='false'
-                aria-label={{t 'osf-components.file-browser.help_modal.file_actions'}}
+                aria-label={{t 'osf-components.file-browser.help_modal.file_actions_icon'}}
                 local-class='FileHelpModal__actions-icon'
                 @icon='ellipsis-v'
             />
             {{t 'osf-components.file-browser.help_modal.download_file_detail_second'}}
             <FaIcon
                 aria-hidden='false'
-                aria-label={{t 'osf-components.file-browser.help_modal.file_actions'}}
+                aria-label={{t 'osf-components.file-browser.help_modal.file_actions_icon'}}
                 local-class='FileHelpModal__actions-icon'
                 @icon='ellipsis-v'
             />

--- a/lib/osf-components/addon/components/file-browser/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/template.hbs
@@ -147,6 +147,8 @@
                 <FileBrowser::HelpModal
                     @isOpen={{this.helpModalOpen}}
                     @onClose={{this.toggleHelpModal}}
+                    @selectable={{@selectable}}
+                    @enableUpload={{@enableUpload}}
                 />
                 {{#if (and @manager.currentFolder.userCanUploadToHere @enableUpload)}}
                     <FileBrowser::AddNew @manager={{@manager}} @setClickableElementId={{uploadWidget.setClickableElementId}} />

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1907,18 +1907,30 @@ osf-components:
             retry: 'retry delete'
         help_modal:
             heading: 'Using the OSF Files Browser'
+            providers: 'See All Files in a Provider'
+            providers_detail: 'All connected storage providers are displayed in the left navbar. Choose one provider to view contents.'
+            select: 'Select Files/Folders'
+            select_detail: 'Click on a row (outside of the file or folder name) to show further actions in the top toolbar. Use Command or Shift keys to select multiple files.'
+            move: Move
+            move_detail: 'You can move your files from one part of your project or component to another. Select the files that you want to move, and then click the “Move” button in the top toolbar. Choose a component, provider, or folder and then click “Move”.'
+            copy: Copy
+            copy_detail: 'You can copy your files from one part of your project or component to another. Select the files that you want to copy, and then click the “Copy” button in the top toolbar. Choose a component, provider, or folder and then click “Copy”. Your files will now appear in both the original and chosen locations.'
+            upload: Upload
+            upload_detail_first: 'There are two ways to upload files. Open the provider or folder where you intend to upload files; you can then drag files from your desktop into files list area OR click the green upload icon' 
+            upload_detail_second: 'and select your files.'
             download_all: 'Download All Files As a Zip'
             download_all_detail: 'Navigate to the “Files” tab in the registration navigation on the left, and then click “Download this folder”.'
             download_folder: 'Download a Folder as Zip'
             download_folder_detail_first: 'To download a specific folder as a zip, click the vertical ellipses'
             download_folder_detail_second: 'to open the dropdown. Click “Download”.<br>Alternatively, open the folder and then click “Download this folder”.'
-            view_files: 'View Files'
+            view_files: 'Open/View Files'
             view_files_detail: 'Click a file name to go to view the file in the OSF. Opens file in a new tab.'
             download_file: 'Download a File'
             download_file_detail_first: 'With the file open: Click the vertical ellipses'
             download_file_detail_second: 'to open the dropdown. Click “Download”. From the file list: Click the vertical ellipses'
             download_file_detail_third: 'of the file to open the dropdown. Click “Download”.'
-            file_actions: 'File actions icon'
+            file_actions_icon: 'File actions icon'
+            upload_icon: 'File upload icon'
 
     subjects:
         browse:


### PR DESCRIPTION


-   Ticket: [ENG-3822]
-   Feature flag: n/a

## Purpose
- Add new content to the file help modal based on what users are able to do

## Summary of Changes
- Add new sections for selecting, moving/copying, uploading files, and selecting file-providers
- Add logic to help modal to show/hide selecting, moving/copying, uploading based on what is allowed in the current view

## Screenshot(s)
<img width="675" alt="image" src="https://user-images.githubusercontent.com/51409893/172704325-a6d756b3-e185-4ef3-aa14-de7c74d5bee5.png">
<img width="666" alt="image" src="https://user-images.githubusercontent.com/51409893/172704378-76537ce9-36ea-4073-b8b3-280cc1eba073.png">


## Side Effects
- None

## QA Notes
- Please check the registration files page and check to see if any inappropriate help text is shown there