### PR TITLE
[ENG-2792] Fix special chars in node license copyright holder

### DIFF
--- a/app/transforms/node-license.ts
+++ b/app/transforms/node-license.ts
@@ -1,6 +1,7 @@
 import Transform from '@ember-data/serializer/transform';
 
 import { NodeLicense } from 'ember-osf-web/models/node';
+import fixSpecialChars from 'ember-osf-web/utils/fix-special-char';
 import { camelizeKeys, snakifyKeys } from 'ember-osf-web/utils/map-keys';
 
 interface SerializedNodeLicense {
@@ -25,7 +26,8 @@ export default class NodeLicenseTransform extends Transform {
         } = camelizeKeys(value) as DeserializedNodeLicense;
 
         return Object.freeze({
-            copyrightHolders: typeof copyrightHolders === 'string' ? copyrightHolders : copyrightHolders.join(', '),
+            copyrightHolders: typeof copyrightHolders === 'string' ? fixSpecialChars(copyrightHolders)
+                : fixSpecialChars(copyrightHolders.join(', ')),
             year,
         });
     }


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-2792]
-   Feature flag: n/a

## Purpose
- Fix special characters (`&`, `>` and `<`) in node-license copyright holder field

## Summary of Changes
- Wrap copyright holder in `fixSpecialChars` in the `node-license` transform

## Screenshot(s)
- After loading a draft registration that had a special character in the copyright holder field:
![image](https://user-images.githubusercontent.com/51409893/187297371-c3fb1d44-3740-46f0-ae91-85514246f470.png)


## Side Effects
- None

## QA Notes
- The copyright holder in the API will still have special characters encoded as `&amp;`, `&gt;`, and `&lt;`. 

[ENG-2792]: https://openscience.atlassian.net/browse/ENG-2792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ