### PR TITLE
Fix AVOL view

### DIFF
--- a/lib/osf-components/addon/components/resources-list/resource-card/template.hbs
+++ b/lib/osf-components/addon/components/resources-list/resource-card/template.hbs
@@ -8,7 +8,7 @@
         />
         {{this.resourceTypeName}}
     </p>
-    {{#unless @resource.apiMeta.anonymous}}
+    {{#if @resource.pid}}
         <p>
             <OsfLink
                 data-test-resource-card-pid-link
@@ -47,7 +47,7 @@
                 </ResourcesList::EditResource>
             {{/if}}
         </p>
-    {{/unless}}
+    {{/if}}
     <ExpandablePreview data-test-resource-card-description>
         {{@resource.description}}
     </ExpandablePreview>

--- a/tests/integration/components/resources-list/resource-card/component-test.ts
+++ b/tests/integration/components/resources-list/resource-card/component-test.ts
@@ -53,6 +53,7 @@ module('Integration | Component | ResourcesList::ResourceCard', hooks => {
     test('it renders anonymized view', async function(assert) {
         const mirageResource = server.create('resource', {
             resourceType: ResourceTypes.Materials,
+            pid: '',
             apiMeta: { version: '0', anonymous: true },
         });
         this.set('resource', mirageResource);


### PR DESCRIPTION
-   Ticket: [Notion](https://www.notion.so/cos/Links-to-doi-org-when-viewing-on-an-AVOL-5af01ba377344b368903114ef89eae02)
-   Feature flag: n/a

## Purpose

For some reason, the anonymized view link wasn't causing us to hide the PID link (I suspect because the meta tag is part of the list and not the individual items of the list, but I didn't look that closely into it). This changes the test to something more direct, so that if the pid value is missing, it won't try to render the link.

## Summary of Changes

1. Use pid value for checking whether to render PID link
2. Update test

