### PR TITLE
[No ticket] Fix ts error for potentially undefined newFileName

### DIFF
--- a/lib/osf-components/addon/components/file-browser/file-rename-modal/component.ts
+++ b/lib/osf-components/addon/components/file-browser/file-rename-modal/component.ts
@@ -28,8 +28,10 @@ export default class FileRenameModal extends Component<Args> {
     }
 
     get isValid() {
-        return (Boolean(this.newFileName) && this.newFileName.trim() !== this.originalFileName &&
-            this.newFileName.trim() !== '');
+        if(this.newFileName) {
+            return (this.newFileName.trim() !== this.originalFileName && this.newFileName.trim() !== '');
+        }
+        return false;
     }
 
     @action


### PR DESCRIPTION
## Purpose

We had a ts error on build that wasn't caught by eslint. Apparently we were too clever with an if statement, and had to be more explicit.

```
lib/osf-components/addon/components/file-browser/file-rename-modal/component.ts:31:46 - error TS2532: Object is possibly 'undefined'.

31         return (Boolean(this.newFileName) && this.newFileName.trim() !== this.originalFileName &&
                                                ~~~~~~~~~~~~~~~~

lib/osf-components/addon/components/file-browser/file-rename-modal/component.ts:32:13 - error TS2532: Object is possibly 'undefined'.

32             this.newFileName.trim() !== '');
               ~~~~~~~~~~~~~~~~
```

## Summary of Changes

1. Wrap return in an if statement to check for the existence of newFileName

## Side Effects

No, this is isolated.

## QA Notes

This should change nothing about the functionality of the rename modal. It should still not allow you to rename a file to pure whitespace nor to the original filename with whitespace on the ends.