### PR TITLE
[ENG-3811] Miscellaneous Bugs

### DIFF
--- a/lib/osf-components/addon/components/file-browser/file-rename-modal/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/file-rename-modal/styles.scss
@@ -1,5 +1,6 @@
 .RenameInput {
     margin-bottom: 24px;
+    width: 50vw;
 }
 
 .RenameInput > Input {


### PR DESCRIPTION
-   Ticket: https://openscience.atlassian.net/browse/ENG-3811
-   Feature flag: feature/file-rename-vw

## Purpose

These changes update the width of the modal to accommodate fifty percent of the viewport width.

## Summary of Changes

1. lib/osf-components/addon/components/file-browser/file-rename-modal/styles.scss
   -Styling was added to the styles.scss file for the FileRenameModal component

## Screenshot(s)

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/82047646/173424275-b18cf347-6b0c-4186-b975-55fcb1e63648.png">
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/82047646/173425115-52d9008a-701f-4561-8c47-4d97bebc5766.png">

## Side Effects

This change should have no formal side effects. It will however change the UI (view) to make the modal display wider.

## QA Notes

-Does the modal still render properly?
-Do all translation strings also still render?
-How does the modal look in mobile. Ironically, this is similar to the original display in desktop. Do you think it should be wider in mobile or does the styling work here as well?