### PR TITLE
[ENG-3879] Show dataverse specific info

### DIFF
--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -17,6 +17,9 @@
         <div local-class='FlexContainerRow'>
             <h2 data-test-filename>
                 {{this.model.name}}
+                {{#if this.model.providerSpecificData.titleSuffix}}
+                    {{this.model.providerSpecificData.titleSuffix}}
+                {{/if}}
                 {{#if this.viewedVersion}}
                     ({{t 'general.version'}}: {{this.viewedVersion}})
                 {{/if}}

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -16,10 +16,7 @@
         </h3>
         <div local-class='FlexContainerRow'>
             <h2 data-test-filename>
-                {{this.model.name}}
-                {{#if this.model.providerSpecificData.titleSuffix}}
-                    {{this.model.providerSpecificData.titleSuffix}}
-                {{/if}}
+                {{this.model.displayName}}
                 {{#if this.viewedVersion}}
                     ({{t 'general.version'}}: {{this.viewedVersion}})
                 {{/if}}

--- a/app/packages/files/dataverse-file.ts
+++ b/app/packages/files/dataverse-file.ts
@@ -1,6 +1,15 @@
 import FileModel from 'ember-osf-web/models/file';
-import File from 'ember-osf-web/packages/files/file';
+import File, { ProviderSpecificData } from 'ember-osf-web/packages/files/file';
 import CurrentUserService from 'ember-osf-web/services/current-user';
+
+interface DataverseExtraInfo {
+    datasetVersion: 'latest-published' | 'latest';
+    fileId: string;
+    hasPublishedVersion: boolean;
+    hashes: {
+        md5: string,
+    };
+}
 
 export default class DataverseFile extends File {
     shouldShowRevisions = false;
@@ -12,5 +21,13 @@ export default class DataverseFile extends File {
 
     get currentUserPermission() {
         return 'read';
+    }
+
+    get providerSpecificData(): ProviderSpecificData {
+        const fileExtra = this.fileModel.extra as DataverseExtraInfo;
+        const translationPrefix = 'osf-components.file-browser.provider-specific-data.dataverse.';
+        return {
+            titleSuffix: this.intl.t(translationPrefix + fileExtra.datasetVersion),
+        };
     }
 }

--- a/app/packages/files/dataverse-file.ts
+++ b/app/packages/files/dataverse-file.ts
@@ -1,5 +1,5 @@
 import FileModel from 'ember-osf-web/models/file';
-import File, { ProviderSpecificData } from 'ember-osf-web/packages/files/file';
+import File from 'ember-osf-web/packages/files/file';
 import CurrentUserService from 'ember-osf-web/services/current-user';
 
 interface DataverseExtraInfo {
@@ -23,11 +23,10 @@ export default class DataverseFile extends File {
         return 'read';
     }
 
-    get providerSpecificData(): ProviderSpecificData {
+    get displayName() {
         const fileExtra = this.fileModel.extra as DataverseExtraInfo;
-        const translationPrefix = 'osf-components.file-browser.provider-specific-data.dataverse.';
-        return {
-            titleSuffix: this.intl.t(translationPrefix + fileExtra.datasetVersion),
-        };
+        const translationKeyPrefix = 'osf-components.file-browser.provider-specific-data.dataverse.';
+        const fileNameSuffix = ' ' + this.intl.t(translationKeyPrefix + fileExtra.datasetVersion);
+        return this.fileModel.name + fileNameSuffix;
     }
 }

--- a/app/packages/files/file.ts
+++ b/app/packages/files/file.ts
@@ -43,10 +43,6 @@ export interface WaterButlerRevision {
     };
 }
 
-export interface ProviderSpecificData {
-    titleSuffix?: string;
-}
-
 export default abstract class File {
     @tracked fileModel: FileModel;
     @tracked totalFileCount = 0;
@@ -100,6 +96,10 @@ export default abstract class File {
     }
 
     get name() {
+        return this.fileModel.name;
+    }
+
+    get displayName() {
         return this.fileModel.name;
     }
 

--- a/app/packages/files/file.ts
+++ b/app/packages/files/file.ts
@@ -43,6 +43,10 @@ export interface WaterButlerRevision {
     };
 }
 
+export interface ProviderSpecificData {
+    titleSuffix?: string;
+}
+
 export default abstract class File {
     @tracked fileModel: FileModel;
     @tracked totalFileCount = 0;

--- a/lib/osf-components/addon/components/file-actions-menu/template.hbs
+++ b/lib/osf-components/addon/components/file-actions-menu/template.hbs
@@ -6,7 +6,7 @@
     as |dropdown|
 >
     <dropdown.trigger
-        aria-label={{t 'file_actions_menu.actions' filename=@item.name}} 
+        aria-label={{t 'file_actions_menu.actions' filename=@item.displayName}} 
         data-test-file-download-share-trigger
         data-analytics-name='File actions'
     >
@@ -40,8 +40,8 @@
             </dd.trigger>
         </FileEmbedMenu>
         <SharingIcons::Dropdown
-            @title={{@item.name}}
-            @description={{@item.name}}
+            @title={{@item.displayName}}
+            @description={{@item.displayName}}
             @hyperlink={{@item.links.html}}
             @showText={{true}}
             as |dd|

--- a/lib/osf-components/addon/components/file-browser/file-item/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/file-item/template.hbs
@@ -22,7 +22,7 @@
         {{/if}}
         <div local-class='FileList__item__name {{unless @isDesktop 'name__mobile'}}'>
             {{#if @item.isCheckedOut}}
-                <span local-class='CheckoutSpan'>
+                <span data-test-file-list-checkout local-class='CheckoutSpan'>
                     <FaIcon local-class='CheckoutIcon' @icon='lock' />
                     <BsTooltip
                         @placement='right'
@@ -33,6 +33,7 @@
                 </span>
             {{/if}}
             <OsfLink
+                data-test-file-list-link
                 data-analytics-name='Open file'
                 aria-label={{if
                     @item.showAsUnviewed
@@ -48,6 +49,9 @@
                 />
                 <span data-test-file-name>
                     {{@item.name}}
+                    {{#if @item.providerSpecificData.titleSuffix}}
+                        {{@item.providerSpecificData.titleSuffix}}
+                    {{/if}}
                 </span>
             </OsfLink>
         </div>

--- a/lib/osf-components/addon/components/file-browser/file-item/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/file-item/template.hbs
@@ -9,7 +9,7 @@
                 data-analytics-name='Select file'
                 data-analytics-category='checkbox'
                 data-test-select-file={{@item.id}}
-                aria-label={{t 'osf-components.file-browser.select_file' fileName=@item.name}}
+                aria-label={{t 'osf-components.file-browser.select_file' fileName=@item.displayName}}
                 {{on 'click' (action @manager.selectFile @item)}}
                 local-class='Label'
             >
@@ -37,8 +37,8 @@
                 data-analytics-name='Open file'
                 aria-label={{if
                     @item.showAsUnviewed
-                    (t 'osf-components.file-browser.view_unseen_file' fileName=@item.name)
-                    (t 'osf-components.file-browser.view_file' fileName=@item.name)
+                    (t 'osf-components.file-browser.view_unseen_file' fileName=@item.displayName)
+                    (t 'osf-components.file-browser.view_file' fileName=@item.displayName)
                 }}
                 @href={{@item.links.html}}
                 @target='_blank'
@@ -48,10 +48,7 @@
                     @prefix='far' @icon='file-alt' @fixedWidth={{true}}
                 />
                 <span data-test-file-name>
-                    {{@item.name}}
-                    {{#if @item.providerSpecificData.titleSuffix}}
-                        {{@item.providerSpecificData.titleSuffix}}
-                    {{/if}}
+                    {{@item.displayName}}
                 </span>
             </OsfLink>
         </div>

--- a/tests/integration/components/file-browser/file-item/component-test.ts
+++ b/tests/integration/components/file-browser/file-item/component-test.ts
@@ -19,7 +19,6 @@ interface FileItem {
     links: Links;
     dateModified: string;
     id: string;
-    providerSpecificData?: any;
     isCheckedOut?: boolean;
     showAsUnviewed?: boolean;
 }

--- a/tests/integration/components/file-browser/file-item/component-test.ts
+++ b/tests/integration/components/file-browser/file-item/component-test.ts
@@ -1,10 +1,12 @@
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { TestContext } from 'ember-intl/test-support';
+import { TestContext, t } from 'ember-intl/test-support';
 import { click } from 'ember-osf-web/tests/helpers';
 import { setupRenderingTest } from 'ember-qunit';
 import moment from 'moment';
 import { module, test } from 'qunit';
+
+import styles from 'osf-components/components/file-browser/file-item/styles';
 
 interface Links {
     html: string;
@@ -16,6 +18,9 @@ interface FileItem {
     links: Links;
     dateModified: string;
     id: string;
+    providerSpecificData?: any;
+    isCheckedOut?: boolean;
+    showAsUnviewed?: boolean;
 }
 
 interface Manager {
@@ -90,4 +95,46 @@ module('Integration | Component | file-browser :: file-item', hooks => {
             assert.dom('[data-test-embed-button]').exists('Embed button exists');
             assert.dom('[data-test-social-sharing-button]').exists('Share button exists');
         });
+
+    test('it renders checked-out file', async function(this: FileItemTestContext, assert) {
+        this.manager.parentFolder = 'fakeParentFolder';
+        this.item.isCheckedOut = true;
+        await render(
+            hbs`<FileBrowser::FileItem @manager={{this.manager}} @item={{this.item}} @isDesktop={{true}} />`,
+        );
+        assert.dom('[data-test-file-list-checkout]').exists('Checkout icon exists');
+        assert.dom('[data-test-file-list-link]').hasAria('label',
+            t('osf-components.file-browser.view_file', { fileName: this.item.name }), 'Correct aria-label');
+        assert.dom('[data-test-file-list-link]').doesNotHaveClass(styles.Unviewed, 'Link is not styled as unviewed');
+        assert.dom('[data-test-file-list-link]').hasText(this.item.name, 'Link has correct text');
+    });
+
+    test('it renders unviewed file', async function(this: FileItemTestContext, assert) {
+        this.manager.parentFolder = 'fakeParentFolder';
+        this.item.showAsUnviewed = true;
+        await render(
+            hbs`<FileBrowser::FileItem @manager={{this.manager}} @item={{this.item}} @isDesktop={{true}} />`,
+        );
+        assert.dom('[data-test-file-list-checkout]').doesNotExist('Checkout icon does not exist');
+        assert.dom('[data-test-file-list-link]').hasAria('label',
+            t('osf-components.file-browser.view_unseen_file', { fileName: this.item.name }), 'Correct aria-label');
+        assert.dom('[data-test-file-list-link]').hasClass(styles.Unviewed, 'Link is styled as unviewed');
+        assert.dom('[data-test-file-list-link]').hasText(this.item.name, 'Link has correct text');
+    });
+
+    test('it renders provider-specific data', async function(this: FileItemTestContext, assert) {
+        this.manager.parentFolder = 'fakeParentFolder';
+        this.item.providerSpecificData = {
+            titleSuffix: 'fakeTitleSuffix',
+        };
+        await render(
+            hbs`<FileBrowser::FileItem @manager={{this.manager}} @item={{this.item}} @isDesktop={{true}} />`,
+        );
+        assert.dom('[data-test-file-list-checkout]').doesNotExist('Checkout icon does not exist');
+        assert.dom('[data-test-file-list-link]').hasAria('label',
+            t('osf-components.file-browser.view_file', { fileName: this.item.name }), 'Correct aria-label');
+        assert.dom('[data-test-file-list-link]').doesNotHaveClass(styles.Unviewed, 'Link is not styled as unviewed');
+        assert.dom('[data-test-file-list-link]')
+            .hasText(this.item.name + ' ' + this.item.providerSpecificData.titleSuffix, 'Link has correct text');
+    });
 });

--- a/tests/integration/components/file-browser/file-item/component-test.ts
+++ b/tests/integration/components/file-browser/file-item/component-test.ts
@@ -15,6 +15,7 @@ interface Links {
 
 interface FileItem {
     name: string;
+    displayName: string;
     links: Links;
     dateModified: string;
     id: string;
@@ -42,6 +43,7 @@ module('Integration | Component | file-browser :: file-item', hooks => {
         this.item = {
             id: 'fakeId',
             name: 'Push&Pull',
+            displayName: 'Push&Pull',
             links: {
                 html: 'thisisafakelink',
                 download: 'thisisafakedownloadlink',
@@ -64,7 +66,7 @@ module('Integration | Component | file-browser :: file-item', hooks => {
             );
             assert.dom('[data-test-indented="false"][data-test-file-list-item]').exists('File item exists');
             assert.dom('[data-test-file-name]').exists('File name exists');
-            assert.dom('[data-test-file-name]').hasText(this.item.name, 'File name is correct');
+            assert.dom('[data-test-file-name]').hasText(this.item.displayName, 'File name is correct');
             assert.dom('[data-test-file-modified-date]').exists('Modified date exists');
             assert.dom('[data-test-file-modified-date]').hasText(
                 moment(this.item.dateModified).format('YYYY-MM-DD hh:mm A'),
@@ -84,7 +86,7 @@ module('Integration | Component | file-browser :: file-item', hooks => {
             );
             assert.dom('[data-test-indented="true"][data-test-file-list-item]').exists('File item exists');
             assert.dom('[data-test-file-name]').exists('File name exists');
-            assert.dom('[data-test-file-name]').hasText(this.item.name, 'File name is correct');
+            assert.dom('[data-test-file-name]').hasText(this.item.displayName, 'File name is correct');
             assert.dom('[data-test-file-modified-date]').exists('Modified date exists');
             assert.dom('[data-test-file-modified-date]').hasText(
                 moment(this.item.dateModified).format('YYYY-MM-DD hh:mm A'),
@@ -104,9 +106,9 @@ module('Integration | Component | file-browser :: file-item', hooks => {
         );
         assert.dom('[data-test-file-list-checkout]').exists('Checkout icon exists');
         assert.dom('[data-test-file-list-link]').hasAria('label',
-            t('osf-components.file-browser.view_file', { fileName: this.item.name }), 'Correct aria-label');
+            t('osf-components.file-browser.view_file', { fileName: this.item.displayName }), 'Correct aria-label');
         assert.dom('[data-test-file-list-link]').doesNotHaveClass(styles.Unviewed, 'Link is not styled as unviewed');
-        assert.dom('[data-test-file-list-link]').hasText(this.item.name, 'Link has correct text');
+        assert.dom('[data-test-file-list-link]').hasText(this.item.displayName, 'Link has correct text');
     });
 
     test('it renders unviewed file', async function(this: FileItemTestContext, assert) {
@@ -117,24 +119,9 @@ module('Integration | Component | file-browser :: file-item', hooks => {
         );
         assert.dom('[data-test-file-list-checkout]').doesNotExist('Checkout icon does not exist');
         assert.dom('[data-test-file-list-link]').hasAria('label',
-            t('osf-components.file-browser.view_unseen_file', { fileName: this.item.name }), 'Correct aria-label');
+            t('osf-components.file-browser.view_unseen_file', { fileName: this.item.displayName }),
+            'Correct aria-label');
         assert.dom('[data-test-file-list-link]').hasClass(styles.Unviewed, 'Link is styled as unviewed');
-        assert.dom('[data-test-file-list-link]').hasText(this.item.name, 'Link has correct text');
-    });
-
-    test('it renders provider-specific data', async function(this: FileItemTestContext, assert) {
-        this.manager.parentFolder = 'fakeParentFolder';
-        this.item.providerSpecificData = {
-            titleSuffix: 'fakeTitleSuffix',
-        };
-        await render(
-            hbs`<FileBrowser::FileItem @manager={{this.manager}} @item={{this.item}} @isDesktop={{true}} />`,
-        );
-        assert.dom('[data-test-file-list-checkout]').doesNotExist('Checkout icon does not exist');
-        assert.dom('[data-test-file-list-link]').hasAria('label',
-            t('osf-components.file-browser.view_file', { fileName: this.item.name }), 'Correct aria-label');
-        assert.dom('[data-test-file-list-link]').doesNotHaveClass(styles.Unviewed, 'Link is not styled as unviewed');
-        assert.dom('[data-test-file-list-link]')
-            .hasText(this.item.name + ' ' + this.item.providerSpecificData.titleSuffix, 'Link has correct text');
+        assert.dom('[data-test-file-list-link]').hasText(this.item.displayName, 'Link has correct text');
     });
 });

--- a/tests/unit/packages/files/dataverse-file-test.ts
+++ b/tests/unit/packages/files/dataverse-file-test.ts
@@ -1,0 +1,29 @@
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { t } from 'ember-intl/test-support';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import DataverseFile from 'ember-osf-web/packages/files/dataverse-file';
+
+module('Unit | Packages | files | dataverse-file', hooks => {
+    setupTest(hooks);
+    setupMirage(hooks);
+    test('proper display names', async function(assert) {
+        const mirageFilePublished = server.create('file');
+        mirageFilePublished.extra.datasetVersion = 'latest-published';
+        const publishedFile = await this.owner.lookup('service:store').findRecord('file', mirageFilePublished.id);
+        const publishedDataverseFile = new DataverseFile(this.owner.lookup('service:current-user'), publishedFile);
+        const publishedSuffix = t('osf-components.file-browser.provider-specific-data.dataverse.latest-published');
+        assert.equal(publishedDataverseFile.displayName,
+            publishedDataverseFile.name + ' ' + publishedSuffix,
+            'Published dataverse file has correct display name');
+
+        const mirageFileDraft = server.create('file');
+        mirageFileDraft.extra.datasetVersion = 'latest';
+        const draftFile = await this.owner.lookup('service:store').findRecord('file', mirageFileDraft.id);
+        const draftDataverseFile = new DataverseFile(this.owner.lookup('service:current-user'), draftFile);
+        const draftSuffix = t('osf-components.file-browser.provider-specific-data.dataverse.latest');
+        assert.equal(draftDataverseFile.displayName,
+            draftDataverseFile.name + ' ' + draftSuffix,
+            'Draft dataverse file has correct display name');
+    });
+});

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1898,6 +1898,10 @@ osf-components:
             onedrive: 'OneDrive'
             owncloud: 'ownCloud'
             s3: 'Amazon S3'
+        provider-specific-data:
+            dataverse:
+                latest-published: '(Published)'
+                latest: '(Draft)'
         empty_folder: 'This folder is empty.'
         breadcrumbs: 'Breadcrumb'
         create_folder:


### PR DESCRIPTION
-   Ticket: [ENG-3879]
-   Feature flag: n/a

## Purpose
- Show which files are draft vs published for dataverse

## Summary of Changes
- Add `providerSpecificData` object to File abstract class
  - Add `titleSuffix` to this object
  - Add suffix for file list view and file detail view
- Add test for checked out, unviewed, and dataverse files

## Screenshot(s)
- list view
<img width="1139" alt="image" src="https://user-images.githubusercontent.com/51409893/178295784-ea753eec-3881-4473-ae96-dd90d2bfddd3.png">
- file detail view
<img width="657" alt="image" src="https://user-images.githubusercontent.com/51409893/178296473-1a2430de-7c9f-4abc-999f-7ecd0eb0c3d5.png">


## Side Effects
- None

## QA Notes
- We show both versions as separate files in the file list view, so I've added some text to distinguish which one is the published version

[ENG-3879]: https://openscience.atlassian.net/browse/ENG-3879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ