### PR TITLE
[Hotfix(?)][ENG-3811] Prevent recursive move/copy

### DIFF
--- a/lib/osf-components/addon/components/move-file-modal/list-item/component.ts
+++ b/lib/osf-components/addon/components/move-file-modal/list-item/component.ts
@@ -26,7 +26,8 @@ export default class ListItemComponent extends Component<ListItemArgs> {
     @service toast!: Toast;
 
     get isBeingMoved() {
-        return this.args.filesToMove.includes(this.args.item as File);
+        const { item, filesToMove } = this.args;
+        return filesToMove.findBy('id', item.id);
     }
 
     get isReadOnlyProvider() {

--- a/lib/osf-components/addon/components/move-file-modal/list-item/component.ts
+++ b/lib/osf-components/addon/components/move-file-modal/list-item/component.ts
@@ -45,13 +45,6 @@ export default class ListItemComponent extends Component<ListItemArgs> {
         return this.isBeingMoved || this.isReadOnlyProvider || currentUserIsReadOnly;
     }
 
-    get destinationSelectHelpText() {
-        if (this.args.currentNode && !this.args.currentNode.userHasWritePermission) {
-            return this.intl.t('osf-components.move_file_modal.no_write_permission');
-        }
-        return this.intl.t('osf-components.move_file_modal.select_provider');
-    }
-
     get assetPrefix() {
         return config.assetsPrefix;
     }

--- a/lib/osf-components/addon/components/move-file-modal/list-item/template.hbs
+++ b/lib/osf-components/addon/components/move-file-modal/list-item/template.hbs
@@ -18,7 +18,7 @@
             data-analytics-name='Go to nested folder'
             data-test-move-to-folder={{@item.name}}
             @layout='fake-link'
-            local-class='NavButton {{if this.isReadOnlyProvider 'InvalidDestination'}}'
+            local-class='NavButton {{if this.shouldDisable 'InvalidDestination'}}'
             disabled={{this.shouldDisable}}
             {{on 'click' (fn @onFolderSelect @item)}}
         >

--- a/lib/osf-components/addon/components/move-file-modal/list-item/template.hbs
+++ b/lib/osf-components/addon/components/move-file-modal/list-item/template.hbs
@@ -31,10 +31,16 @@
                     >
                     {{t (concat 'osf-components.file-browser.storage_providers.' @item.name)}}
                     {{#if this.isReadOnlyProvider}}
-                        <span local-class='ReadOnlyProvider'>
+                        <span>
                             {{t 'osf-components.move_file_modal.read_only_provider'}}
                         </span>
                     {{/if}}
+                {{else if this.isBeingMoved}}
+                    <FaIcon @icon='folder-open' />
+                    {{@item.name}}
+                    <span>
+                        {{t (concat 'osf-components.move_file_modal.'(if @preserveOriginal 'is_being_copied' 'is_being_moved'))}}
+                    </span>
                 {{else}}
                     <FaIcon @icon='folder-open' />
                     {{@item.name}}

--- a/lib/osf-components/addon/components/move-file-modal/template.hbs
+++ b/lib/osf-components/addon/components/move-file-modal/template.hbs
@@ -118,6 +118,7 @@
                         @onNodeSelect={{this.updateNode}}
                         @onFolderSelect={{this.updateFolder}}
                         @isProvider={{eq this.breadcrumbs.length 0}}
+                        @preserveOriginal={{@preserveOriginal}}
                     />
                 </:item>
                 <:empty>

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1831,6 +1831,8 @@ osf-components:
         no_children: 'No children'
         no_folders: 'No files or folders'
         read_only_provider: '- Cannot move or copy to this file provider'
+        is_being_moved: '- This folder is being moved'
+        is_being_copied: '- This folder is being copied'
         read_only_warning: 'Moving or copying files to this file provider is not supported. Please select a different provider.'
         icon_alt: 'Icon for {provider}'
         moving_files: 'Moving...'


### PR DESCRIPTION
-   Ticket: [ENG-3811]
-   Feature flag: n/a

## Purpose
- Don't allow users to move/copy folders into themselves

## Summary of Changes
- Properly check if an item in the move-modal destination list is one of the files being moved
- Add new translation string
- Remove unused class and properties

## Screenshot(s)
Write/Admin users:
![image](https://user-images.githubusercontent.com/51409893/175328915-583729ff-f3bb-40fe-86e0-e801675b2408.png)

Read users:
![image](https://user-images.githubusercontent.com/51409893/175328826-0291b107-7eaf-4ee5-b192-f007becb0397.png)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- Users should no longer be able to copy/move folders into themselves and should be shown appropriate descriptive text as to why certain destination options are disabled

[ENG-3811]: https://openscience.atlassian.net/browse/ENG-3811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ