### PR TITLE
[ENG-4033] Bottom of hanging letters cut off on file detail page

### DIFF
--- a/app/guid-file/styles.scss
+++ b/app/guid-file/styles.scss
@@ -24,6 +24,7 @@
     overflow: hidden;
     white-space: nowrap;
     max-width: 70vw;
+    height: 40px;
 }
 
 .ProjectLink {


### PR DESCRIPTION
-   Ticket: [ENG-4033]
-   Feature flag: n/a

## Purpose

Fixed the text from being cut off. It was a side-effect of the "overflow: hidden" attribute

## Summary of Changes

Add a height: 40px attribute to the class

## QA Notes

Make sure the text is no cropped.


[ENG-4033]: https://openscience.atlassian.net/browse/ENG-4033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ