### PR TITLE
[ENG-3811] Prevent 410 errors when moving files out of OsfStorage

### DIFF
--- a/app/models/file.ts
+++ b/app/models/file.ts
@@ -150,7 +150,7 @@ export default class FileModel extends BaseFileItem {
                 resource: node.id,
                 ...options,
             }),
-        }).then(() => this.reload());
+        });
     }
 
     copy(node: AbstractNodeModel, path: string, provider: string, options?: { conflict: string }): Promise<null> {


### PR DESCRIPTION

-   Ticket: [ENG-3811]
-   Feature flag: n/a

## Purpose
- Prevent 410 errors when moving files out of OsfStorage

## Summary of Changes
- Stop doing a `file.reload` after a file has moved. Not sure why this was there in the first place, but maybe it was needed for some Quickfiles stuff?

## Screenshot(s)
- NA
## Side Effects
- hopefully none
## QA Notes
- Moving files out of OsfStorage should no longer cause errors

[ENG-3811]: https://openscience.atlassian.net/browse/ENG-3811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ