### PR TITLE
Add width to edit dialog

### DIFF
--- a/lib/osf-components/addon/components/resources-list/edit-resource/component.ts
+++ b/lib/osf-components/addon/components/resources-list/edit-resource/component.ts
@@ -10,6 +10,7 @@ import IntlService from 'ember-intl/services/intl';
 import RegistrationModel from 'ember-osf-web/models/registration';
 import ResourceModel, { ResourceTypes } from 'ember-osf-web/models/resource';
 import buildChangeset from 'ember-osf-web/utils/build-changeset';
+import Media from 'ember-responsive';
 import { tracked } from 'tracked-built-ins';
 
 interface Args {
@@ -28,6 +29,7 @@ export default class EditResourceModal extends Component<Args> {
     @service toast!: Toastr;
     @service intl!: IntlService;
     @service store!: DS.Store;
+    @service media!: Media;
 
     availableTypes = Object.values(ResourceTypes);
     resourceValidations: ValidationObject<ResourceValidations> = {
@@ -46,6 +48,10 @@ export default class EditResourceModal extends Component<Args> {
     @tracked changeset: any;
     @tracked resource?: ResourceModel = this.args.resource;
     @tracked shouldShowPreview = false;
+
+    get isMobile() {
+        return this.media.isMobile;
+    }
 
     @task
     async onOpen() {

--- a/lib/osf-components/addon/components/resources-list/edit-resource/styles.scss
+++ b/lib/osf-components/addon/components/resources-list/edit-resource/styles.scss
@@ -1,3 +1,7 @@
 .EditResourceDialog {
     width: 60vw;
 }
+
+.EditResourceDialogMobile {
+    width: 90vw;
+}

--- a/lib/osf-components/addon/components/resources-list/edit-resource/styles.scss
+++ b/lib/osf-components/addon/components/resources-list/edit-resource/styles.scss
@@ -1,3 +1,3 @@
-.editResourceDialog {
+.EditResourceDialog {
     width: 60vw;
 }

--- a/lib/osf-components/addon/components/resources-list/edit-resource/styles.scss
+++ b/lib/osf-components/addon/components/resources-list/edit-resource/styles.scss
@@ -1,0 +1,3 @@
+.editResourceDialog {
+    width: 60vw;
+}

--- a/lib/osf-components/addon/components/resources-list/edit-resource/template.hbs
+++ b/lib/osf-components/addon/components/resources-list/edit-resource/template.hbs
@@ -1,7 +1,7 @@
 <OsfDialog
     @onOpen={{perform this.onOpen}}
     @onClose={{this.onClose}}
-    local-class='EditResourceDialog'
+    local-class={{if this.isMobile 'EditResourceDialogMobile' 'EditResourceDialog'}}
     as |dialog|
 >
     <dialog.trigger

--- a/lib/osf-components/addon/components/resources-list/edit-resource/template.hbs
+++ b/lib/osf-components/addon/components/resources-list/edit-resource/template.hbs
@@ -1,6 +1,7 @@
 <OsfDialog
     @onOpen={{perform this.onOpen}}
     @onClose={{this.onClose}}
+    local-class='editResourceDialog'
     as |dialog|
 >
     <dialog.trigger

--- a/lib/osf-components/addon/components/resources-list/edit-resource/template.hbs
+++ b/lib/osf-components/addon/components/resources-list/edit-resource/template.hbs
@@ -1,7 +1,7 @@
 <OsfDialog
     @onOpen={{perform this.onOpen}}
     @onClose={{this.onClose}}
-    local-class='editResourceDialog'
+    local-class='EditResourceDialog'
     as |dialog|
 >
     <dialog.trigger


### PR DESCRIPTION
-   Ticket: [Notion](https://www.notion.so/cos/Add-edit-dialog-needs-a-width-c851803fa9f146bea3282f5c86b39b46)
-   Feature flag: n/a

## Purpose

Added a width to the edit dialog box

## Summary of Changes

1. Add local class
2. Add width to style of local-class
3. Add mobile checking and styling

## Screenshot(s)

Before:
<img width="308" alt="Screen Shot 2022-08-01 at 9 31 58 AM" src="https://user-images.githubusercontent.com/6599111/182383479-dd7da3e3-bd95-46c0-9800-b1ea3ed818f1.png">
<img width="757" alt="Screen Shot 2022-08-01 at 9 09 10 AM" src="https://user-images.githubusercontent.com/6599111/182383482-8b416a19-f831-442d-b653-87f3cbcd2b54.png">

After:
<img width="1199" alt="Screen Shot 2022-08-02 at 8 38 36 AM" src="https://user-images.githubusercontent.com/6599111/182383501-35cb08c2-63bc-40b6-b927-912a7b8ecbbe.png">
<img width="614" alt="Screen Shot 2022-08-02 at 10 57 52 AM" src="https://user-images.githubusercontent.com/6599111/182406423-6d83411b-ee6b-435a-ae77-9e31c8a9934f.png">



## Side Effects

Nope

