### PR TITLE
[ENG-3849] Add file sizes to list view

### DIFF
--- a/app/packages/files/file.ts
+++ b/app/packages/files/file.ts
@@ -10,6 +10,7 @@ import NodeModel from 'ember-osf-web/models/node';
 import { Permission } from 'ember-osf-web/models/osf-model';
 import CurrentUserService from 'ember-osf-web/services/current-user';
 import captureException, { getApiErrorMessage } from 'ember-osf-web/utils/capture-exception';
+import humanFileSize from 'ember-osf-web/utils/human-file-size';
 
 
 export enum FileSortKey {
@@ -73,6 +74,10 @@ export default abstract class File {
 
     get showAsUnviewed() {
         return !this.fileModel.currentUserHasViewed;
+    }
+
+    get size() {
+        return humanFileSize(this.fileModel.size);
     }
 
     get currentUserPermission(): string {

--- a/lib/osf-components/addon/components/file-browser/file-item/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/file-item/styles.scss
@@ -45,15 +45,33 @@
     background-image: linear-gradient(90deg, rgba(236, 240, 241, 0) 0%, #ecf0f1 12%, #ecf0f1 89%, rgba(236, 240, 241, 0) 100%);
 }
 
-.FileList__item__options {
+.FileList__item__date {
     display: flex;
     align-items: center;
+    flex: 2;
+}
+
+.FileList__item__options {
+    display: flex;
+    align-items: flex-end;
+    flex: 1;
 }
 
 .FileList__item__name {
     display: flex;
     align-items: center;
     z-index: 9;
+    flex: 4;
+}
+
+.name__mobile {
+    flex: 7;
+}
+
+.FileList__item__size {
+    display: flex;
+    flex: 1;
+    align-items: center;
 }
 
 .NoShrink {

--- a/lib/osf-components/addon/components/file-browser/file-item/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/file-item/template.hbs
@@ -56,7 +56,9 @@
                 data-test-file-list-size
                 local-class='FileList__item__size'
             >
-                {{@item.size}}
+                {{#if @item.fileModel.size}}
+                    {{@item.size}}
+                {{/if}}
             </div>
             <div
                 data-test-file-list-date

--- a/lib/osf-components/addon/components/file-browser/file-item/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/file-item/template.hbs
@@ -20,7 +20,7 @@
                 />
             </label>
         {{/if}}
-        <div local-class='FileList__item__name'>
+        <div local-class='FileList__item__name {{unless @isDesktop 'name__mobile'}}'>
             {{#if @item.isCheckedOut}}
                 <span>
                     <FaIcon local-class='CheckoutIcon' @icon='lock' />
@@ -51,15 +51,25 @@
                 </span>
             </OsfLink>
         </div>
-        <div
-            data-test-file-list-date
-            local-class='FileList__item__options NoShrink'
-        >
-            {{#if (and @isDesktop @item.dateModified)}}
-                <span data-test-file-modified-date>
-                    {{moment-format @item.dateModified 'YYYY-MM-DD hh:mm A'}}
-                </span>
-            {{/if}}
+        {{#if @isDesktop}}
+            <div
+                data-test-file-list-size
+                local-class='FileList__item__size'
+            >
+                {{@item.size}}
+            </div>
+            <div
+                data-test-file-list-date
+                local-class='FileList__item__date NoShrink'
+            >
+                {{#if @item.dateModified}}
+                    <span data-test-file-modified-date>
+                        {{moment-format @item.dateModified 'YYYY-MM-DD hh:mm A'}}
+                    </span>
+                {{/if}}
+            </div>
+        {{/if}}
+        <div data-test-file-list-options local-class='FileList__item__options'>
             {{#unless @manager.selectedFiles}}
                 <FileActionsMenu @item={{@item}} @onDelete={{@manager.reload}} @manager={{@manager}} @allowRename={{true}} />
             {{/unless}}

--- a/lib/osf-components/addon/components/file-browser/folder-item/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/folder-item/styles.scss
@@ -47,11 +47,13 @@
     display: flex;
     align-items: center;
     z-index: 9;
+    flex: 7;
 }
 
 .FileList__item__options {
     display: flex;
-    align-items: center;
+    align-items: flex-end;
+    flex: 1;
 }
 
 .MobileDropdownTrigger {


### PR DESCRIPTION
-   Ticket: [ENG-3849]
-   Feature flag: n/a

## Purpose

Show the file sizes on the files page list view

## Summary of Changes

1. Make the flexbox into pretty columns
2. Add the file sizes to the list view

## Screenshot(s)
<img width="1558" alt="Screen Shot 2022-06-14 at 9 30 42 AM" src="https://user-images.githubusercontent.com/6599111/173594195-51153a2a-b4c6-4942-a7f9-625e40e8a526.png">

<img width="1062" alt="Screen Shot 2022-06-14 at 9 30 50 AM" src="https://user-images.githubusercontent.com/6599111/173594235-721cbcc6-4bbd-4b53-a5b9-3a8beed9ef8c.png">

<img width="837" alt="Screen Shot 2022-06-14 at 9 30 55 AM" src="https://user-images.githubusercontent.com/6599111/173594263-44c94f24-0c5c-444e-9683-d5a988e22a9f.png">

<img width="1741" alt="Screen Shot 2022-06-14 at 1 43 09 PM" src="https://user-images.githubusercontent.com/6599111/173648116-a4670db7-0ff5-4526-a45e-e36d122277d6.png">

<img width="1741" alt="Screen Shot 2022-06-14 at 1 43 26 PM" src="https://user-images.githubusercontent.com/6599111/173648357-15776c24-d83e-415a-af02-8b94187bc499.png">

## Side Effects

Shouldn't be.



[ENG-3849]: https://openscience.atlassian.net/browse/ENG-3849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ