### PR TITLE
[ENG-3886] Hide node-files page links based on permission

### DIFF
--- a/app/guid-node/files/provider/controller.ts
+++ b/app/guid-node/files/provider/controller.ts
@@ -2,8 +2,11 @@ import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import Media from 'ember-responsive';
 
+import CurrentUser from 'ember-osf-web/services/current-user';
+
 export default class GuidNodeFilesProvider extends Controller {
     @service media!: Media;
+    @service currentUser!: CurrentUser;
 
     get isDesktop() {
         return this.media.isDesktop;

--- a/app/guid-node/files/provider/route.ts
+++ b/app/guid-node/files/provider/route.ts
@@ -8,13 +8,10 @@ import Intl from 'ember-intl/services/intl';
 import Toast from 'ember-toastr/services/toast';
 import FileProviderModel from 'ember-osf-web/models/file-provider';
 import NodeModel from 'ember-osf-web/models/node';
-import { Permission } from 'ember-osf-web/models/osf-model';
 import { GuidRouteModel } from 'ember-osf-web/resolve-guid/guid-route';
-import CurrentUser from 'ember-osf-web/services/current-user';
 import captureException, { getApiErrorMessage } from 'ember-osf-web/utils/capture-exception';
 
 export default class GuidNodeFilesProviderRoute extends Route.extend({}) {
-    @service currentUser!: CurrentUser;
     @service intl!: Intl;
     @service toast!: Toast;
 
@@ -30,9 +27,7 @@ export default class GuidNodeFilesProviderRoute extends Route.extend({}) {
                 },
             );
             const provider = fileProviders.findBy('id', fileProviderId) as FileProviderModel;
-            const hasWritePermission = node.currentUserPermissions.includes(Permission.Write);
-            const isViewOnly = Boolean(this.currentUser.viewOnlyToken);
-            return {provider, fileProviders, node, hasWritePermission, isViewOnly};
+            return {provider, fileProviders, node};
         } catch (e) {
             const errorMessage = this.intl.t(
                 'osf-components.file-browser.errors.load_file_providers',

--- a/app/guid-node/files/provider/template.hbs
+++ b/app/guid-node/files/provider/template.hbs
@@ -81,16 +81,14 @@
                     @label={{t 'node.left_nav.wiki'}}
                 />
             {{/if}}
-            {{#unless this.model.providerTask.value.isViewOnly}}
-                <leftNav.link
-                    data-test-analytics-link
-                    data-analytics-name='Analytics' 
-                    @route='guid-node.analytics'
-                    @models={{array this.model.node.guid}}
-                    @icon='chart-bar'
-                    @label={{t 'node.left_nav.analytics'}}
-                />
-            {{/unless}}
+            <leftNav.link
+                data-test-analytics-link
+                data-analytics-name='Analytics' 
+                @route='guid-node.analytics'
+                @models={{array this.model.node.guid}}
+                @icon='chart-bar'
+                @label={{t 'node.left_nav.analytics'}}
+            />
             {{#unless this.model.providerTask.value.node.isAnonymous}}
                 <leftNav.link
                     data-test-registrations-link
@@ -101,15 +99,17 @@
                     @label={{t 'node.left_nav.registrations'}}
                 />
             {{/unless}}
-            {{#unless this.model.providerTask.value.isViewOnly}}
-                <leftNav.link
-                    data-test-contributors-link
-                    data-analytics-name='Contributors'
-                    @href='/{{this.model.node.guid}}/contributors/'
-                    @icon='users'
-                    @label={{t 'node.left_nav.contributors'}}
-                />
-                {{#if this.model.providerTask.value.hasWritePermission}}
+            {{#unless this.currentUser.viewOnlyToken}}
+                {{#if this.this.model.providerTask.value.node.userHasReadPermission}}
+                    <leftNav.link
+                        data-test-contributors-link
+                        data-analytics-name='Contributors'
+                        @href='/{{this.model.node.guid}}/contributors/'
+                        @icon='users'
+                        @label={{t 'node.left_nav.contributors'}}
+                    />
+                {{/if}}
+                {{#if this.model.providerTask.value.node.userHasWritePermission}}
                     <leftNav.link
                         data-test-addons-link
                         data-analytics-name='Add-ons'
@@ -118,13 +118,15 @@
                         @label={{t 'node.left_nav.add-ons'}}
                     />
                 {{/if}}
-                <leftNav.link
-                    data-test-settings-link
-                    data-analytics-name='Settings'
-                    @href='/{{this.model.node.guid}}/settings/'
-                    @icon='cogs'
-                    @label={{t 'node.left_nav.settings'}}
-                />
+                {{#if this.this.model.providerTask.value.node.userHasReadPermission}}
+                    <leftNav.link
+                        data-test-settings-link
+                        data-analytics-name='Settings'
+                        @href='/{{this.model.node.guid}}/settings/'
+                        @icon='cogs'
+                        @label={{t 'node.left_nav.settings'}}
+                    />
+                {{/if}}
             {{/unless}}
         </layout.leftNavOld>
         <layout.main local-class='OverviewBody'>
@@ -134,13 +136,13 @@
                 {{#let (get mapper this.model.providerName) as |ProviderManager|}}
                     <ProviderManager
                         @provider={{this.model.providerTask.value.provider}}
-                        @isViewOnly={{this.model.providerTask.value.isViewOnly}}
+                        @isViewOnly={{this.model.providerTask.value.currentUser.viewOnlyToken}}
                         as |manager|
                     >
                         <div local-class='FileBrowser'>
                             <FileBrowser
                                 @manager={{manager}}
-                                @selectable={{not this.model.providerTask.value.isViewOnly}}
+                                @selectable={{not this.model.providerTask.value.currentUser.viewOnlyToken}}
                                 @enableUpload={{true}}
                             />
                         </div>

--- a/app/guid-node/files/provider/template.hbs
+++ b/app/guid-node/files/provider/template.hbs
@@ -81,14 +81,16 @@
                     @label={{t 'node.left_nav.wiki'}}
                 />
             {{/if}}
-            <leftNav.link
-                data-test-analytics-link
-                data-analytics-name='Analytics' 
-                @route='guid-node.analytics'
-                @models={{array this.model.node.guid}}
-                @icon='chart-bar'
-                @label={{t 'node.left_nav.analytics'}}
-            />
+            {{#if (or this.model.providerTask.value.node.public this.model.providerTask.value.node.userHasReadPermission)}}
+                <leftNav.link
+                    data-test-analytics-link
+                    data-analytics-name='Analytics' 
+                    @route='guid-node.analytics'
+                    @models={{array this.model.node.guid}}
+                    @icon='chart-bar'
+                    @label={{t 'node.left_nav.analytics'}}
+                />
+            {{/if}}
             {{#unless this.model.providerTask.value.node.isAnonymous}}
                 <leftNav.link
                     data-test-registrations-link
@@ -100,7 +102,7 @@
                 />
             {{/unless}}
             {{#unless this.currentUser.viewOnlyToken}}
-                {{#if this.this.model.providerTask.value.node.userHasReadPermission}}
+                {{#if this.model.providerTask.value.node.userHasReadPermission}}
                     <leftNav.link
                         data-test-contributors-link
                         data-analytics-name='Contributors'

--- a/app/models/node.ts
+++ b/app/models/node.ts
@@ -87,7 +87,7 @@ export default class NodeModel extends AbstractNodeModel.extend(Validations, Col
     @attr('fixstring') title!: string;
     @attr('fixstring') description!: string;
     @attr('node-category') category!: NodeCategory;
-     @attr('boolean') currentUserIsContributor!: boolean;
+    @attr('boolean') currentUserIsContributor!: boolean;
     @attr('boolean') fork!: boolean;
     @alias('fork') isFork!: boolean;
     @attr('boolean') collection!: boolean;

--- a/tests/acceptance/guid-node/files-test.ts
+++ b/tests/acceptance/guid-node/files-test.ts
@@ -10,6 +10,7 @@ import { click, setupOSFApplicationTest, visit } from 'ember-osf-web/tests/helpe
 import NodeModel from 'ember-osf-web/models/node';
 import FileModel from 'ember-osf-web/models/file';
 import FileProviderModel from 'ember-osf-web/models/file-provider';
+import { Permission } from 'ember-osf-web/models/osf-model';
 
 interface GuidNodeTestContext extends TestContext {
     node: ModelInstance<NodeModel>;
@@ -31,7 +32,34 @@ module('Acceptance | guid-node/files', hooks => {
         });
     });
 
+    test('left-nav: VOL', async function(this: GuidNodeTestContext, assert) {
+        const currentUser = this.owner.lookup('service:current-user');
+        currentUser.viewOnlyToken = 'SomeVolToken';
+        await visit(`/${this.node.id}/files`);
+        assert.equal(currentRouteName(), 'guid-node.files.provider', 'VOL: Current route is files');
+        assert.dom('[data-test-overview-link]').exists('VOL: Overview link exists');
+        assert.dom('[data-test-files-link]').exists('VOL: Files link exists');
+        assert.dom('[data-test-analytics-link]').exists('VOL: Analytics link exists');
+        assert.dom('[data-test-registrations-link]').exists('VOL: Registrations link exists');
+        assert.dom('[data-test-contributors-link]').doesNotExist('VOL: Contributors link does not exist');
+        assert.dom('[data-test-settings-link]').doesNotExist('VOL: Settings link does not exist');
+    });
+
+    test('left-nav: AVOL', async function(this: GuidNodeTestContext, assert) {
+        const node = await this.owner.lookup('service:store').findRecord('node', this.node.id);
+        node.apiMeta = { version: '2', anonymous: true };
+        await visit(`/${this.node.id}/files`);
+        assert.equal(currentRouteName(), 'guid-node.files.provider', 'AVOL: Current route is files');
+        assert.dom('[data-test-overview-link]').exists('AVOL: Overview link exists');
+        assert.dom('[data-test-files-link]').exists('AVOL: Files link exists');
+        assert.dom('[data-test-analytics-link]').exists('AVOL: Analytics link exists');
+        assert.dom('[data-test-registrations-link]').doesNotExist('AVOL: Registrations link does not exist');
+        assert.dom('[data-test-contributors-link]').doesNotExist('AVOL: Contributors link does not exist');
+        assert.dom('[data-test-settings-link]').doesNotExist('AVOL: Settings link does not exist');
+    });
+
     test('read user', async function(this: GuidNodeTestContext, assert) {
+        this.node.currentUserPermissions = [Permission.Read];
         await visit(`/${this.node.id}/files`);
 
         assert.equal(currentRouteName(), 'guid-node.files.provider', 'Current route is files');

--- a/tests/acceptance/guid-node/files-test.ts
+++ b/tests/acceptance/guid-node/files-test.ts
@@ -32,6 +32,17 @@ module('Acceptance | guid-node/files', hooks => {
         });
     });
 
+    test('left-nav: logged out', async function(this: GuidNodeTestContext, assert) {
+        await visit(`/${this.node.id}/files`);
+        assert.equal(currentRouteName(), 'guid-node.files.provider', 'logged out: Current route is files');
+        assert.dom('[data-test-overview-link]').exists('logged out: Overview link exists');
+        assert.dom('[data-test-files-link]').exists('logged out: Files link exists');
+        assert.dom('[data-test-analytics-link]').exists('logged out: Analytics link exists');
+        assert.dom('[data-test-registrations-link]').exists('logged out: Registrations link exists');
+        assert.dom('[data-test-contributors-link]').doesNotExist('logged out: Contributors link does not exist');
+        assert.dom('[data-test-settings-link]').doesNotExist('logged out: Settings link does not exist');
+    });
+
     test('left-nav: VOL', async function(this: GuidNodeTestContext, assert) {
         const currentUser = this.owner.lookup('service:current-user');
         currentUser.viewOnlyToken = 'SomeVolToken';


### PR DESCRIPTION
-   Ticket: [ENG-3886]
-   Feature flag: n/a

## Purpose
- Hide `Contributors` and `Settings` link for non-contributors

## Summary of Changes
- Add condition to show/hide Contributors and Settings links
- Remove logic around Analytics link (doesn't match legacy page)

## Screenshot(s)
- AVOL:
  - <img width="269" alt="image" src="https://user-images.githubusercontent.com/51409893/178378152-89b5fae0-eaab-4728-a12e-38ee6e7b3bcd.png">
  - <img width="195" alt="image" src="https://user-images.githubusercontent.com/51409893/178378182-04af66f8-b63d-4572-8033-1bd7aed76bf9.png">


- VOL:
  - <img width="347" alt="image" src="https://user-images.githubusercontent.com/51409893/178378095-825250d7-696b-4de2-a095-fb2c6c5358c9.png">
  - <img width="190" alt="image" src="https://user-images.githubusercontent.com/51409893/178378128-5a0946d5-42b3-4198-91f8-8f745780f3c5.png">


- Non-Contrib:
  - <img width="567" alt="image" src="https://user-images.githubusercontent.com/51409893/178378016-8025ca20-f0a9-4cec-a0be-e1a3b0694ed7.png">
  - <img width="228" alt="image" src="https://user-images.githubusercontent.com/51409893/178378049-16ea3026-e592-454f-a06d-6feeb3d8e391.png">

- Read-only:
  - <img width="677" alt="image" src="https://user-images.githubusercontent.com/51409893/178377951-fc7ff8dd-f13a-481b-beca-2ea9d2a01c66.png">
  - <img width="207" alt="image" src="https://user-images.githubusercontent.com/51409893/178377980-1f481c61-6791-41a1-84c6-a33a8103f941.png">


- Admin:
  - <img width="569" alt="image" src="https://user-images.githubusercontent.com/51409893/178377853-595efef9-59c6-4ebc-bf1c-f9be055ae552.png">
  - <img width="151" alt="image" src="https://user-images.githubusercontent.com/51409893/178377900-caecf9ab-9e03-4f14-9b43-ee8cc219c93e.png">


## Side Effects
- Analytics link was hidden prior, but that didn't match the legacy page's behavior

## QA Notes
- The screenshots for VOL and AVOL are for logged out users. Logged out users should see the same links as any other non-contributor (Files, Wiki, Analytics, Registrations)

[ENG-3886]: https://openscience.atlassian.net/browse/ENG-3886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ