### PR TITLE
Add link to help docs

### DIFF
--- a/lib/osf-components/addon/components/resources-list/styles.scss
+++ b/lib/osf-components/addon/components/resources-list/styles.scss
@@ -16,7 +16,12 @@
 .AddResourceHeading {
     display: flex;
     flex-direction: row;
+    align-items: center;
     margin-bottom: 10px;
+}
+
+.HelpLink {
+    padding: 0 8px;
 }
 
 .TriggerButton.TriggerButton {

--- a/lib/osf-components/addon/components/resources-list/template.hbs
+++ b/lib/osf-components/addon/components/resources-list/template.hbs
@@ -4,7 +4,13 @@
         data-test-add-resource-section
     >
         <span>{{t 'osf-components.resources-list.add_instructions'}}</span>
-        {{!-- help icon --}}
+        <OsfLink
+            aria-label={{t 'osf-components.resources-list.help_doc_link'}}
+            local-class='HelpLink'
+            @href='https://help.osf.io/article/410-registration-files'
+        >
+            <FaIcon @icon= 'question-circle' />
+        </OsfLink>
         <ResourcesList::EditResource
             @registration={{@registration}}
             @reload={{this.reload}}

--- a/lib/osf-components/addon/components/resources-list/template.hbs
+++ b/lib/osf-components/addon/components/resources-list/template.hbs
@@ -5,6 +5,7 @@
     >
         <span>{{t 'osf-components.resources-list.add_instructions'}}</span>
         <OsfLink
+            data-test-resource-help-link
             aria-label={{t 'osf-components.resources-list.help_doc_link'}}
             local-class='HelpLink'
             @href='https://help.osf.io/article/410-registration-files'

--- a/tests/integration/components/resources-list/component-test.ts
+++ b/tests/integration/components/resources-list/component-test.ts
@@ -28,6 +28,7 @@ module('Integration | Component | ResourcesList', hooks => {
         await render(hbs`<ResourcesList @registration={{this.registration}} />`);
         assert.dom('[data-test-add-resource-section]')
             .containsText(t('osf-components.resources-list.add_instructions'), 'Add resource instructions shown');
+        assert.dom('data-test-resource-help-link').exists('Help link exists');
         assert.dom('[data-test-resource-card-type]').exists('resource cards shown');
     });
 

--- a/tests/integration/components/resources-list/component-test.ts
+++ b/tests/integration/components/resources-list/component-test.ts
@@ -28,7 +28,7 @@ module('Integration | Component | ResourcesList', hooks => {
         await render(hbs`<ResourcesList @registration={{this.registration}} />`);
         assert.dom('[data-test-add-resource-section]')
             .containsText(t('osf-components.resources-list.add_instructions'), 'Add resource instructions shown');
-        assert.dom('data-test-resource-help-link').exists('Help link exists');
+        assert.dom('[data-test-resource-help-link]').exists('Help link exists');
         assert.dom('[data-test-resource-card-type]').exists('resource cards shown');
     });
 

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1709,6 +1709,7 @@ routes:
 osf-components:
     resources-list:
         add_instructions: 'Link a DOI from a repository to your registration by clicking the green “+” button. Contributors affirmed to adhere to the criteria for each badge.'
+        help_doc_link: 'Learn more about linking resources to your registration'
         add_button_aria_label: 'Add resource'
         data: Data
         materials: Materials


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Add link to help guides for resources
## Summary of Changes
- Add new link in the top of resources page
- Add new translation
- TODO: add this link to the leftnav when it is ready
## Screenshot(s)
![image](https://user-images.githubusercontent.com/51409893/184216285-5cb368d3-1c51-4a61-bedc-74b4fb911742.png)

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- The helpdocs don't have a section for resources yet, but should before this feature is released