### PR TITLE
[ENG-1641] Draft registration save before exit

### DIFF
--- a/lib/osf-components/addon/components/contributors/card/editable/template.hbs
+++ b/lib/osf-components/addon/components/contributors/card/editable/template.hbs
@@ -20,6 +20,8 @@
             <OsfLink
                 data-test-contributor-link={{@contributor.id}}
                 data-analytics-name='View user'
+                @target='_blank'
+                @rel='noopener noreferrer'
                 @href={{concat '/' @contributor.users.id '/'}}
             >
                 {{@contributor.users.fullName}}

--- a/lib/osf-components/addon/components/contributors/card/editable/template.hbs
+++ b/lib/osf-components/addon/components/contributors/card/editable/template.hbs
@@ -21,7 +21,6 @@
                 data-test-contributor-link={{@contributor.id}}
                 data-analytics-name='View user'
                 @target='_blank'
-                @rel='noopener noreferrer'
                 @href={{concat '/' @contributor.users.id '/'}}
             >
                 {{@contributor.users.fullName}}

--- a/lib/osf-components/addon/modifiers/before-unload.ts
+++ b/lib/osf-components/addon/modifiers/before-unload.ts
@@ -1,0 +1,21 @@
+import Modifier from 'ember-modifier';
+
+interface BeforeUnloadModifierArgs {
+    positional: any;
+    named: {};
+}
+
+export default class BeforeUnloadModifier extends Modifier<BeforeUnloadModifierArgs> {
+    listener?: any;
+    didReceiveArguments() {
+        if (this.listener) {
+            window.removeEventListener('beforeunload', this.listener);
+        }
+        this.listener = this.args.positional[0];
+        window.addEventListener('beforeunload', this.listener);
+    }
+
+    willRemove() {
+        window.removeEventListener('beforeunload', this.listener);
+    }
+}

--- a/lib/osf-components/app/modifiers/before-unload.js
+++ b/lib/osf-components/app/modifiers/before-unload.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/modifiers/before-unload';

--- a/lib/registries/addon/drafts/draft/-components/right-nav/template.hbs
+++ b/lib/registries/addon/drafts/draft/-components/right-nav/template.hbs
@@ -74,10 +74,15 @@
     </span>
 {{/if}}
 <span local-class='SaveMessage'>
-    {{t 'registries.drafts.draft.form.last_saved'}}
-    <TimeSince
-        @date={{@draftManager.draftRegistration.datetimeUpdated}}
-    />
+    {{#if @draftManager.autoSaving}}
+        <LoadingIndicator @inline={{true}} @dark={{true}}/>
+        {{t 'registries.drafts.draft.auto_saving'}}
+    {{else}}
+        {{t 'registries.drafts.draft.form.last_saved'}}
+        <TimeSince
+            @date={{@draftManager.draftRegistration.datetimeUpdated}}
+        />
+    {{/if}}
 </span>
 
 {{#if @draftManager.currentUserIsAdmin}}

--- a/lib/registries/addon/drafts/draft/controller.ts
+++ b/lib/registries/addon/drafts/draft/controller.ts
@@ -36,9 +36,8 @@ export default class RegistriesDraft extends Controller {
             draftRegistrationManager.saveWithToast.isRunning ||
             draftRegistrationManager.lastSaveFailed) {
             event.preventDefault();
+            event.returnValue = this.intl.t('registries.drafts.draft.save_before_exit');
             taskFor(draftRegistrationManager.saveWithToast).perform();
-            return event.returnValue = this.intl.t('registries.drafts.draft.save_before_exit');
         }
-        return;
     }
 }

--- a/lib/registries/addon/drafts/draft/controller.ts
+++ b/lib/registries/addon/drafts/draft/controller.ts
@@ -4,13 +4,16 @@ import { alias, not } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 
 import Media from 'ember-responsive';
+import IntlService from 'ember-intl/services/intl';
 
 import BrandModel from 'ember-osf-web/models/brand';
 import ProviderModel from 'ember-osf-web/models/provider';
 import Registration from 'ember-osf-web/models/registration';
+import { taskFor } from 'ember-concurrency-ts';
 
 export default class RegistriesDraft extends Controller {
     @service media!: Media;
+    @service intl!: IntlService;
 
     @not('media.isDesktop') showMobileView!: boolean;
 
@@ -26,16 +29,15 @@ export default class RegistriesDraft extends Controller {
     }
 
     @action
-    saveDirtyChanges(event: BeforeUnloadEvent) {
-        // console.log('saveDirtyChanges');
-        // on[Metadata/Page]Input.isRunning as proxy for isDirty? :/
+    saveBeforeUnload(event: BeforeUnloadEvent) {
         const { draftRegistrationManager } = this.model;
         if (draftRegistrationManager.onMetadataInput.isRunning ||
-            draftRegistrationManager.onPageInput.isRunning) {
+            draftRegistrationManager.onPageInput.isRunning ||
+            draftRegistrationManager.lastSaveFailed) {
             event.preventDefault();
-            return event.returnValue = 'prevent unload and save';
+            taskFor(draftRegistrationManager.saveWithToast).perform();
+            return event.returnValue = this.intl.t('registries.drafts.draft.save_before_exit');
         }
-
-        return event.returnValue = 'continue unload without save';
+        return;
     }
 }

--- a/lib/registries/addon/drafts/draft/controller.ts
+++ b/lib/registries/addon/drafts/draft/controller.ts
@@ -33,6 +33,7 @@ export default class RegistriesDraft extends Controller {
         const { draftRegistrationManager } = this.model;
         if (draftRegistrationManager.onMetadataInput.isRunning ||
             draftRegistrationManager.onPageInput.isRunning ||
+            draftRegistrationManager.saveWithToast.isRunning ||
             draftRegistrationManager.lastSaveFailed) {
             event.preventDefault();
             taskFor(draftRegistrationManager.saveWithToast).perform();

--- a/lib/registries/addon/drafts/draft/controller.ts
+++ b/lib/registries/addon/drafts/draft/controller.ts
@@ -24,4 +24,18 @@ export default class RegistriesDraft extends Controller {
     onSubmitRedirect(registrationId: Registration) {
         this.transitionToRoute('overview.index', registrationId);
     }
+
+    @action
+    saveDirtyChanges(event: BeforeUnloadEvent) {
+        // console.log('saveDirtyChanges');
+        // on[Metadata/Page]Input.isRunning as proxy for isDirty? :/
+        const { draftRegistrationManager } = this.model;
+        if (draftRegistrationManager.onMetadataInput.isRunning ||
+            draftRegistrationManager.onPageInput.isRunning) {
+            event.preventDefault();
+            return event.returnValue = 'prevent unload and save';
+        }
+
+        return event.returnValue = 'continue unload without save';
+    }
 }

--- a/lib/registries/addon/drafts/draft/draft-registration-manager.ts
+++ b/lib/registries/addon/drafts/draft/draft-registration-manager.ts
@@ -137,7 +137,6 @@ export default class DraftRegistrationManager {
                 const errorMessage = this.intl.t('registries.drafts.draft.form.failed_auto_save');
                 captureException(e, { errorMessage });
                 this.toast.error(getApiErrorMessage(e), errorMessage);
-                throw e;
             }
         }
     }
@@ -206,7 +205,6 @@ export default class DraftRegistrationManager {
             const errorMessage = this.intl.t('registries.drafts.draft.metadata.failed_auto_save');
             captureException(e, { errorMessage });
             this.toast.error(getApiErrorMessage(e), errorMessage);
-            throw e;
         }
     }
 

--- a/lib/registries/addon/drafts/draft/draft-registration-manager.ts
+++ b/lib/registries/addon/drafts/draft/draft-registration-manager.ts
@@ -54,7 +54,7 @@ export default class DraftRegistrationManager {
     @alias('draftRegistration.currentUserIsAdmin') currentUserIsAdmin!: boolean;
     @alias('provider.reviewsWorkflow') reviewsWorkflow?: string;
     @alias('draftRegistration.hasProject') hasProject?: boolean;
-    @or('onPageInput.isRunning', 'onMetadataInput.isRunning') autoSaving!: boolean;
+    @alias('draftRegistration.isSaving') autoSaving!: boolean;
     @or('initializePageManagers.isRunning', 'initializeMetadataChangeset.isRunning') initializing!: boolean;
     @not('registrationResponsesIsValid') hasInvalidResponses!: boolean;
     @filterBy('pageManagers', 'isVisited', true) visitedPages!: PageManager[];

--- a/lib/registries/addon/drafts/draft/draft-registration-manager.ts
+++ b/lib/registries/addon/drafts/draft/draft-registration-manager.ts
@@ -242,9 +242,7 @@ export default class DraftRegistrationManager {
     onPageChange(currentPage: number) {
         if (this.hasVisitedPages) {
             this.validateAllVisitedPages();
-            this.metadataChangeset.validate();
             taskFor(this.saveAllVisitedPages).perform();
-            taskFor(this.updateDraftRegistrationAndSave).perform();
         }
         this.markCurrentPageVisited(currentPage);
     }

--- a/lib/registries/addon/drafts/draft/route.ts
+++ b/lib/registries/addon/drafts/draft/route.ts
@@ -71,12 +71,8 @@ export default class DraftRegistrationRoute extends Route {
         };
     }
 
-    afterModel() {
-        this.router.on('routeWillChange', this.onRouteWillChange);
-    }
-
     @action
-    onRouteWillChange(transition: Transition) {
+    willTransition(transition: Transition) {
         const { draftRegistrationManager } = this.controller.model;
         const draftIsDirty = draftRegistrationManager.onMetadataInput.isRunning ||
             draftRegistrationManager.onPageInput.isRunning ||

--- a/lib/registries/addon/drafts/draft/route.ts
+++ b/lib/registries/addon/drafts/draft/route.ts
@@ -68,6 +68,17 @@ export default class DraftRegistrationRoute extends Route {
         };
     }
 
+    afterModel() {
+        this.router.on('routeWillChange', transition => {
+            // console.log('routeWillChange', transition);
+            // TODO: check for dirty chnages?
+            if (!transition.to.name.includes(this.routeName) &&
+                !confirm('Replace with a good translated string')) {
+                transition.abort();
+            }
+        });
+    }
+
     @action
     didTransition() {
         this.analytics.trackPage();

--- a/lib/registries/addon/drafts/draft/route.ts
+++ b/lib/registries/addon/drafts/draft/route.ts
@@ -1,12 +1,14 @@
 import Store from '@ember-data/store';
 import { getOwner } from '@ember/application';
 import { action } from '@ember/object';
+import Transition from '@ember/routing/-private/transition';
 import Route from '@ember/routing/route';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 import { waitFor } from '@ember/test-waiters';
 import { task } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
+import Intl from 'ember-intl/services/intl';
 
 import requireAuth from 'ember-osf-web/decorators/require-auth';
 import DraftRegistration from 'ember-osf-web/models/draft-registration';
@@ -28,6 +30,7 @@ export default class DraftRegistrationRoute extends Route {
     @service analytics!: Analytics;
     @service store!: Store;
     @service router!: RouterService;
+    @service intl!: Intl;
 
     @task
     @waitFor
@@ -69,14 +72,22 @@ export default class DraftRegistrationRoute extends Route {
     }
 
     afterModel() {
-        this.router.on('routeWillChange', transition => {
-            // console.log('routeWillChange', transition);
-            // TODO: check for dirty chnages?
-            if (!transition.to.name.includes(this.routeName) &&
-                !confirm('Replace with a good translated string')) {
+        this.router.on('routeWillChange', this.onRouteWillChange);
+    }
+
+    @action
+    onRouteWillChange(transition: Transition) {
+        const { draftRegistrationManager } = this.controller.model;
+        const draftIsDirty = draftRegistrationManager.onMetadataInput.isRunning ||
+            draftRegistrationManager.onPageInput.isRunning ||
+            draftRegistrationManager.saveWithToast.isRunning ||
+            draftRegistrationManager.lastSaveFailed;
+        if (!transition.to.name.includes(this.routeName) && draftIsDirty) {
+            if (!window.confirm(this.intl.t('registries.drafts.draft.save_before_exit'))) {
                 transition.abort();
+                taskFor(draftRegistrationManager.saveWithToast).perform();
             }
-        });
+        }
     }
 
     @action

--- a/lib/registries/addon/drafts/draft/route.ts
+++ b/lib/registries/addon/drafts/draft/route.ts
@@ -74,11 +74,12 @@ export default class DraftRegistrationRoute extends Route {
     @action
     willTransition(transition: Transition) {
         const { draftRegistrationManager } = this.controller.model;
+        const notBeingDeleted = !draftRegistrationManager.deleteDraft.isRunning;
         const draftIsDirty = draftRegistrationManager.onMetadataInput.isRunning ||
             draftRegistrationManager.onPageInput.isRunning ||
             draftRegistrationManager.saveWithToast.isRunning ||
             draftRegistrationManager.lastSaveFailed;
-        if (!transition.to.name.includes(this.routeName) && draftIsDirty) {
+        if (!transition.to.name.includes(this.routeName) && draftIsDirty && notBeingDeleted) {
             if (!window.confirm(this.intl.t('registries.drafts.draft.save_before_exit'))) {
                 transition.abort();
                 taskFor(draftRegistrationManager.saveWithToast).perform();

--- a/lib/registries/addon/drafts/draft/template.hbs
+++ b/lib/registries/addon/drafts/draft/template.hbs
@@ -78,7 +78,10 @@
                         @navMode={{leftNav.leftGutterMode}}
                     />
                 </layout.leftNav>
-                <layout.main local-class='Main'>
+                <layout.main
+                    {{before-unload this.saveDirtyChanges}}
+                    local-class='Main'
+                >
                     {{outlet}}
                 </layout.main>
                 {{#unless this.showMobileView}}

--- a/lib/registries/addon/drafts/draft/template.hbs
+++ b/lib/registries/addon/drafts/draft/template.hbs
@@ -79,7 +79,7 @@
                     />
                 </layout.leftNav>
                 <layout.main
-                    {{before-unload this.saveDirtyChanges}}
+                    {{before-unload this.saveBeforeUnload}}
                     local-class='Main'
                 >
                     {{outlet}}

--- a/lib/registries/addon/edit-revision/-components/right-nav/template.hbs
+++ b/lib/registries/addon/edit-revision/-components/right-nav/template.hbs
@@ -73,10 +73,15 @@
     </span>
 {{/if}}
 <span local-class='SaveMessage'>
-    {{t 'registries.drafts.draft.form.last_saved'}}
-    <TimeSince
-        @date={{@revisionManager.revision.dateModified}}
-    />
+    {{#if @revisionManager.autoSaving}}
+        <LoadingIndicator @inline={{true}} @dark={{true}} />
+        {{t 'registries.drafts.draft.auto_saving'}}
+    {{else}}
+        {{t 'registries.drafts.draft.form.last_saved'}}
+        <TimeSince
+            @date={{@revisionManager.revision.dateModified}}
+        />
+    {{/if}}
 </span>
 
 {{#if @revisionManager.showDeleteButton}}

--- a/lib/registries/addon/edit-revision/controller.ts
+++ b/lib/registries/addon/edit-revision/controller.ts
@@ -28,9 +28,8 @@ export default class EditRevisionController extends Controller {
             revisionManager.saveWithToast.isRunning ||
             revisionManager.lastSaveFailed) {
             event.preventDefault();
+            event.returnValue = this.intl.t('registries.drafts.draft.save_before_exit');
             taskFor(revisionManager.saveWithToast).perform();
-            return event.returnValue = this.intl.t('registries.drafts.draft.save_before_exit');
         }
-        return;
     }
 }

--- a/lib/registries/addon/edit-revision/controller.ts
+++ b/lib/registries/addon/edit-revision/controller.ts
@@ -1,7 +1,9 @@
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
 import { alias, not } from '@ember/object/computed';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
+import { taskFor } from 'ember-concurrency-ts';
 import IntlService from 'ember-intl/services/intl';
 import RegistrationModel from 'ember-osf-web/models/registration';
 import SchemaResponseModel from 'ember-osf-web/models/schema-response';
@@ -17,4 +19,18 @@ export default class EditRevisionController extends Controller {
 
     @alias('model.revisionManager.revision') revision?: SchemaResponseModel;
     @alias('model.revisionManager.registration') registration?: RegistrationModel;
+
+    @action
+    saveBeforeUnload(event: BeforeUnloadEvent) {
+        const { revisionManager } = this.model;
+        if (revisionManager.onJustificationInput.isRunning ||
+            revisionManager.onPageInput.isRunning ||
+            revisionManager.saveWithToast.isRunning ||
+            revisionManager.lastSaveFailed) {
+            event.preventDefault();
+            taskFor(revisionManager.saveWithToast).perform();
+            return event.returnValue = this.intl.t('registries.drafts.draft.save_before_exit');
+        }
+        return;
+    }
 }

--- a/lib/registries/addon/edit-revision/revision-manager.ts
+++ b/lib/registries/addon/edit-revision/revision-manager.ts
@@ -164,7 +164,6 @@ export default class RevisionManager {
                 const errorMessage = this.intl.t('registries.drafts.draft.form.failed_auto_save');
                 captureException(e, { errorMessage });
                 this.toast.error(getApiErrorMessage(e), errorMessage);
-                throw e;
             }
         }
     }
@@ -225,7 +224,6 @@ export default class RevisionManager {
             const errorMessage = this.intl.t('registries.drafts.draft.metadata.failed_auto_save');
             captureException(e, { errorMessage });
             this.toast.error(getApiErrorMessage(e), errorMessage);
-            throw e;
         }
     }
 

--- a/lib/registries/addon/edit-revision/revision-manager.ts
+++ b/lib/registries/addon/edit-revision/revision-manager.ts
@@ -52,7 +52,7 @@ export default class RevisionManager {
     schemaBlocks!: SchemaBlock[];
 
     @alias('registration.currentUserIsReadOnly') currentUserIsReadOnly!: boolean;
-    @or('onPageInput.isRunning', 'onJustificationInput.isRunning') autoSaving!: boolean;
+    @alias('revision.isSaving') autoSaving!: boolean;
     @or('initializePageManagers.isRunning', 'initializeRevisionChangeset.isRunning') initializing!: boolean;
     @not('registrationResponsesIsValid') hasInvalidResponses!: boolean;
     @filterBy('pageManagers', 'isVisited', true) visitedPages!: PageManager[];

--- a/lib/registries/addon/edit-revision/route.ts
+++ b/lib/registries/addon/edit-revision/route.ts
@@ -70,11 +70,12 @@ export default class EditRevisionRoute extends Route {
     @action
     willTransition(transition: Transition) {
         const { revisionManager } = this.controller.model;
+        const notBeingDeleted = !revisionManager.deleteRevision.isRunning;
         const draftIsDirty = revisionManager.onJustificationInput.isRunning ||
             revisionManager.onPageInput.isRunning ||
             revisionManager.saveWithToast.isRunning ||
             revisionManager.lastSaveFailed;
-        if (!transition.to.name.includes(this.routeName) && draftIsDirty) {
+        if (!transition.to.name.includes(this.routeName) && draftIsDirty && notBeingDeleted) {
             if (!window.confirm(this.intl.t('registries.edit_revision.save_before_exit'))) {
                 transition.abort();
                 taskFor(revisionManager.saveWithToast).perform();

--- a/lib/registries/addon/edit-revision/route.ts
+++ b/lib/registries/addon/edit-revision/route.ts
@@ -1,5 +1,6 @@
 import { getOwner } from '@ember/application';
 import Store from '@ember-data/store';
+import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import RouterService from '@ember/routing/router-service';
 import Transition from '@ember/routing/-private/transition';

--- a/lib/registries/addon/edit-revision/template.hbs
+++ b/lib/registries/addon/edit-revision/template.hbs
@@ -77,7 +77,10 @@
                         @navMode={{leftNav.leftGutterMode}}
                     />
                 </layout.leftNav>
-                <layout.main local-class='Main'>
+                <layout.main
+                    {{before-unload this.saveBeforeUnload}}
+                    local-class='Main'
+                >
                     {{outlet}}
                 </layout.main>
                 {{#unless this.showMobileView}}

--- a/tests/engines/registries/acceptance/edit-revision/revision-test.ts
+++ b/tests/engines/registries/acceptance/edit-revision/revision-test.ts
@@ -5,13 +5,16 @@ import {
     currentURL,
     fillIn,
     find,
+    triggerKeyEvent,
 } from '@ember/test-helpers';
 import { ModelInstance } from 'ember-cli-mirage';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { timeout } from 'ember-concurrency';
 import { TestContext, t } from 'ember-intl/test-support';
 import { percySnapshot } from 'ember-percy';
 import { setBreakpoint } from 'ember-responsive/test-support';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import { getHrefAttribute, visit } from 'ember-osf-web/tests/helpers';
 import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
@@ -401,6 +404,74 @@ module('Registries | Acceptance | registries revision', hooks => {
         await click('[data-test-goto-previous-page]');
 
         assert.dom('[data-test-page-label]').containsText('This is the second page');
+    });
+
+    test('it shows failed saves/deletes', async function(this: RevisionTestContext, assert) {
+        server.namespace = '/v2';
+        server.patch('/schema_responses/:id', () => ({
+            errors: [{ detail: 'Fail to save schema response' }],
+        }), 400);
+        server.del('/schema_responses/:id', () => ({
+            errors: [{ detail: 'Fail to delete schema response' }],
+        }), 403);
+        const initiatedBy = server.create('user', 'loggedIn');
+        const revision = server.create(
+            'schema-response', {
+                initiatedBy,
+                revisionResponses: {},
+                registration: this.registration,
+            },
+        );
+
+        await visit(`/registries/revisions/${revision.id}/`);
+        // Fail justification save
+        await triggerKeyEvent('textarea[name="revisionJustification"]', 'keyup', 32);
+        assert.dom('#toast-container', document as any).containsText(
+            t('registries.drafts.draft.metadata.failed_auto_save'),
+            'Error toast on failed metadata save',
+        );
+        // wait for toast to disappear. TODO: find a better way to do this. sinon.useFakeTimers()??
+        await timeout(5000);
+
+        // Fail form save
+        await click('[data-test-goto-next-page]');
+        await triggerKeyEvent('[data-test-text-input] input', 'keyup', 32);
+        assert.dom('#toast-container', document as any).containsText(
+            t('registries.drafts.draft.form.failed_auto_save'),
+            'Error toast on failed page save',
+        );
+
+        // Fail delete
+        await click('[data-test-delete-button]');
+        await click('[data-test-confirm-delete]');
+        assert.dom('#toast-container', document as any).hasTextContaining(
+            t('registries.edit_revision.delete_modal.delete_error'),
+            'Error toast on failed draft delete',
+        );
+    });
+
+    test('it warns users when navigating/closing window', async function(this: RevisionTestContext, assert) {
+        const confirm = sinon.fake();
+        window.confirm = confirm;
+        const beforeunload = sinon.fake();
+        window.onbeforeunload = beforeunload;
+        const initiatedBy = server.create('user', 'loggedIn');
+        const revision = server.create(
+            'schema-response', {
+                initiatedBy,
+                revisionResponses: {},
+                registration: this.registration,
+            },
+        );
+
+        await visit(`/registries/revisions/${revision.id}/`);
+
+        triggerKeyEvent('textarea[name="revisionJustification"]', 'keyup', 32);
+        await click('[data-test-add-new-button]');
+        sinon.assert.calledOnce(confirm);
+        window.dispatchEvent(new Event('beforeunload'));
+        sinon.assert.calledOnce(beforeunload);
+        assert.ok('it warns users when navigating/closing window');
     });
 
     // TODO: investigate why validation status doesn't update when we have responses defined in the revision

--- a/tests/integration/modifiers/before-unload-test.ts
+++ b/tests/integration/modifiers/before-unload-test.ts
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { TestContext } from 'ember-test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+interface ModifierTestContext extends TestContext {
+    listener: any;
+}
+
+module('Integration | Modifier | before-unload', hooks => {
+    setupRenderingTest(hooks);
+
+    test('it adds event listener', async function(this: ModifierTestContext, assert) {
+        this.listener = sinon.fake();
+
+        await render(hbs`<div {{before-unload this.listener}}></div>`);
+        sinon.assert.notCalled(this.listener);
+        window.dispatchEvent(new Event('beforeunload'));
+        sinon.assert.calledOnce(this.listener);
+        assert.ok(true, 'beforeunload listener called');
+    });
+});

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1205,6 +1205,9 @@ registries:
             body: 'Are you sure you want to delete this draft update?'
             button: 'Delete Draft Update'
             delete_error: 'Unable to delete update'
+        save_before_exit: 'Unsaved changes present. Are you sure you want to leave this page?'
+        save_success: 'Auto-save successful'
+        save_failed: 'Save failed'
     index:
         lead: 'The <span class="f-w-lg">open</span> registries network'
         see_example: 'See an example'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1169,6 +1169,9 @@ registries:
                 body: 'Are you sure you want to delete this draft registration?'
                 button: 'Delete Draft'
                 delete_error: 'Unable to delete draft registration'
+            save_before_exit: 'Unsaved changes present. Are you sure you want to leave this page?'
+            save_success: 'Auto-save successful'
+            save_failed: 'Save failed'
     edit_revision:
         revisionJustification: 'Justification for update'
         updatedResponseKeys: 'List of updated registration questions'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1169,6 +1169,7 @@ registries:
                 body: 'Are you sure you want to delete this draft registration?'
                 button: 'Delete Draft'
                 delete_error: 'Unable to delete draft registration'
+            auto_saving: 'Auto-saving'
             save_before_exit: 'Unsaved changes present. Are you sure you want to leave this page?'
             save_success: 'Auto-save successful'
             save_failed: 'Save failed'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1244,7 +1244,7 @@ registries:
             save: 'Save'
             clear_all: 'Clear all'
         add_license: 'Add license'
-        license_help_text: 'A license tells others how they can use your work in the future and only applies to the information and files submitted with the registration. For more information, see this <a href="https://help.osf.io/hc/en-us/articles/360019739014-Licensing">article on licenses</a>.'
+        license_help_text: 'A license tells others how they can use your work in the future and only applies to the information and files submitted with the registration. For more information, see this <a href="https://help.osf.io/hc/en-us/articles/360019739014-Licensing" target="_blank" rel="noopener noreferrer">article on licenses</a>.'
         affiliated_institutions: 'Affiliated institutions'
         category: Category
         choose_license: 'Choose a License'


### PR DESCRIPTION
-   Ticket: [ENG-1641]
-   Feature flag: n/a

## Purpose
- Let users know they have unsaved changes before they exit the draft registration workflow
- Let users know when an autosave is in progress

## Summary of Changes
- Change some of the links on the Draft Registration Metadata page to open in a new tab to prevent users from navigating away
- Add a new `{{before-unload}}` modifier
- Add logic to show popup if the draft has pending changes
  - One to handle `onBeforeUnload` (closing or refreshing the browser window)
  - One to handle route transitions (clicking the "Add new"/"My Registrations" buttons or navigating away within the app)
- Add same logic for edit-revision workflow
- Update rightnav template to show when an autosave is in progress

## Screenshot(s)
- Edit revision workflow. When navigating away within 3 seconds of updating the revision justification:
![image](https://user-images.githubusercontent.com/51409893/189439437-f408a409-5c96-4349-bf86-cea612b65725.png)

- Draft registration workflow. When trying to refresh the tab within 3 seconds of updating a response:
![image](https://user-images.githubusercontent.com/51409893/189439732-653b62ca-fa37-4abc-8546-d042a6dce657.png)

- Autosave indicator:
![image](https://user-images.githubusercontent.com/51409893/190270478-61150bfd-3b7d-4f0e-ab70-552ba01071cd.png)

## Side Effects
- I've made it so that clicking the contributor names link, as the license help link, on the Metadata page opens in a new tab. Less of a side-effect, but more a preference.

## QA Notes
- There is a 3 second delay before the last user input and when the autosave kicks off. If a user tries to close the tab or reload the page during that 3 second window, a prompt should show up asking if they _really_ want to leave. If they hit cancel, the save should trigger and once successful or unsuccessful, a toast message should appear indicating the save went through or not


[ENG-1641]: https://openscience.atlassian.net/browse/ENG-1641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ