### PR TITLE
[ENG-3811] Warning for special chars in help modal

### DIFF
--- a/lib/osf-components/addon/components/file-browser/help-modal/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/help-modal/styles.scss
@@ -16,3 +16,7 @@
 .FileHelpModal__actions-icon {
     color: var(--primary-color);
 }
+
+.FileHelpModal__inline-icon {
+    margin: 0 3px;
+}

--- a/lib/osf-components/addon/components/file-browser/help-modal/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/help-modal/template.hbs
@@ -23,12 +23,12 @@
                 <FaIcon
                     aria-hidden='false'
                     aria-label={{t 'osf-components.file-browser.help_modal.upload_icon'}}
-                    local-class='FileHelpModal__upload-icon'
+                    local-class='FileHelpModal__upload-icon FileHelpModal__inline-icon'
                     @size='2x'
                     @fixedWidth={{true}}
                     @icon='plus'
                 />
-                {{t 'osf-components.file-browser.help_modal.upload_detail_second'}}
+                {{t 'osf-components.file-browser.help_modal.upload_detail_second' htmlSafe=true}}
             </p>
             <h3>{{t 'osf-components.file-browser.help_modal.create_folder'}}</h3>
             <p>{{t 'osf-components.file-browser.help_modal.create_folder_detail'}}</p>
@@ -38,7 +38,7 @@
                 <FaIcon
                     aria-hidden='false'
                     aria-label={{t 'osf-components.file-browser.help_modal.file_actions_icon'}}
-                    local-class='FileHelpModal__actions-icon'
+                    local-class='FileHelpModal__actions-icon FileHelpModal__inline-icon'
                     @icon='ellipsis-v'
                 />
                 {{t 'osf-components.file-browser.help_modal.rename_detail_second' htmlSafe=true}}
@@ -51,7 +51,7 @@
                 <FaIcon
                     aria-hidden='false'
                     aria-label={{t 'osf-components.file-browser.help_modal.file_actions_icon'}}
-                    local-class='FileHelpModal__actions-icon'
+                    local-class='FileHelpModal__actions-icon FileHelpModal__inline-icon'
                     @icon='ellipsis-v'
                 />
                 {{t 'osf-components.file-browser.help_modal.move_detail_second'}}
@@ -62,7 +62,7 @@
                 <FaIcon
                     aria-hidden='false'
                     aria-label={{t 'osf-components.file-browser.help_modal.file_actions_icon'}}
-                    local-class='FileHelpModal__actions-icon'
+                    local-class='FileHelpModal__actions-icon FileHelpModal__inline-icon'
                     @icon='ellipsis-v'
                 />
                 {{t 'osf-components.file-browser.help_modal.copy_detail_second'}}
@@ -76,7 +76,7 @@
             <FaIcon
                 aria-hidden='false'
                 aria-label={{t 'osf-components.file-browser.help_modal.file_actions_icon'}}
-                local-class='FileHelpModal__actions-icon'
+                local-class='FileHelpModal__actions-icon FileHelpModal__inline-icon'
                 @icon='ellipsis-v'
             />
             {{t 'osf-components.file-browser.help_modal.download_folder_detail_second' htmlSafe=true}}
@@ -87,14 +87,14 @@
             <FaIcon
                 aria-hidden='false'
                 aria-label={{t 'osf-components.file-browser.help_modal.file_actions_icon'}}
-                local-class='FileHelpModal__actions-icon'
+                local-class='FileHelpModal__actions-icon FileHelpModal__inline-icon'
                 @icon='ellipsis-v'
             />
             {{t 'osf-components.file-browser.help_modal.download_file_detail_second'}}
             <FaIcon
                 aria-hidden='false'
                 aria-label={{t 'osf-components.file-browser.help_modal.file_actions_icon'}}
-                local-class='FileHelpModal__actions-icon'
+                local-class='FileHelpModal__actions-icon FileHelpModal__inline-icon'
                 @icon='ellipsis-v'
             />
             {{t 'osf-components.file-browser.help_modal.download_file_detail_third'}}

--- a/lib/osf-components/addon/components/file-browser/help-modal/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/help-modal/template.hbs
@@ -41,7 +41,7 @@
                     local-class='FileHelpModal__actions-icon'
                     @icon='ellipsis-v'
                 />
-                {{t 'osf-components.file-browser.help_modal.rename_detail_second'}}
+                {{t 'osf-components.file-browser.help_modal.rename_detail_second' htmlSafe=true}}
             </p>
         {{/if}}
         {{#if @selectable}}

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1926,7 +1926,7 @@ osf-components:
             create_folder_detail: 'To create a folder to help organize your files, click the green plus symbol, then click “Create a Folder” (note: You can also organize your project content by creating Components).'
             rename: 'Rename a folder or file'
             rename_detail_first: 'In the files list, select the file that you want to rename and click the vertical ellipses'
-            rename_detail_second: 'to open the dropdown. Select “Rename”.'
+            rename_detail_second: 'to open the dropdown. Select “Rename”. (Note: Some special characters, like <code>&</code>, <code>%</code>, and <code>/</code> may cause unexpected behavior).'
             move: Move
             move_detail_first: 'You can move your files from one part of your project or component to another. Select the files that you want to move, and click the vertical ellipses'
             move_detail_second: 'to open the dropdown, then click “move”. Choose a component, provider, or folder and then click “Move”.'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1921,9 +1921,9 @@ osf-components:
             view_files_detail: 'Click a file name to go to view the file in the OSF. Opens file in a new tab.'
             upload: Upload
             upload_detail_first: 'There are two ways to upload files. Open the storage provider or folder where you intend to upload files; you can then drag files from your desktop into files list area OR click the green plus symbol' 
-            upload_detail_second: ', then click “Upload Files”, and select your files.'
+            upload_detail_second: ', then click “Upload Files”, and select your files. (Note: File names with special characters, like <code>&</code>, <code>%</code>, and <code>/</code> may cause unexpected behavior).'
             create_folder: 'Create a folder'
-            create_folder_detail: 'To create a folder to help organize your files, click the green plus symbol, then click “Create a Folder” (note: You can also organize your project content by creating Components).'
+            create_folder_detail: 'To create a folder to help organize your files, click the green plus symbol, then click “Create a Folder”. (Note: You can also organize your project content by creating Components).'
             rename: 'Rename a folder or file'
             rename_detail_first: 'In the files list, select the file that you want to rename and click the vertical ellipses'
             rename_detail_second: 'to open the dropdown. Select “Rename”. (Note: Some special characters, like <code>&</code>, <code>%</code>, and <code>/</code> may cause unexpected behavior).'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1921,12 +1921,12 @@ osf-components:
             view_files_detail: 'Click a file name to go to view the file in the OSF. Opens file in a new tab.'
             upload: Upload
             upload_detail_first: 'There are two ways to upload files. Open the storage provider or folder where you intend to upload files; you can then drag files from your desktop into files list area OR click the green plus symbol' 
-            upload_detail_second: ', then click “Upload Files”, and select your files. (Note: File names with special characters, like <code>&</code>, <code>%</code>, and <code>/</code> may cause unexpected behavior).'
+            upload_detail_second: ', then click “Upload Files”, and select your files. (Note: File names with special characters, like <code>&</code>, <code>%</code>, and <code>/</code> may cause unexpected behavior with certain addons).'
             create_folder: 'Create a folder'
             create_folder_detail: 'To create a folder to help organize your files, click the green plus symbol, then click “Create a Folder”. (Note: You can also organize your project content by creating Components).'
             rename: 'Rename a folder or file'
             rename_detail_first: 'In the files list, select the file that you want to rename and click the vertical ellipses'
-            rename_detail_second: 'to open the dropdown. Select “Rename”. (Note: Some special characters, like <code>&</code>, <code>%</code>, and <code>/</code> may cause unexpected behavior).'
+            rename_detail_second: 'to open the dropdown. Select “Rename”. (Note: Some special characters, like <code>&</code>, <code>%</code>, and <code>/</code> may cause unexpected behavior with certain addons).'
             move: Move
             move_detail_first: 'You can move your files from one part of your project or component to another. Select the files that you want to move, and click the vertical ellipses'
             move_detail_second: 'to open the dropdown, then click “move”. Choose a component, provider, or folder and then click “Move”.'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1921,12 +1921,12 @@ osf-components:
             view_files_detail: 'Click a file name to go to view the file in the OSF. Opens file in a new tab.'
             upload: Upload
             upload_detail_first: 'There are two ways to upload files. Open the storage provider or folder where you intend to upload files; you can then drag files from your desktop into files list area OR click the green plus symbol' 
-            upload_detail_second: ', then click “Upload Files”, and select your files. (Note: File names with special characters, like <code>&</code>, <code>%</code>, and <code>/</code> may cause unexpected behavior with certain addons).'
+            upload_detail_second: ', then click “Upload Files”, and select your files. Note: File names with special characters may cause unexpected behavior with certain addons.'
             create_folder: 'Create a folder'
-            create_folder_detail: 'To create a folder to help organize your files, click the green plus symbol, then click “Create a Folder”. (Note: You can also organize your project content by creating Components).'
+            create_folder_detail: 'To create a folder to help organize your files, click the green plus symbol, then click “Create a Folder”. Note: You can also organize your project content by creating Components.'
             rename: 'Rename a folder or file'
             rename_detail_first: 'In the files list, select the file that you want to rename and click the vertical ellipses'
-            rename_detail_second: 'to open the dropdown. Select “Rename”. (Note: Some special characters, like <code>&</code>, <code>%</code>, and <code>/</code> may cause unexpected behavior with certain addons).'
+            rename_detail_second: 'to open the dropdown. Select “Rename”. Note: Some special characters may cause unexpected behavior with certain addons.'
             move: Move
             move_detail_first: 'You can move your files from one part of your project or component to another. Select the files that you want to move, and click the vertical ellipses'
             move_detail_second: 'to open the dropdown, then click “move”. Choose a component, provider, or folder and then click “Move”.'


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-3811]
-   Feature flag: n/a

## Purpose
- add some text to warn users about special characters in the file browser's help modal

## Summary of Changes
- Update translation for Upload and Rename section of help modal

## Screenshot(s)
![Screen Shot 2022-06-17 at 10 58 01 AM](https://user-images.githubusercontent.com/51409893/174323780-9e41dca2-15f4-4d16-88d5-fd0401bb68d2.png)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-3811]: https://openscience.atlassian.net/browse/ENG-3811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ