### PR TITLE
Add error toast if DOI validation fails

### DIFF
--- a/lib/osf-components/addon/components/resources-list/edit-resource/component.ts
+++ b/lib/osf-components/addon/components/resources-list/edit-resource/component.ts
@@ -116,6 +116,9 @@ export default class EditResourceModal extends Component<Args> {
                         'pid',
                         message,
                     );
+                } else {
+                    this.toast.error(getApiErrorMessage(e),
+                        this.intl.t('osf-components.resources-list.edit_resource.failed_to_validate'));
                 }
             }
         }

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1747,6 +1747,7 @@ osf-components:
             output_type: 'Resource type'
             description: 'Description'
             check_your_doi: 'Check your DOI for accuracy.'
+            failed_to_validate: 'Failed to validate DOI'
             add_success: 'Resource successfully added.'
             add_failure: 'Failed to add resource.'
             save_success: 'Resource successfully saved.'


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Give indication that the DOI validation fails
## Summary of Changes
- Add toast behavior if the error returned from API is not a 400

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
