### PR TITLE
[ENG-3885][Bug-fix] Add left margin to resource card badges list

### DIFF
--- a/lib/osf-components/addon/components/open-badges-list/open-badge-card/styles.scss
+++ b/lib/osf-components/addon/components/open-badges-list/open-badge-card/styles.scss
@@ -1,4 +1,6 @@
 .badgeItem {
+    display: inline-flex;
+    flex-direction: row;
     margin-bottom: 10px;
 }
 

--- a/lib/osf-components/addon/components/open-badges-list/styles.scss
+++ b/lib/osf-components/addon/components/open-badges-list/styles.scss
@@ -1,4 +1,24 @@
 .title {
     font-weight: 700;
-    margin-top: 0;
+}
+
+.badgeList {
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: left;
+    align-items: stretch;
+    margin-left: 9px;
+}
+
+.badgeList p {
+    margin-left: 9px;
+}
+
+.badgeList a {
+    justify-content: left;
+    margin-left: 2px;
+}
+
+.badgeList span {
+    margin-right: 2px;
 }

--- a/lib/osf-components/addon/components/open-badges-list/styles.scss
+++ b/lib/osf-components/addon/components/open-badges-list/styles.scss
@@ -12,6 +12,7 @@
 
 .badgeList p {
     margin-left: 9px;
+    margin-top: 14px;
 }
 
 .badgeList a {


### PR DESCRIPTION
-   Ticket: https://openscience.atlassian.net/browse/ENG-3885
-   Feature flag: feature/resource-card-add-left-margin

## Purpose

The purpose of these changes was to add margin and padding to the resource list on the card view.

## Summary of Changes

Some flexbox, padding and margin were added to the open-badges-list and the open-badge-card scss files.

## Screenshot(s)

Before:
<img width="1454" alt="My Registrations" src="https://user-images.githubusercontent.com/82047646/185503061-220519fa-68c7-427c-bd36-8ff704950060.png">
After:
<img width="1677" alt="image" src="https://user-images.githubusercontent.com/82047646/185630545-a15aef77-8563-41cf-9b8a-98d63a5a6a69.png">

## Side Effects

No, not currently.

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
