### PR TITLE
[ENG-3811] Don't allow copying of folders in VOL

### DIFF
--- a/lib/osf-components/addon/components/file-browser/folder-item/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/folder-item/template.hbs
@@ -77,17 +77,19 @@
                                 {{t 'general.move'}}
                             </Button>
                         {{/if}}
-                        <Button
-                            @layout='fake-link'
-                            local-class='DropdownItem'
-                            data-test-copy-button
-                            {{on 'click' (queue (action (mut this.useCopyModal) true) (action (mut this.moveModalOpen) true))}}
-                        >
-                            <FaIcon
-                                @icon='copy'
-                            />
-                            {{t 'general.copy'}}
-                        </Button>
+                        {{#unless @manager.isViewOnly}}
+                            <Button
+                                @layout='fake-link'
+                                local-class='DropdownItem'
+                                data-test-copy-button
+                                {{on 'click' (queue (action (mut this.useCopyModal) true) (action (mut this.moveModalOpen) true))}}
+                            >
+                                <FaIcon
+                                    @icon='copy'
+                                />
+                                {{t 'general.copy'}}
+                            </Button>
+                        {{/unless}}
                         {{#if @item.currentUserCanDelete}}
                             <Button
                                 @layout='fake-link'


### PR DESCRIPTION
-   Ticket: [ENG-3811]
-   Feature flag: n/a

## Purpose

Prevent the copy button from showing up on the folder menu when in a View Only Link

## Summary of Changes

1. Hide the button conditionally

## Screenshot(s)

<img width="1760" alt="Screen Shot 2022-06-13 at 11 56 39 AM" src="https://user-images.githubusercontent.com/6599111/173395533-5bc7fd53-2e43-49dd-964d-2ce54a09b94d.png">




[ENG-3811]: https://openscience.atlassian.net/browse/ENG-3811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ