### PR TITLE
[ENG-3811] Fix a11y problems with unseen file versions

### DIFF
--- a/lib/osf-components/addon/components/file-browser/file-item/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/file-item/styles.scss
@@ -12,7 +12,7 @@
 }
 
 .Unviewed {
-    font-weight: 600;
+    font-weight: 800;
 }
 
 .Indent {

--- a/lib/osf-components/addon/components/file-browser/file-item/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/file-item/template.hbs
@@ -34,7 +34,11 @@
             {{/if}}
             <OsfLink
                 data-analytics-name='Open file'
-                aria-label={{t 'osf-components.file-browser.view_file' fileName=@item.name}}
+                aria-label={{if
+                    @item.showAsUnviewed
+                    (t 'osf-components.file-browser.view_unseen_file' fileName=@item.name)
+                    (t 'osf-components.file-browser.view_file' fileName=@item.name)
+                }}
                 @href={{@item.links.html}}
                 @target='_blank'
                 local-class={{if @item.showAsUnviewed 'Unviewed'}}

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1864,6 +1864,7 @@ osf-components:
         clear_selection: 'Clear selection'
         checked_out_file: 'This file is checked out. Functionality is limited until it is checked in.'
         view_file: 'View file in a new window: {fileName}'
+        view_unseen_file: 'View unseen version of file in a new window: {fileName}'
         view_folder: 'View contents of folder: {folderName}'
         filter_placeholder: 'Filter current list'
         sort: 'Sort by: '


### PR DESCRIPTION
-   Ticket: [ENG-3811]
-   Feature flag: n/a

## Purpose

Fix accessibility problems related to unseen file versions

## Summary of Changes

1. Make the bold text bolder
2. Have the aria label change based on whether you've seen the version or not

## Screenshot(s)

<img width="1760" alt="Screen Shot 2022-06-10 at 9 43 14 AM" src="https://user-images.githubusercontent.com/6599111/173080805-a6706fef-d07b-4e29-b0f3-a327ba6789fc.png">

<img width="549" alt="Screen Shot 2022-06-10 at 9 49 17 AM" src="https://user-images.githubusercontent.com/6599111/173080838-8acc9132-6a79-441f-ad3b-e3ee9a5f956f.png">


## Side Effects

No, this is pretty isolated.

## QA Notes



[ENG-3811]: https://openscience.atlassian.net/browse/ENG-3811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ