### PR TITLE
[ENG-3880] Add file tests

### DIFF
--- a/lib/osf-components/addon/components/file-browser/add-new/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/add-new/template.hbs
@@ -6,6 +6,7 @@
         as |dropdown|
     >
         <dropdown.trigger
+            data-test-add-new-trigger
             aria-label={{t 'osf-components.file-browser.add_button_aria'}}
             local-class='TriggerButton {{if dropdown.isOpen 'CloseButton'}}'>
             <FaIcon @icon='plus' @size='2x' @fixedWidth={{true}} />

--- a/lib/osf-components/addon/components/file-browser/component.ts
+++ b/lib/osf-components/addon/components/file-browser/component.ts
@@ -10,6 +10,7 @@ import StorageManager from 'osf-components/components/storage-provider-manager/s
 interface Args {
     manager: StorageManager;
     selectable?: boolean;
+    enableUpload?: boolean;
 }
 
 export default class FileBrowser extends Component<Args> {

--- a/lib/osf-components/addon/components/file-browser/delete-file-modal/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/delete-file-modal/template.hbs
@@ -4,6 +4,7 @@ as |dialog|>
     <dialog.trigger>
         <Button
             data-test-bulk-delete-trigger
+            data-analytics-name='Bulk file delete'
             @type='destroy'
             {{on 'click' dialog.open}}
         >

--- a/lib/osf-components/addon/components/file-browser/delete-file-modal/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/delete-file-modal/template.hbs
@@ -3,6 +3,7 @@
 as |dialog|>
     <dialog.trigger>
         <Button
+            data-test-bulk-delete-trigger
             @type='destroy'
             {{on 'click' dialog.open}}
         >

--- a/lib/osf-components/addon/components/file-browser/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/template.hbs
@@ -98,6 +98,7 @@
                 {{#if @manager.currentFolder.userCanDeleteFromHere}}
                     <Button
                         data-test-bulk-move-trigger
+                        data-analytics-name='Bulk move files'
                         @layout='fake-link'
                         {{on 'click' (queue (action (mut this.useCopyModal) false) (action (mut this.moveModalOpen) true))}}
                     >
@@ -107,6 +108,7 @@
                 {{/if}}
                 <Button
                     data-test-bulk-copy-trigger
+                    data-analytics-name='Bulk copy files'
                     @layout='fake-link'
                     {{on 'click' (queue (action (mut this.useCopyModal) true) (action (mut this.moveModalOpen) true))}}
                 >

--- a/lib/osf-components/addon/components/file-browser/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/template.hbs
@@ -97,6 +97,7 @@
             {{#if (gt @manager.selectedFiles.length 0)}}
                 {{#if @manager.currentFolder.userCanDeleteFromHere}}
                     <Button
+                        data-test-bulk-move-trigger
                         @layout='fake-link'
                         {{on 'click' (queue (action (mut this.useCopyModal) false) (action (mut this.moveModalOpen) true))}}
                     >
@@ -105,6 +106,7 @@
                     </Button>
                 {{/if}}
                 <Button
+                    data-test-bulk-copy-trigger
                     @layout='fake-link'
                     {{on 'click' (queue (action (mut this.useCopyModal) true) (action (mut this.moveModalOpen) true))}}
                 >
@@ -191,7 +193,7 @@
             {{/if}}
         </:item>
         <:empty>
-            <div local-class='EmptyText'>
+            <div data-test-empty-folder local-class='EmptyText'>
                 {{t 'osf-components.file-browser.empty_folder'}}
             </div>
         </:empty>

--- a/mirage/factories/file.ts
+++ b/mirage/factories/file.ts
@@ -54,7 +54,7 @@ export default Factory.extend<MirageFile & FileTraits>({
     path(i: number) {
         return `/${i}`;
     },
-    checkout: 'null',
+    checkout: null,
     tags() {
         return faker.lorem.words(5).split(' ');
     },

--- a/tests/acceptance/guid-node/files-test.ts
+++ b/tests/acceptance/guid-node/files-test.ts
@@ -3,7 +3,7 @@ import { ModelInstance } from 'ember-cli-mirage';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { t } from 'ember-intl/test-support';
 import { TestContext } from 'ember-test-helpers';
-// import { percySnapshot } from 'ember-percy';
+import { percySnapshot } from 'ember-percy';
 import { module, test } from 'qunit';
 
 import { click, setupOSFApplicationTest, visit } from 'ember-osf-web/tests/helpers';
@@ -48,6 +48,7 @@ module('Acceptance | guid-node/files', hooks => {
 
         // Check file actions
         await click(`[data-test-file-list-item="${this.file.id}"] [data-test-file-download-share-trigger]`);
+        await percySnapshot(assert);
         assert.dom('[data-test-copy-button]').exists('Single file copy available');
         assert.dom('[data-test-move-button]').doesNotExist('Single file move not available');
         assert.dom('[data-test-delete-button]').doesNotExist('Single file delete not available');
@@ -71,6 +72,7 @@ module('Acceptance | guid-node/files', hooks => {
         this.osfStorage!.rootFolder.update({files: []});
 
         await visit(`/${this.node.id}/files`);
+        await percySnapshot(assert);
         assert.dom('[data-test-file-list-item]').doesNotExist('No file or folder items');
         assert.dom('[data-test-empty-folder]')
             .containsText(t('osf-components.file-browser.empty_folder'), 'Empty folder');
@@ -80,6 +82,7 @@ module('Acceptance | guid-node/files', hooks => {
         this.node.update({ currentUserPermissions: ['admin', 'write', 'read'] });
         await visit(`/${this.node.id}/files`);
         await click(`[data-test-select-file="${this.file.id}"]`);
+        await percySnapshot(assert);
         assert.dom('[data-test-bulk-move-trigger]').exists('Bulk move available');
         assert.dom('[data-test-bulk-copy-trigger]').exists('Bulk copy available');
         assert.dom('[data-test-bulk-delete-trigger]').exists('Bulk delete available');

--- a/tests/acceptance/guid-node/files-test.ts
+++ b/tests/acceptance/guid-node/files-test.ts
@@ -1,30 +1,103 @@
 import { currentRouteName } from '@ember/test-helpers';
+import { ModelInstance } from 'ember-cli-mirage';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { t } from 'ember-intl/test-support';
+import { TestContext } from 'ember-test-helpers';
 // import { percySnapshot } from 'ember-percy';
 import { module, test } from 'qunit';
 
-import { setupOSFApplicationTest, visit } from 'ember-osf-web/tests/helpers';
+import { click, setupOSFApplicationTest, visit } from 'ember-osf-web/tests/helpers';
+import NodeModel from 'ember-osf-web/models/node';
+import FileModel from 'ember-osf-web/models/file';
+import FileProviderModel from 'ember-osf-web/models/file-provider';
+
+interface GuidNodeTestContext extends TestContext {
+    node: ModelInstance<NodeModel>;
+    osfStorage: ModelInstance<FileProviderModel>;
+    file: ModelInstance<FileModel>;
+}
 
 module('Acceptance | guid-node/files', hooks => {
     setupOSFApplicationTest(hooks);
     setupMirage(hooks);
 
-    test('leftnav for read user', async function(assert) {
-        const node = server.create('node', 'withFiles', 'withStorage');
-        await visit(`/${node.id}/files`);
+    hooks.beforeEach(async function(this: GuidNodeTestContext) {
+        this.node = server.create('node', 'withFiles','withStorage');
+        this.osfStorage = this.node.files.models.firstObject!;
+        this.file = server.create('file', {
+            id: 'hello',
+            target: this.node,
+            parentFolder: this.osfStorage.rootFolder,
+        });
+    });
+
+    test('read user', async function(this: GuidNodeTestContext, assert) {
+        await visit(`/${this.node.id}/files`);
 
         assert.equal(currentRouteName(), 'guid-node.files.provider', 'Current route is files');
+
+        // Check leftnav
         assert.dom('[data-test-overview-link]').exists('Overview link exists');
         assert.dom('[data-test-files-link]').exists('Files link exists');
-        // check active tab + file providers
+        assert.dom('[data-test-file-providers-list]')
+            .containsText(t('registries.overview.files.storage_providers.osfstorage'), 'Osf Storage shown as provider');
         assert.dom('[data-test-analytics-link]').exists('Analytics link exists');
         assert.dom('[data-test-registrations-link]').exists('Registrations link exists');
         assert.dom('[data-test-contributors-link]').exists('Contributors link exists');
         assert.dom('[data-test-settings-link]').exists('Settings link exists');
+
+        // Check file actions
+        await click(`[data-test-file-list-item="${this.file.id}"] [data-test-file-download-share-trigger]`);
+        assert.dom('[data-test-copy-button]').exists('Single file copy available');
+        assert.dom('[data-test-move-button]').doesNotExist('Single file move not available');
+        assert.dom('[data-test-delete-button]').doesNotExist('Single file delete not available');
+        assert.dom('[data-test-rename-link]').doesNotExist('Single file rename not available');
+        await click(`[data-test-file-list-item="${this.file.id}"] [data-test-file-download-share-trigger]`);
+
+        // Check bulk file actions
+        await click(`[data-test-select-file="${this.file.id}"]`);
+        assert.dom('[data-test-bulk-copy-trigger]').exists('Bulk copy available');
+        assert.dom('[data-test-bulk-move-trigger]').doesNotExist('Bulk move not available');
+        assert.dom('[data-test-bulk-delete-trigger]').doesNotExist('Bulk delete not available');
+
+        await click('[data-test-bulk-copy-trigger]');
+        assert.dom('[data-test-dialog]').containsText(t('osf-components.move_file_modal.no_write_permission'),
+            'Copy modal has permission-related message');
+        assert.dom('[data-test-move-files-button]').isDisabled('Copy button disabled');
+        assert.dom('[data-test-move-files-button]').containsText(t('general.copy'));
     });
 
-    // test no files
-    // test selecting files + file actions
-    // test switching providers
-    // test links for different user permissions and VOL status and wiki enabled
+    test('No files', async function(this: GuidNodeTestContext, assert) {
+        this.osfStorage!.rootFolder.update({files: []});
+
+        await visit(`/${this.node.id}/files`);
+        assert.dom('[data-test-file-list-item]').doesNotExist('No file or folder items');
+        assert.dom('[data-test-empty-folder]')
+            .containsText(t('osf-components.file-browser.empty_folder'), 'Empty folder');
+    });
+
+    test('Multi-file actions', async function(this: GuidNodeTestContext, assert) {
+        this.node.update({ currentUserPermissions: ['admin', 'write', 'read'] });
+        await visit(`/${this.node.id}/files`);
+        await click(`[data-test-select-file="${this.file.id}"]`);
+        assert.dom('[data-test-bulk-move-trigger]').exists('Bulk move available');
+        assert.dom('[data-test-bulk-copy-trigger]').exists('Bulk copy available');
+        assert.dom('[data-test-bulk-delete-trigger]').exists('Bulk delete available');
+
+        await click('[data-test-bulk-move-trigger]');
+        assert.dom('[data-test-dialog]').doesNotContainText(t('osf-components.move_file_modal.no_write_permission'),
+            'Move modal does not show permission-related message');
+    });
+
+    test('Switching providers', async function(this: GuidNodeTestContext, assert) {
+        server.create('file-provider', {
+            provider: 'bitbucket',
+            name: 'bitbucket',
+            target: this.node,
+        });
+        await visit(`/${this.node.id}/files`);
+        assert.dom('[data-test-files-provider-link="bitbucket"').exists('Bitbucket shown');
+        assert.dom('[data-test-files-provider-link="bitbucket"').hasAttribute('href',
+            `/${this.node.id}/files/bitbucket`, 'Links to bitbucket files');
+    });
 });

--- a/tests/engines/registries/acceptance/overview/files-test.ts
+++ b/tests/engines/registries/acceptance/overview/files-test.ts
@@ -5,7 +5,7 @@ import { module, test } from 'qunit';
 import { t } from 'ember-intl/test-support';
 
 import { Permission } from 'ember-osf-web/models/osf-model';
-import { currentURL, visit } from 'ember-osf-web/tests/helpers';
+import { click, currentURL, visit } from 'ember-osf-web/tests/helpers';
 import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
 
 module('Registries | Acceptance | overview.files', hooks => {
@@ -42,6 +42,7 @@ module('Registries | Acceptance | overview.files', hooks => {
         assert.dom('[data-test-file-search]').exists('File search input exists');
         assert.dom('[data-test-file-sort-trigger]').exists('File sort trigger exists');
         assert.dom('[data-test-file-help]').exists('File help button exists');
+        assert.dom('[data-test-add-new-trigger]').doesNotExist('Add new button not shown');
 
         assert.dom('[data-test-file-providers-list]').containsText(
             t('osf-components.file-browser.storage_providers.osfstorage'),'File providers list contains OSF Storage',
@@ -53,9 +54,30 @@ module('Registries | Acceptance | overview.files', hooks => {
             'Download all from here button has the right download link',
         );
 
-        // assert.dom('[data-test-file-list-item]').exists({ count: files.length }, 'Files displayed');
-        // assert.dom('[data-test-file-list-link]').containsText('Name', 'File name displayed');
-        // assert.dom('[data-test-file-list-date]').containsText('Date', 'File date displayed');
-        // assert.dom('[data-test-file-download-share-trigger]').exists('File download/share trigger exists');
+        assert.dom('[data-test-file-list-item]').exists('Files displayed');
+        assert.dom('[data-test-file-name]').exists('File name displayed');
+        assert.dom('[data-test-file-list-date]').exists('File date displayed');
+        assert.dom('[data-test-file-download-share-trigger]').exists('File download/share trigger exists');
+        await click('[data-test-file-download-share-trigger]');
+        assert.dom('[data-test-download-button]').exists('Download button exists');
+        assert.dom('[data-test-embed-button]').exists('Embed button exists');
+        assert.dom('[data-test-social-sharing-button]').exists('Share button exists');
+        assert.dom('[data-test-delete-button]').doesNotExist('Delete button not shown');
+        assert.dom('[data-test-rename-link]').doesNotExist('Rename button not shown');
+        assert.dom('[data-test-move-button]').doesNotExist('Move button not shown');
+        assert.dom('[data-test-copy-button]').doesNotExist('Copy button not shown');
+
+    });
+
+    test('No files', async assert => {
+        const registration = server.create('registration');
+
+        await visit(`/${registration.id}/files`);
+        await percySnapshot(assert);
+        assert.equal(currentURL(), `/${registration.id}/files`, 'At registration files list URL');
+
+        assert.dom('[data-test-file-list-item]').doesNotExist('No files displayed');
+        assert.dom('[data-test-empty-folder]')
+            .containsText(t('osf-components.file-browser.empty_folder'), 'Empty folder');
     });
 });

--- a/tests/integration/components/file-browser/component-test.ts
+++ b/tests/integration/components/file-browser/component-test.ts
@@ -14,7 +14,7 @@ import stripHtmlTags from 'ember-osf-web/utils/strip-html-tags';
 
 interface FileBrowserTestContext extends TestContext {
     mirageNode: ModelInstance<NodeModel>;
-    osfStorageProvider: FileProviderModel;
+    osfStorageProvider: ModelInstance<FileProviderModel>;
     topLevelFiles: Array<ModelInstance<FileModel>>;
     topLevelFolder: ModelInstance<FileModel>;
     secondaryLevelFiles: Array<ModelInstance<FileModel>>;
@@ -26,17 +26,17 @@ module('Integration | Component | file-browser', hooks => {
     hooks.beforeEach(function(this: FileBrowserTestContext) {
         this.store = this.owner.lookup('service:store');
         this.mirageNode = server.create('node', 'withFiles', 'withStorage', 'currentUserAdmin');
-        const osfStorage = this.mirageNode.files.models[0];
+        this.osfStorageProvider = this.mirageNode.files.models[0];
         this.topLevelFiles = server.createList('file', 2, {
             target: this.mirageNode,
-            parentFolder: osfStorage.rootFolder,
+            parentFolder: this.osfStorageProvider.rootFolder,
         });
         this.topLevelFolder = server.create('file', {
             target: this.mirageNode,
-            parentFolder: osfStorage.rootFolder,
+            parentFolder: this.osfStorageProvider.rootFolder,
             kind: FileItemKinds.Folder,
         });
-        osfStorage.rootFolder.update({ files: [...this.topLevelFiles, this.topLevelFolder] });
+        this.osfStorageProvider.rootFolder.update({ files: [...this.topLevelFiles, this.topLevelFolder] });
         this.secondaryLevelFiles = server.createList('file', 2, {
             target: this.mirageNode,
             parentFolder: this.topLevelFolder,
@@ -46,9 +46,6 @@ module('Integration | Component | file-browser', hooks => {
 
     test('it renders and navigates through folders',
         async function(this: FileBrowserTestContext, assert) {
-            const node = await this.store.findRecord('node', this.mirageNode.id);
-            const storageProviders = await node.files;
-            this.osfStorageProvider = storageProviders.toArray()[0];
             await render(hbs`
                 <StorageProviderManager::StorageManager @provider={{this.osfStorageProvider}} as |manager|>
                     <FileBrowser @manager={{manager}} @enableUpload={{true}} />
@@ -86,9 +83,6 @@ module('Integration | Component | file-browser', hooks => {
 
     test('it renders and select files/folders',
         async function(this: FileBrowserTestContext, assert) {
-            const node = await this.store.findRecord('node', this.mirageNode.id);
-            const storageProviders = await node.files;
-            this.osfStorageProvider = storageProviders.toArray()[0];
             await render(hbs`
                 <StorageProviderManager::StorageManager @provider={{this.osfStorageProvider}} as |manager|>
                     <FileBrowser @manager={{manager}} @selectable={{true}} />
@@ -120,9 +114,7 @@ module('Integration | Component | file-browser', hooks => {
     test('it renders non-selectable lists for registrations',
         async function(this: FileBrowserTestContext, assert) {
             const mirageRegistration = server.create('registration', 'withFiles');
-            const registration = await this.store.findRecord('registration', mirageRegistration.id);
-            const storageProviders = await registration.files;
-            this.osfStorageProvider = storageProviders.toArray()[0];
+            this.osfStorageProvider = mirageRegistration.files.models[0];
             await render(hbs`
                 <StorageProviderManager::StorageManager @provider={{this.osfStorageProvider}} as |manager|>
                     <FileBrowser @manager={{manager}} @selectable={{false}} />
@@ -135,9 +127,6 @@ module('Integration | Component | file-browser', hooks => {
 
     test('it renders help text for nodes',
         async function(this: FileBrowserTestContext, assert) {
-            const node = await this.store.findRecord('node', this.mirageNode.id);
-            const storageProviders = await node.files;
-            this.osfStorageProvider = storageProviders.toArray()[0];
             await render(hbs`
                 <StorageProviderManager::StorageManager @provider={{this.osfStorageProvider}} as |manager|>
                     <FileBrowser @manager={{manager}} @enableUpload={{true}} @selectable={{true}} />
@@ -165,9 +154,7 @@ module('Integration | Component | file-browser', hooks => {
     test('it renders help text for registrations',
         async function(this: FileBrowserTestContext, assert) {
             const mirageRegistration = server.create('registration', 'withFiles');
-            const registration = await this.store.findRecord('registration', mirageRegistration.id);
-            const storageProviders = await registration.files;
-            this.osfStorageProvider = storageProviders.toArray()[0];
+            this.osfStorageProvider = mirageRegistration.files.models[0];
             await render(hbs`
                 <StorageProviderManager::StorageManager @provider={{this.osfStorageProvider}} as |manager|>
                     <FileBrowser @manager={{manager}} @selectable={{false}} />

--- a/tests/integration/components/file-browser/component-test.ts
+++ b/tests/integration/components/file-browser/component-test.ts
@@ -14,7 +14,7 @@ import stripHtmlTags from 'ember-osf-web/utils/strip-html-tags';
 
 interface FileBrowserTestContext extends TestContext {
     mirageNode: ModelInstance<NodeModel>;
-    osfStorageProvider: ModelInstance<FileProviderModel>;
+    osfStorageProvider: FileProviderModel;
     topLevelFiles: Array<ModelInstance<FileModel>>;
     topLevelFolder: ModelInstance<FileModel>;
     secondaryLevelFiles: Array<ModelInstance<FileModel>>;
@@ -26,17 +26,17 @@ module('Integration | Component | file-browser', hooks => {
     hooks.beforeEach(function(this: FileBrowserTestContext) {
         this.store = this.owner.lookup('service:store');
         this.mirageNode = server.create('node', 'withFiles', 'withStorage', 'currentUserAdmin');
-        this.osfStorageProvider = this.mirageNode.files.models[0];
+        const osfStorage = this.mirageNode.files.models[0];
         this.topLevelFiles = server.createList('file', 2, {
             target: this.mirageNode,
-            parentFolder: this.osfStorageProvider.rootFolder,
+            parentFolder: osfStorage.rootFolder,
         });
         this.topLevelFolder = server.create('file', {
             target: this.mirageNode,
-            parentFolder: this.osfStorageProvider.rootFolder,
+            parentFolder: osfStorage.rootFolder,
             kind: FileItemKinds.Folder,
         });
-        this.osfStorageProvider.rootFolder.update({ files: [...this.topLevelFiles, this.topLevelFolder] });
+        osfStorage.rootFolder.update({ files: [...this.topLevelFiles, this.topLevelFolder] });
         this.secondaryLevelFiles = server.createList('file', 2, {
             target: this.mirageNode,
             parentFolder: this.topLevelFolder,
@@ -46,6 +46,9 @@ module('Integration | Component | file-browser', hooks => {
 
     test('it renders and navigates through folders',
         async function(this: FileBrowserTestContext, assert) {
+            const node = await this.store.findRecord('node', this.mirageNode.id);
+            const storageProviders = await node.files;
+            this.osfStorageProvider = storageProviders.toArray()[0];
             await render(hbs`
                 <StorageProviderManager::StorageManager @provider={{this.osfStorageProvider}} as |manager|>
                     <FileBrowser @manager={{manager}} @enableUpload={{true}} />
@@ -83,6 +86,9 @@ module('Integration | Component | file-browser', hooks => {
 
     test('it renders and select files/folders',
         async function(this: FileBrowserTestContext, assert) {
+            const node = await this.store.findRecord('node', this.mirageNode.id);
+            const storageProviders = await node.files;
+            this.osfStorageProvider = storageProviders.toArray()[0];
             await render(hbs`
                 <StorageProviderManager::StorageManager @provider={{this.osfStorageProvider}} as |manager|>
                     <FileBrowser @manager={{manager}} @selectable={{true}} />
@@ -114,7 +120,9 @@ module('Integration | Component | file-browser', hooks => {
     test('it renders non-selectable lists for registrations',
         async function(this: FileBrowserTestContext, assert) {
             const mirageRegistration = server.create('registration', 'withFiles');
-            this.osfStorageProvider = mirageRegistration.files.models[0];
+            const registration = await this.store.findRecord('registration', mirageRegistration.id);
+            const storageProviders = await registration.files;
+            this.osfStorageProvider = storageProviders.toArray()[0];
             await render(hbs`
                 <StorageProviderManager::StorageManager @provider={{this.osfStorageProvider}} as |manager|>
                     <FileBrowser @manager={{manager}} @selectable={{false}} />
@@ -127,6 +135,9 @@ module('Integration | Component | file-browser', hooks => {
 
     test('it renders help text for nodes',
         async function(this: FileBrowserTestContext, assert) {
+            const node = await this.store.findRecord('node', this.mirageNode.id);
+            const storageProviders = await node.files;
+            this.osfStorageProvider = storageProviders.toArray()[0];
             await render(hbs`
                 <StorageProviderManager::StorageManager @provider={{this.osfStorageProvider}} as |manager|>
                     <FileBrowser @manager={{manager}} @enableUpload={{true}} @selectable={{true}} />
@@ -154,7 +165,9 @@ module('Integration | Component | file-browser', hooks => {
     test('it renders help text for registrations',
         async function(this: FileBrowserTestContext, assert) {
             const mirageRegistration = server.create('registration', 'withFiles');
-            this.osfStorageProvider = mirageRegistration.files.models[0];
+            const registration = await this.store.findRecord('registration', mirageRegistration.id);
+            const storageProviders = await registration.files;
+            this.osfStorageProvider = storageProviders.toArray()[0];
             await render(hbs`
                 <StorageProviderManager::StorageManager @provider={{this.osfStorageProvider}} as |manager|>
                     <FileBrowser @manager={{manager}} @selectable={{false}} />


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-3880]
-   Feature flag: n/a

## Purpose
- Add/edit test for files page functionality

## Summary of Changes
- Add data-test selectors
- Edit Registration Files test
- Edit FileBrowser component test
- Edit Node Files test

## Screenshot(s)
- NA

## Side Effects
- I can sleep better at night knowing we have test coverage for some of this

## QA Notes
-  I've added data-test selectors for the bulk file actions: `data-test-bulk-copy-trigger`, `data-test-bulk-move-trigger`, and `data-test-bulk-delete-trigger`
- I've added a data-test selector for the green "Add new" omni button: `data-test-add-new-trigger`

[ENG-3880]: https://openscience.atlassian.net/browse/ENG-3880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ