### PR TITLE
[ENG-3881] Style long file names better

### DIFF
--- a/lib/osf-components/addon/components/file-browser/file-item/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/file-item/styles.scss
@@ -4,7 +4,7 @@
     justify-content: space-between;
     padding: 12px 0;
     border-top: solid 1px $color-border-gray;
-    height: 60px;
+    min-height: 60px;
 
     span {
         margin: 0 6px;
@@ -67,7 +67,7 @@
 
 .FileList__item__options {
     display: flex;
-    align-items: flex-end;
+    align-items: center;
     flex: 1;
 }
 

--- a/lib/osf-components/addon/components/file-browser/folder-item/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/folder-item/styles.scss
@@ -4,7 +4,7 @@
     justify-content: space-between;
     padding: 12px 0;
     border-top: solid 1px $color-border-gray;
-    height: 60px;
+    min-height: 60px;
 
     span {
         margin: 0 6px;
@@ -61,7 +61,7 @@
 
 .FileList__item__options {
     display: flex;
-    align-items: flex-end;
+    align-items: center;
     flex: 1;
 }
 


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-3881]
-   Feature flag: n/a

## Purpose
- Show long files names a bit more appropriately

## Summary of Changes
- change file-list height to accommodate long file names
- change file/folder-action menu placement to be in the center

## Screenshot(s)
Before:
![image](https://user-images.githubusercontent.com/51409893/175376230-ea209336-d65b-440b-abbe-9eba74137288.png)

After:
![image](https://user-images.githubusercontent.com/51409893/175375950-6bc34fc3-0fdf-4693-aef9-292b44684bad.png)

After(Mobile):
![image](https://user-images.githubusercontent.com/51409893/175378422-11948f76-46fa-4eed-bdbd-8151a3671e5c.png)


## Side Effects
- A single entry could get potentially very long if the file/folder name is really long, but I think hiding the name would be a worse UX

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-3881]: https://openscience.atlassian.net/browse/ENG-3881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ