### PR TITLE
[ENG-3882] Prevent special chars and show error messages

### DIFF
--- a/app/models/file.ts
+++ b/app/models/file.ts
@@ -22,6 +22,9 @@ export interface FileLinks extends BaseFileLinks {
     render?: Link;
 }
 
+// Character that need to be excluded: ()<>~!@$&*:;,'"\|/?
+export const forbiddenFileNameCharacters = /[()<>~!@$&*:;,"\\|/?]/;
+
 export default class FileModel extends BaseFileItem {
     @attr() links!: FileLinks;
     @attr('fixstring') name!: string;

--- a/lib/osf-components/addon/components/file-browser/add-new/create-folder-modal/component.ts
+++ b/lib/osf-components/addon/components/file-browser/add-new/create-folder-modal/component.ts
@@ -17,17 +17,23 @@ export default class CreateFolderModal extends Component<Args> {
 
     get isInvalid() {
         const trimmedName = this.newFolderName.trim();
-        return !trimmedName || this.containsForbiddenChars;
+        return !trimmedName || this.containsForbiddenChars || this.endsWithDot;
     }
 
     get containsForbiddenChars() {
         return this.newFolderName && forbiddenFileNameCharacters.test(this.newFolderName);
     }
 
+    get endsWithDot() {
+        return this.newFolderName && this.newFolderName.endsWith('.');
+    }
+
     get errorText() {
         let errorTextKey = 'osf-components.file-browser.create_folder.error_';
         if (this.containsForbiddenChars) {
             errorTextKey += 'forbidden_chars';
+        } else if (this.endsWithDot) {
+            errorTextKey += 'ends_with_dot';
         } else {
             errorTextKey += 'message';
         }

--- a/lib/osf-components/addon/components/file-browser/add-new/create-folder-modal/component.ts
+++ b/lib/osf-components/addon/components/file-browser/add-new/create-folder-modal/component.ts
@@ -1,7 +1,9 @@
+import { inject as service } from '@ember/service';
+import Intl from 'ember-intl/services/intl';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { taskFor } from 'ember-concurrency-ts';
 
+import { forbiddenFileNameCharacters } from 'ember-osf-web/models/file';
 import StorageManager from 'osf-components/components/storage-provider-manager/storage-manager/component';
 
 interface Args {
@@ -10,9 +12,25 @@ interface Args {
 }
 
 export default class CreateFolderModal extends Component<Args> {
+    @service intl!: Intl;
     @tracked newFolderName = '';
 
-    get shouldDisable() {
-        return taskFor(this.args.manager.createNewFolder).isRunning || !this.newFolderName;
+    get isInvalid() {
+        const trimmedName = this.newFolderName.trim();
+        return !trimmedName || this.containsForbiddenChars;
+    }
+
+    get containsForbiddenChars() {
+        return this.newFolderName && forbiddenFileNameCharacters.test(this.newFolderName);
+    }
+
+    get errorText() {
+        let errorTextKey = 'osf-components.file-browser.create_folder.error_';
+        if (this.containsForbiddenChars) {
+            errorTextKey += 'forbidden_chars';
+        } else {
+            errorTextKey += 'message';
+        }
+        return this.intl.t(errorTextKey);
     }
 }

--- a/lib/osf-components/addon/components/file-browser/add-new/create-folder-modal/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/add-new/create-folder-modal/styles.scss
@@ -1,0 +1,10 @@
+.RenameInput {
+    min-width: 50vw;
+    width: 100%;
+}
+
+.ErrorText {
+    color: $color-text-gray;
+    font-style: italic;
+    font-weight: 400;
+}

--- a/lib/osf-components/addon/components/file-browser/add-new/create-folder-modal/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/add-new/create-folder-modal/template.hbs
@@ -16,13 +16,17 @@
                     (action (mut this.newFolderName) '')
                 }}
                 @value={{this.newFolderName}}
+                local-class='RenameInput'
             />
+            {{#if this.isInvalid}}
+                <p local-class='ErrorText'>{{this.errorText}}</p>
+            {{/if}}
         </label>
     </dialog.main>
     <dialog.footer>
         <Button
             @type='create'
-            disabled={{this.shouldDisable}}
+            disabled={{or @manager.createNewFolder.isRunning this.isInvalid}}
             {{on 'click'
                 (queue
                     (perform @manager.createNewFolder this.newFolderName)

--- a/lib/osf-components/addon/components/file-browser/add-new/create-folder-modal/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/add-new/create-folder-modal/template.hbs
@@ -3,10 +3,10 @@
     @onClose={{queue (action (mut @isOpen) false) (action (mut this.newFolderName) '')}}
     as |dialog|
 >
-    <dialog.heading>
+    <dialog.heading data-test-create-folder-heading>
         {{t 'osf-components.file-browser.create_folder.title'}}
     </dialog.heading>
-    <dialog.main>
+    <dialog.main data-test-create-folder-main>
         <label>
             <p>{{t 'osf-components.file-browser.create_folder.new_folder_name'}}</p>
             <Input
@@ -19,12 +19,14 @@
                 local-class='RenameInput'
             />
             {{#if this.isInvalid}}
-                <p local-class='ErrorText'>{{this.errorText}}</p>
+                <p local-class='ErrorText' data-test-new-folder-error>{{this.errorText}}</p>
             {{/if}}
         </label>
     </dialog.main>
     <dialog.footer>
         <Button
+            data-test-create-folder-button
+            data-analytics-name='Create folder'
             @type='create'
             disabled={{or @manager.createNewFolder.isRunning this.isInvalid}}
             {{on 'click'

--- a/lib/osf-components/addon/components/file-browser/add-new/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/add-new/template.hbs
@@ -6,6 +6,7 @@
         as |dropdown|
     >
         <dropdown.trigger
+            data-analytics-name='Add file or folder omnibutton'
             data-test-add-new-trigger
             aria-label={{t 'osf-components.file-browser.add_button_aria'}}
             local-class='TriggerButton {{if dropdown.isOpen 'CloseButton'}}'>
@@ -18,12 +19,16 @@
             {{will-destroy (fn @setClickableElementId '')}}
         >
             <Button
+                data-analytics-name='Open create folder modal'
+                data-test-create-folder
                 @layout='fake-link'
                 {{on 'click' (fn (mut this.createFolderModalOpen) true)}}
             >
                 {{t 'osf-components.file-browser.create_folder.title'}}
             </Button>
             <Button
+                data-analytics-name='Upload file'
+                data-test-upload-file
                 @layout='fake-link'
                 id={{uploadButtonId}}
             >

--- a/lib/osf-components/addon/components/file-browser/file-rename-modal/component.ts
+++ b/lib/osf-components/addon/components/file-browser/file-rename-modal/component.ts
@@ -6,6 +6,8 @@ import Toast from 'ember-toastr/services/toast';
 import { restartableTask } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 import Intl from 'ember-intl/services/intl';
+
+import { forbiddenFileNameCharacters } from 'ember-osf-web/models/file';
 import File from 'ember-osf-web/packages/files/file';
 import StorageManager from 'osf-components/components/storage-provider-manager/storage-manager/component';
 
@@ -28,10 +30,26 @@ export default class FileRenameModal extends Component<Args> {
     }
 
     get isValid() {
-        if(this.newFileName) {
+        if(this.newFileName && !this.containsForbiddenChars) {
             return (this.newFileName.trim() !== this.originalFileName && this.newFileName.trim() !== '');
         }
         return false;
+    }
+
+    get containsForbiddenChars() {
+        return this.newFileName && forbiddenFileNameCharacters.test(this.newFileName);
+    }
+
+    get errorText() {
+        let errorTextKey = 'osf-components.file-browser.file_rename_modal.error_';
+        if (!this.newFileName) {
+            errorTextKey += 'empty_name';
+        } else if (this.containsForbiddenChars) {
+            errorTextKey += 'forbidden_chars';
+        } else {
+            errorTextKey += 'message';
+        }
+        return this.intl.t(errorTextKey);
     }
 
     @action

--- a/lib/osf-components/addon/components/file-browser/file-rename-modal/component.ts
+++ b/lib/osf-components/addon/components/file-browser/file-rename-modal/component.ts
@@ -30,7 +30,7 @@ export default class FileRenameModal extends Component<Args> {
     }
 
     get isValid() {
-        if(this.newFileName && !this.containsForbiddenChars) {
+        if(this.newFileName && !this.containsForbiddenChars && !this.endsWithDot) {
             return (this.newFileName.trim() !== this.originalFileName && this.newFileName.trim() !== '');
         }
         return false;
@@ -40,10 +40,16 @@ export default class FileRenameModal extends Component<Args> {
         return this.newFileName && forbiddenFileNameCharacters.test(this.newFileName);
     }
 
+    get endsWithDot() {
+        return this.newFileName && this.newFileName.endsWith('.');
+    }
+
     get errorText() {
         let errorTextKey = 'osf-components.file-browser.file_rename_modal.error_';
         if (!this.newFileName) {
             errorTextKey += 'empty_name';
+        } else if (this.endsWithDot) {
+            errorTextKey += 'ends_with_dot';
         } else if (this.containsForbiddenChars) {
             errorTextKey += 'forbidden_chars';
         } else {

--- a/lib/osf-components/addon/components/file-browser/file-rename-modal/styles.scss
+++ b/lib/osf-components/addon/components/file-browser/file-rename-modal/styles.scss
@@ -20,4 +20,7 @@
     }
 }
 
-
+.ErrorText {
+    color: $color-text-gray;
+    font-style: italic;
+}

--- a/lib/osf-components/addon/components/file-browser/file-rename-modal/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/file-rename-modal/template.hbs
@@ -20,6 +20,11 @@
                     dialog.close
                 }}
             />
+            {{#unless this.isValid}}
+                <p local-class='ErrorText'>
+                    {{this.errorText}}
+                </p>
+            {{/unless}}
         </div>
     </dialog.main>
     <dialog.footer>

--- a/lib/osf-components/addon/components/file-browser/file-rename-modal/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/file-rename-modal/template.hbs
@@ -9,7 +9,7 @@
         {{t 'osf-components.file-browser.file_rename_modal.heading'}}
     </dialog.heading>
     <dialog.main>
-        <div local-class='RenameInput'>
+        <div data-test-rename-main local-class='RenameInput'>
             <Input
                 data-test-user-input
                 aria-label={{t 'osf-components.file-browser.file_rename_modal.input_aria'}}

--- a/mirage/serializers/file-provider.ts
+++ b/mirage/serializers/file-provider.ts
@@ -62,6 +62,7 @@ export default class FileSerializer extends ApplicationSerializer<MirageFileProv
         return {
             ...super.buildNormalLinks(model),
             upload: `${apiUrl}/v2/${pathName}/${model.targetId.id}/files/${model.name}/upload`,
+            new_folder: `${apiUrl}/v2/${pathName}/${model.targetId.id}/files/${model.name}/upload/?kind=folder`,
         };
     }
 }

--- a/mirage/serializers/file.ts
+++ b/mirage/serializers/file.ts
@@ -68,6 +68,7 @@ export default class FileSerializer extends ApplicationSerializer<MirageFile> {
         const { id } = model;
         return {
             ...super.buildNormalLinks(model),
+            new_folder: model.kind === 'folder' ? `${apiUrl}/wb/files/${id}/upload/?kind=folder` : undefined,
             upload: `${apiUrl}/wb/files/${id}/upload/`,
             download: `${apiUrl}/wb/files/${id}/download/`,
             move: `${apiUrl}/wb/files/${id}/move/`,

--- a/tests/integration/components/file-browser/component-test.ts
+++ b/tests/integration/components/file-browser/component-test.ts
@@ -234,9 +234,8 @@ module('Integration | Component | file-browser', hooks => {
             await click('[data-test-create-folder-button]');
 
             assert.dom('[data-test-create-folder-heading]').doesNotExist('Create folder modal autocloses');
-            assert.dom(`
-                [data-test-file-list-link][aria-label="
-                    ${t('osf-components.file-browser.view_folder', {folderName: 'Shiny New Folder'})}
-                "]`).exists('Shiny new folder exists');
+            const newFolderAria = t('osf-components.file-browser.view_folder', {folderName: 'Shiny New Folder'});
+            assert.dom(`[data-test-file-list-link][aria-label="${newFolderAria}"]`)
+                .exists('Shiny new folder exists');
         });
 });

--- a/tests/integration/components/file-browser/component-test.ts
+++ b/tests/integration/components/file-browser/component-test.ts
@@ -217,15 +217,22 @@ module('Integration | Component | file-browser', hooks => {
 
             await fillIn('[data-test-create-folder-main] input', '     ');
             assert.dom('[data-test-new-folder-error]').containsText(
-                t('osf-components.file-browser.create_folder.error_message'), 'Folder cant be empty',
+                t('osf-components.file-browser.create_folder.error_message'), 'Folder cannot be empty',
             );
             assert.dom('[data-test-create-folder-button]').isDisabled('Create folder button is still still disabled');
 
             await fillIn('[data-test-create-folder-main] input', 'new fo/der?');
             assert.dom('[data-test-new-folder-error]').containsText(
-                t('osf-components.file-browser.create_folder.error_forbidden_chars'), 'Folder cant have special chars',
+                t('osf-components.file-browser.create_folder.error_forbidden_chars'),
+                'Folder cannot have special chars',
             );
-            assert.dom('[data-test-create-folder-button]').isDisabled('Create folder button is still still disabled');
+            assert.dom('[data-test-create-folder-button]').isDisabled('Create folder button is still x3 disabled');
+
+            await fillIn('[data-test-create-folder-main] input', 'new folder.');
+            assert.dom('[data-test-new-folder-error]').containsText(
+                t('osf-components.file-browser.create_folder.error_ends_with_dot'), 'Folder name cannot end with a dot',
+            );
+            assert.dom('[data-test-create-folder-button]').isDisabled('Create folder button is still x4 disabled');
 
             await fillIn('[data-test-create-folder-main] input', 'Shiny New Folder');
             assert.dom('[data-test-new-folder-error]').doesNotExist('No error message shown');

--- a/tests/integration/components/file-browser/component-test.ts
+++ b/tests/integration/components/file-browser/component-test.ts
@@ -234,6 +234,9 @@ module('Integration | Component | file-browser', hooks => {
             await click('[data-test-create-folder-button]');
 
             assert.dom('[data-test-create-folder-heading]').doesNotExist('Create folder modal autocloses');
-            assert.dom('[data-test-file-list-item]').containsText('Shiny New Folder');
+            assert.dom(`
+                [data-test-file-list-link][aria-label="
+                    ${t('osf-components.file-browser.view_folder', {folderName: 'Shiny New Folder'})}
+                "]`).exists('Shiny new folder exists');
         });
 });

--- a/tests/integration/components/file-browser/file-rename-modal/component-test.ts
+++ b/tests/integration/components/file-browser/file-rename-modal/component-test.ts
@@ -64,8 +64,26 @@ module('Integration | Component | file-browser :: file-rename-modal', hooks => {
             assert.dom('[data-test-disabled-rename]').hasText(stripHtmlTags(
                 t('osf-components.file-browser.file_rename_modal.save'),
             ));
+            assert.dom('[data-test-rename-main]').containsText(
+                t('osf-components.file-browser.file_rename_modal.error_message'),
+            );
 
             await fillIn('[data-test-user-input]', 'What is the great globe itself but a Loose-Fish?');
+            assert.dom('[data-test-rename-main]').containsText(
+                t('osf-components.file-browser.file_rename_modal.error_forbidden_chars'),
+            );
+
+            await fillIn('[data-test-user-input]', '      ');
+            assert.dom('[data-test-rename-main]').containsText(
+                t('osf-components.file-browser.file_rename_modal.error_message'),
+            );
+
+            await fillIn('[data-test-user-input]', 'This will error.');
+            assert.dom('[data-test-rename-main]').containsText(
+                t('osf-components.file-browser.file_rename_modal.error_ends_with_dot'),
+            );
+
+            await fillIn('[data-test-user-input]', 'Save this file');
             assert.dom('[data-test-disabled-rename]').isEnabled('Save button is enabled');
         });
 });

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1906,6 +1906,8 @@ osf-components:
             error_title: 'Failed to create folder'
             error_409: 'A folder with that name already exists'
             error_generic: 'Something went wrong. Please try again.'
+            error_message: 'Please enter a folder name.'
+            error_forbidden_chars: 'Please remove special characters from the folder name.'
         add_button_aria: 'Add files or folders here'
         upload_file: 'Upload file'
         uploading_file: 'Uploading {fileCount, plural, one {# file} other {# files}}'
@@ -1968,6 +1970,8 @@ osf-components:
             clear_aria: 'Clear input field'
             success_message: 'File successfully renamed.'
             error_message: 'Please rename the file.'
+            error_empty_name: 'Please enter a new file name.'
+            error_forbidden_chars: 'Please remove special characters from the file name.'
             retry_message: 'Rename failed.'
 
     subjects:

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1907,6 +1907,7 @@ osf-components:
             error_409: 'A folder with that name already exists'
             error_generic: 'Something went wrong. Please try again.'
             error_message: 'Please enter a folder name.'
+            error_ends_with_dot: 'File name cannot end with period'
             error_forbidden_chars: 'Please remove special characters from the folder name.'
         add_button_aria: 'Add files or folders here'
         upload_file: 'Upload file'
@@ -1970,7 +1971,7 @@ osf-components:
             clear_aria: 'Clear input field'
             success_message: 'File successfully renamed.'
             error_message: 'Please rename the file.'
-            error_empty_name: 'Please enter a new file name.'
+            error_ends_with_dot: 'File name cannot end with a period.'
             error_forbidden_chars: 'Please remove special characters from the file name.'
             retry_message: 'Rename failed.'
 


### PR DESCRIPTION
-   Ticket: [ENG-3882]
-   Feature flag: n/a

## Purpose
- Disallow special characters in new folders and file/folder rename modals

## Summary of Changes
- Add logic to check against forbidden special chars for file rename and new folder modal
- Add error messages to those modals

## Screenshot(s)
- Rename
  - Desktop:
  - ![image](https://user-images.githubusercontent.com/51409893/177358365-54ada530-4d00-44eb-8b47-7f578ad6aed6.png)

  - Mobile:
  - ![image](https://user-images.githubusercontent.com/51409893/177358305-a41026cb-d236-49c8-9ce9-d2d03e796795.png)
- New folder
  - Desktop
  - ![image](https://user-images.githubusercontent.com/51409893/177358510-9f2cc4e9-e59f-4a27-aad8-19f984019a2a.png)
  - Mobile
  - ![image](https://user-images.githubusercontent.com/51409893/177358569-7413731d-ccc0-4ff5-a013-0a981b1efb3e.png)




## Side Effects
- Renaming existing files/folders that already have special characters will need to have those special characters removed

## QA Notes
- The special characters that we disallow are `()<>~!@$&*:;,'"|/?`
- For a more detailed breakdown of which providers have trouble with specific characters, please check [the JIRA ticket](https://openscience.atlassian.net/browse/ENG-3882)

[ENG-3882]: https://openscience.atlassian.net/browse/ENG-3882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ