### PR TITLE
[ENG-3905] rename open_badges to related_resource_types

### DIFF
--- a/lib/registries/addon/components/registries-search-result/template.hbs
+++ b/lib/registries/addon/components/registries-search-result/template.hbs
@@ -3,7 +3,7 @@
     data-analytics-scope='Registries search results'
     ...attributes
 >
-    <div class={{if @result.openBadges 'col-xs-10 col-sm-9' 'col-xs-12'}}>
+    <div class={{if @result.relatedResourceTypes 'col-xs-10 col-sm-9' 'col-xs-12'}}>
         <h3 local-class='RegistriesSearchResult__Title'>
             <OsfLink
                 data-test-result-title-id={{@result.id}}
@@ -59,15 +59,15 @@
             {{math @result.description}}
         </p>
     </div>
-    {{#if @result.openBadges}}
+    {{#if @result.relatedResourceTypes}}
         <div class='col-xs-2 col-sm-3' local-class='OpenBadges'>
             <OpenBadgesList
                 @registration={{@result.id}}
-                @hasData={{@result.openBadges.data}}
-                @hasMaterials={{@result.openBadges.materials}}
-                @hasAnalyticCode={{@result.openBadges.analytic_code}}
-                @hasPapers={{@result.openBadges.papers}}
-                @hasSupplements={{@result.openBadges.supplements}}
+                @hasData={{@result.relatedResourceTypes.data}}
+                @hasMaterials={{@result.relatedResourceTypes.materials}}
+                @hasAnalyticCode={{@result.relatedResourceTypes.analytic_code}}
+                @hasPapers={{@result.relatedResourceTypes.papers}}
+                @hasSupplements={{@result.relatedResourceTypes.supplements}}
             />
         </div>
     {{/if}}

--- a/lib/registries/addon/services/share-search.ts
+++ b/lib/registries/addon/services/share-search.ts
@@ -86,7 +86,7 @@ export interface ShareContributor {
     orderCited: number;
 }
 
-export interface OpenBadges {
+export interface RelatedResourceTypes {
     data: boolean;
     materials: boolean;
     analytic_code: boolean;
@@ -110,7 +110,7 @@ export interface ShareRegistration {
     tags: string[];
     title: string;
     withdrawn: boolean;
-    openBadges: OpenBadges;
+    relatedResourceTypes?: RelatedResourceTypes;
 }
 
 export interface SourceDescriptor {
@@ -242,7 +242,7 @@ export default class ShareSearch extends Search {
                 datePublished: r._source.date_published ? new Date(r._source.date_published) : undefined,
                 tags: r._source.tags.map(unescapeXMLEntities),
                 withdrawn: r._source.withdrawn,
-                openBadges: r._source.open_badges,
+                relatedResourceTypes: r._source.osf_related_resource_types,
             };
         });
     }

--- a/tests/engines/registries/unit/services/share-search-test.ts
+++ b/tests/engines/registries/unit/services/share-search-test.ts
@@ -30,6 +30,13 @@ function getSearchResponse(identifiers?: string[]) {
                     sources: ['OSF', 'OSF Registries'],
                     subjects: [],
                     subject_synonyms: [],
+                    osf_related_resource_types: {
+                        data: true,
+                        papers: true,
+                        analytic_code: false,
+                        materials: false,
+                        supplements: false,
+                    },
                     lists: {
                         contributors: [{
                             id: '6402D-242-421',
@@ -83,6 +90,13 @@ module('Registries | Unit | Service | share-search', hooks => {
         assert.equal(registrations[0].tags[0], '&');
         assert.equal(registrations[0].contributors[0].name, 'Graham > Berlin');
         assert.equal(registrations[0].contributors[1].name, 'Nicole < Grant');
+        assert.deepEqual(registrations[0].relatedResourceTypes, {
+            data: true,
+            papers: true,
+            analytic_code: false,
+            materials: false,
+            supplements: false,
+        });
     });
 
     test('recognizes all OSF source envs', function(this: TestContext, assert) {


### PR DESCRIPTION
rename `open_badges` to `related_resource_types`, aligning with:
https://github.com/CenterForOpenScience/SHARE/pull/793
https://github.com/CenterForOpenScience/osf.io/pull/10004

<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-3905]
-   Feature flag: n/a

## Purpose

<!-- Describe the purpose of your changes. -->

## Summary of Changes

<!-- Briefly describe or list your changes. -->

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-3905]: https://openscience.atlassian.net/browse/ENG-3905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ