### PR TITLE
Add resource bugfixes

### DIFF
--- a/lib/osf-components/addon/components/resources-list/edit-resource/component.ts
+++ b/lib/osf-components/addon/components/resources-list/edit-resource/component.ts
@@ -73,6 +73,8 @@ export default class EditResourceModal extends Component<Args> {
             }
             this.resource = undefined;
             this.changeset = undefined;
+        } else {
+            this.changeset.rollback();
         }
         this.shouldShowPreview = false;
     }
@@ -97,7 +99,11 @@ export default class EditResourceModal extends Component<Args> {
                 if (onSuccess) {
                     onSuccess();
                 }
+                if (this.resource?.finalized) {
+                    this.toast.success(this.intl.t('osf-components.resources-list.edit_resource.save_success'));
+                }
             } catch (e) {
+                this.resource?.rollbackAttributes();
                 if (e.errors[0].status === '400') {
                     this.changeset.addError(
                         'pid',

--- a/lib/osf-components/addon/components/resources-list/edit-resource/component.ts
+++ b/lib/osf-components/addon/components/resources-list/edit-resource/component.ts
@@ -77,14 +77,26 @@ export default class EditResourceModal extends Component<Args> {
         this.shouldShowPreview = false;
     }
 
+    @action
+    goToPreview() {
+        this.shouldShowPreview = true;
+    }
+
+    @action
+    goToEdit() {
+        this.shouldShowPreview = false;
+    }
+
     @task
     @waitFor
-    async goToPreview() {
+    async save(onSuccess?: () => void) {
         this.changeset.validate();
         if (this.changeset.get('isValid')) {
             try {
                 await this.changeset.save();
-                this.shouldShowPreview = true;
+                if (onSuccess) {
+                    onSuccess();
+                }
             } catch (e) {
                 if (e.errors[0].status === '400') {
                     this.changeset.addError(
@@ -99,11 +111,6 @@ export default class EditResourceModal extends Component<Args> {
                 }
             }
         }
-    }
-
-    @action
-    goToEdit() {
-        this.shouldShowPreview = false;
     }
 
     @task

--- a/lib/osf-components/addon/components/resources-list/edit-resource/template.hbs
+++ b/lib/osf-components/addon/components/resources-list/edit-resource/template.hbs
@@ -75,7 +75,6 @@
             >
                 {{t 'general.add'}}
             </Button>
-
         {{else}}
             <Button
                 data-test-cancel-button
@@ -84,14 +83,25 @@
             >
                 {{t 'general.cancel'}}
             </Button>
-            <Button
-                data-test-preview-button
-                data-analytics-name='Preview resource'
-                @type={{'primary'}}
-                {{on 'click' (perform this.goToPreview)}}
-            >
-                {{t 'osf-components.resources-list.edit_resource.preview'}}
-            </Button>
+            {{#if @resource}}
+                <Button
+                    data-test-save-button
+                    data-analytics-name='Save resource'
+                    @type={{'primary'}}
+                    {{on 'click' (perform this.save (queue dialog.close @reload))}}
+                >
+                    {{t 'general.save'}}
+                </Button>
+            {{else}}
+                <Button
+                    data-test-preview-button
+                    data-analytics-name='Preview resource'
+                    @type={{'primary'}}
+                    {{on 'click' (perform this.save this.goToPreview)}}
+                >
+                    {{t 'osf-components.resources-list.edit_resource.preview'}}
+                </Button>
+            {{/if}}
         {{/if}}
     </dialog.footer>
 </OsfDialog>

--- a/lib/osf-components/addon/components/resources-list/edit-resource/template.hbs
+++ b/lib/osf-components/addon/components/resources-list/edit-resource/template.hbs
@@ -10,7 +10,7 @@
         {{yield dialog}}
     </dialog.trigger>
     <dialog.heading>
-        {{t 'osf-components.resources-list.edit_resource.heading'}}
+        {{t (concat 'osf-components.resources-list.edit_resource.'(if @resource 'edit_heading' 'add_heading'))}}
     </dialog.heading>
     <dialog.main>
         {{#if this.shouldShowPreview}}

--- a/lib/osf-components/addon/components/resources-list/resource-card/template.hbs
+++ b/lib/osf-components/addon/components/resources-list/resource-card/template.hbs
@@ -19,7 +19,7 @@
             {{#if @editable}}
                 <ResourcesList::DeleteResource
                     @resource={{@resource}}
-                    @onDelete={{@onDelete}}
+                    @onDelete={{@reload}}
                     as |modal|
                 >
                     <Button
@@ -33,6 +33,7 @@
                 </ResourcesList::DeleteResource>
                 <ResourcesList::EditResource
                     @resource={{@resource}}
+                    @reload={{@reload}}
                     as |modal|
                 >
                     <Button

--- a/lib/osf-components/addon/components/resources-list/template.hbs
+++ b/lib/osf-components/addon/components/resources-list/template.hbs
@@ -34,7 +34,7 @@
         <ResourcesList::ResourceCard
             @resource={{resource}}
             @editable={{@registration.userHasWritePermission}}
-            @onDelete={{this.reload}}
+            @reload={{this.reload}}
         />
     </:item>
     <:empty>

--- a/tests/integration/components/resources-list/edit-resource/component-test.ts
+++ b/tests/integration/components/resources-list/edit-resource/component-test.ts
@@ -46,6 +46,9 @@ module('Integration | Component | ResourcesList::EditResource', hooks => {
         `);
         await untrackedClicked('[data-test-open]');
         mirageRegistration.reload();
+        assert.dom('[data-test-dialog]').containsText(
+            this.intl.t('osf-components.resources-list.edit_resource.add_heading'), 'Modal heading is correct',
+        );
         assert.equal(mirageRegistration.resources.length, 1, 'registration has exactly one resource');
         await click('[data-test-preview-button]');
         assert.dom('[data-test-validation-errors="pid"]').exists('DOI validation error message exists');
@@ -134,6 +137,9 @@ module('Integration | Component | ResourcesList::EditResource', hooks => {
             </ResourcesList::EditResource>
         `);
         await untrackedClicked('[data-test-open]');
+        assert.dom('[data-test-dialog]').containsText(
+            this.intl.t('osf-components.resources-list.edit_resource.edit_heading'), 'Modal heading is correct',
+        );
         assert.dom('[data-test-doi-field] > div > div > input').hasValue('10.101/yeji');
         assert.dom('[data-test-resource-type-field] > div').hasText(
             this.intl.t('osf-components.resources-list.analytic_code'),

--- a/tests/integration/components/resources-list/edit-resource/component-test.ts
+++ b/tests/integration/components/resources-list/edit-resource/component-test.ts
@@ -233,5 +233,16 @@ module('Integration | Component | ResourcesList::EditResource', hooks => {
         mirageResource.reload();
         assert.equal(mirageResource.pid, '10.101/lia', 'PID is reverted to original changed');
         assert.equal(mirageResource.resourceType, ResourceTypes.AnalyticCode, 'Resource type reverted');
+
+        await untrackedClicked('[data-test-open]');
+        assert.dom('[data-test-doi-field] > div > div > input').hasValue('10.101/lia');
+        await fillIn('[data-test-doi-field] > div > div > input', '01.101/lia');
+        await selectChoose('[data-test-resource-type-field]', this.intl.t('osf-components.resources-list.data'));
+        await click('[data-test-save-button]');
+        assert.dom('[data-test-validation-errors="pid"]').exists('DOI validation error message exists');
+        await click('[data-test-cancel-button]');
+        mirageResource.reload();
+        assert.equal(mirageResource.pid, '10.101/lia', 'PID is reverted after failed save');
+        assert.equal(mirageResource.resourceType, ResourceTypes.AnalyticCode, 'Resource type reverted');
     });
 });

--- a/tests/integration/components/resources-list/edit-resource/component-test.ts
+++ b/tests/integration/components/resources-list/edit-resource/component-test.ts
@@ -141,7 +141,8 @@ module('Integration | Component | ResourcesList::EditResource', hooks => {
         assert.dom('[data-test-description-field] > div > textarea').hasValue('Hello, my name is Stevie');
         await fillIn('[data-test-doi-field] > div > div > input', 'https://invalid_url');
         assert.dom('[data-test-validation-errors="resourceType"]').doesNotExist();
-        await click('[data-test-preview-button]');
+        assert.dom('[data-test-preview-button]').doesNotExist('No preview option if resource already exists');
+        await click('[data-test-save-button]');
         assert.dom('[data-test-validation-errors="pid"]').exists('DOI validation error message exists');
         assert.dom('[data-test-validation-errors="pid"]').hasText(
             this.intl.t(
@@ -154,39 +155,77 @@ module('Integration | Component | ResourcesList::EditResource', hooks => {
         );
         await fillIn('[data-test-doi-field] > div > div > input', '10.101/ryujin');
         await selectChoose('[data-test-resource-type-field]', this.intl.t('osf-components.resources-list.materials'));
-        await click('[data-test-preview-button]');
-        assert.dom('[data-test-resource-card-type]').exists('Shows type in preview');
-        assert.dom('[data-test-resource-card-type]').hasText(
-            this.intl.t('osf-components.resources-list.materials'),
-            'Type is correct',
-        );
-        assert.dom('[data-test-resource-card-pid-link]').exists('Shows DOI link in preview');
-        assert.dom('[data-test-resource-card-pid-link]').hasText('https://doi.org/10.101/ryujin', 'DOI is correct');
-        assert.dom('[data-test-resource-card-description]').exists('Show description in preview');
-        assert.dom('[data-test-resource-card-description]').hasText(
-            'Hello, my name is Stevie',
-            'Description is correct',
-        );
-        await click('[data-test-edit-button]');
-        await fillIn('[data-test-doi-field] > div > div > input', '10.101/yuna');
         await fillIn('[data-test-description-field] > div > textarea', "Actually, I'm lying. It's really Bebe");
-        await selectChoose('[data-test-resource-type-field]', this.intl.t('osf-components.resources-list.data'));
-        await click('[data-test-preview-button]');
-        assert.dom('[data-test-resource-card-type]').hasText(
-            this.intl.t('osf-components.resources-list.data'),
-            'Type is correct',
-        );
-        assert.dom('[data-test-resource-card-pid-link]').hasText('https://doi.org/10.101/yuna', 'DOI is correct');
-        assert.dom('[data-test-resource-card-description]').hasText(
-            "Actually, I'm lying. It's really Bebe",
-            'Description is correct',
-        );
-        await click('[data-test-add-button]');
+        await click('[data-test-save-button]');
+        assert.dom('[data-test-dialog]').doesNotExist('Dialog closes after editing resource');
         mirageResource.reload();
-        assert.equal(mirageResource.pid, '10.101/yuna', 'PID is changed');
-        assert.equal(mirageResource.resourceType, ResourceTypes.Data, 'Resource type is changed');
+        assert.equal(mirageResource.pid, '10.101/ryujin', 'PID is changed');
+        assert.equal(mirageResource.resourceType, ResourceTypes.Materials, 'Resource type is changed');
         assert.equal(mirageResource.description, "Actually, I'm lying. It's really Bebe");
         assert.ok(mirageResource.finalized, 'Resource is finalized');
         sinon.assert.calledOnce(this.reload);
+    });
+
+    test('it destroys unfinalized resource on close', async function(this: EditResourceTestContext, assert) {
+        const mirageRegistration = server.create('registration', 'currentUserAdmin');
+        assert.equal(mirageRegistration.resources.length, 0, 'registration does not have any resource');
+        this.registration = await this.store.findRecord('registration', mirageRegistration.id);
+        await render(hbs`
+            <ResourcesList::EditResource @registration={{this.registration}} @reload={{this.reload}} as |modal| >
+                <Button
+                    data-test-open
+                    {{on 'click' modal.open}}
+                >
+                </Button>
+            </ResourcesList::EditResource>
+        `);
+        await untrackedClicked('[data-test-open]');
+        mirageRegistration.reload();
+        assert.equal(mirageRegistration.resources.length, 1, 'registration has exactly one resource');
+        await click('[data-test-cancel-button]');
+        mirageRegistration.reload();
+        assert.equal(mirageRegistration.resources.length, 0, 'registration no longer has resource');
+
+        await untrackedClicked('[data-test-open]');
+        mirageRegistration.reload();
+        assert.equal(mirageRegistration.resources.length, 1, 'registration again has one resource');
+        await fillIn('[data-test-doi-field] > div > div > input', '10.101/chaeryeong');
+        await selectChoose('[data-test-resource-type-field]', this.intl.t('osf-components.resources-list.data'));
+        await click('[data-test-preview-button]');
+        await click('[data-test-close-dialog]');
+        mirageRegistration.reload();
+        assert.equal(mirageRegistration.resources.length, 0, 'registration no longer has resource, even after preview');
+    });
+
+    test('it preserves existing/finalized resource', async function(this: EditResourceTestContext, assert) {
+        const mirageRegistration = server.create('registration', 'currentUserAdmin');
+        const mirageResource = server.create('resource', {
+            resourceType: ResourceTypes.AnalyticCode,
+            pid: '10.101/lia',
+            registration: mirageRegistration,
+        });
+        this.registration = await this.store.findRecord('registration', mirageRegistration.id);
+        this.resource = await this.store.findRecord('resource', mirageResource.id);
+        await render(hbs`
+            <ResourcesList::EditResource
+                @registration={{this.registration}}
+                @resource={{this.resource}}
+                @reload={{this.reload}}
+            as |modal| >
+                <Button
+                    data-test-open
+                    {{on 'click' modal.open}}
+                >
+                </Button>
+            </ResourcesList::EditResource>
+        `);
+        await untrackedClicked('[data-test-open]');
+        assert.dom('[data-test-doi-field] > div > div > input').hasValue('10.101/lia');
+        await fillIn('[data-test-doi-field] > div > div > input', '10.101/julia');
+        await selectChoose('[data-test-resource-type-field]', this.intl.t('osf-components.resources-list.data'));
+        await click('[data-test-close-dialog]');
+        mirageResource.reload();
+        assert.equal(mirageResource.pid, '10.101/lia', 'PID is reverted to original changed');
+        assert.equal(mirageResource.resourceType, ResourceTypes.AnalyticCode, 'Resource type reverted');
     });
 });

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1721,7 +1721,8 @@ osf-components:
         edit_resource:
             edit_button_aria_label: 'Edit resource'
             preview: 'Preview'
-            heading: 'Add new resource'
+            edit_heading: 'Edit resource'
+            add_heading: 'Add new resource'
             doi: 'DOI'
             output_type: 'Resource type'
             description: 'Description'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1729,6 +1729,7 @@ osf-components:
             check_your_doi: 'Check your DOI for accuracy.'
             add_success: 'Resource successfully added.'
             add_failure: 'Failed to add resource.'
+            save_success: 'Resource successfully saved.'
         delete_resource:
             title: 'Delete resource'
             body: 'Are you sure you want to delete this resource? This cannot be undone.'


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Address issues found with Add/Edit Resource modal
  - unfinalized resources weren't being deleted properly
  - User changes were persisting in an unintuitive way when editing an existing resource 

## Summary of Changes
- Remove "Preview" functionality when editing existing resource
- Delete unfinalized resource when adding a new resource
- Change modal header if adding or editing resource
- Update tests

## Screenshot(s)
- Editing existing resource now shows "Save" instead of "Preview" (Adding new one is unchanged). Modal header is also changed to "Edit resource"
![image](https://user-images.githubusercontent.com/51409893/183146969-10f9eb18-5aa9-4c6e-8bab-f6a4a5dc8cde.png)

## Side Effects
- Users won't be able to preview the changes made to an existing resource, but they can just edit it again :/
## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
