### PR TITLE
Add margin-bottom to resource heading

### DIFF
--- a/lib/osf-components/addon/components/resources-list/styles.scss
+++ b/lib/osf-components/addon/components/resources-list/styles.scss
@@ -13,9 +13,10 @@
     border-top: solid 1px $color-border-gray;
 }
 
-.Flexbox {
+.AddResourceHeading {
     display: flex;
     flex-direction: row;
+    margin-bottom: 10px;
 }
 
 .TriggerButton.TriggerButton {

--- a/lib/osf-components/addon/components/resources-list/template.hbs
+++ b/lib/osf-components/addon/components/resources-list/template.hbs
@@ -1,6 +1,6 @@
 {{#if @registration.userHasWritePermission}}
     <div
-        local-class='Flexbox'
+        local-class='AddResourceHeading'
         data-test-add-resource-section
     >
         <span>{{t 'osf-components.resources-list.add_instructions'}}</span>


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [Notion ticket](https://www.notion.so/cos/Add-White-Space-c07d80684c634b619167679de22e84d5)
-   Feature flag: n/a

## Purpose
- Add margin to add resource heading

## Summary of Changes
- Add 10px margin-bottom to the section explaining how to add new resource
- Rename class to not be misleading

## Screenshot(s)
- Before
![image](https://user-images.githubusercontent.com/51409893/183994600-6c278e19-fc02-4c08-9b4f-c679271d3e93.png)

- After
![image](https://user-images.githubusercontent.com/51409893/183994939-14c735bb-4de9-4d2c-89f7-fdaed61f754a.png)

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
