### PR TITLE
[ENG-3995] Embed OSF 101 video onto logged out homepage and no-content dashboard

### DIFF
--- a/app/dashboard/controller.ts
+++ b/app/dashboard/controller.ts
@@ -160,10 +160,4 @@ export default class Dashboard extends Controller {
         this.set('newNode', newNode);
         this.set('showNewNodeNavigation', true);
     }
-
-    @action
-    viewLearnMore() {
-        window.open('https://help.osf.io/article/342-getting-started-on-the-osf', '_blank');
-
-    }
 }

--- a/app/dashboard/controller.ts
+++ b/app/dashboard/controller.ts
@@ -160,4 +160,10 @@ export default class Dashboard extends Controller {
         this.set('newNode', newNode);
         this.set('showNewNodeNavigation', true);
     }
+
+    @action
+    viewLearnMore() {
+        window.open('https://help.osf.io/article/342-getting-started-on-the-osf', '_blank');
+
+    }
 }

--- a/app/dashboard/styles.scss
+++ b/app/dashboard/styles.scss
@@ -184,18 +184,16 @@
     opacity: 1;
 }
 
-.flex-container {
+.iframe-container {
     display: flex;
     justify-content: center;
     flex-wrap: wrap;
+    margin-top: 20px;
+    margin-bottom: 30px;
 
-    .flex-row {
-        display: inline-flex;
-
-        .osf-video {
-            width: 420px;
-            height: 315px;
-        }
+    .osf-video {
+        width: 560px;
+        height: 315px;
     }
 }
 

--- a/app/dashboard/styles.scss
+++ b/app/dashboard/styles.scss
@@ -85,6 +85,13 @@
     .node-col-headers {
         display: none;
     }
+
+    .iframe-container {
+        .osf-video {
+            width: 336px;
+            height: 190px;
+        }
+    }
 }
 
 @media screen and (min-width: 768px) {

--- a/app/dashboard/styles.scss
+++ b/app/dashboard/styles.scss
@@ -183,3 +183,19 @@
     color: $color-text-placeholder-grey-dark;
     opacity: 1;
 }
+
+.flex-container {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+
+    .flex-row {
+        display: inline-flex;
+
+        .osf-video {
+            width: 420px;
+            height: 315px;
+        }
+    }
+}
+

--- a/app/dashboard/template.hbs
+++ b/app/dashboard/template.hbs
@@ -156,9 +156,9 @@
                                                 <div local-class='iframe-container'>
                                                     <iframe
                                                         local-class='osf-video'
-                                                        src="https://www.youtube.com/embed/iebMBpi0prc" 
+                                                        src='https://www.youtube.com/embed/iebMBpi0prc' 
                                                         title={{t 'dashboard.osf_video'}}
-                                                        frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                                                        frameborder='0' allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture' allowfullscreen></iframe>
                                                 </div>
 
                                                 <OsfLink

--- a/app/dashboard/template.hbs
+++ b/app/dashboard/template.hbs
@@ -152,28 +152,26 @@
                                             <div class='col-sm-12 text-center'>
                                                 <p>{{t 'dashboard.quicksearch.no_projects.line1'}}</p>
                                                 <p>{{t 'dashboard.quicksearch.no_projects.line2'}}</p>
-                                            </div>
-                                            <div class='flex-container'>
-                                                <div local-class='flex-row'>
-                                                    <video
+
+                                                <div local-class='iframe-container'>
+                                                    <iframe
                                                         local-class='osf-video'
-                                                        src='https://www.youtube.com/watch?v=dLEIhJESIQA?autoplay=0&mute=0'
-                                                    />
+                                                        src='https://www.youtube.com/embed/dLEIhJESIQA'
+                                                        title={{t 'dashboard.osf_video'}}
+                                                        frameborder='0' allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture' allowfullscreen
+                                                    ></iframe>
                                                 </div>
-                                            </div>
-                                            <div class='flex-container'>
-                                                <div local-class='flex-row'>
-                                                    <button
-                                                        type='button'
-                                                        class='btn btn-primary'
-                                                        onclick={{action this.viewLearnMore}}
-                                                    >
-                                                        {{t 'dashboard.learn_more'}}
-                                                    </button>
-                                                </div>
-                                            </div>
-                                            <div class='col-sm-12 text-center'>
-                                                <img src='/assets/images/dashboard/quicksearch-min.png' alt='{{t 'dashboard.quicksearch.no_projects.preview_alt'}}' class='img-responsive center-block'>
+
+                                                <OsfLink
+                                                    data-test-get-started-button
+                                                    data-analytics-name='Get started button'
+                                                    class='btn btn-primary'
+                                                    local-class='startButton'
+                                                    @target='_blank'
+                                                    @href='https://help.osf.io/article/342-getting-started-on-the-osf'
+                                                >
+                                                    {{t 'dashboard.getting_started'}}
+                                                </OsfLink>
                                             </div>
                                         </div>
                                     {{/if}}

--- a/app/dashboard/template.hbs
+++ b/app/dashboard/template.hbs
@@ -156,10 +156,9 @@
                                                 <div local-class='iframe-container'>
                                                     <iframe
                                                         local-class='osf-video'
-                                                        src='https://www.youtube.com/embed/dLEIhJESIQA'
+                                                        src="https://www.youtube.com/embed/iebMBpi0prc" 
                                                         title={{t 'dashboard.osf_video'}}
-                                                        frameborder='0' allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture' allowfullscreen
-                                                    ></iframe>
+                                                        frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
                                                 </div>
 
                                                 <OsfLink

--- a/app/dashboard/template.hbs
+++ b/app/dashboard/template.hbs
@@ -152,6 +152,27 @@
                                             <div class='col-sm-12 text-center'>
                                                 <p>{{t 'dashboard.quicksearch.no_projects.line1'}}</p>
                                                 <p>{{t 'dashboard.quicksearch.no_projects.line2'}}</p>
+                                            </div>
+                                            <div class='flex-container'>
+                                                <div local-class='flex-row'>
+                                                    <video
+                                                        local-class='osf-video'
+                                                        src='https://www.youtube.com/watch?v=dLEIhJESIQA?autoplay=0&mute=0'
+                                                    />
+                                                </div>
+                                            </div>
+                                            <div class='flex-container'>
+                                                <div local-class='flex-row'>
+                                                    <button
+                                                        type='button'
+                                                        class='btn btn-primary'
+                                                        onclick={{action this.viewLearnMore}}
+                                                    >
+                                                        {{t 'dashboard.learn_more'}}
+                                                    </button>
+                                                </div>
+                                            </div>
+                                            <div class='col-sm-12 text-center'>
                                                 <img src='/assets/images/dashboard/quicksearch-min.png' alt='{{t 'dashboard.quicksearch.no_projects.preview_alt'}}' class='img-responsive center-block'>
                                             </div>
                                         </div>

--- a/app/home/-components/support-section/styles.scss
+++ b/app/home/-components/support-section/styles.scss
@@ -69,6 +69,19 @@
     .container h1 {
         font-size: 36px;
     }
+
+    .iframe-container {
+        justify-content: center;
+       
+        &.flex-row {
+            display: flex;
+        }
+
+        .osf-video {
+            width: 336px;
+            height: 190px;
+        }
+    }
 }
 
 @media (max-width: 613px) {

--- a/app/home/-components/support-section/styles.scss
+++ b/app/home/-components/support-section/styles.scss
@@ -15,9 +15,13 @@
     }
 }
 
-.osf-video {
-    width: 420px;
-    height: 315px;
+.iframe-container {
+    margin-bottom: 30px;
+
+    .osf-video {
+        width: 560px;
+        height: 315px;
+    }
 }
 
 .supportItem {

--- a/app/home/-components/support-section/styles.scss
+++ b/app/home/-components/support-section/styles.scss
@@ -15,6 +15,11 @@
     }
 }
 
+.osf-video {
+    width: 420px;
+    height: 315px;
+}
+
 .supportItem {
     display: inline-block;
 }

--- a/app/home/-components/support-section/template.hbs
+++ b/app/home/-components/support-section/template.hbs
@@ -11,10 +11,9 @@
         <div local-class='flex-row iframe-container'>
             <iframe
                 local-class='osf-video'
-                src='https://www.youtube.com/embed/dLEIhJESIQA'
+                src="https://www.youtube.com/embed/iebMBpi0prc" 
                 title={{t 'new-home.support-section.osf_video'}}
-                frameborder='0' allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture' allowfullscreen
-            ></iframe>
+                frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
     </div>
     <div local-class='flex-container'>

--- a/app/home/-components/support-section/template.hbs
+++ b/app/home/-components/support-section/template.hbs
@@ -9,6 +9,14 @@
     </header>
     <div local-class='flex-container'>
         <div local-class='flex-row'>
+            <video
+                local-class='osf-video'
+                src='https://www.youtube.com/watch?v=dLEIhJESIQA?autoplay=0&mute=0'
+            />
+        </div>
+    </div>
+    <div local-class='flex-container'>
+        <div local-class='flex-row'>
             <div>
                 <Home::-Components::SupportSection::SupportItem
                     data-test-support-search

--- a/app/home/-components/support-section/template.hbs
+++ b/app/home/-components/support-section/template.hbs
@@ -8,7 +8,7 @@
         </h1>
     </header>
     <div local-class='flex-container'>
-        <div local-class='flex-row'>
+        <div local-class='flex-row iframe-container'>
             <iframe
                 local-class='osf-video'
                 src='https://www.youtube.com/embed/dLEIhJESIQA'

--- a/app/home/-components/support-section/template.hbs
+++ b/app/home/-components/support-section/template.hbs
@@ -11,9 +11,9 @@
         <div local-class='flex-row iframe-container'>
             <iframe
                 local-class='osf-video'
-                src="https://www.youtube.com/embed/iebMBpi0prc" 
+                src='https://www.youtube.com/embed/iebMBpi0prc' 
                 title={{t 'new-home.support-section.osf_video'}}
-                frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                frameborder='0' allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture' allowfullscreen></iframe>
         </div>
     </div>
     <div local-class='flex-container'>

--- a/app/home/-components/support-section/template.hbs
+++ b/app/home/-components/support-section/template.hbs
@@ -9,10 +9,12 @@
     </header>
     <div local-class='flex-container'>
         <div local-class='flex-row'>
-            <video
+            <iframe
                 local-class='osf-video'
-                src='https://www.youtube.com/watch?v=dLEIhJESIQA?autoplay=0&mute=0'
-            />
+                src='https://www.youtube.com/embed/dLEIhJESIQA'
+                title={{t 'new-home.support-section.osf_video'}}
+                frameborder='0' allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture' allowfullscreen
+            ></iframe>
         </div>
     </div>
     <div local-class='flex-container'>

--- a/lib/osf-components/addon/components/osf-link/component.ts
+++ b/lib/osf-components/addon/components/osf-link/component.ts
@@ -20,7 +20,7 @@ const {
     },
 } = config;
 
-type AnchorRel = 'noreferrer' | 'noopener';
+type AnchorRel = 'noreferrer' | 'noopener' | 'noopener noreferrer';
 type AnchorTarget = '_self' | '_blank' | '_parent' | '_top';
 
 @tagName('')
@@ -36,7 +36,7 @@ export default class OsfLink extends Component {
     queryParams?: Record<string, unknown>;
     fragment?: string;
 
-    rel: AnchorRel = 'noopener';
+    rel: AnchorRel = 'noopener noreferrer';
     target: AnchorTarget = '_self';
 
     onClick?: () => void;

--- a/tests/integration/components/osf-link/component-test.ts
+++ b/tests/integration/components/osf-link/component-test.ts
@@ -29,7 +29,6 @@ module('Integration | Component | osf-link', hooks => {
                 {{t 'dashboard.getting_started'}}
             </OsfLink>
         `);
-        // await pauseTest();
         assert.dom('[data-test-get-started-button]').exists();
         assert.dom('[data-test-get-started-button]').hasText('Getting Started');
         assert.dom('[data-test-get-started-button]').hasClass('btn');
@@ -50,7 +49,6 @@ module('Integration | Component | osf-link', hooks => {
                 {{t 'dashboard.getting_started'}}
             </OsfLink>
         `);
-        // await pauseTest();
         assert.dom('[data-test-get-started-button]').exists();
         assert.dom('[data-test-get-started-button]').hasText('Getting Started');
         assert.dom('[data-test-get-started-button]').hasClass('btn');

--- a/tests/integration/components/osf-link/component-test.ts
+++ b/tests/integration/components/osf-link/component-test.ts
@@ -1,0 +1,31 @@
+import { render } from '@ember/test-helpers';
+// import { pauseTest } from '@ember/test-helpers/setup-context';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+
+module('Integration | Component | osf-link', hooks => {
+    setupRenderingTest(hooks);
+
+    test('it renders blocks the right way', async assert => {
+        await render(hbs`
+            <OsfLink
+                data-test-get-started-button
+                data-analytics-name='Get started button'
+                class='btn btn-primary'
+                local-class='startButton'
+                @target='_blank'
+                @href='https://osf.io'
+            >
+                {{t 'dashboard.getting_started'}}
+            </OsfLink>
+        `);
+        // await pauseTest();
+        assert.dom('[data-test-get-started-button]').exists();
+        assert.dom('[data-test-get-started-button]').hasText('Getting Started');
+        assert.dom('[data-test-get-started-button]').hasClass('btn');
+        assert.dom('[data-test-get-started-button]').hasClass('btn-primary');
+        assert.dom('[data-test-get-started-button][href$="https://osf.io"]').exists('The href is correct');
+    });
+});

--- a/tests/integration/components/osf-link/component-test.ts
+++ b/tests/integration/components/osf-link/component-test.ts
@@ -1,6 +1,5 @@
 import { render} from '@ember/test-helpers';
 import Ember from 'ember';
-// import { pauseTest } from '@ember/test-helpers/setup-context';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -17,7 +16,7 @@ module('Integration | Component | osf-link', hooks => {
         Ember.onerror = orgOnError;
     });
 
-    test('it renders blocks the right way', async assert => {
+    test('it renders the osf-link correctly for an @href', async assert => {
         await render(hbs`
             <OsfLink
                 data-test-get-started-button
@@ -36,6 +35,27 @@ module('Integration | Component | osf-link', hooks => {
         assert.dom('[data-test-get-started-button]').hasClass('btn');
         assert.dom('[data-test-get-started-button]').hasClass('btn-primary');
         assert.dom('[data-test-get-started-button][href$="https://osf.io"]').exists('The href is correct');
+    });
+
+    test('it renders the osf-link correctly for an empty @href', async assert => {
+        await render(hbs`
+            <OsfLink
+                data-test-get-started-button
+                data-analytics-name='Get started button'
+                class='btn btn-primary'
+                local-class='startButton'
+                @target='_blank'
+                @href=' '
+            >
+                {{t 'dashboard.getting_started'}}
+            </OsfLink>
+        `);
+        // await pauseTest();
+        assert.dom('[data-test-get-started-button]').exists();
+        assert.dom('[data-test-get-started-button]').hasText('Getting Started');
+        assert.dom('[data-test-get-started-button]').hasClass('btn');
+        assert.dom('[data-test-get-started-button]').hasClass('btn-primary');
+        assert.dom('[data-test-get-started-button][href$=" "]').exists('The href is correct');
     });
 
     test('it should throw an error without an array @models', async assert => {
@@ -58,4 +78,66 @@ module('Integration | Component | osf-link', hooks => {
             </OsfLink>
         `);
     });
+
+    test('it should throw an error without an @href or @route', async assert => {
+        Ember.onerror = (error: Error) => {
+            assert.equal(error.message,
+                'Assertion Failed: Must pass `@href` xor `@route`. Did you pass `href` instead of `@href`?');
+        };
+
+        await render(hbs`
+            <OsfLink
+                data-test-get-started-button
+                data-analytics-name='Get started button'
+                class='btn btn-primary'
+                local-class='startButton'
+                @target='_blank'
+            >
+                {{t 'dashboard.getting_started'}}
+            </OsfLink>
+        `);
+    });
+
+    test('it should throw an error with @href and @route set to empty', async assert => {
+        Ember.onerror = (error: Error) => {
+            assert.equal(error.message,
+                'Assertion Failed: Both `@href` and `@route` were improperly set (probably to empty strings)');
+        };
+
+        await render(hbs`
+            <OsfLink
+                data-test-get-started-button
+                data-analytics-name='Get started button'
+                class='btn btn-primary'
+                local-class='startButton'
+                @target='_blank'
+                @href=''
+                @route=''
+            >
+                {{t 'dashboard.getting_started'}}
+            </OsfLink>
+        `);
+    });
+
+    test('it should throw an error with @models and not @route', async assert => {
+        Ember.onerror = (error: Error) => {
+            assert.equal(error.message,
+                'Assertion Failed: `@models` makes sense only with `@route`');
+        };
+
+        await render(hbs`
+            <OsfLink
+                data-test-get-started-button
+                data-analytics-name='Get started button'
+                class='btn btn-primary'
+                local-class='startButton'
+                @target='_blank'
+                @href='should pass'
+                @models={{array 'hello'}}
+            >
+                {{t 'dashboard.getting_started'}}
+            </OsfLink>
+        `);
+    });
+
 });

--- a/tests/integration/components/osf-link/component-test.ts
+++ b/tests/integration/components/osf-link/component-test.ts
@@ -1,4 +1,5 @@
-import { render } from '@ember/test-helpers';
+import { render} from '@ember/test-helpers';
+import Ember from 'ember';
 // import { pauseTest } from '@ember/test-helpers/setup-context';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
@@ -7,6 +8,14 @@ import { module, test } from 'qunit';
 
 module('Integration | Component | osf-link', hooks => {
     setupRenderingTest(hooks);
+
+    let orgOnError: any;
+    hooks.beforeEach(function() {
+        orgOnError = Ember.onerror;
+    });
+    hooks.afterEach(function() {
+        Ember.onerror = orgOnError;
+    });
 
     test('it renders blocks the right way', async assert => {
         await render(hbs`
@@ -27,5 +36,26 @@ module('Integration | Component | osf-link', hooks => {
         assert.dom('[data-test-get-started-button]').hasClass('btn');
         assert.dom('[data-test-get-started-button]').hasClass('btn-primary');
         assert.dom('[data-test-get-started-button][href$="https://osf.io"]').exists('The href is correct');
+    });
+
+    test('it should throw an error without an array @models', async assert => {
+        Ember.onerror = (error: Error) => {
+            assert.equal(error.message,
+                'Assertion Failed: `@models` must be undefined or an array. Consider using the `array` helper.');
+        };
+
+        await render(hbs`
+            <OsfLink
+                @models='error'
+                data-test-get-started-button
+                data-analytics-name='Get started button'
+                class='btn btn-primary'
+                local-class='startButton'
+                @target='_blank'
+                @href='https://osf.io'
+            >
+                {{t 'dashboard.getting_started'}}
+            </OsfLink>
+        `);
     });
 });

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -147,7 +147,8 @@ dashboard:
             preview_alt: 'Preview of a full quick projects screen'
         private_parent: 'Private project / '
         private_grandparent: 'Private project / Private / '
-    learn_more: 'Getting Started'
+    getting_started: 'Getting Started'
+    osf_video: 'OSF 101 Video'
     noteworthy:
         description: 'Discover public projects'
         new_and_noteworthy: 'New and noteworthy'
@@ -373,6 +374,7 @@ new-home:
     support-section:
         header: 'How OSF supports your research'
         arrow: arrow
+        osf_video: 'OSF 101 Video' 
         search:
             header: 'Search and Discover'
             description: 'Find papers, data, and materials to inspire your next research project. Search public projects to build on the work of others and find new collaborators.'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -147,6 +147,7 @@ dashboard:
             preview_alt: 'Preview of a full quick projects screen'
         private_parent: 'Private project / '
         private_grandparent: 'Private project / Private / '
+    learn_more: 'Getting Started'
     noteworthy:
         description: 'Discover public projects'
         new_and_noteworthy: 'New and noteworthy'


### PR DESCRIPTION
-   Ticket: [ENG-3995]
-   Feature flag: n/a

## Purpose

Add a video to the dashboard logged out page about how to use the OSF

Add the same video and a link to the "Getting Started" guide on the logged in dashboard page without a collection.

## Summary of Changes

Updated to .hbs files

## Screenshot
![logged-in-screen-shot](https://user-images.githubusercontent.com/369083/189413515-f4807c2e-aaf1-4ac3-b579-72caac62c101.png)

![logged-out-screen-shot](https://user-images.githubusercontent.com/369083/189413521-03d09c9b-1500-4a2e-a148-dffba34831df.png)
(s)

## Side Effects

Falling asleep watching a one hour video without chapters.

## QA Notes

See if the video loads and button works on the /dashboard and the video plays on the home page when not logged in.


[ENG-3995]: https://openscience.atlassian.net/browse/ENG-3995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ