### PR TITLE
Remove overzealous aria-label

### DIFF
--- a/lib/osf-components/addon/components/form-controls/power-select/template.hbs
+++ b/lib/osf-components/addon/components/form-controls/power-select/template.hbs
@@ -25,7 +25,6 @@
             as |option|
         >
             <span
-                aria-label={{option}}
                 data-test-option={{option}}
             >
                 {{yield option}}


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: []
-   Feature flag: n/a

## Purpose
- Remove unnecessary aria-label

## Summary of Changes
- Remove redundant aria-label
  - This aria-label was actually bad if we had placeholder text for when a selection's value was 'undefined'. The screenreader would say "Undefined" instead of the placeholder text

## Screenshot(s)
- NA
<!-- Attach screenshots if applicable. -->

## Side Effects
- I don't think there should be  any. If there are other cases of placeholder text used when a dropdown's value is undefined, this should fix that as well.

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
