### PR TITLE
Match font weight on resource icons

### DIFF
--- a/lib/osf-components/addon/components/open-resource/styles.scss
+++ b/lib/osf-components/addon/components/open-resource/styles.scss
@@ -1,6 +1,5 @@
 .OutputResource_figure {
     display: flex;
-    font-weight: 100;
     padding-left: 9px;
     padding-top: 3px;
 }


### PR DESCRIPTION
-   Ticket: [Notion](https://www.notion.so/cos/Adjust-font-weight-of-left-nav-resources-text-to-match-the-node-card-resources-list-645d7c3035e44e58bd4c0089af21a381)
-   Feature flag: n/a

## Purpose

Make the font weight of the leftnav resource icons match the font weight of the other resource icons.

## Summary of Changes

1. Remove font-weight line from css

## Screenshot(s)

New leftnav:
<img width="204" alt="Screen Shot 2022-08-16 at 4 22 47 PM" src="https://user-images.githubusercontent.com/6599111/184978548-7b9ab1f8-d24c-47e7-a99b-63e71a28b014.png">

Existing My Registrations page:
<img width="216" alt="Screen Shot 2022-08-16 at 4 22 54 PM" src="https://user-images.githubusercontent.com/6599111/184978585-a20421d5-c662-4535-b9a0-f24a588a8629.png">
