### PR TITLE
Allow search results from OSF to use routed links

### DIFF
--- a/lib/registries/addon/components/registries-search-result/template.hbs
+++ b/lib/registries/addon/components/registries-search-result/template.hbs
@@ -5,14 +5,25 @@
 >
     <div class={{if @result.relatedResourceTypes 'col-xs-10 col-sm-9' 'col-xs-12'}}>
         <h3 local-class='RegistriesSearchResult__Title'>
-            <OsfLink
-                data-test-result-title-id={{@result.id}}
-                @href={{@result.mainLink}}
-                data-analytics-name='Result Title{{if @provider (concat ' ' @provider.name)}}'
-            >
-                {{math @result.title}}
-            </OsfLink>
-
+            {{#if @result.relatedResourceTypes}}
+                {{!-- This means it's an OSF resource, which means it'll have a guid --}}
+                <OsfLink
+                    data-test-result-title-id={{@result.sourceUniqueId}}
+                    @route='registries.overview'
+                    @models={{array @result.sourceUniqueId}}
+                    data-analytics-name='Result Title{{if @provider (concat ' ' @provider.name)}}'
+                >
+                    {{math @result.title}}
+                </OsfLink>
+            {{else}}
+                <OsfLink
+                    data-test-result-title-id={{@result.id}}
+                    @href={{@result.mainLink}}
+                    data-analytics-name='Result Title{{if @provider (concat ' ' @provider.name)}}'
+                >
+                    {{math @result.title}}
+                </OsfLink>
+            {{/if}}
             {{#if @result.withdrawn}}
                 <span class='label label-default'>{{t 'registries.discover.search_result.withdrawn'}}</span>
             {{/if}}
@@ -62,7 +73,7 @@
     {{#if @result.relatedResourceTypes}}
         <div class='col-xs-2 col-sm-3' local-class='OpenBadges'>
             <OpenBadgesList
-                @registration={{@result.id}}
+                @registration={{@result.sourceUniqueId}}
                 @hasData={{@result.relatedResourceTypes.data}}
                 @hasMaterials={{@result.relatedResourceTypes.materials}}
                 @hasAnalyticCode={{@result.relatedResourceTypes.analytic_code}}

--- a/lib/registries/addon/services/share-search.ts
+++ b/lib/registries/addon/services/share-search.ts
@@ -111,6 +111,7 @@ export interface ShareRegistration {
     title: string;
     withdrawn: boolean;
     relatedResourceTypes?: RelatedResourceTypes;
+    sourceUniqueId: string;
 }
 
 export interface SourceDescriptor {
@@ -243,6 +244,7 @@ export default class ShareSearch extends Search {
                 tags: r._source.tags.map(unescapeXMLEntities),
                 withdrawn: r._source.withdrawn,
                 relatedResourceTypes: r._source.osf_related_resource_types,
+                sourceUniqueId: r._source.source_unique_id,
             };
         });
     }

--- a/mirage/views/share-search.ts
+++ b/mirage/views/share-search.ts
@@ -58,6 +58,7 @@ interface SerializedRegistration {
     type: string;
     withdrawn: boolean;
     osf_related_resource_types?: RelatedResourceTypes;
+    source_unique_id?: string;
 }
 
 interface SearchHit {
@@ -186,6 +187,7 @@ function serializeRegistration(reg: ModelInstance<RegistrationModel>): Serialize
             papers: reg.hasPapers,
             supplements: reg.hasSupplements,
         },
+        source_unique_id: reg.id,
     };
 }
 

--- a/tests/engines/registries/unit/services/share-search-test.ts
+++ b/tests/engines/registries/unit/services/share-search-test.ts
@@ -37,6 +37,7 @@ function getSearchResponse(identifiers?: string[]) {
                         materials: false,
                         supplements: false,
                     },
+                    source_unique_id: 'w4yhb',
                     lists: {
                         contributors: [{
                             id: '6402D-242-421',
@@ -97,6 +98,7 @@ module('Registries | Unit | Service | share-search', hooks => {
             materials: false,
             supplements: false,
         });
+        assert.equal(registrations[0].sourceUniqueId, 'w4yhb');
     });
 
     test('recognizes all OSF source envs', function(this: TestContext, assert) {


### PR DESCRIPTION
-   Ticket: [Notion bug](https://www.notion.so/cos/Link-to-resources-from-SHARE-is-using-the-wrong-ID-741b68ff3a1c4ce5891cd8fbc24ee750)

## Purpose

Links to the resource page were broken because the ID I was using from SHARE to point to a guid-based route was not a GUID. This takes advantage of a new field returned from SHARE that gives us the guid, in the case of OSF-based results. **Note:** ~~We want to avoid merging this until we do a reindex of SHARE, because if not, registrations that have resources but have not been updated since this morning will break the search page.~~ I think SHARE is reindexed on staging2 by now.

## Summary of Changes

1. Add new property to SHARE results 
2. Have main link to registration overview page in SHARE results link using the new property in case of OSF-based registrations
3. Have resource links use the new property instead of a SHARE-internal ID that I was using
4. Update mirage for SHARE
5. Test SHARE mirage for new property

## Side Effects

No.

## QA Notes

This should fix the links for the resources on the discover page to actually go to the right place.