### PR TITLE
[ENG-3811] Don't show copy button or allow selections if view only

### DIFF
--- a/app/guid-node/files/provider/template.hbs
+++ b/app/guid-node/files/provider/template.hbs
@@ -134,10 +134,15 @@
                 {{#let (get mapper this.model.providerName) as |ProviderManager|}}
                     <ProviderManager
                         @provider={{this.model.providerTask.value.provider}}
+                        @isViewOnly={{this.model.providerTask.value.isViewOnly}}
                         as |manager|
                     >
                         <div local-class='FileBrowser'>
-                            <FileBrowser @manager={{manager}} @selectable={{true}} @enableUpload={{true}} />
+                            <FileBrowser
+                                @manager={{manager}}
+                                @selectable={{not this.model.providerTask.value.isViewOnly}}
+                                @enableUpload={{true}}
+                            />
                         </div>
                     </ProviderManager>
                 {{/let}}

--- a/lib/osf-components/addon/components/file-actions-menu/template.hbs
+++ b/lib/osf-components/addon/components/file-actions-menu/template.hbs
@@ -82,17 +82,19 @@
                     {{t 'general.move'}}
                 </Button>
             {{/if}}
-            <Button
-                @layout='fake-link'
-                local-class='DropdownItem'
-                data-test-copy-button
-                {{on 'click' (queue (action (mut this.useCopyModal) true) (action (mut this.moveModalOpen) true))}}
-            >
-                <FaIcon
-                    @icon='copy'
-                />
-                {{t 'general.copy'}}
-            </Button>
+            {{#unless @manager.isViewOnly}}
+                <Button
+                    @layout='fake-link'
+                    local-class='DropdownItem'
+                    data-test-copy-button
+                    {{on 'click' (queue (action (mut this.useCopyModal) true) (action (mut this.moveModalOpen) true))}}
+                >
+                    <FaIcon
+                        @icon='copy'
+                    />
+                    {{t 'general.copy'}}
+                </Button>
+            {{/unless}}
         {{/if}}
     </dropdown.content>
 </ResponsiveDropdown>

--- a/lib/osf-components/addon/components/storage-provider-manager/storage-manager/template.hbs
+++ b/lib/osf-components/addon/components/storage-provider-manager/storage-manager/template.hbs
@@ -1,5 +1,6 @@
 {{yield (hash
     provider=@provider
+    isViewOnly=@isViewOnly
     hasMore=this.hasMore
     isLoading=this.getCurrentFolderItems.isRunning
     filter=this.filter


### PR DESCRIPTION
-   Ticket: [ENG-3811]
-   Feature flag: n/a

## Purpose

Prevent copy from being an option if using a view-only link.

## Summary of Changes

1. Pass around isViewOnly
2. Disable selections for view_only links
3. Hide copy button for view_only links

## Screenshot(s)

<img width="1760" alt="Screen Shot 2022-06-10 at 2 20 59 PM" src="https://user-images.githubusercontent.com/6599111/173128472-72f02ea4-9fc6-4cb4-adef-5da756ac3e87.png">


## Side Effects

Prooobably not

## QA Notes



[ENG-3811]: https://openscience.atlassian.net/browse/ENG-3811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ