### PR TITLE
Revert "[ENG-3748] Remove opacity filter from branded providers"

### DIFF
--- a/lib/registries/addon/components/hero-overlay/styles.scss
+++ b/lib/registries/addon/components/hero-overlay/styles.scss
@@ -30,6 +30,7 @@
 
     &::after {
         @include primary-color-bg;
+        opacity: 0.4;
         display: block;
         z-index: -1; /* should be in front of the ::before defined below */
     }


### PR DESCRIPTION
Reverts CenterForOpenScience/ember-osf-web#1568

Relevant flowdock conversation here: https://www.flowdock.com/app/cos/embosf/threads/L1C4u55cVmIEYH_TBhClo33qRfo
Key takeaway: removing the opacity from the overlay hid the banner image below it. Extra work would have been needed to balance out background image, brand color, registration title, etc