### PR TITLE
[ENG-3943] Revert dialog z-index and change file-action behavior

### DIFF
--- a/lib/osf-components/addon/components/file-actions-menu/template.hbs
+++ b/lib/osf-components/addon/components/file-actions-menu/template.hbs
@@ -22,7 +22,10 @@
         </OsfLink>
         {{#if @item.currentUserCanDelete}}
             <Button @layout='fake-link' local-class='DropdownItem' data-test-delete-button
-                {{on 'click' (fn (mut this.isDeleteModalOpen) true)}}
+                {{on 'click' (queue
+                    dropdown.close
+                    (fn (mut this.isDeleteModalOpen) true)
+                )}}
             >
                 <FaIcon @icon='trash-alt' />
                 {{t 'osf-components.file-browser.delete'}}
@@ -64,7 +67,10 @@
                         data-test-rename-link
                         data-analytics-name='Rename file'
                         local-class='DropdownItem'
-                        {{on 'click' this.openRenameModal}}
+                        {{on 'click' (queue
+                            dropdown.close
+                            this.openRenameModal
+                        )}}
                     >
                         <FaIcon @icon='pencil-alt' />
                         {{t 'file_actions_menu.rename'}}
@@ -74,7 +80,11 @@
                     @layout='fake-link'
                     local-class='DropdownItem'
                     data-test-move-button
-                    {{on 'click' (queue (action (mut this.useCopyModal) false) (action (mut this.moveModalOpen) true))}}
+                    {{on 'click' (queue
+                        dropdown.close
+                        (action (mut this.useCopyModal) false)
+                        (action (mut this.moveModalOpen) true)
+                    )}}
                 >
                     <FaIcon
                         @icon='arrow-right'
@@ -87,7 +97,11 @@
                     @layout='fake-link'
                     local-class='DropdownItem'
                     data-test-copy-button
-                    {{on 'click' (queue (action (mut this.useCopyModal) true) (action (mut this.moveModalOpen) true))}}
+                    {{on 'click' (queue
+                        dropdown.close
+                        (action (mut this.useCopyModal) true)
+                        (action (mut this.moveModalOpen) true)
+                    )}}
                 >
                     <FaIcon
                         @icon='copy'

--- a/lib/osf-components/addon/components/file-browser/folder-item/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/folder-item/template.hbs
@@ -69,8 +69,12 @@
                         {{#if @item.currentUserCanDelete}}
                             <Button
                                 @layout='fake-link'
-                                data-test-delete-button
-                                {{on 'click' (queue (action (mut this.useCopyModal) false) (action (mut this.moveModalOpen) true))}}
+                                data-test-move-button
+                                {{on 'click' (queue
+                                    dropdown.close
+                                    (action (mut this.useCopyModal) false)
+                                    (action (mut this.moveModalOpen) true)
+                                )}}
                             >
                                 <FaIcon
                                     @icon='arrow-right'
@@ -83,7 +87,11 @@
                                 @layout='fake-link'
                                 local-class='DropdownItem'
                                 data-test-copy-button
-                                {{on 'click' (queue (action (mut this.useCopyModal) true) (action (mut this.moveModalOpen) true))}}
+                                {{on 'click' (queue
+                                    dropdown.close
+                                    (action (mut this.useCopyModal) true)
+                                    (action (mut this.moveModalOpen) true)
+                                )}}
                             >
                                 <FaIcon
                                     @icon='copy'
@@ -97,7 +105,10 @@
                                 data-test-rename-link
                                 data-analytics-name='Rename folder'
                                 local-class='DropdownItem'
-                                {{on 'click' (fn (mut this.renameModalOpen) true)}}
+                                {{on 'click' (queue
+                                    dropdown.close
+                                    (fn (mut this.renameModalOpen) true)
+                                )}}
                             >
                                 <FaIcon @icon='pencil-alt' />
                                 {{t 'file_actions_menu.rename'}}
@@ -105,8 +116,11 @@
                             <Button
                                 @layout='fake-link'
                                 local-class='DropdownItem'
-                                data-test-move-button
-                                {{on 'click' (fn (mut this.isDeleteModalOpen) true)}}
+                                data-test-delete-button
+                                {{on 'click' (queue
+                                    dropdown.close
+                                    (fn (mut this.isDeleteModalOpen) true)
+                                )}}
                             >
                                 <FaIcon @icon='trash-alt' />
                                 {{t 'osf-components.file-browser.delete'}}

--- a/lib/osf-components/addon/components/osf-dialog/styles.scss
+++ b/lib/osf-components/addon/components/osf-dialog/styles.scss
@@ -11,7 +11,7 @@
     align-items: center;
     justify-content: center;
 
-    z-index: 1100;
+    z-index: 900;
     background-color: rgba(0, 0, 0, 0.5);
 }
 

--- a/lib/osf-components/addon/components/resources-list/edit-resource/template.hbs
+++ b/lib/osf-components/addon/components/resources-list/edit-resource/template.hbs
@@ -38,7 +38,6 @@
                         @label={{t 'osf-components.resources-list.edit_resource.output_type'}}
                         @options={{this.availableTypes}}
                         @searchEnabled={{false}}
-                        @renderInPlace={{true}}
                         as |type|
                     >
                         {{t (concat 'osf-components.resources-list.' type)}}


### PR DESCRIPTION
-   Ticket: [ENG-3943]
-   Feature flag: n/a

## Purpose
- Revert z-index of dialog backgrounds to prevent bad behaviors associated with dropdowns in modal windows
  - We bumped the z-index up due to some issues with mobile view for Files Page Phase II in this PR here: https://github.com/CenterForOpenScience/ember-osf-web/pull/1529 to address the problem found here: https://www.notion.so/cos/Files-Page-Phase-II-Bugs-Found-2daf0384e75f43c18bef48c60e4b58be#02af2801c0f243b99b4c8be9ab0aef28
- Prevent issue where opening the "Resource Type" dropdown using the 🔽 down caret would immediately close the dropdown options

## Summary of Changes
- Revert z-index for dialog background to 900
- Close dropdown when selecting a file/folder action to prevent them from showing up simultaneously and obscuring each other

## Screenshot(s)
Prevents dropdown content from being hidden behind blurred background as seen here:
![image](https://user-images.githubusercontent.com/51409893/182443024-b91779b9-77e0-4b51-90a3-d4f3b0505180.png)

Should also avoid views like this:
![image](https://user-images.githubusercontent.com/51409893/182465915-92c010ef-97dd-4c21-8f80-4a6accf9e47e.png)



## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- The sharing and embed options for files/folders shows up on top of the existing folder/file action dropdown menu in mobile view (behavior unchanged), but opening the delete, move/copy, and rename modals should automatically close the file/folder action dropdown menu


[ENG-3943]: https://openscience.atlassian.net/browse/ENG-3943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ