### PR TITLE
[ENG-3811] Disable copying for registration files

### DIFF
--- a/app/packages/files/file.ts
+++ b/app/packages/files/file.ts
@@ -87,6 +87,10 @@ export default abstract class File {
         return 'read';
     }
 
+    get targetIsRegistration(){
+        return this.fileModel.target.get('modelName') === 'registration';
+    }
+
     get currentUserCanDelete() {
         return (this.fileModel.target.get('modelName') !== 'registration' && this.currentUserPermission === 'write');
     }

--- a/lib/osf-components/addon/components/file-actions-menu/template.hbs
+++ b/lib/osf-components/addon/components/file-actions-menu/template.hbs
@@ -82,7 +82,7 @@
                     {{t 'general.move'}}
                 </Button>
             {{/if}}
-            {{#unless @manager.isViewOnly}}
+            {{#if (not (or @manager.isViewOnly @item.targetIsRegistration))}}
                 <Button
                     @layout='fake-link'
                     local-class='DropdownItem'
@@ -94,7 +94,7 @@
                     />
                     {{t 'general.copy'}}
                 </Button>
-            {{/unless}}
+            {{/if}}
         {{/if}}
     </dropdown.content>
 </ResponsiveDropdown>

--- a/lib/osf-components/addon/components/file-browser/folder-item/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/folder-item/template.hbs
@@ -77,7 +77,7 @@
                                 {{t 'general.move'}}
                             </Button>
                         {{/if}}
-                        {{#unless @manager.isViewOnly}}
+                        {{#if (not (or @manager.isViewOnly @item.targetIsRegistration))}}
                             <Button
                                 @layout='fake-link'
                                 local-class='DropdownItem'
@@ -89,7 +89,7 @@
                                 />
                                 {{t 'general.copy'}}
                             </Button>
-                        {{/unless}}
+                        {{/if}}
                         {{#if @item.currentUserCanDelete}}
                             <Button
                                 @layout='fake-link'


### PR DESCRIPTION
-   Ticket: [ENG-3811]
-   Feature flag: n/a

## Purpose

Make sure the copy option is not available if you're viewing a registrations' files

## Summary of Changes

1. Add a getter for target is registration 
2. Disable copy button on file menu
3. Disable copy button on folder menu

## Screenshot(s)
<img width="1462" alt="Screen Shot 2022-06-14 at 2 40 22 PM" src="https://user-images.githubusercontent.com/6599111/173665283-a4296e47-3151-49c5-be1b-76ce77af7c76.png">
<img width="1462" alt="Screen Shot 2022-06-14 at 2 40 30 PM" src="https://user-images.githubusercontent.com/6599111/173665306-dfd59c55-af82-44d8-b82a-d2461160169c.png">
<img width="1462" alt="Screen Shot 2022-06-14 at 2 41 13 PM" src="https://user-images.githubusercontent.com/6599111/173665330-368e54ad-9986-432a-a95f-0e67c47b024c.png">
<img width="1462" alt="Screen Shot 2022-06-14 at 2 41 17 PM" src="https://user-images.githubusercontent.com/6599111/173665344-97768c5a-1114-40cd-b064-f299f907fb78.png">

## Side Effects

No
