### PR TITLE
Add translation string for case of undefined resource type

### DIFF
--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1714,6 +1714,7 @@ osf-components:
         analytic_code: 'Analytic Code'
         papers: 'Papers'
         supplements: 'Supplements'
+        undefined: 'Choose one'
         no-resources: 'This registration has no resources.'
         badge_alt: '{type} badge'
         edit_resource:


### PR DESCRIPTION
## Purpose

When first creating a Resource, the back end send us a resource with a type of Undefined. The user has to choose a non-undefined type. There was no translation string for this case, so this PR adds that translation string.

## Summary of Changes

1. Add translation string

## Screenshot(s)

Buggy state:
<img width="757" alt="Screen Shot 2022-08-01 at 9 09 10 AM" src="https://user-images.githubusercontent.com/6599111/182158780-15e5db80-5ee2-433c-bbd7-a1421ca62f8a.png">

Mockups:
<img width="584" alt="Screen Shot 2022-08-01 at 9 45 14 AM" src="https://user-images.githubusercontent.com/6599111/182161812-30e210bf-0c62-4868-a3cc-361f9719e9ce.png">



