### PR TITLE
[ENG-3811] Miscellaneous bugs

### DIFF
--- a/app/errors.ts
+++ b/app/errors.ts
@@ -1,5 +1,19 @@
 /* eslint-disable max-classes-per-file */
-export class OsfError { }
+export class OsfError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.message = 'An error occured.';
+        this.name = 'OsfError';
+    }
+}
 
 export class NotLoggedIn extends OsfError {}
 /* eslint-enable max-classes-per-file */
+
+export class NotUpdatedError extends OsfError {
+    constructor(message: string) {
+        super(message);
+        this.message = 'File name not reset.';
+        this.name = 'NotUpdatedError';
+    }
+}

--- a/lib/osf-components/addon/components/file-browser/file-rename-modal/component.ts
+++ b/lib/osf-components/addon/components/file-browser/file-rename-modal/component.ts
@@ -7,6 +7,7 @@ import { restartableTask } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 import Intl from 'ember-intl/services/intl';
 import File from 'ember-osf-web/packages/files/file';
+import { NotUpdatedError } from 'ember-osf-web/errors';
 
 interface Args {
     manager: StorageManager;
@@ -32,7 +33,21 @@ export default class FileRenameModal extends Component<Args> {
 
     @action
     resetFileNameValue() {
-        this.newFileName =  this.originalFileName;
+        try {
+            return this.newFileName = this.originalFileName;
+
+        } catch (e) {
+            throw new NotUpdatedError('New file name not updated.');
+        }
+    }
+
+    updateOriginalName(newName: string) {
+        try {
+            return this.originalFileName = newName;
+
+        } catch (e) {
+            throw new NotUpdatedError('Original file name not updated.');
+        }
     }
 
     @restartableTask
@@ -51,6 +66,7 @@ export default class FileRenameModal extends Component<Args> {
         } catch(e) {
             this.toast.error(this.intl.t('osf-components.file-browser.file_rename_modal.retry_message'));
         }
+        this.updateOriginalName(newName);
         return newName;
     }
 }


### PR DESCRIPTION
-   Ticket: https://openscience.atlassian.net/browse/ENG-3811
-   Feature flag: feature/file-rename-error-handling

## Purpose

The purpose of these changes were to improve the overall handling of exceptions and errors that occur when renaming a file.

## Summary of Changes

The OsfError class has been extended from the base Error class. Message and name have been given default values. Logic has been added with try/catch blocks upon resetting the file name following a cancel and updating the original name when a successful request is made.

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

This should help mitigate side effects where the retrieved value was not properly set.

## QA Notes

-Is a unique error passed back for unsuccessful file resets and updates to the original file name.