### PR TITLE
[ENG-3811] Queue move

### DIFF
--- a/app/models/file.ts
+++ b/app/models/file.ts
@@ -135,9 +135,8 @@ export default class FileModel extends BaseFileItem {
         }).then(() => this.reload());
     }
 
-    async move(node: AbstractNodeModel, path: string, provider: string, options?: { conflict: string }): any {// tODO: fix this
-        let xhrStatus = null;
-        const data = await this.currentUser.authenticatedAJAX({
+    async move(node: AbstractNodeModel, path: string, provider: string, options?: { conflict: string }): Promise<null> {
+        const req = await this.currentUser.authenticatedAJAX({
             url: getHref(this.links.move),
             type: 'POST',
             xhrFields: { withCredentials: true },
@@ -151,9 +150,11 @@ export default class FileModel extends BaseFileItem {
                 resource: node.id,
                 ...options,
             }),
-            complete: xhr => xhrStatus = xhr.status,
+            success: (data, _, xhr) => {
+                data.status = xhr.status;
+            },
         });
-        return { data, xhrStatus };
+        return req;
     }
 
     copy(node: AbstractNodeModel, path: string, provider: string, options?: { conflict: string }): Promise<null> {

--- a/app/models/file.ts
+++ b/app/models/file.ts
@@ -135,8 +135,9 @@ export default class FileModel extends BaseFileItem {
         }).then(() => this.reload());
     }
 
-    move(node: AbstractNodeModel, path: string, provider: string, options?: { conflict: string }): Promise<null> {
-        return this.currentUser.authenticatedAJAX({
+    async move(node: AbstractNodeModel, path: string, provider: string, options?: { conflict: string }): any {// tODO: fix this
+        let xhrStatus = null;
+        const data = await this.currentUser.authenticatedAJAX({
             url: getHref(this.links.move),
             type: 'POST',
             xhrFields: { withCredentials: true },
@@ -150,7 +151,9 @@ export default class FileModel extends BaseFileItem {
                 resource: node.id,
                 ...options,
             }),
+            complete: xhr => xhrStatus = xhr.status,
         });
+        return { data, xhrStatus };
     }
 
     copy(node: AbstractNodeModel, path: string, provider: string, options?: { conflict: string }): Promise<null> {

--- a/app/models/file.ts
+++ b/app/models/file.ts
@@ -157,8 +157,8 @@ export default class FileModel extends BaseFileItem {
         return req;
     }
 
-    copy(node: AbstractNodeModel, path: string, provider: string, options?: { conflict: string }): Promise<null> {
-        return this.currentUser.authenticatedAJAX({
+    async copy(node: AbstractNodeModel, path: string, provider: string, options?: { conflict: string }): Promise<null> {
+        const req = await this.currentUser.authenticatedAJAX({
             url: getHref(this.links.move),
             type: 'POST',
             xhrFields: { withCredentials: true },
@@ -172,7 +172,11 @@ export default class FileModel extends BaseFileItem {
                 resource: node.id,
                 ...options,
             }),
+            success: (data, _, xhr) => {
+                data.status = xhr.status;
+            },
         }).then(() => this.reload());
+        return req;
     }
 
     delete(): Promise<null> {

--- a/app/packages/files/file.ts
+++ b/app/packages/files/file.ts
@@ -184,7 +184,8 @@ export default abstract class File {
     @task
     @waitFor
     async move(node: NodeModel, path: string, provider: string, options?: { conflict: string }) {
-        return await this.fileModel.move(node, path, provider, options);
+        const { data, xhrStatus } = await this.fileModel.move(node, path, provider, options);
+        return { data, xhrStatus };
     }
 
     @task

--- a/app/packages/files/file.ts
+++ b/app/packages/files/file.ts
@@ -184,8 +184,7 @@ export default abstract class File {
     @task
     @waitFor
     async move(node: NodeModel, path: string, provider: string, options?: { conflict: string }) {
-        const { data, xhrStatus } = await this.fileModel.move(node, path, provider, options);
-        return { data, xhrStatus };
+        return await this.fileModel.move(node, path, provider, options);
     }
 
     @task

--- a/lib/osf-components/addon/components/move-file-modal/component.ts
+++ b/lib/osf-components/addon/components/move-file-modal/component.ts
@@ -210,7 +210,9 @@ export default class MoveFileModalComponent extends Component<MoveFileModalArgs>
     @waitFor
     async moveFile(file: File, destinationNode: NodeModel, path: string, provider: string,
         options?: { conflict: string }) {
-        await taskFor(file.move).perform(destinationNode, path, provider, options);
+        const { data, xhrStatus } = await taskFor(file.move).perform(destinationNode, path, provider, options);
+        data.status = xhrStatus;
+        return data;
     }
 
     @task

--- a/lib/osf-components/addon/components/move-file-modal/component.ts
+++ b/lib/osf-components/addon/components/move-file-modal/component.ts
@@ -210,9 +210,7 @@ export default class MoveFileModalComponent extends Component<MoveFileModalArgs>
     @waitFor
     async moveFile(file: File, destinationNode: NodeModel, path: string, provider: string,
         options?: { conflict: string }) {
-        const { data, xhrStatus } = await taskFor(file.move).perform(destinationNode, path, provider, options);
-        data.status = xhrStatus;
-        return data;
+        await taskFor(file.move).perform(destinationNode, path, provider, options);
     }
 
     @task

--- a/lib/osf-components/addon/components/move-file-modal/component.ts
+++ b/lib/osf-components/addon/components/move-file-modal/component.ts
@@ -45,7 +45,7 @@ export default class MoveFileModalComponent extends Component<MoveFileModalArgs>
     @tracked totalFiles? = 0;
     @tracked breadcrumbs: Array<ProviderFile | File> = [];
 
-    @tracked fileActionTasks: Array<TaskInstance<void>> = [];
+    @tracked fileActionTasks: Array<TaskInstance<null>> = [];
 
     get itemList() {
         return [...this.filesList, ...this.childNodeList];
@@ -210,7 +210,7 @@ export default class MoveFileModalComponent extends Component<MoveFileModalArgs>
     @waitFor
     async moveFile(file: File, destinationNode: NodeModel, path: string, provider: string,
         options?: { conflict: string }) {
-        await taskFor(file.move).perform(destinationNode, path, provider, options);
+        return await taskFor(file.move).perform(destinationNode, path, provider, options);
     }
 
     @task
@@ -235,7 +235,7 @@ export default class MoveFileModalComponent extends Component<MoveFileModalArgs>
     @waitFor
     async copyFile(file: File, destinationNode: NodeModel, path: string, provider: string,
         options?: { conflict: string }) {
-        await taskFor(file.copy).perform(destinationNode, path, provider, options);
+        return await taskFor(file.copy).perform(destinationNode, path, provider, options);
     }
 
     @task

--- a/lib/osf-components/addon/components/move-file-modal/template.hbs
+++ b/lib/osf-components/addon/components/move-file-modal/template.hbs
@@ -29,6 +29,7 @@
                             {{else if (not taskInstance.hasStarted)}}
                                 {{t (concat 'osf-components.move_file_modal.'(if @preserveOriginal 'awaiting_copy' 'awaiting_move')) fileName=file.name}}
                             {{else if taskInstance.isSuccessful}}
+                                {{taskInstance.value.status}}
                                 {{t (concat 'osf-components.move_file_modal.'(if @preserveOriginal 'success_copy' 'success_move')) fileName=file.name}}
                                 <FaIcon @icon='check' local-class='success'/>
                             {{else if taskInstance.isError}}

--- a/lib/osf-components/addon/components/move-file-modal/template.hbs
+++ b/lib/osf-components/addon/components/move-file-modal/template.hbs
@@ -29,8 +29,11 @@
                             {{else if (not taskInstance.hasStarted)}}
                                 {{t (concat 'osf-components.move_file_modal.'(if @preserveOriginal 'awaiting_copy' 'awaiting_move')) fileName=file.name}}
                             {{else if taskInstance.isSuccessful}}
-                                {{taskInstance.value.status}}
-                                {{t (concat 'osf-components.move_file_modal.'(if @preserveOriginal 'success_copy' 'success_move')) fileName=file.name}}
+                                {{#if (eq taskInstance.value.status 202)}}
+                                    {{t (concat 'osf-components.move_file_modal.'(if @preserveOriginal 'copy_queued' 'move_queued')) fileName=file.name}}
+                                {{else}}
+                                    {{t (concat 'osf-components.move_file_modal.'(if @preserveOriginal 'success_copy' 'success_move')) fileName=file.name}}
+                                {{/if}}
                                 <FaIcon @icon='check' local-class='success'/>
                             {{else if taskInstance.isError}}
                                 {{t (concat 'osf-components.move_file_modal.'(if @preserveOriginal 'error_copy' 'error_move')) fileName=file.name}}

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1837,6 +1837,8 @@ osf-components:
         awaiting_copy: 'Waiting to copy {fileName}'
         moving_file: 'Moving {fileName}'
         copying_file: 'Copying {fileName}'
+        move_queued: '{fileName] queued for move. Email will be sent when the move is complete.'
+        copy_queued: '{fileName} queued for copy. Email will be sent when the copy is complete.'
         success_move: 'Successfully moved {fileName}'
         success_copy: 'Successfully copied {fileName}'
         error_move: 'Failed to move {fileName}'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1837,7 +1837,7 @@ osf-components:
         awaiting_copy: 'Waiting to copy {fileName}'
         moving_file: 'Moving {fileName}'
         copying_file: 'Copying {fileName}'
-        move_queued: '{fileName] queued for move. Email will be sent when the move is complete.'
+        move_queued: '{fileName} queued for move. Email will be sent when the move is complete.'
         copy_queued: '{fileName} queued for copy. Email will be sent when the copy is complete.'
         success_move: 'Successfully moved {fileName}'
         success_copy: 'Successfully copied {fileName}'


### PR DESCRIPTION
-   Ticket: [ENG-3811]
-   Feature flag: n/a

## Purpose
- Show better message when file moves are queued

## Summary of Changes
- cram the xhr status onto the file model's `move` and `copy` methods (Shoutout to @adlius )
- check status on move-file-modal template and show more informative message

## Screenshot(s)
![image](https://user-images.githubusercontent.com/51409893/173156461-bee63e95-e910-4dd3-9dfb-e8fb3ea4c9c2.png)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-3811]: https://openscience.atlassian.net/browse/ENG-3811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ