### PR TITLE
[ENG-3811] Show add new dropdown on the other right side (the left side)

### DIFF
--- a/lib/osf-components/addon/components/file-browser/add-new/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/add-new/template.hbs
@@ -2,7 +2,7 @@
     <ResponsiveDropdown
         @renderInPlace={{true}}
         @buttonStyling={{false}}
-        @horizontalPosition='left'
+        @horizontalPosition='right'
         as |dropdown|
     >
         <dropdown.trigger


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-3811] 
-   Feature flag: n/a

## Purpose
- Adjust where the "Add new file" dropdown content shows up to prevent it from going off screen

## Summary of Changes
- Switch counterintuitive argument

## Screenshot(s)
Prevents:
 
![image](https://user-images.githubusercontent.com/51409893/174325000-291b400e-9d67-4038-b527-6d492581f2af.png)

Now renders to the left:
![image](https://user-images.githubusercontent.com/51409893/174325622-fc669559-60e4-43b3-885a-b60a15319a0d.png)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-3811]: https://openscience.atlassian.net/browse/ENG-3811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ