### PR TITLE
Add whitespace above description

### DIFF
--- a/lib/osf-components/addon/components/resources-list/edit-resource/styles.scss
+++ b/lib/osf-components/addon/components/resources-list/edit-resource/styles.scss
@@ -6,6 +6,10 @@
     width: 90vw;
 }
 
+.DescriptionField {
+    margin-top: 15px;
+}
+
 .PreviewText {
     padding-bottom: 10px;
     border-bottom: solid 1px $color-border-gray;

--- a/lib/osf-components/addon/components/resources-list/edit-resource/template.hbs
+++ b/lib/osf-components/addon/components/resources-list/edit-resource/template.hbs
@@ -47,6 +47,7 @@
                     </form.select>
                     <form.textarea
                         data-test-description-field
+                        local-class='DescriptionField'
                         @valuePath={{'description'}}
                         @label={{t 'osf-components.resources-list.edit_resource.description'}}
                     />


### PR DESCRIPTION
-   Ticket: [Notion card](https://www.notion.so/cos/Add-whitespace-between-Resource-type-and-description-in-Add-Edit-resource-modal-3b5c5ad4640e436fa1478c3dae9ecf4a)
-   Feature flag: n/a

## Purpose
- Add some whitespace above the "Description" in the add/edit resource modal

## Summary of Changes
- Add class to modal description

## Screenshot(s)
- before screenshot in the notion card
- After
![image](https://user-images.githubusercontent.com/51409893/185435270-b8791b65-de56-4ada-830a-584ccffd52c4.png)
![image](https://user-images.githubusercontent.com/51409893/185435363-2e51d908-5218-482f-acb6-cebdb2bdd33b.png)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
