### PR TITLE
Remove badges list padding for mobile view

### DIFF
--- a/lib/osf-components/addon/components/node-card/styles.scss
+++ b/lib/osf-components/addon/components/node-card/styles.scss
@@ -121,4 +121,5 @@
 
 .OpenBadges__mobile {
     width: 10%;
+    padding-left: 0;
 }


### PR DESCRIPTION


-   Ticket: [notion card](https://www.notion.so/cos/Registration-badges-go-off-the-card-in-mobile-view-1a85009ebe1b4fde9e2d0747a8ef2e99)
-   Feature flag: n/a

## Purpose
- Fix some mobile view issues with node cards

## Summary of Changes
- Remove padding for mobile view node-card badges list

## Screenshot(s)
prevents this issue
![Untitled (2)](https://user-images.githubusercontent.com/51409893/184431104-7cc345be-0081-4e8b-83d2-f8802e21e123.png)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
