### PR TITLE
[ENG-3811] Make it easier to select rows

### DIFF
--- a/lib/osf-components/addon/components/file-browser/file-item/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/file-item/styles.scss
@@ -60,8 +60,11 @@
 .FileList__item__name {
     display: flex;
     align-items: center;
-    z-index: 9;
     flex: 4;
+    
+    a {
+        z-index: 9;
+    }
 }
 
 .name__mobile {

--- a/lib/osf-components/addon/components/file-browser/folder-item/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/folder-item/styles.scss
@@ -15,6 +15,7 @@
         overflow: hidden;
         white-space: normal;
         text-align: left;
+        z-index: 9;
     }
 }
 
@@ -46,7 +47,6 @@
 .FileList__item__name {
     display: flex;
     align-items: center;
-    z-index: 9;
     flex: 7;
 }
 

--- a/lib/osf-components/addon/components/file-browser/folder-item/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/folder-item/template.hbs
@@ -20,22 +20,23 @@
                 />
             </label>
         {{/if}}
-
-        <Button
-            data-test-file-list-link
-            data-analytics-name='View folder'
-            aria-label={{t 'osf-components.file-browser.view_folder' folderName=@item.name}}
-            @layout='fake-link'
-            local-class='FileList__item__name FolderButton'
-            {{on 'click' (fn @manager.goToFolder @item)}}
-        >
-            <FaIcon
-                @icon='folder' @fixedWidth={{true}}
-            />
-            <span data-test-folder-name>
-                {{@item.name}}
-            </span>
-        </Button>
+        <div local-class='FileList__item__name'>
+            <Button
+                data-test-file-list-link
+                data-analytics-name='View folder'
+                aria-label={{t 'osf-components.file-browser.view_folder' folderName=@item.name}}
+                @layout='fake-link'
+                local-class='FolderButton'
+                {{on 'click' (fn @manager.goToFolder @item)}}
+            >
+                <FaIcon
+                    @icon='folder' @fixedWidth={{true}}
+                />
+                <span data-test-folder-name>
+                    {{@item.name}}
+                </span>
+            </Button>
+        </div>
         {{#if this.showActionsDropdown}}
             <div
                 data-test-file-list-date

--- a/lib/osf-components/addon/components/file-browser/folder-item/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/folder-item/template.hbs
@@ -22,7 +22,7 @@
         {{/if}}
         <div local-class='FileList__item__name'>
             <Button
-                data-test-file-list-link
+                data-test-file-list-link={{@item.id}}
                 data-analytics-name='View folder'
                 aria-label={{t 'osf-components.file-browser.view_folder' folderName=@item.name}}
                 @layout='fake-link'

--- a/tests/integration/components/file-browser/component-test.ts
+++ b/tests/integration/components/file-browser/component-test.ts
@@ -59,7 +59,7 @@ module('Integration | Component | file-browser', hooks => {
             }
             assert.dom(`[data-test-file-list-item="${this.topLevelFolder.id}"]`).exists('Top level folder exists');
             // Go to nested folder
-            await click(`[data-test-file-list-item="${this.topLevelFolder.id}"] > button`);
+            await click(`[data-test-file-list-link="${this.topLevelFolder.id}"]`);
             for (const item of this.secondaryLevelFiles) {
                 assert.dom(`[data-test-file-list-item='${item.id}'][data-test-indented='true']`)
                     .exists('Secondary level file exists');
@@ -72,7 +72,7 @@ module('Integration | Component | file-browser', hooks => {
             }
             assert.dom(`[data-test-file-list-item="${this.topLevelFolder.id}"]`).exists('Top level folder exists');
             // Go to nested folder again
-            await click(`[data-test-file-list-item="${this.topLevelFolder.id}"] > button`);
+            await click(`[data-test-file-list-link="${this.topLevelFolder.id}"]`);
             // Back to parent using breadcrumb navigation
             await click('[data-test-breadcrumb="osfstorage"]');
             for (const item of this.topLevelFiles) {


### PR DESCRIPTION
-   Ticket: [ENG-3811]
-   Feature flag: n/a

## Purpose

When I added the file sizes, I made the flex box act columnar. This had the side-effect of extending the divs/buttons that had a z-index of 9, making the click target for a selection much smaller than it had been. This reduces the surface area of the z-indexed items to just be the clickable targets and prevents the button from extending the width of the column in the case of folders.

## Summary of Changes

1. Juggle around z-index
2. Restrict size of button to not be the width of the column

## Side Effects

Should just make things easier to select. Smaller item names will have smaller click targets.

## QA Notes

If you were selecting rows the same way our unit tests were, you may need to update Selenium to use a new, better test selector. Instead of doing `[data-test-file-list-item="${folderName}"] > button` you'd want to do `[data-test-file-list-link="${folderName}"]`.

[ENG-3811]: https://openscience.atlassian.net/browse/ENG-3811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ