### PR TITLE
Don't show popover when not showing leftnav

### DIFF
--- a/lib/registries/addon/overview/controller.ts
+++ b/lib/registries/addon/overview/controller.ts
@@ -11,6 +11,7 @@ import { GuidRouteModel } from 'ember-osf-web/resolve-guid/guid-route';
 import pathJoin from 'ember-osf-web/utils/path-join';
 
 import Intl from 'ember-intl/services/intl';
+import Media from 'ember-responsive';
 import RouterService from '@ember/routing/router-service';
 import Features from 'ember-feature-flags';
 
@@ -36,6 +37,7 @@ export default class Overview extends Controller {
     @service router!: RouterService;
     @service features!: Features;
     model!: GuidRouteModel<Registration>;
+    @service media!: Media;
 
     queryParams = ['mode', 'revisionId'];
     supportEmail = supportEmail;
@@ -48,6 +50,10 @@ export default class Overview extends Controller {
 
     get registrationFilesPageEnabled() {
         return this.features.isEnabled(registrationFilesPage);
+    }
+
+    get showNewFeaturePopover() {
+        return this.media.isDesktop;
     }
 
     get showMetadata() {

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -107,17 +107,19 @@
                                 @label={{t 'registries.overview.resources.title'}}
                                 id={{id}}
                             />
-                            <NewFeaturePopover
-                                @triggerElement={{concat '#' id}}
-                                @featureCookie={{this.outputFeaturePopoverCookie}}
-                            >
-                                <:header>
-                                    {{t 'registries.overview.files.outputFeaturePopoverHeading'}}
-                                </:header>
-                                <:body>
-                                    {{t 'registries.overview.files.outputFeaturePopoverBody'}}
-                                </:body>
-                            </NewFeaturePopover>
+                            {{#if this.showNewFeaturePopover}}
+                                <NewFeaturePopover
+                                    @triggerElement={{concat '#' id}}
+                                    @featureCookie={{this.outputFeaturePopoverCookie}}
+                                >
+                                    <:header>
+                                        {{t 'registries.overview.files.outputFeaturePopoverHeading'}}
+                                    </:header>
+                                    <:body>
+                                        {{t 'registries.overview.files.outputFeaturePopoverBody'}}
+                                    </:body>
+                                </NewFeaturePopover>
+                            {{/if}}
                         {{/let}}
                     {{/if}}
                     {{#if this.registration.wikiEnabled}}


### PR DESCRIPTION
-   Ticket: [Notion](https://www.notion.so/cos/Hide-New-feature-popover-on-mobile-7443be0a51bb4fe2b7870bc9e5499589)

## Purpose

Hide the New Feature Popover when in tablet or mobile view, since that's when the leftnav will be potentially hidden, so the popover would otherwise point at nothing.

I tried to do this using the popover's `shouldShow` getter, but it resulted in erratic behavior. Basically, it would work if you started in mobile view, but if you went from desktop to mobile view, it would still show the popover. Also, I didn't want to put the logic on the popover itself since, in this particular instance, we're hiding it for both tablet and mobile view, not just mobile view, and that won't always necessarily be true for the popover.

One oddity with this implementation is that if you close the popover without clicking "never show again", then go to mobile, then go to desktop, the popover will come back.

## Summary of Changes

1. Make a check for isDesktop
2. Only show popover if on desktop

