### PR TITLE
Click outside feature popover closes the popover

### DIFF
--- a/lib/osf-components/addon/components/new-feature-popover/component.ts
+++ b/lib/osf-components/addon/components/new-feature-popover/component.ts
@@ -19,6 +19,16 @@ export default class NewFeaturePopover extends Component<Args> {
     }
 
     @action
+    setClickOutsideHandler(element: HTMLElement, [closePopover]:[any]) {
+        const bodyElement = document.querySelector('body');
+        bodyElement?.addEventListener('click', event => {
+            if (!event.composedPath().includes(element)) {
+                closePopover();
+            }
+        });
+    }
+
+    @action
     onAccept() {
         if (this.notAgain) {
             this.cookies.write(this.args.featureCookie, 1, {

--- a/lib/osf-components/addon/components/new-feature-popover/component.ts
+++ b/lib/osf-components/addon/components/new-feature-popover/component.ts
@@ -19,16 +19,6 @@ export default class NewFeaturePopover extends Component<Args> {
     }
 
     @action
-    setClickOutsideHandler(element: HTMLElement, [closePopover]:[any]) {
-        const bodyElement = document.querySelector('body');
-        bodyElement?.addEventListener('click', event => {
-            if (!event.composedPath().includes(element)) {
-                closePopover();
-            }
-        });
-    }
-
-    @action
     onAccept() {
         if (this.notAgain) {
             this.cookies.write(this.args.featureCookie, 1, {

--- a/lib/osf-components/addon/components/new-feature-popover/template.hbs
+++ b/lib/osf-components/addon/components/new-feature-popover/template.hbs
@@ -17,7 +17,7 @@
     <footer
         data-test-popover-footer
         local-class='FlexFooter'
-        {{did-insert this.setClickOutsideHandler popover.close}}
+        {{on-click-outside popover.close}}
     >
         {{yield to='footer'}}
         <label data-test-not-again-checkbox>

--- a/lib/osf-components/addon/components/new-feature-popover/template.hbs
+++ b/lib/osf-components/addon/components/new-feature-popover/template.hbs
@@ -14,13 +14,18 @@
         {{yield to='body'}} 
     </section>
 
-    <footer data-test-popover-footer local-class='FlexFooter'>
+    <footer
+        data-test-popover-footer
+        local-class='FlexFooter'
+        {{did-insert this.setClickOutsideHandler popover.close}}
+    >
         {{yield to='footer'}}
         <label data-test-not-again-checkbox>
             {{t 'osf-components.new-feature-popover.doNotShowAgain'}}
             <Input @type='checkbox' @checked={{this.notAgain}} />
         </label>
         <Button
+            id='unique-button'
             data-test-got-it-button
             @type='primary'
             {{on 'click' popover.close}}

--- a/lib/osf-components/addon/components/new-feature-popover/template.hbs
+++ b/lib/osf-components/addon/components/new-feature-popover/template.hbs
@@ -25,7 +25,6 @@
             <Input @type='checkbox' @checked={{this.notAgain}} />
         </label>
         <Button
-            id='unique-button'
             data-test-got-it-button
             @type='primary'
             {{on 'click' popover.close}}

--- a/lib/osf-components/addon/modifiers/on-click-outside.ts
+++ b/lib/osf-components/addon/modifiers/on-click-outside.ts
@@ -1,0 +1,13 @@
+import { modifier } from 'ember-modifier';
+
+export default modifier((element: HTMLElement, [callback]: [any]) => {
+    function handleClick(event: Event) {
+        if (!element.contains(event.target as any)) {
+            callback();
+        }
+    }
+    document.addEventListener('click', handleClick);
+    return () => {
+        document.removeEventListener('click', callback);
+    };
+});

--- a/lib/osf-components/app/modifiers/on-click-outside.js
+++ b/lib/osf-components/app/modifiers/on-click-outside.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/modifiers/on-click-outside';


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose

Clicking outside the feature popover footer section should close the popover.

## Summary of Changes

Added a `on-click-ouside` modifier to handle click outside behavior.

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
