### PR TITLE
[ENG-3811] Fix storage limit async call and DRY

### DIFF
--- a/app/packages/files/osf-storage-file.ts
+++ b/app/packages/files/osf-storage-file.ts
@@ -38,15 +38,7 @@ export default class OsfStorageFile extends File {
     }
 }
 
-export function underStorageLimit(target: NodeModel) {
-    const storage = target.get('storage');
-    const storageLimitStatus = storage.get('storageLimitStatus');
-    const isPublic = target.get('public');
-    if (storageLimitStatus === 'OVER_PUBLIC') {
-        return false;
-    }
-    if (isPublic === false && storageLimitStatus === 'OVER_PRIVATE') {
-        return false;
-    }
-    return true;
+export async function underStorageLimit(target: NodeModel) {
+    const storage = await target.get('storage');
+    return !storage.isOverStorageCap;
 }


### PR DESCRIPTION
-   Ticket: [ENG-3811]
-   Feature flag: n/a

## Purpose

When the backend is fixed for the storage limit calculation problem, this will still be needed to ensure that the call completes before the calculation is made.

## Summary of Changes

1. Await the call to storage
2. DRY up the code



[ENG-3811]: https://openscience.atlassian.net/browse/ENG-3811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ