### PR TITLE
[ENG-1119] Show full doi url for registration doi

### DIFF
--- a/lib/osf-components/addon/components/node-doi/template.hbs
+++ b/lib/osf-components/addon/components/node-doi/template.hbs
@@ -3,5 +3,5 @@
     data-test-registration-doi
     @href={{@manager.nodeDoiUrl}}
 >
-    {{@manager.nodeDoi}}
+    {{@manager.nodeDoiUrl}}
 </OsfLink>


### PR DESCRIPTION
-   Ticket: [ENG-1119]

## Purpose

Instead of showing just the DOI for registration DOIs, show the full URL. Note: There's an alternative approach to this where we have the [backend return to us the full URI](https://github.com/CenterForOpenScience/osf.io/pull/9825). Once that's in, if we want we can alter the computed property that this uses to just grab the value of the full URI instead, so this is a good intermediate step to the backend changing.

## Summary of Changes

1. Use the doi url property instead of the doi property

## Screenshot(s)
<img width="295" alt="Screen Shot 2022-08-31 at 9 15 20 AM" src="https://user-images.githubusercontent.com/6599111/187689757-ef38a956-8942-4d1c-8e16-ea4fabcebed7.png">


## Side Effects

No, this is isolated



[ENG-1119]: https://openscience.atlassian.net/browse/ENG-1119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ