### PR TITLE
[ENG-2293] Don't try to filter on subjects

### DIFF
--- a/lib/registries/addon/discover/controller.ts
+++ b/lib/registries/addon/discover/controller.ts
@@ -278,7 +278,6 @@ export default class Discover extends Controller.extend(discoverQueryParams.Mixi
             filters: OrderedSet([
                 ...this.sourceFilters,
                 ...this.registrationTypes,
-                ...this.subjects,
                 ...this.additionalFilters,
             ]),
         });


### PR DESCRIPTION
-   Ticket: [ENG-2293]

## Purpose

Don't try to filter on subjects. It's not fully implemented, so it causes a particular bug when the query parameter is in the url. This is a minimal-change fix to this to keep the search page from being stuck on zero search results, rather than finishing out the feature or deleting it entirely.

## Summary of Changes

1. Remove the subjects filter from the list of filters. (h/t @futa-ikeda)

## Screenshot(s)

Before:
<img width="307" alt="Screen Shot 2022-08-31 at 3 33 29 PM" src="https://user-images.githubusercontent.com/6599111/187767512-c374b39a-a1b8-485e-9ff0-29e1d1d06897.png">


After:
<img width="305" alt="Screen Shot 2022-08-31 at 3 34 20 PM" src="https://user-images.githubusercontent.com/6599111/187767539-d238cf59-8e51-4eb9-acb7-081c3dd10372.png">


## Side Effects

Won't be able to filter on subjects, but we couldn't before, so… no?



[ENG-2293]: https://openscience.atlassian.net/browse/ENG-2293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ