### PR TITLE
Add extra validation for resource type

### DIFF
--- a/lib/osf-components/addon/components/resources-list/edit-resource/component.ts
+++ b/lib/osf-components/addon/components/resources-list/edit-resource/component.ts
@@ -3,7 +3,7 @@ import { inject as service } from '@ember/service';
 import { waitFor } from '@ember/test-waiters';
 import Component from '@glimmer/component';
 import { ValidationObject } from 'ember-changeset-validations';
-import { validatePresence } from 'ember-changeset-validations/validators';
+import { validateExclusion, validatePresence } from 'ember-changeset-validations/validators';
 import { task } from 'ember-concurrency';
 import DS from 'ember-data';
 import IntlService from 'ember-intl/services/intl';
@@ -38,11 +38,19 @@ export default class EditResourceModal extends Component<Args> {
             presence: true,
             translationArgs: { description: this.intl.t('osf-components.resources-list.edit_resource.doi') },
         })],
-        resourceType: [validatePresence({
-            type: 'blank',
-            presence: true,
-            translationArgs: { description: this.intl.t('osf-components.resources-list.edit_resource.output_type') },
-        })],
+        resourceType: [
+            validatePresence({
+                type: 'blank',
+                presence: true,
+                translationArgs: {
+                    description: this.intl.t('osf-components.resources-list.edit_resource.output_type'),
+                },
+            }),
+            validateExclusion({
+                list: ['undefined'],
+                type: 'mustSelect',
+            }),
+        ],
     };
 
     @tracked changeset: any;


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Prevent users from adding a resource of type 'undefined'

## Summary of Changes
- Explicitly check if resource type is 'undefined'

## Screenshot(s)
![image](https://user-images.githubusercontent.com/51409893/182474369-3856993f-87ec-4dfa-9467-bd98c71c217b.png)
## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
