### PR TITLE
[ENG-3914] New route

### DIFF
--- a/lib/registries/addon/overview/files/styles.scss
+++ b/lib/registries/addon/overview/files/styles.scss
@@ -1,0 +1,45 @@
+.NavTabs {
+    border-bottom-color: #d0d0d0;
+    border-bottom-width: 1px;
+    width: 100%;
+    border-bottom-style: solid;
+
+    ul {
+
+        list-style-image: none;
+        list-style-position: outside;
+        list-style-type: none;
+        margin-left: 0;
+        margin-bottom: 0;
+        line-height: 20px;
+        padding: 0 0 41px;
+
+        a {
+            box-sizing: border-box;
+            border: 0;
+            color: $color-text-black;
+            background: none;
+            padding: 10px 15px;
+            float: left;
+    
+            
+        }
+
+        a:hover {
+            border: 0;
+            color: $color-text-gray;
+            background-color: #e4e4e4;
+            border-bottom-color: $color-text-gray;
+            border-bottom-width: 2px;
+            border-bottom-style: solid;
+        }
+
+        a:global(.active) {
+            color: $color-text-gray;
+            background-color: #e4e4e4;
+            border-bottom-color: $color-text-gray;
+            border-bottom-width: 2px;
+            border-bottom-style: solid;
+        }
+    }
+}

--- a/lib/registries/addon/overview/files/template.hbs
+++ b/lib/registries/addon/overview/files/template.hbs
@@ -1,3 +1,28 @@
 {{page-title (t 'registries.overview.files.title')}}
+<div local-class='NavTabs'>
+    <ul>
+        <li local-class='NavItem {{if (not (eq this.model.currentRoute 'overview.files.outputs')) 'Selected'}}'>
+            <OsfLink
+                data-test-files-tab-link
+                data-analytics-name='Files tab'
+                @route='registries.overview.files.provider'
+                @models={{array this.model.guid 'osfstorage'}}
+            >
+                {{t 'registries.files.tabs.files'}}
+            </OsfLink>
+        </li>
+        <li local-class='NavItem {{if (eq this.model.currentRoute 'overview.files.outputs') 'Selected'}}'>
+            <OsfLink
+                data-test-outputs-tab-link
+                data-analytics-name='Outputs tab'
+                @route='registries.overview.files.outputs'
+                @models={{array this.model.guid}}
+            >
+                {{t 'registries.files.tabs.outputs'}}
+            </OsfLink>
+            
+        </li>
+    </ul>
+</div>
 
 {{outlet}}

--- a/lib/registries/addon/overview/files/template.hbs
+++ b/lib/registries/addon/overview/files/template.hbs
@@ -20,7 +20,6 @@
             >
                 {{t 'registries.files.tabs.outputs'}}
             </OsfLink>
-            
         </li>
     </ul>
 </div>

--- a/lib/registries/addon/overview/files/template.hbs
+++ b/lib/registries/addon/overview/files/template.hbs
@@ -1,7 +1,7 @@
 {{page-title (t 'registries.overview.files.title')}}
 <div local-class='NavTabs'>
     <ul>
-        <li local-class='NavItem {{if (not (eq this.model.currentRoute 'overview.files.outputs')) 'Selected'}}'>
+        <li local-class='NavItem'>
             <OsfLink
                 data-test-files-tab-link
                 data-analytics-name='Files tab'
@@ -11,7 +11,7 @@
                 {{t 'registries.files.tabs.files'}}
             </OsfLink>
         </li>
-        <li local-class='NavItem {{if (eq this.model.currentRoute 'overview.files.outputs') 'Selected'}}'>
+        <li local-class='NavItem'>
             <OsfLink
                 data-test-outputs-tab-link
                 data-analytics-name='Outputs tab'

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -64,8 +64,8 @@
                         @models={{array this.registration.id}} @icon='home' @label={{t 'registries.overview.title'}} />
                     {{#if this.registrationFilesPageEnabled}}
                         <leftNav.link data-analytics-name='Files' 
-                            @route='registries.overview.files'
-                            @models={{array this.registration.id}}
+                            @route='registries.overview.files.provider'
+                            @models={{array this.registration.id 'osfstorage'}}
                             @icon='file-alt'
                             @label={{t 'registries.overview.files.title'}}
                         />

--- a/lib/registries/addon/routes.ts
+++ b/lib/registries/addon/routes.ts
@@ -41,6 +41,7 @@ export default buildRoutes(function() {
         this.route('comments');
         this.route('files', function() {
             this.route('provider', { path: '/:providerId' });
+            this.route('outputs');
         });
         this.route('forks');
         this.route('links');

--- a/mirage/factories/root.ts
+++ b/mirage/factories/root.ts
@@ -10,6 +10,7 @@ const {
         navigation,
         storageI18n,
         verifyEmailModals,
+        registrationFilesPage,
     },
 } = config;
 
@@ -35,6 +36,7 @@ export const defaultRootAttrs = {
         ...Object.values(navigation),
         storageI18n,
         verifyEmailModals,
+        registrationFilesPage,
     ])],
     message: 'Welcome to the OSF API.',
     version: '2.8',

--- a/tests/engines/registries/acceptance/overview/files-test.ts
+++ b/tests/engines/registries/acceptance/overview/files-test.ts
@@ -69,6 +69,40 @@ module('Registries | Acceptance | overview.files', hooks => {
 
     });
 
+    test('Files tabs', async assert => {
+        const registration = server.create(
+            'registration',
+            { currentUserPermissions: [Permission.Admin] },
+            'withFiles',
+        );
+
+        await visit(`/${registration.id}/files`);
+        assert.equal(currentURL(), `/${registration.id}/files`, 'At registration files list URL');
+        assert.equal(currentRouteName(), 'registries.overview.files.provider', 'At the files provider route');
+
+        assert.dom('[data-test-files-tab-link]').exists('Files tab exists');
+        assert.dom('[data-test-files-tab-link]').hasClass('active', 'Files tab is highlighted');
+        assert.dom('[data-test-outputs-tab-link]').exists('Outputs tab exists');
+
+        await click('[data-test-outputs-tab-link]');
+        assert.equal(
+            currentURL(),
+            `/--registries/${registration.id}/files/outputs?mode=&revisionId=&view_only=`,
+            'At registration outputs list URL',
+        );
+        assert.equal(currentRouteName(), 'registries.overview.files.outputs', 'At the outputs route');
+        assert.dom('[data-test-outputs-tab-link]').hasClass('active', 'Outputs tab is highlighted');
+
+        await click('[data-test-files-tab-link]');
+        assert.equal(
+            currentURL(),
+            `/--registries/${registration.id}/files/osfstorage?mode=&revisionId=&view_only=`,
+            'At registration files list URL again',
+        );
+        assert.equal(currentRouteName(), 'registries.overview.files.provider', 'At the files provider route again');
+
+    });
+
     test('No files', async assert => {
         const registration = server.create('registration');
 

--- a/tests/engines/registries/acceptance/overview/index-test.ts
+++ b/tests/engines/registries/acceptance/overview/index-test.ts
@@ -69,6 +69,10 @@ module('Registries | Acceptance | overview.index', hooks => {
             name: 'Links',
             route: 'registries.overview.links',
             url: `/--registries/${this.registration.id}/links`,
+        }, {
+            name: 'Files',
+            route: 'registries.overview.files.provider',
+            url: `/--registries/${this.registration.id}/files/osfstorage`,
         }];
 
         for (const testCase of testCases) {
@@ -83,9 +87,6 @@ module('Registries | Acceptance | overview.index', hooks => {
 
     test('sidenav hrefs', async function(this: OverviewTestContext, assert: Assert) {
         const testCases = [{
-            selector: '[data-analytics-name="Files"]',
-            href: `/${this.registration.id}/files/`,
-        }, {
             selector: '[data-test-wiki-link]',
             href: `/${this.registration.id}/wiki/`,
         }];

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1594,6 +1594,11 @@ registries:
         learnMore: 'Click <a href="https://help.osf.io/hc/en-us/articles/360035806634-Edit-Registration-Metadata" target="_blank">here</a>  to learn more.'
         next: Next
         cancel_update: 'Cancel update'
+    files:
+        tabs:
+            files: 'Files'
+            outputs: 'Outputs'
+
 meetings:
     index:
         meetings-list:


### PR DESCRIPTION
-   Ticket: [ENG-3914]
-   Feature flag: n/a

## Purpose

Add the new route, and tabs to take advantage of the route, for output reporting.

## Summary of Changes

1. Add route
2. Add tabs and styling
3. Correct link in leftnav for files so it will have the proper file route to prevent regression
4. Add registries files flag to mirage default root scenario
5. Test tabs
6. Add localization strings

## Screenshot(s)
<img width="1462" alt="Screen Shot 2022-07-12 at 9 05 50 AM" src="https://user-images.githubusercontent.com/6599111/178496883-49e6e26e-9230-459b-8935-f1c606511b7f.png">

<img width="1462" alt="Screen Shot 2022-07-12 at 9 05 45 AM" src="https://user-images.githubusercontent.com/6599111/178496891-d0d9f917-c3dc-4830-9a9f-b38abb1f6aab.png">

## Side Effects

Shouldn't be.

## QA Notes

Make sure the tabs go where they're supposed to.


[ENG-3914]: https://openscience.atlassian.net/browse/ENG-3914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ