### PR TITLE
Remove metadata panel on registries components page

### DIFF
--- a/lib/registries/addon/overview/controller.ts
+++ b/lib/registries/addon/overview/controller.ts
@@ -51,7 +51,10 @@ export default class Overview extends Controller {
     }
 
     get showMetadata() {
-        if (this.router.currentRouteName.includes('registries.overview.files')) {
+        if (
+            this.router.currentRouteName.includes('registries.overview.files') ||
+            this.router.currentRouteName.includes('registries.overview.children')
+        ) {
             return false;
         }
         return true;


### PR DESCRIPTION
-   Ticket: [Notion](https://www.notion.so/cos/Badge-and-Labels-are-Oddly-Aligned-b6c1ffe18826470da119945092177d12)
## Purpose

Make the node cards on the components tab of the registries overview look better by removing the right panel and giving the cards more room to breathe.

## Summary of Changes

1. Remove metadata panel on registries components page.

## Screenshot(s)

<img width="1414" alt="Screen Shot 2022-08-11 at 4 37 03 PM" src="https://user-images.githubusercontent.com/6599111/184355659-e47196a5-e8d3-4213-afdb-755281ddd5ea.png">

## Side Effects

No, this is isolated.

