### PR TITLE
A11y fixes

### DIFF
--- a/lib/osf-components/addon/components/resources-list/edit-resource/styles.scss
+++ b/lib/osf-components/addon/components/resources-list/edit-resource/styles.scss
@@ -5,3 +5,8 @@
 .EditResourceDialogMobile {
     width: 90vw;
 }
+
+.PreviewText {
+    padding-bottom: 10px;
+    border-bottom: solid 1px $color-border-gray;
+}

--- a/lib/osf-components/addon/components/resources-list/edit-resource/template.hbs
+++ b/lib/osf-components/addon/components/resources-list/edit-resource/template.hbs
@@ -14,7 +14,7 @@
     </dialog.heading>
     <dialog.main>
         {{#if this.shouldShowPreview}}
-            <p>
+            <p local-class='PreviewText'>
                 {{t 'osf-components.resources-list.edit_resource.check_your_doi'}}
             </p>
             <ResourcesList::ResourceCard @resource={{this.resource}} @editable={{false}} />

--- a/lib/osf-components/addon/components/resources-list/resource-card/styles.scss
+++ b/lib/osf-components/addon/components/resources-list/resource-card/styles.scss
@@ -1,10 +1,3 @@
-.resourceItem {
-    list-style: none;
-    padding: 12px 0;
-    border-top: solid 1px $color-border-gray;
-    min-height: 60px;
-}
-
 .resourceType {
     display: inline-flex;
     font-weight: bold;
@@ -17,11 +10,10 @@
     margin: 0 6px;
 }
 
-.EditButton {
+.EditButtons {
     float: right;
 }
 
 .DeleteButton {
-    float: right;
     color: $brand-danger;
 }

--- a/lib/osf-components/addon/components/resources-list/resource-card/template.hbs
+++ b/lib/osf-components/addon/components/resources-list/resource-card/template.hbs
@@ -1,22 +1,35 @@
-<li local-class='resourceItem'>
-    <p data-test-resource-card-type local-class='resourceType'>
-        <img
-            src={{this.resourceIcon}}
-            alt={{t 'osf-components.resources-list.badge_alt' type=this.resourceTypeName}}
-            data-test-resource-card-icon
-            local-class='icon'
-        />
-        {{this.resourceTypeName}}
-    </p>
-    {{#unless @resource.apiMeta.anonymous}}
-        <p>
-            <OsfLink
-                data-test-resource-card-pid-link
-                @href={{concat 'https://doi.org/' @resource.pid}}
-            >
-                {{concat 'https://doi.org/' @resource.pid}}
-            </OsfLink>
-            {{#if @editable}}
+<p data-test-resource-card-type local-class='resourceType'>
+    <img
+        src={{this.resourceIcon}}
+        alt={{t 'osf-components.resources-list.badge_alt' type=this.resourceTypeName}}
+        data-test-resource-card-icon
+        local-class='icon'
+    />
+    {{this.resourceTypeName}}
+</p>
+{{#unless @resource.apiMeta.anonymous}}
+    <p>
+        <OsfLink
+            data-test-resource-card-pid-link
+            @href={{concat 'https://doi.org/' @resource.pid}}
+        >
+            {{concat 'https://doi.org/' @resource.pid}}
+        </OsfLink>
+        {{#if @editable}}
+            <div local-class='EditButtons'>
+                <ResourcesList::EditResource
+                    @resource={{@resource}}
+                    @reload={{@reload}}
+                    as |modal|
+                >
+                    <Button
+                        aria-label={{t 'osf-components.resources-list.edit_resource.edit_button_aria_label'}}
+                        @layout='fake-link'
+                        {{on 'click' modal.open}}
+                    >
+                        <FaIcon @icon='pencil-alt' @fixedWidth={{true}} />
+                    </Button>
+                </ResourcesList::EditResource>
                 <ResourcesList::DeleteResource
                     @resource={{@resource}}
                     @onDelete={{@reload}}
@@ -31,24 +44,10 @@
                         <FaIcon @icon='trash-alt' @fixedWidth={{true}} />
                     </Button>
                 </ResourcesList::DeleteResource>
-                <ResourcesList::EditResource
-                    @resource={{@resource}}
-                    @reload={{@reload}}
-                    as |modal|
-                >
-                    <Button
-                        local-class='EditButton'
-                        aria-label={{t 'osf-components.resources-list.edit_resource.edit_button_aria_label'}}
-                        @layout='fake-link'
-                        {{on 'click' modal.open}}
-                    >
-                        <FaIcon @icon='pencil-alt' @fixedWidth={{true}} />
-                    </Button>
-                </ResourcesList::EditResource>
-            {{/if}}
-        </p>
-    {{/unless}}
-    <ExpandablePreview data-test-resource-card-description>
-        {{@resource.description}}
-    </ExpandablePreview>
-</li>
+            </div>
+        {{/if}}
+    </p>
+{{/unless}}
+<ExpandablePreview data-test-resource-card-description>
+    {{@resource.description}}
+</ExpandablePreview>

--- a/lib/osf-components/addon/components/resources-list/styles.scss
+++ b/lib/osf-components/addon/components/resources-list/styles.scss
@@ -1,4 +1,3 @@
-
 .ResourceList {
     list-style-type: none;
     padding: 0;
@@ -7,6 +6,14 @@
         border-bottom: solid 1px $color-border-gray;
     }
 }
+
+.ResourceItem {
+    list-style: none;
+    padding: 12px 0;
+    border-top: solid 1px $color-border-gray;
+    min-height: 60px;
+}
+
 
 .EmptyList {
     padding: 12px 0;

--- a/lib/osf-components/addon/components/resources-list/template.hbs
+++ b/lib/osf-components/addon/components/resources-list/template.hbs
@@ -31,11 +31,13 @@
         local-class='ResourceList'
 >
     <:item as |resource|>
-        <ResourcesList::ResourceCard
-            @resource={{resource}}
-            @editable={{@registration.userHasWritePermission}}
-            @reload={{this.reload}}
-        />
+        <li local-class='ResourceItem'>
+            <ResourcesList::ResourceCard
+                @resource={{resource}}
+                @editable={{@registration.userHasWritePermission}}
+                @reload={{this.reload}}
+            />
+        </li>
     </:item>
     <:empty>
         <li local-class='EmptyList'>{{t 'osf-components.resources-list.no-resources'}}</li>


### PR DESCRIPTION

-   Ticket: []
-   Feature flag: n/a

## Purpose
- Fix tab order in editable resource card
- Remove `<li>` from ResourceCard component, so we don't have a `<li>` that's not wrapped in a `<ul>`

## Summary of Changes
- Wrap edit and delete button in a div, change their order
- Move `<li>` wrapper from ResourceCard component to ResourcesList

## Screenshot(s)
- No visible changes

## Side Effects
- none
## QA Notes
- Tab order should be "as expected" now, and shouldn't have an a11y issue in the Add Resource modal
