### PR TITLE
[ENG-3811] Prevent replace on rename conflict

### DIFF
--- a/lib/osf-components/addon/components/file-browser/file-rename-modal/component.ts
+++ b/lib/osf-components/addon/components/file-browser/file-rename-modal/component.ts
@@ -46,7 +46,7 @@ export default class FileRenameModal extends Component<Args> {
 
         try {
             const trimmedName = newName.trim();
-            await this.args.item.rename(trimmedName, 'replace');
+            await this.args.item.rename(trimmedName, '');
             this.toast.success(successMessage);
         } catch(e) {
             this.toast.error(this.intl.t('osf-components.file-browser.file_rename_modal.retry_message'));


### PR DESCRIPTION

-   Ticket: [ENG-3811]
-   Feature flag: n/a

## Purpose
- Don't replace files/folders when there is a name conflict
  - instead appends (1), (2), etc depending on number of duplicate file/folder names discovered (similar to macOS's handling of dupe file names)

## Summary of Changes
- set `conflict` param to empty string to override default `replace` behavior

## Screenshot(s)
- Result of trying to name two folders `aaa`
![image](https://user-images.githubusercontent.com/51409893/173438340-e1bc0892-c06a-4198-a2f1-2c12bd5723e0.png)
 - Result of trying to name a second file `test.txt` and another file renamed to `test(2).txt`
![image](https://user-images.githubusercontent.com/51409893/173438366-e992b479-42f0-4c4e-883f-189f2216e67f.png)


## Side Effects
- None
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- we should now no longer be replacing files when there is a name conflict

[ENG-3811]: https://openscience.atlassian.net/browse/ENG-3811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ