### PR TITLE
Open links in a new tab

### DIFF
--- a/lib/osf-components/addon/components/resources-list/resource-card/template.hbs
+++ b/lib/osf-components/addon/components/resources-list/resource-card/template.hbs
@@ -43,6 +43,8 @@
         <OsfLink
             data-test-resource-card-pid-link
             @href={{concat 'https://doi.org/' @resource.pid}}
+            @target='_blank'
+            @rel='noopener noreferrer'
         >
             {{concat 'https://doi.org/' @resource.pid}}
         </OsfLink>

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -147,13 +147,15 @@
                         <div data-test-resources-wrapper local-class='ResourcesWrapper'>
                             <div local-class='ResourcesWrapper_title'>
                                 <h3>{{t 'registries.overview.resources.left_nav_title'}}</h3>
-                                <FaIcon local-class='HelpIcon' @icon='question-circle' />
-                                <BsTooltip
-                                    @placement='right'
-                                    @triggerEvents='hover'
+                                <OsfLink
+                                    data-test-resource-leftnav-help-link
+                                    aria-label={{t 'osf-components.resources-list.help_doc_link'}}
+                                    @target='_blank'
+                                    @rel='noopener noreferrer'
+                                    @href='https://help.osf.io/article/410-registration-files'
                                 >
-                                    {{t 'registries.overview.resources.help_icon'}}
-                                </BsTooltip>
+                                    <FaIcon local-class='HelpIcon' @icon='question-circle' />
+                                </OsfLink>
                             </div>
                             <OpenResource
                                 data-test-data-resource


### PR DESCRIPTION
-   Tickets: 
    - [Notion ticket 1](https://www.notion.so/cos/Open-Check-DOI-for-accuracy-in-a-new-tab-8a682761e99a48f090704472360294a7)
    - [Notion ticket 2](https://www.notion.so/cos/Have-in-leftnav-go-to-help-guides-in-a-new-tab-fd5aee5565ef400ebfe41556c6f881f7)
-   Feature flag: n/a

## Purpose

Open some links in a new tab. *Note*: Links to help docs are still temporary and need replacing before deploying.

## Summary of Changes

1. Add link to help docs to the leftnav question mark icon
2. Make link to DOI in the add modal's preview open the doi in a new tab

