### PR TITLE
Fix SHARE search results in mirage view

### DIFF
--- a/mirage/views/share-search.ts
+++ b/mirage/views/share-search.ts
@@ -5,7 +5,7 @@ import Contributor from 'ember-osf-web/models/contributor';
 import RegistrationModel from 'ember-osf-web/models/registration';
 
 import { MirageExternalRegistration } from 'ember-osf-web/mirage/models/external-registration';
-import { OpenBadges } from 'registries/services/share-search';
+import { RelatedResourceTypes } from 'registries/services/share-search';
 
 const {
     OSF: {
@@ -57,7 +57,7 @@ interface SerializedRegistration {
     title: string;
     type: string;
     withdrawn: boolean;
-    open_badges?: OpenBadges;
+    osf_related_resource_types?: RelatedResourceTypes;
 }
 
 interface SearchHit {
@@ -179,7 +179,7 @@ function serializeRegistration(reg: ModelInstance<RegistrationModel>): Serialize
         tags: ['project'],
         withdrawn: reg.withdrawn,
         identifiers: [`${osfUrl}${reg.id}/`],
-        open_badges: {
+        osf_related_resource_types: {
             data: reg.hasData,
             materials: reg.hasMaterials,
             analytic_code: reg.hasAnalyticCode,


### PR DESCRIPTION
-   Ticket: n/a
-   Feature flag: n/a

## Purpose

When https://github.com/CenterForOpenScience/ember-osf-web/pull/1603 was merged, it didn't quite have everything it needed, and while things work great on staging, they didn't work in mirage. This corrects that.

## Summary of Changes

1. Update mirage view for SHARE search results

## Screenshot(s)

<img width="1414" alt="Screen Shot 2022-08-09 at 9 37 35 AM" src="https://user-images.githubusercontent.com/6599111/183663812-9b638711-1051-4d53-97d3-d39f1d76fb55.png">

## Side Effects

Nope.

## QA Notes

No QA necessary for this one; it's entirely developer-facing.