### PR TITLE
[ENG-4014] Fix icons for registries leftnav show/hide in mobile view

### DIFF
--- a/lib/registries/addon/overview/-components/overview-header/template.hbs
+++ b/lib/registries/addon/overview/-components/overview-header/template.hbs
@@ -19,7 +19,7 @@
                             aria-label={{t 'registries.overview.toggle_navbar'}}
                             data-analytics-name='Show sidenav'
                         >
-                            {{nav.icon (if @sidenavGutterClosed 'bars' 'times')}}
+                            <nav.icon @icon={{if @sidenavGutterClosed 'bars' 'times'}} />
                         </nav.buttons.default>
                     </nav.bordered-section>
 


### PR DESCRIPTION
-   Ticket: [ENG-4014]
-   Feature flag: n/a

## Purpose

The fontawesome upgrade requires no positional arguments for FaIcon. I thought I had caught all of them, but at least one set got past me.

## Summary of Changes

1. Fix icons for registries leftnav show/hide in mobile view

## Screenshot(s)
![Screen Shot 2022-09-13 at 10 10 17 AM](https://user-images.githubusercontent.com/6599111/189931723-cc77ebf5-f6a5-4add-b0f1-9eafeee3039d.png)

![Screen Shot 2022-09-13 at 10 10 20 AM](https://user-images.githubusercontent.com/6599111/189931757-b0e624a2-c6bf-4d6b-90f4-349feb5dac42.png)


## Side Effects

No, this is isolated


[ENG-4014]: https://openscience.atlassian.net/browse/ENG-4014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ