### PR TITLE
Use correct link for leftnav help

### DIFF
--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -154,7 +154,7 @@
                                     aria-label={{t 'osf-components.resources-list.help_doc_link'}}
                                     @target='_blank'
                                     @rel='noopener noreferrer'
-                                    @href='https://help.osf.io/article/410-registration-files'
+                                    @href='https://help.osf.io/article/452-open-practice-badges'
                                 >
                                     <FaIcon local-class='HelpIcon' @icon='question-circle' />
                                 </OsfLink>


### PR DESCRIPTION
-   Ticket: [Notion](https://www.notion.so/cos/Replace-help-guide-link-with-real-link-in-leftnav-a8c9ed25146548e99ac48b0ff6d7fd57)
-   Feature flag: n/a

## Purpose

We just got the link for the leftnav help, so this replaces the old, placeholder link with the new one. Note: the link will not be live yet, it's in preview-only for now.

## Summary of Changes

1. Use new link

