### PR TITLE
Move edit/delete buttons in resource card

### DIFF
--- a/lib/osf-components/addon/components/resources-list/resource-card/styles.scss
+++ b/lib/osf-components/addon/components/resources-list/resource-card/styles.scss
@@ -1,5 +1,4 @@
 .resourceType {
-    display: inline-flex;
     font-weight: bold;
 }
 

--- a/lib/osf-components/addon/components/resources-list/resource-card/template.hbs
+++ b/lib/osf-components/addon/components/resources-list/resource-card/template.hbs
@@ -6,6 +6,37 @@
         local-class='icon'
     />
     {{this.resourceTypeName}}
+    {{#if @editable}}
+        <div local-class='EditButtons'>
+            <ResourcesList::EditResource
+                @resource={{@resource}}
+                @reload={{@reload}}
+                as |modal|
+            >
+                <Button
+                    aria-label={{t 'osf-components.resources-list.edit_resource.edit_button_aria_label'}}
+                    @layout='fake-link'
+                    {{on 'click' modal.open}}
+                >
+                    <FaIcon @icon='pencil-alt' @fixedWidth={{true}} />
+                </Button>
+            </ResourcesList::EditResource>
+            <ResourcesList::DeleteResource
+                @resource={{@resource}}
+                @onDelete={{@reload}}
+                as |modal|
+            >
+                <Button
+                    local-class='DeleteButton'
+                    aria-label={{t 'osf-components.resources-list.delete_resource.title'}}
+                    @layout='fake-link'
+                    {{on 'click' modal.open}}
+                >
+                    <FaIcon @icon='trash-alt' @fixedWidth={{true}} />
+                </Button>
+            </ResourcesList::DeleteResource>
+        </div>
+    {{/if}}
 </p>
 {{#if @resource.pid}}
     <p>
@@ -15,37 +46,6 @@
         >
             {{concat 'https://doi.org/' @resource.pid}}
         </OsfLink>
-        {{#if @editable}}
-            <div local-class='EditButtons'>
-                <ResourcesList::EditResource
-                    @resource={{@resource}}
-                    @reload={{@reload}}
-                    as |modal|
-                >
-                    <Button
-                        aria-label={{t 'osf-components.resources-list.edit_resource.edit_button_aria_label'}}
-                        @layout='fake-link'
-                        {{on 'click' modal.open}}
-                    >
-                        <FaIcon @icon='pencil-alt' @fixedWidth={{true}} />
-                    </Button>
-                </ResourcesList::EditResource>
-                <ResourcesList::DeleteResource
-                    @resource={{@resource}}
-                    @onDelete={{@reload}}
-                    as |modal|
-                >
-                    <Button
-                        local-class='DeleteButton'
-                        aria-label={{t 'osf-components.resources-list.delete_resource.title'}}
-                        @layout='fake-link'
-                        {{on 'click' modal.open}}
-                    >
-                        <FaIcon @icon='trash-alt' @fixedWidth={{true}} />
-                    </Button>
-                </ResourcesList::DeleteResource>
-            </div>
-        {{/if}}
     </p>
 {{/if}}
 <ExpandablePreview data-test-resource-card-description>


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [Notion card](https://www.notion.so/cos/Resource-Card-Move-Edit-and-Delete-resource-buttons-to-same-line-as-resource-type-2a60928d5aa040b6a92520a872ccf678)
-   Feature flag: n/a

## Purpose
- Prevent unexpected whitespace of resource cards in mobile view

## Summary of Changes
- Move edit/delete buttons in resource card to same line as resource type

## Screenshot(s)
Before:
![image](https://user-images.githubusercontent.com/51409893/184956142-65150879-8e48-42e6-b1af-0252344e3e43.png)


After:
![image](https://user-images.githubusercontent.com/51409893/184955684-794c183c-19bb-4f87-a58e-b01634edc0bf.png)

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
