### PR TITLE
Prevent doi prefix text-wrap. Change prefix background color

### DIFF
--- a/lib/osf-components/addon/components/validated-input/text/styles.scss
+++ b/lib/osf-components/addon/components/validated-input/text/styles.scss
@@ -6,7 +6,7 @@
 .Prefix {
     background-color: $color-bg-gray-light;
     border-right: solid 1px $color-border-gray;
-    padding: 6px 12px;
+    padding: 6px;
     flex-shrink: 0;
 
 }

--- a/lib/osf-components/addon/components/validated-input/text/styles.scss
+++ b/lib/osf-components/addon/components/validated-input/text/styles.scss
@@ -1,5 +1,14 @@
-.PrefixedInputBox {
-    display: flex !important;
+:global(.form-control).PrefixedInputBox {
+    display: flex;
+    padding: 0;
+}
+
+.Prefix {
+    background-color: $color-bg-gray-light;
+    border-right: solid 1px $color-border-gray;
+    padding: 6px 12px;
+    flex-shrink: 0;
+
 }
 
 .PrefixedInput {

--- a/lib/osf-components/addon/components/validated-input/text/template.hbs
+++ b/lib/osf-components/addon/components/validated-input/text/template.hbs
@@ -9,7 +9,7 @@
 }}
     {{#if @prefix}}
         <div class='form-control' local-class='PrefixedInputBox' >
-            <span>{{@prefix}}</span>
+            <span local-class='Prefix'>{{@prefix}}</span>
             <Input
                 aria-label={{this.ariaLabel}}
                 @id={{or @uniqueID inputElementId}}


### PR DESCRIPTION
-   Ticket: [Notion card](https://www.notion.so/cos/Add-Edit-resource-on-small-screens-b4ce82cc55914699966f7ee89b61aa21)
-   Feature flag: n/a

## Purpose
- Prevent text-wrap of "doi.org" prefix
- Change styling of uneditable prefix to make it more clear that it is not an editable part of the text-input

## Summary of Changes
- CSS changes

## Screenshot(s)
- Prior on Galaxy S8+:
![image](https://user-images.githubusercontent.com/51409893/185494447-58a337d3-29e5-43f9-8074-fdf63ba508f4.png)

- After on Galaxy S8+:
![image](https://user-images.githubusercontent.com/51409893/185497751-5c776e46-b965-4490-8ba3-d1e822d162da.png)

- After desktop:
![image](https://user-images.githubusercontent.com/51409893/185497782-c2b7d9ba-1c3f-4cdf-b090-0ec17d918a91.png)


## Side Effects
- ~~The right border is not fully visible on small screens...~~

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
