### PR TITLE
[ENG-3748] Simplify branded reg pages to just use brand background img

### DIFF
--- a/lib/registries/addon/components/hero-overlay/styles.scss
+++ b/lib/registries/addon/components/hero-overlay/styles.scss
@@ -13,26 +13,12 @@
         @include primary-color-bg;
         background: var(--hero-background-img-url);
         background-size: cover;
-        z-index: -1; /* should be in front of the ::before defined below */
+        z-index: -1;
         display: block;
     }
 
     h1 {
         color: $color-text-white;
-    }
-}
-
-:global(.with-custom-branding) .HeroOverlay {
-    &::before {
-        @include primary-color-bg;
-        display: block;
-        z-index: -2; /* behind the ::after image */
-    }
-
-    &::after {
-        opacity: 0.4;
-        filter: grayscale(1);
-        z-index: -1;
     }
 }
 


### PR DESCRIPTION
-   Ticket: [ENG-3748]
-   Feature flag: n/a

## Purpose
- Remove some of the complexities around how we use brand colors and images in the registries header

## Summary of Changes
- Remove the logic pertaining to how we show brand color/images on the registries header, so the only thing shown in the header will just be the brand's hero image 
- Accessibility/color contrast on branded registry pages is gonna be a little whacky until we change the brand assets to a more appropriate color

## Screenshot(s)
- A lot of the external registries will look funny until their brand assets are updated, so I imagine most registries won't look good until those images are updated
- Before (Solid brand primary color background with 40% opacity and greyscaled image on top) :
![image](https://user-images.githubusercontent.com/51409893/187992431-d6bd51e2-b721-444f-a5b2-d18fcb794d0d.png)

- After (Just the image, no greyscale or opacity) :
![image](https://user-images.githubusercontent.com/51409893/187992384-afabcf40-c4df-4ef1-8c1a-78c2e2469f64.png)


## Side Effects
- Community-operated registries will need to go over their branding and update the logos/banner images accordingly

## QA Notes
- We have a number of community operated registries and their assets will need to be updated to have sufficient color contrast

[ENG-3748]: https://openscience.atlassian.net/browse/ENG-3748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ