### PR TITLE
Hide resource badges for certain registration states

### DIFF
--- a/app/models/registration.ts
+++ b/app/models/registration.ts
@@ -165,6 +165,13 @@ export default class RegistrationModel extends NodeModel.extend(Validations) {
     // Write-only relationships
     @belongsTo('draft-registration', { inverse: null })
     draftRegistration!: DraftRegistrationModel;
+
+    get resourcesVisible(): boolean {
+        return ![
+            RegistrationReviewStates.Initial,
+            RegistrationReviewStates.Pending,
+        ].includes(this.reviewsState) && !this.withdrawn && !this.archiving;
+    }
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/lib/osf-components/addon/components/node-card/template.hbs
+++ b/lib/osf-components/addon/components/node-card/template.hbs
@@ -220,7 +220,7 @@
                 {{/if}}
             </div>
         </span>
-        {{#if @node.isRegistration}}
+        {{#if (and @node.isRegistration @node.resourcesVisible)}}
             <span local-class='OpenBadges {{if this.isMobile 'OpenBadges__mobile'}}'>
                 <OpenBadgesList
                     @hasData={{@node.hasData}}

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -96,26 +96,30 @@
                             {{/each}}
                         </div>
                     {{/if}}
-                    {{#let (unique-id 'resource-link') as |id|}}
-                        <leftNav.link data-analytics-name='Resources' 
-                            @route='registries.overview.resources'
-                            @models={{array this.registration.id}}
-                            @icon='archive'
-                            @label={{t 'registries.overview.resources.title'}}
-                            id={{id}}
-                        />
-                        <NewFeaturePopover
-                            @triggerElement={{concat '#' id}}
-                            @featureCookie={{this.outputFeaturePopoverCookie}}
-                        >
-                            <:header>
-                                {{t 'registries.overview.files.outputFeaturePopoverHeading'}}
-                            </:header>
-                            <:body>
-                                {{t 'registries.overview.files.outputFeaturePopoverBody'}}
-                            </:body>
-                        </NewFeaturePopover>
-                    {{/let}}
+                    {{#if this.registration.resourcesVisible}}
+                        {{#let (unique-id 'resource-link') as |id|}}
+                            <leftNav.link 
+                                data-test-resource-link
+                                data-analytics-name='Resources'
+                                @route='registries.overview.resources'
+                                @models={{array this.registration.id}}
+                                @icon='archive'
+                                @label={{t 'registries.overview.resources.title'}}
+                                id={{id}}
+                            />
+                            <NewFeaturePopover
+                                @triggerElement={{concat '#' id}}
+                                @featureCookie={{this.outputFeaturePopoverCookie}}
+                            >
+                                <:header>
+                                    {{t 'registries.overview.files.outputFeaturePopoverHeading'}}
+                                </:header>
+                                <:body>
+                                    {{t 'registries.overview.files.outputFeaturePopoverBody'}}
+                                </:body>
+                            </NewFeaturePopover>
+                        {{/let}}
+                    {{/if}}
                     {{#if this.registration.wikiEnabled}}
                         <leftNav.link
                             data-test-wiki-link

--- a/tests/engines/registries/acceptance/overview/index-test.ts
+++ b/tests/engines/registries/acceptance/overview/index-test.ts
@@ -6,7 +6,7 @@ import { percySnapshot } from 'ember-percy';
 import { TestContext } from 'ember-test-helpers';
 import { module, test } from 'qunit';
 
-import Registration from 'ember-osf-web/models/registration';
+import Registration, { RegistrationReviewStates } from 'ember-osf-web/models/registration';
 import { click, currentURL, visit } from 'ember-osf-web/tests/helpers';
 import { loadEngine, setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
 
@@ -52,7 +52,7 @@ module('Registries | Acceptance | overview.index', hooks => {
         const analyticsEngine = await loadEngine('analytics-page', 'guid-registration.analytics');
 
         analyticsEngine.register('service:keen', KeenStub);
-
+        this.registration.reviewsState = RegistrationReviewStates.Accepted;
         const testCases = [{
             name: 'Comments',
             route: 'registries.overview.comments',
@@ -114,6 +114,16 @@ module('Registries | Acceptance | overview.index', hooks => {
         await visit(`/${this.registration.id}`);
 
         assert.dom('[data-test-wiki-link]').doesNotExist('Wiki link hidden because wiki disabled');
+    });
+
+    test('resource link hidden if not approved', async function(this: OverviewTestContext, assert: Assert){
+        this.registration.reviewsState = RegistrationReviewStates.Initial;
+        await visit(`/${this.registration.id}`);
+        assert.dom('[data-analytics-name="Resources"]').doesNotExist('Resource link hidden for initial state');
+
+        this.registration.reviewsState = RegistrationReviewStates.Pending;
+        await visit(`/${this.registration.id}`);
+        assert.dom('[data-analytics-name="Resources"]').doesNotExist('Resource link hidden for pending state');
     });
 
     test('withdrawn tombstone', async function(this: OverviewTestContext, assert: Assert) {

--- a/tests/integration/components/node-card/component-test.ts
+++ b/tests/integration/components/node-card/component-test.ts
@@ -2,6 +2,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupIntl, t, TestContext } from 'ember-intl/test-support';
+import { RegistrationReviewStates } from 'ember-osf-web/models/registration';
 import { RevisionReviewStates } from 'ember-osf-web/models/schema-response';
 import { setupRenderingTest } from 'ember-qunit';
 import moment from 'moment';
@@ -109,5 +110,29 @@ module('Integration | Component | node-card', hooks => {
 
         assert.dom('[data-test-update-button]').exists('Update button exists.');
         assert.dom('[data-test-update-button]').hasText(t('node_card.update_button').toString());
+        assert.dom('[data-test-badge-list]').exists('Badge list exists');
+    });
+
+    test('it renders pending registration', async function(this: TestContext, assert) {
+        this.owner.register('service:router', OsfLinkRouterStub);
+        const registration = server.create('registration', {
+            reviewsState: RegistrationReviewStates.Pending,
+        }, 'currentUserAdmin');
+        const registrationModel = await this.store.findRecord('registration', registration.id);
+        this.set('node', registrationModel);
+
+        await render(hbs`
+            <NodeCard
+                @node={{this.node}}
+                @showTags={{true}}
+                @delete={{this.delete}}
+            />
+        `);
+        assert.dom('[data-test-node-title]').exists('Node title exists');
+        assert.dom('[data-test-description-label]').exists('Description label exists');
+        assert.dom('[data-test-view-button]').exists('View button exists');
+        assert.dom('[data-test-update-button]').doesNotExist('Update button does not exist.');
+        assert.dom('[data-test-view-changes-button]').doesNotExist('Continue update button does not exist.');
+        assert.dom('[data-test-badge-list]').doesNotExist('Badge list does not exist');
     });
 });


### PR DESCRIPTION
-   Ticket: [[Notion card]](https://www.notion.so/cos/Remove-Front-end-option-to-add-Resource-for-certain-registration-states-9780597577c7436e91b83b345aff6841)
-   Feature flag: n/a

## Purpose
- Prevent users from adding resources when not appropriate
- Prevent showing resource badges if users cannot add resources
## Summary of Changes
- Update Overview leftnav to hide resources if the registration is not accepted by admins or moderators
- Update node-card to hide resource badges if registration is not accepted by admins or moderators
- Update tests

## Screenshot(s)
- Node cards
![image](https://user-images.githubusercontent.com/51409893/183922502-20099571-203c-4e5a-8284-359307d606cd.png)


## Side Effects
None

## QA Notes
- If an admin/write user manually enters the overview/resources page manually, it will still look like they can add a resource, but the resource they add there won't persist and behave strangely