### PR TITLE
[ENG-3917] Create folder/rename file bugs

### DIFF
--- a/lib/osf-components/addon/components/file-browser/add-new/create-folder-modal/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/add-new/create-folder-modal/template.hbs
@@ -10,11 +10,11 @@
         <label>
             <p>{{t 'osf-components.file-browser.create_folder.new_folder_name'}}</p>
             <Input
-                @enter={{queue
+                @enter={{unless this.isInvalid (queue
                     (perform @manager.createNewFolder this.newFolderName)
                     (action (mut @isOpen) false)
                     (action (mut this.newFolderName) '')
-                }}
+                )}}
                 @value={{this.newFolderName}}
                 local-class='RenameInput'
             />

--- a/lib/osf-components/addon/components/file-browser/file-rename-modal/component.ts
+++ b/lib/osf-components/addon/components/file-browser/file-rename-modal/component.ts
@@ -68,12 +68,12 @@ export default class FileRenameModal extends Component<Args> {
     async updateFileName() {
         const newName = this.newFileName;
         const successMessage = this.intl.t('osf-components.file-browser.file_rename_modal.success_message');
-        if (!newName) {
+        if (!this.isValid) {
             return;
         }
 
         try {
-            const trimmedName = newName.trim();
+            const trimmedName = newName!.trim();
             await this.args.item.rename(trimmedName, '');
             this.toast.success(successMessage);
             this.args.manager.reload();

--- a/lib/osf-components/addon/components/file-browser/file-rename-modal/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/file-rename-modal/template.hbs
@@ -15,10 +15,10 @@
                 aria-label={{t 'osf-components.file-browser.file_rename_modal.input_aria'}}
                 @value={{this.newFileName}}
                 @type='text'
-                @enter={{queue
+                @enter={{if this.isValid (queue
                     (perform this.updateFileName)
                     dialog.close
-                }}
+                )}}
             />
             {{#unless this.isValid}}
                 <p local-class='ErrorText'>

--- a/tests/integration/components/file-browser/file-rename-modal/component-test.ts
+++ b/tests/integration/components/file-browser/file-rename-modal/component-test.ts
@@ -1,4 +1,4 @@
-import { render } from '@ember/test-helpers';
+import { render, triggerKeyEvent } from '@ember/test-helpers';
 import fillIn from '@ember/test-helpers/dom/fill-in';
 import { hbs } from 'ember-cli-htmlbars';
 import { t, TestContext } from 'ember-intl/test-support';
@@ -16,15 +16,18 @@ interface FileItem {
     links: Links;
     dateModified: string;
     id: string;
+    rename: () => void;
 }
 
 interface Manager {
     parentFolder: any;
+    reload: () => void;
 }
 
 interface FileRenameModalTestContext extends TestContext {
     manager: Manager;
     item: FileItem;
+    isOpen: boolean;
 }
 
 module('Integration | Component | file-browser :: file-rename-modal', hooks => {
@@ -38,10 +41,13 @@ module('Integration | Component | file-browser :: file-rename-modal', hooks => {
                 download: 'thisisafakedownloadlink',
             },
             dateModified: Date(),
+            rename: () => {/* noop */},
         };
         this.manager = {
             parentFolder: null,
+            reload: () => {/* noop */},
         };
+        this.isOpen = true;
     });
 
     test('it renders with a disabled button when name is the same, button enabled whem name is different',
@@ -85,5 +91,33 @@ module('Integration | Component | file-browser :: file-rename-modal', hooks => {
 
             await fillIn('[data-test-user-input]', 'Save this file');
             assert.dom('[data-test-disabled-rename]').isEnabled('Save button is enabled');
+        });
+
+    test('enter key triggers rename',
+        async function(this: FileRenameModalTestContext, assert): Promise<void> {
+            // check toast in lieu of modal closing
+            await render(
+                hbs`<FileBrowser::FileRenameModal @manager={{this.manager}} @item={{this.item}} @isOpen={{true}}/>`,
+            );
+            assert.dom('[data-test-file-rename-modal]').exists('File rename modal exists');
+            assert.dom('[data-test-user-input]').hasValue(this.item.name, 'File name pre-populated');
+            assert.dom('[data-test-disabled-rename]').isDisabled('Save button is disabled');
+            assert.dom('[data-test-rename-main]').containsText(
+                t('osf-components.file-browser.file_rename_modal.error_message'),
+            );
+            await triggerKeyEvent('[data-test-user-input]', 'keydown', 'Enter');
+            assert.dom('#toast-container', document as any).doesNotExist('Rename not triggered when no name change');
+
+            await fillIn('[data-test-user-input]', '');
+            assert.dom('[data-test-rename-main]').containsText(
+                t('osf-components.file-browser.file_rename_modal.error_empty_name'),
+            );
+            await triggerKeyEvent('[data-test-user-input]', 'keydown', 'Enter');
+            assert.dom('#toast-container', document as any).doesNotExist('Rename not triggered when name is empty');
+
+            await fillIn('[data-test-user-input]', 'New File Name');
+            assert.dom('[data-test-disabled-rename]').isEnabled('Save button is now enabled');
+            await triggerKeyEvent('[data-test-user-input]', 'keydown', 'Enter');
+            assert.dom('#toast-container', document as any).doesNotExist('Rename is fired');
         });
 });

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1975,6 +1975,7 @@ osf-components:
             clear_aria: 'Clear input field'
             success_message: 'File successfully renamed.'
             error_message: 'Please rename the file.'
+            error_empty_name: 'Please enter a file name.'
             error_ends_with_dot: 'File name cannot end with a period.'
             error_forbidden_chars: 'Please remove special characters from the file name.'
             retry_message: 'Rename failed.'


### PR DESCRIPTION
-   Ticket: [ENG-3917]
-   Feature flag: n/a

## Purpose
- Fix bugs with rename file and create folder modals when users hit "Enter" key to submit
- Add missing translation key
## Summary of Changes
- Only submit name change/new folder when users hit "Enter" for these modals
- Add missing translation key

## Screenshot(s)
- NA
## Side Effects
- NA
## QA Notes
- Rename modal with no text/whitespace only has been fixed as well


[ENG-3917]: https://openscience.atlassian.net/browse/ENG-3917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ