### PR TITLE
[ENG-3511] Fix analytics page linked projects list

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -67,6 +67,7 @@ const App = Application.extend({
                 services: [
                     'intl',
                     'cookies',
+                    'current-user',
                     'store',
                     'analytics',
                     'ready',
@@ -76,6 +77,7 @@ const App = Application.extend({
                     'head-data',
                     'osf-modal-state',
                     'osf-router',
+                    'toast',
                 ],
                 externalRoutes: {
                     nodeForks: 'guid-node.forks',

--- a/lib/analytics-page/addon/engine.js
+++ b/lib/analytics-page/addon/engine.js
@@ -12,6 +12,7 @@ const Eng = Engine.extend({
         services: [
             'intl',
             'cookies',
+            'current-user',
             'store',
             'analytics',
             'ready',
@@ -21,6 +22,7 @@ const Eng = Engine.extend({
             'osf-router',
             'page-title-list',
             'head-data',
+            'toast',
         ],
         externalRoutes: [
             'nodeForks',


### PR DESCRIPTION
-   Ticket: [ENG-3511]

## Purpose

The linked projects list in the project analytics engine wasn't rendering. It looks like, sometime after we implemented the list, we added the toast and current-user services to the node-card (or something in the node-card chain). Those services weren't in the analytics engine, so the rendering of the node-card broke. This corrects that problem.

## Summary of Changes

1. Add missing services to engine

## Screenshot(s)
<img width="620" alt="Screen Shot 2022-09-01 at 9 23 19 AM" src="https://user-images.githubusercontent.com/6599111/187933082-8f83c76a-98e0-43e4-942f-e96effe816f4.png">


## Side Effects

Nah.
