### PR TITLE
Open resource help link in new tab

### DIFF
--- a/lib/osf-components/addon/components/resources-list/template.hbs
+++ b/lib/osf-components/addon/components/resources-list/template.hbs
@@ -9,6 +9,7 @@
             aria-label={{t 'osf-components.resources-list.help_doc_link'}}
             local-class='HelpLink'
             @target='_blank'
+            @rel='noopener noreferrer'
             @href='https://help.osf.io/article/410-registration-files'
         >
             <FaIcon @icon= 'question-circle' />

--- a/lib/osf-components/addon/components/resources-list/template.hbs
+++ b/lib/osf-components/addon/components/resources-list/template.hbs
@@ -8,6 +8,7 @@
             data-test-resource-help-link
             aria-label={{t 'osf-components.resources-list.help_doc_link'}}
             local-class='HelpLink'
+            @target='_blank'
             @href='https://help.osf.io/article/410-registration-files'
         >
             <FaIcon @icon= 'question-circle' />


### PR DESCRIPTION
-   Ticket: [notion card](https://www.notion.so/cos/Help-link-open-help-doc-in-new-tab-d303461852f6479e97b6b82d73aca5c6)
-   Feature flag: n/a

## Purpose
- Open registration resources help link in a new tab

## Summary of Changes

## Screenshot(s)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
