### PR TITLE
Make dialog box scroll on overflow

### DIFF
--- a/lib/analytics-page/addon/application/styles.scss
+++ b/lib/analytics-page/addon/application/styles.scss
@@ -15,6 +15,11 @@
     margin-top: 20px;
 }
 
+:global(.modal-body) {
+    max-height: 80vh;
+    overflow: scroll;
+}
+
 .CountBox {
     text-align: center;
 


### PR DESCRIPTION
## Purpose

The modal for the links on the project analytics page doesn't scroll. Instead, it just runs off the screen if there's too much content, and that content will never be seen. This makes it so that the dialog box behaves properly with the scrolling and the not overfilling the screen.

## Summary of Changes

1. Add max-height to the modal
2. Set overflow to scroll

## Screenshot(s)

<img width="636" alt="Screen Shot 2022-09-02 at 9 23 19 AM" src="https://user-images.githubusercontent.com/6599111/188175527-f64288fd-90a1-4285-bb85-5db8574cef81.png">

## Side Effects

If there were any other `bs-modal-simple`s on the page, they would also be upgraded. But there aren't, so this is isolated.
