### PR TITLE
Disable buttons while tasks are running

### DIFF
--- a/lib/osf-components/addon/components/resources-list/edit-resource/template.hbs
+++ b/lib/osf-components/addon/components/resources-list/edit-resource/template.hbs
@@ -67,13 +67,18 @@
                 data-test-add-button
                 data-analytics-name='Add resource'
                 @type='create'
+                disabled={{this.finalize.isRunning}}
                 {{on 'click' (queue
                     (perform this.finalize)
                     dialog.close
                     @reload
                 )}}
             >
-                {{t 'general.add'}}
+                {{#if this.finalize.isRunning}}
+                    <LoadingIndicator @inline={{true}}/>
+                {{else}}
+                    {{t 'general.add'}}
+                {{/if}}
             </Button>
         {{else}}
             <Button
@@ -88,18 +93,28 @@
                     data-test-save-button
                     data-analytics-name='Save resource'
                     @type={{'primary'}}
+                    disabled={{this.save.isRunning}}
                     {{on 'click' (perform this.save (queue dialog.close @reload))}}
                 >
-                    {{t 'general.save'}}
+                    {{#if this.save.isRunning}}
+                        <LoadingIndicator @inline={{true}} />
+                    {{else}}
+                        {{t 'general.save'}}
+                    {{/if}}
                 </Button>
             {{else}}
                 <Button
                     data-test-preview-button
                     data-analytics-name='Preview resource'
                     @type={{'primary'}}
+                    disabled={{this.save.isRunning}}
                     {{on 'click' (perform this.save this.goToPreview)}}
                 >
-                    {{t 'osf-components.resources-list.edit_resource.preview'}}
+                    {{#if this.save.isRunning}}
+                        <LoadingIndicator @inline={{true}} />
+                    {{else}}
+                        {{t 'osf-components.resources-list.edit_resource.preview'}}
+                    {{/if}}
                 </Button>
             {{/if}}
         {{/if}}


### PR DESCRIPTION
-   Ticket: [Notion card](https://www.notion.so/cos/Disable-add-edit-buttons-when-saving-e8a2ace5fdaa4cc6b650e80e9dc4fe7f)
-   Feature flag: n/a

## Purpose
- Disable Preview and Save buttons while those tasks are running
- Show loading indicator while those tasks are running

## Summary of Changes
- Basically exactly what was mentioned above

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
