### PR TITLE
[ENG-3811] Fix storage limit code

### DIFF
--- a/app/packages/files/osf-storage-file.ts
+++ b/app/packages/files/osf-storage-file.ts
@@ -12,9 +12,11 @@ export default class OsfStorageFile extends File {
 
     get userCanMoveToHere(): boolean {
         const target = this.fileModel.target as unknown as NodeModel;
+        if (target.get('modelName') === 'registration') {
+            return false;
+        }
         const storage = target.get('storage');
         if (this.currentUserPermission === 'write' &&
-            this.fileModel.target.get('modelName') !== 'registration' &&
             this.isFolder &&
             !storage.get('isOverStorageCap')
         ) {

--- a/app/packages/files/osf-storage-file.ts
+++ b/app/packages/files/osf-storage-file.ts
@@ -11,10 +11,12 @@ export default class OsfStorageFile extends File {
     }
 
     get userCanMoveToHere(): boolean {
+        const target = this.fileModel.target as unknown as NodeModel;
+        const storage = target.get('storage');
         if (this.currentUserPermission === 'write' &&
             this.fileModel.target.get('modelName') !== 'registration' &&
             this.isFolder &&
-            this.isUnderStorageLimit
+            !storage.get('isOverStorageCap')
         ) {
             return true;
         }
@@ -29,16 +31,7 @@ export default class OsfStorageFile extends File {
         return this.userCanMoveToHere;
     }
 
-    get isUnderStorageLimit() {
-        return underStorageLimit(this.fileModel.target as unknown as NodeModel);
-    }
-
     get isCheckedOut() {
         return Boolean(this.fileModel.checkout);
     }
-}
-
-export async function underStorageLimit(target: NodeModel) {
-    const storage = await target.get('storage');
-    return !storage.isOverStorageCap;
 }

--- a/app/packages/files/osf-storage-provider-file.ts
+++ b/app/packages/files/osf-storage-provider-file.ts
@@ -1,5 +1,4 @@
 import { FileSortKey } from 'ember-osf-web/packages/files/file';
-import { underStorageLimit } from 'ember-osf-web/packages/files/osf-storage-file';
 import FileProviderModel from 'ember-osf-web/models/file-provider';
 import OsfStorageFile from 'ember-osf-web/packages/files/osf-storage-file';
 import ProviderFile from 'ember-osf-web/packages/files/provider-file';
@@ -27,10 +26,12 @@ export default class OsfStorageProviderFile extends ProviderFile {
     }
 
     get userCanMoveToHere(): boolean {
+        const target = this.fileModel.target as unknown as NodeModel;
+        const storage = target.get('storage');
         if (this.currentUserPermission === 'write' &&
             this.fileModel.target.get('modelName') !== 'registration' &&
             this.isFolder &&
-            underStorageLimit(this.fileModel.target as unknown as NodeModel)
+            !storage.get('isOverStorageCap')
         ) {
             return true;
         }

--- a/app/packages/files/osf-storage-provider-file.ts
+++ b/app/packages/files/osf-storage-provider-file.ts
@@ -27,9 +27,11 @@ export default class OsfStorageProviderFile extends ProviderFile {
 
     get userCanMoveToHere(): boolean {
         const target = this.fileModel.target as unknown as NodeModel;
+        if (target.get('modelName') === 'registration') {
+            return false;
+        }
         const storage = target.get('storage');
         if (this.currentUserPermission === 'write' &&
-            this.fileModel.target.get('modelName') !== 'registration' &&
             this.isFolder &&
             !storage.get('isOverStorageCap')
         ) {

--- a/lib/osf-components/addon/components/file-browser/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/template.hbs
@@ -95,7 +95,7 @@
         </div>
         <div local-class='OptionBar__right'>
             {{#if (gt @manager.selectedFiles.length 0)}}
-                {{#if @manager.currentFolder.userCanUploadToHere}}
+                {{#if @manager.currentFolder.userCanDeleteFromHere}}
                     <Button
                         @layout='fake-link'
                         {{on 'click' (queue (action (mut this.useCopyModal) false) (action (mut this.moveModalOpen) true))}}

--- a/mirage/scenarios/dashboard.ts
+++ b/mirage/scenarios/dashboard.ts
@@ -47,7 +47,7 @@ export function dashboardScenario(server: Server, currentUser: ModelInstance<Use
         id: 'file5',
         title: 'With some files',
         currentUserPermissions: [Permission.Read, Permission.Write],
-    }, 'withFiles');
+    }, 'withFiles', 'withStorage');
 
     // NOTE: Some institutions are already created by this point
     server.createList('institution', 20);

--- a/tests/acceptance/guid-node/files-test.ts
+++ b/tests/acceptance/guid-node/files-test.ts
@@ -10,7 +10,7 @@ module('Acceptance | guid-node/files', hooks => {
     setupMirage(hooks);
 
     test('leftnav for read user', async function(assert) {
-        const node = server.create('node', 'withFiles');
+        const node = server.create('node', 'withFiles', 'withStorage');
         await visit(`/${node.id}/files`);
 
         assert.equal(currentRouteName(), 'guid-node.files.provider', 'Current route is files');


### PR DESCRIPTION
-   Ticket: [ENG-3811]
-   Feature flag: n/a

## Purpose

Make storage usage actually work in the places it needs to. The basic problem was that, while getters get magic from ember to wait for async calls as part of .get(), they don't get access to that if the gets are in another async function. So I moved the getters for the storage limit into the getters for the properties that need that info.

## Summary of Changes

1. Remove async helper function
2. Update `userCanMoveToHere`
3. Fix incorrect property on multi-select move button
4. Add 'withStorage' trait where needed

## Side Effects

You have to use the 'withStorage' trait if you want a mirage node that can use its files page. ~~Also, this will generate a 404 in the console of a registration's file list page because there's no storage endpoint. This should be easily fixed when I have a moment.~~ Fixed

## QA Notes

This should work this time, hopefully without any weird edge cases.

[ENG-3811]: https://openscience.atlassian.net/browse/ENG-3811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ