### PR TITLE
[ENG-3811] Wrap current destination node in move-file-modal

### DIFF
--- a/lib/osf-components/addon/components/move-file-modal/current-node-item/styles.scss
+++ b/lib/osf-components/addon/components/move-file-modal/current-node-item/styles.scss
@@ -1,3 +1,8 @@
+.CurrentNodeButton {
+    white-space: normal;
+    text-align: start;
+}
+
 .DestinationSelectHelpText {
     margin-top: 8px;
     padding: 0 1em;

--- a/lib/osf-components/addon/components/move-file-modal/current-node-item/template.hbs
+++ b/lib/osf-components/addon/components/move-file-modal/current-node-item/template.hbs
@@ -2,6 +2,7 @@
     <Button
         data-test-go-to-current-node-file-providers
         @layout='fake-link'
+        local-class='CurrentNodeButton'
         {{on 'click' (fn @onNodeSelect @node)}}
     >
         <NodeCard::NodeIcon @category={{@node.category}} />


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-3811]
-   Feature flag: n/a

## Purpose
- Prevent current destination node name from getting cut off in move/copy file modal in mobile

## Summary of Changes
- Wrap. That. Text

## Screenshot(s)
Prevents following:
![image](https://user-images.githubusercontent.com/51409893/174160118-99be3b8a-5b79-45ab-9101-e6ef4d3b7631.png)

Looks like:
![image](https://user-images.githubusercontent.com/51409893/174160173-94392d7d-27f1-4ad2-9fb0-722828789eb4.png)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-3811]: https://openscience.atlassian.net/browse/ENG-3811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ