### PR TITLE
[No ticket] Hide add-resource button if resources are not visible

### DIFF
--- a/lib/osf-components/addon/components/resources-list/template.hbs
+++ b/lib/osf-components/addon/components/resources-list/template.hbs
@@ -1,4 +1,4 @@
-{{#if @registration.userHasWritePermission}}
+{{#if (and @registration.userHasWritePermission @registration.resourcesVisible)}}
     <div
         local-class='AddResourceHeading'
         data-test-add-resource-section


### PR DESCRIPTION
-   Ticket: [Notion card](https://www.notion.so/cos/Hide-Add-resource-button-for-pending-registrations-fb4c68591c814f439098a076949ff62c)
-   Feature flag: n/a

## Purpose
- Hide the Add Resource button if the registration is not in a state that can accept resources, as the modal behaves a bit erratically when the registration is in that state (ie: can't select a resource type)

## Summary of Changes
- Update condition to show add button

## Screenshot(s)
Registration pending moderation when a user manually goes to the resources page:
![image](https://user-images.githubusercontent.com/51409893/185961594-2b50c8c7-3271-4099-a850-c7aeae2c787c.png)


## Side Effects
None

## QA Notes
Users _shouldn't_ be going to the resources page (resource link hidden in the leftnav) when a registration is pending admin/moderator approval, but some people (like me) might manually go to the resources page and get confused when they see that big green button