### PR TITLE
Resource error handling

### DIFF
--- a/lib/osf-components/addon/components/resources-list/edit-resource/component.ts
+++ b/lib/osf-components/addon/components/resources-list/edit-resource/component.ts
@@ -104,15 +104,17 @@ export default class EditResourceModal extends Component<Args> {
                 }
             } catch (e) {
                 this.resource?.rollbackAttributes();
-                if (e.errors[0].status === '400') {
+                const error = e.errors[0];
+                if (error.status === '400') {
+                    let message = this.intl.t('validationErrors.invalid', {
+                        description: this.intl.t('osf-components.resources-list.edit_resource.doi'),
+                    });
+                    if (error.source.pointer === '/data/attributes') {
+                        message = this.intl.t('osf-components.resources-list.edit_resource.doi_already_used');
+                    }
                     this.changeset.addError(
                         'pid',
-                        this.intl.t(
-                            'validationErrors.invalid',
-                            {
-                                description: this.intl.t('osf-components.resources-list.edit_resource.doi'),
-                            },
-                        ),
+                        message,
                     );
                 }
             }

--- a/mirage/views/resource.ts
+++ b/mirage/views/resource.ts
@@ -18,7 +18,13 @@ export function updateResource(this: HandlerContext, schema: Schema, request: Re
     };
     if ('pid' in attributes) {
         if (!attributes.pid || !attributes.pid.startsWith('10.')) {
-            return new Response(400);
+            return new Response(400, {}, {
+                errors: [{
+                    status: '400',
+                    detail: 'invalid doi',
+                    source: {pointer: '/data/attributes/pid'},
+                }],
+            });
         }
     }
     resource.update(attributes);

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1724,6 +1724,7 @@ osf-components:
             edit_heading: 'Edit resource'
             add_heading: 'Add new resource'
             doi: 'DOI'
+            doi_already_used: 'A resource with this DOI and type already exists.'
             output_type: 'Resource type'
             description: 'Description'
             check_your_doi: 'Check your DOI for accuracy.'


### PR DESCRIPTION
-   Ticket: [notion ticket](https://www.notion.so/cos/Misleading-error-message-when-updating-a-resource-e01b8a4f655e40c796116fb2587e614f)
-   Feature flag: n/a

## Purpose
- Give better error messaging for DOIs conflicts
## Summary of Changes
- Check error source  on error and change error message accordingly
## Screenshot(s)
![image](https://user-images.githubusercontent.com/51409893/184435768-cf70f9b1-8583-48b1-9950-f01e4879a399.png)
## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
