### PR TITLE
[ENG-4010] Address deprecated router event

### DIFF
--- a/app/instance-initializers/router.ts
+++ b/app/instance-initializers/router.ts
@@ -1,0 +1,68 @@
+import ApplicationInstance from '@ember/application/instance';
+import Transition from '@ember/routing/-private/transition';
+import RouterService from '@ember/routing/router-service';
+import Ember from 'ember';
+import Features from 'ember-feature-flags/services/features';
+
+import { Blocker } from 'ember-osf-web/services/ready';
+import transitionTargetURL from 'ember-osf-web/utils/transition-target-url';
+
+import config from 'ember-get-config';
+
+const {
+    featureFlagNames: {
+        routes: routeFlags,
+    },
+} = config;
+
+export function initialize(appInstance: ApplicationInstance): void {
+    const routerService = appInstance.lookup('service:router') as RouterService;
+    const currentUser = appInstance.lookup('service:current-user');
+    const features = appInstance.lookup('service:features') as Features;
+    const statusMessages = appInstance.lookup('service:status-messages');
+    const ready = appInstance.lookup('service:ready');
+
+    // eslint-disable-next-line ember/avoid-leaking-state-in-ember-objects
+    let readyBlocker = null as Blocker | null;
+
+    routerService.on('routeWillChange', (transition: Transition) => {
+        if (!readyBlocker || readyBlocker.isDone()) {
+            readyBlocker = ready.getBlocker();
+        }
+
+        const isInitialTransition = transition.sequence === 0;
+        if (!isInitialTransition) {
+            const flag = routeFlags[transition.targetName];
+            if (flag && !features.isEnabled(flag)) {
+                if (!Ember.testing) {
+                    try {
+                        window.location.assign(transitionTargetURL(transition));
+                    } catch (e) {
+                        window.location.reload();
+                    }
+                }
+                transition.abort();
+            }
+        }
+
+        routerService._super(transition);
+    });
+
+    routerService.on('routeDidChange', (transition: Transition) => {
+        currentUser.checkShowTosConsentBanner();
+        statusMessages.updateMessages();
+        if (!transition.queryParamsOnly) {
+            const { rootElement: rootElementSelector } = appInstance as any;
+            const rootElement = document.querySelector(rootElementSelector);
+            rootElement.scrollIntoView();
+        }
+
+        if (readyBlocker && !readyBlocker.isDone()) {
+            readyBlocker.done();
+        }
+    });
+}
+
+export default {
+    initialize,
+};

--- a/app/instance-initializers/router.ts
+++ b/app/instance-initializers/router.ts
@@ -17,14 +17,11 @@ const {
 
 export function initialize(appInstance: ApplicationInstance): void {
     const routerService = appInstance.lookup('service:router') as RouterService;
-    const currentUser = appInstance.lookup('service:current-user');
-    const features = appInstance.lookup('service:features') as Features;
-    const statusMessages = appInstance.lookup('service:status-messages');
-    const ready = appInstance.lookup('service:ready');
-
     let readyBlocker = null as Blocker | null;
 
     routerService.on('routeWillChange', (transition: Transition) => {
+        const ready = appInstance.lookup('service:ready');
+        const features = appInstance.lookup('service:features') as Features;
         if (!readyBlocker || readyBlocker.isDone()) {
             readyBlocker = ready.getBlocker();
         }
@@ -48,6 +45,8 @@ export function initialize(appInstance: ApplicationInstance): void {
     });
 
     routerService.on('routeDidChange', (transition: Transition) => {
+        const currentUser = appInstance.lookup('service:current-user');
+        const statusMessages = appInstance.lookup('service:status-messages');
         currentUser.checkShowTosConsentBanner();
         statusMessages.updateMessages();
         if (!transition.queryParamsOnly) {

--- a/app/instance-initializers/router.ts
+++ b/app/instance-initializers/router.ts
@@ -22,7 +22,6 @@ export function initialize(appInstance: ApplicationInstance): void {
     const statusMessages = appInstance.lookup('service:status-messages');
     const ready = appInstance.lookup('service:ready');
 
-    // eslint-disable-next-line ember/avoid-leaking-state-in-ember-objects
     let readyBlocker = null as Blocker | null;
 
     routerService.on('routeWillChange', (transition: Transition) => {

--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -5,7 +5,6 @@ self.deprecationWorkflow.config = {
         { handler: 'silence', matchId: 'ember-inflector.globals' },
         { handler: 'silence', matchId: 'ember-metal.get-with-default' },
         { handler: 'silence', matchId: 'computed-property.volatile' },
-        { handler: 'throw', matchId: 'deprecate-router-events' },
         { handler: 'silence', matchId: 'implicit-injections' },
         { handler: 'silence', matchId: 'manager-capabilities.modifiers-3-13' },
         { handler: 'silence', matchId: 'this-property-fallback' },

--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -5,7 +5,7 @@ self.deprecationWorkflow.config = {
         { handler: 'silence', matchId: 'ember-inflector.globals' },
         { handler: 'silence', matchId: 'ember-metal.get-with-default' },
         { handler: 'silence', matchId: 'computed-property.volatile' },
-        { handler: 'silence', matchId: 'deprecate-router-events' },
+        { handler: 'throw', matchId: 'deprecate-router-events' },
         { handler: 'silence', matchId: 'implicit-injections' },
         { handler: 'silence', matchId: 'manager-capabilities.modifiers-3-13' },
         { handler: 'silence', matchId: 'this-property-fallback' },

--- a/handbook-docs/troubleshooting/template.md
+++ b/handbook-docs/troubleshooting/template.md
@@ -52,6 +52,7 @@ parameter. You just need to
 
 Then, either in `beforeEach` or in the particular problematic test:
 
+`this.owner.unregister('service:router');`
 `this.owner.register('service:router', OsfLinkRouterStub);`
 
 ## Buttons in modals aren't tracking analytics events

--- a/tests/engines/registries/integration/components/page-link/component-test.ts
+++ b/tests/engines/registries/integration/components/page-link/component-test.ts
@@ -31,6 +31,7 @@ module('Registries | Integration | Component | page-link', hooks => {
     setupEngineRenderingTest(hooks, 'registries');
 
     hooks.beforeEach(function(this: TestContext) {
+        this.owner.unregister('service:router');
         this.owner.register('service:router', RouterStub);
         this.owner.register('service:osf-router', RouterStub);
         this.owner.register('service:current-user', CurrentUserStub);

--- a/tests/engines/registries/integration/components/side-nav/component-test.ts
+++ b/tests/engines/registries/integration/components/side-nav/component-test.ts
@@ -31,6 +31,7 @@ module('Registries | Integration | Component | side-nav', hooks => {
     setupEngineRenderingTest(hooks, 'registries');
 
     hooks.beforeEach(function(this: TestContext) {
+        this.owner.unregister('service:router');
         this.owner.register('service:router', RouterStub);
         this.owner.register('service:osf-router', RouterStub);
         this.owner.register('service:current-user', CurrentUserStub);

--- a/tests/integration/components/ancestry-display/component-test.ts
+++ b/tests/integration/components/ancestry-display/component-test.ts
@@ -22,6 +22,7 @@ module('Integration | Component | ancestry-display', hooks => {
 
     hooks.beforeEach(function(this: TestContext) {
         this.store = this.owner.lookup('service:store');
+        this.owner.unregister('service:router');
         this.owner.register('service:router', OsfLinkRouterStub.extend({
             urlFor(__: any, modelId: string) {
                 return `/${modelId}`;

--- a/tests/integration/components/contributors/component-test.ts
+++ b/tests/integration/components/contributors/component-test.ts
@@ -25,6 +25,7 @@ module('Integration | Component | contributors', hooks => {
     hooks.beforeEach(function(this: ThisTestContext) {
         this.store = this.owner.lookup('service:store');
         this.currentUser = this.owner.lookup('service:current-user');
+        this.owner.unregister('service:router');
         this.owner.register('service:router', OsfLinkRouterStub);
         server.loadFixtures('schema-blocks');
         server.loadFixtures('registration-schemas');

--- a/tests/integration/components/draft-registration-card/component-test.ts
+++ b/tests/integration/components/draft-registration-card/component-test.ts
@@ -14,6 +14,7 @@ module('Integration | Component | draft-registration-card', hooks => {
     hooks.beforeEach(function(this: TestContext) {
         this.store = this.owner.lookup('service:store');
         this.intl = this.owner.lookup('service:intl');
+        this.owner.unregister('service:router');
         this.owner.register('service:router', OsfLinkRouterStub);
         server.loadFixtures('schema-blocks');
         server.loadFixtures('registration-schemas');

--- a/tests/integration/components/moderators/component-test.ts
+++ b/tests/integration/components/moderators/component-test.ts
@@ -23,6 +23,7 @@ module('Integration | Component | moderators', hooks => {
     hooks.beforeEach(async function(this: ModeratorsTestContext) {
         this.store = this.owner.lookup('service:store');
         this.intl = this.owner.lookup('service:intl');
+        this.owner.unregister('service:router');
         this.owner.register('service:router', OsfLinkRouterStub);
         this.provider = server.create('registration-provider', { id: 'egap', name: 'EGAP' });
         const providerModel = await this.store.findRecord('registration-provider', 'egap');

--- a/tests/integration/components/node-card/component-test.ts
+++ b/tests/integration/components/node-card/component-test.ts
@@ -21,6 +21,7 @@ module('Integration | Component | node-card', hooks => {
     });
 
     test('it renders', async function(this: TestContext, assert) {
+        this.owner.unregister('service:router');
         this.owner.register('service:router', OsfLinkRouterStub);
         const registration = server.create('registration', {
             tags: ['a', 'b', 'c'],
@@ -114,6 +115,7 @@ module('Integration | Component | node-card', hooks => {
     });
 
     test('it renders pending registration', async function(this: TestContext, assert) {
+        this.owner.unregister('service:router');
         this.owner.register('service:router', OsfLinkRouterStub);
         const registration = server.create('registration', {
             reviewsState: RegistrationReviewStates.Pending,

--- a/tests/integration/components/node-description/component-test.ts
+++ b/tests/integration/components/node-description/component-test.ts
@@ -16,6 +16,7 @@ module('Integration | Component | node-description', hooks => {
         this.store = this.owner.lookup('service:store');
     });
     test('it renders', async function(assert) {
+        this.owner.unregister('service:router');
         this.owner.register('service:router', OsfLinkRouterStub);
         const node = server.create('node', {}, 'withContributors');
         const project = await this.store.findRecord('node', node.id, { include: 'bibliographic_contributors' });

--- a/tests/integration/components/node-navbar/component-test.ts
+++ b/tests/integration/components/node-navbar/component-test.ts
@@ -67,6 +67,7 @@ module('Integration | Component | node-navbar', () => {
         setupRenderingTest(hooks);
 
         test('it renders', async function(assert) {
+            this.owner.unregister('service:router');
             this.owner.register('service:router', OsfLinkRouterStub);
 
             this.set('node', new FakeNode());
@@ -273,6 +274,7 @@ module('Integration | Component | node-navbar', () => {
 
         testCases.forEach((testCase, i) => {
             test(`it renders the correct links (${i})`, async function(assert) {
+                this.owner.unregister('service:router');
                 this.owner.register('service:router', OsfLinkRouterStub);
 
                 const node = new FakeNode(testCase.conditions);

--- a/tests/integration/components/node-navbar/component-test.ts
+++ b/tests/integration/components/node-navbar/component-test.ts
@@ -82,6 +82,7 @@ module('Integration | Component | node-navbar', () => {
                     return routeName.includes('guid-node.wiki');
                 },
             });
+            this.owner.unregister('service:router');
             this.owner.register('service:router', routerStub);
 
             this.set('node', new FakeNode([NavCondition.WikiEnabled]));
@@ -99,6 +100,7 @@ module('Integration | Component | node-navbar', () => {
                     return routeName.includes('guid-node.forks');
                 },
             });
+            this.owner.unregister('service:router');
             this.owner.register('service:router', routerStub);
 
             this.set('node', new FakeNode());

--- a/tests/integration/components/node-navbar/link/component-test.ts
+++ b/tests/integration/components/node-navbar/link/component-test.ts
@@ -12,6 +12,7 @@ module('Integration | Component | node-navbar/link', hooks => {
     setupRenderingTest(hooks);
 
     hooks.beforeEach(function(this: TestContext) {
+        this.owner.unregister('service:router');
         this.owner.register('service:router', OsfLinkRouterStub);
     });
 

--- a/tests/integration/components/open-badges-list/component-test.ts
+++ b/tests/integration/components/open-badges-list/component-test.ts
@@ -15,6 +15,7 @@ module('Integration | Component | open-badges-list', hooks => {
 
     hooks.beforeEach(function(this: TestContext) {
         this.store = this.owner.lookup('service:store');
+        this.owner.unregister('service:router');
         this.owner.register('service:router', OsfLinkRouterStub.extend({
             urlFor(__: any, modelId: string) {
                 return `/${modelId}`;
@@ -91,6 +92,7 @@ module('Integration | Component | open-badges-list | open-badge-card', hooks => 
 
     hooks.beforeEach(function(this: TestContext) {
         this.store = this.owner.lookup('service:store');
+        this.owner.unregister('service:router');
         this.owner.register('service:router', OsfLinkRouterStub.extend({
             urlFor(__: any, modelId: string) {
                 return `/${modelId}/resources`;

--- a/tests/integration/components/osf-navbar/auth-dropdown/component-test.ts
+++ b/tests/integration/components/osf-navbar/auth-dropdown/component-test.ts
@@ -29,6 +29,7 @@ module('Integration | Component | osf-navbar/auth-dropdown', hooks => {
         this.owner.register('service:-routing', routingStub);
 
         // Make sure currentURL is always a string
+        this.owner.unregister('service:router');
         this.owner.register('service:router', OsfLinkRouterStub);
     });
 

--- a/tests/integration/components/osf-navbar/component-test.ts
+++ b/tests/integration/components/osf-navbar/component-test.ts
@@ -21,6 +21,7 @@ module('Integration | Component | osf-navbar', hooks => {
 
     hooks.beforeEach(function(this: TestContext) {
         // Make sure currentURL is always a string
+        this.owner.unregister('service:router');
         this.owner.register('service:router', routerStub);
     });
 

--- a/tests/integration/components/registries-side-nav/component-test.ts
+++ b/tests/integration/components/registries-side-nav/component-test.ts
@@ -27,6 +27,7 @@ module('Integration | Component | registries-side-nav', hooks => {
     setupRenderingTest(hooks);
 
     hooks.beforeEach(function(this: TestContext) {
+        this.owner.unregister('service:router');
         this.owner.register('service:router', RouterStub);
         this.owner.register('service:current-user', CurrentUserStub);
     });

--- a/tests/integration/components/registries/my-registrations-list/component-test.ts
+++ b/tests/integration/components/registries/my-registrations-list/component-test.ts
@@ -14,6 +14,7 @@ module('Integration | Component | my-registrations-list', hooks => {
     hooks.beforeEach(async function(this: TestContext) {
         this.store = this.owner.lookup('service:store');
         this.intl = this.owner.lookup('service:intl');
+        this.owner.unregister('service:router');
         this.owner.register('service:router', OsfLinkRouterStub);
     });
 

--- a/tests/integration/components/registries/registration-list/card/component-test.ts
+++ b/tests/integration/components/registries/registration-list/card/component-test.ts
@@ -18,6 +18,7 @@ module('Registries | Integration | Component | registration-list-card', hooks =>
     setupMirage(hooks);
 
     hooks.beforeEach(function(this: ThisTestContext) {
+        this.owner.unregister('service:router');
         this.owner.register('service:router', OsfLinkRouterStub);
         this.store = this.owner.lookup('service:store');
 

--- a/tests/integration/components/registries/registration-list/component-test.ts
+++ b/tests/integration/components/registries/registration-list/component-test.ts
@@ -13,6 +13,7 @@ module('Integration | Component | registration-list', hooks => {
     setupIntl(hooks);
 
     hooks.beforeEach(function(this: TestContext) {
+        this.owner.unregister('service:router');
         this.owner.register('service:router', OsfLinkRouterStub);
         this.store = this.owner.lookup('service:store');
     });

--- a/tests/integration/routes/institutions/dashboard/-components/institutional-users-list/component-test.ts
+++ b/tests/integration/routes/institutions/dashboard/-components/institutional-users-list/component-test.ts
@@ -12,6 +12,7 @@ module('Integration | routes | institutions | dashboard | -components | institut
 
     hooks.beforeEach(function(this: TestContext) {
         this.store = this.owner.lookup('service:store');
+        this.owner.unregister('service:router');
         this.owner.register('service:router', OsfLinkRouterStub);
     });
 

--- a/tests/integration/routes/meetings/index/-components/meetings-list/component-test.ts
+++ b/tests/integration/routes/meetings/index/-components/meetings-list/component-test.ts
@@ -11,6 +11,7 @@ module('Integration | routes | meetings | index | -components | meetings-list', 
     setupMirage(hooks);
 
     hooks.beforeEach(function(this: TestContext) {
+        this.owner.unregister('service:router');
         this.owner.register('service:router', OsfLinkRouterStub);
     });
 

--- a/tests/unit/instance-initializers/router-test.ts
+++ b/tests/unit/instance-initializers/router-test.ts
@@ -1,0 +1,32 @@
+import Application from '@ember/application';
+
+import { initialize } from 'ember-osf-web/instance-initializers/router';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import destroyApp from '../../helpers/destroy-app';
+
+module('Unit | Instance Initializer | router', function(hooks) {
+    setupTest(hooks);
+
+    // TODO: Actually test
+    hooks.beforeEach(function() {
+        this.TestApplication = Application.extend();
+        this.TestApplication.instanceInitializer({
+            name: 'initializer under test',
+            initialize,
+        });
+        this.application = this.TestApplication.create({ autoboot: false });
+        this.instance = this.application.buildInstance();
+    });
+    hooks.afterEach(function() {
+        destroyApp(this.application);
+        destroyApp(this.instance);
+    });
+
+    // Replace this with your real tests.
+    test('it works', async function(assert) {
+        await this.instance.boot();
+
+        assert.ok(true);
+    });
+});

--- a/tests/unit/instance-initializers/router-test.ts
+++ b/tests/unit/instance-initializers/router-test.ts
@@ -1,16 +1,28 @@
 import Application from '@ember/application';
+import ApplicationInstance from '@ember/application/instance';
+import { run } from '@ember/runloop';
+import Resolver from 'ember-resolver';
+import { TestContext } from 'ember-test-helpers';
+import config from 'ember-get-config';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import { initialize } from 'ember-osf-web/instance-initializers/router';
-import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
-import destroyApp from '../../helpers/destroy-app';
 
-module('Unit | Instance Initializer | router', function(hooks) {
-    setupTest(hooks);
+interface InitializerTestContext extends TestContext {
+    TestApplication: any;
+    application: Application;
+    instance: ApplicationInstance;
+}
 
-    // TODO: Actually test
-    hooks.beforeEach(function() {
-        this.TestApplication = Application.extend();
+const { modulePrefix } = config;
+
+module('Unit | Instance Initializer | router', function(this: InitializerTestContext, hooks) {
+    hooks.beforeEach(function(this: InitializerTestContext) {
+        this.TestApplication = class TestApplication extends Application {
+            modulePrefix = modulePrefix;
+            Resolver = Resolver;
+        };
         this.TestApplication.instanceInitializer({
             name: 'initializer under test',
             initialize,
@@ -18,15 +30,19 @@ module('Unit | Instance Initializer | router', function(hooks) {
         this.application = this.TestApplication.create({ autoboot: false });
         this.instance = this.application.buildInstance();
     });
-    hooks.afterEach(function() {
-        destroyApp(this.application);
-        destroyApp(this.instance);
+
+    hooks.afterEach(function(this: InitializerTestContext) {
+        run(this.instance, 'destroy');
+        run(this.application, 'destroy');
     });
 
-    // Replace this with your real tests.
-    test('it works', async function(assert) {
+    test('it sets handlers to router service', async function(this: InitializerTestContext, assert) {
+        const routerService = this.instance.lookup('service:router');
+        const routerOn = sinon.stub(routerService, 'on');
+        assert.ok(routerOn.notCalled, 'Event handlers are not yet set on router service');
         await this.instance.boot();
-
-        assert.ok(true);
+        assert.ok(routerOn.calledTwice, 'handlers set');
+        assert.ok(routerOn.calledWith('routeWillChange', sinon.match.func), 'routeWillChange handler set');
+        assert.ok(routerOn.calledWith('routeDidChange', sinon.match.func), 'routeDidChange handler set');
     });
 });

--- a/tests/unit/metric-adapters/keen-test.ts
+++ b/tests/unit/metric-adapters/keen-test.ts
@@ -80,6 +80,7 @@ module('Unit | Metrics Adapter | keen ', hooks => {
 
     test('getCurrentModelTask - undefined', function(this: SinonTestContext, assert) {
         this.owner.register('route:foo', {}, { instantiate: false });
+        this.owner.unregister('service:router');
         this.owner.register('service:router', Service.extend({
             currentRouteName: 'foo',
         }));
@@ -94,6 +95,7 @@ module('Unit | Metrics Adapter | keen ', hooks => {
 
         this.owner.register('route:foo', { currentModel: { taskInstance } }, { instantiate: false });
         this.owner.register('route:foo.bar', { currentModel: { taskInstance: undefined } }, { instantiate: false });
+        this.owner.unregister('service:router');
         this.owner.register('service:router', Service.extend({
             currentRouteName: 'foo.bar',
         }));


### PR DESCRIPTION
-   Ticket: [ENG-4010]
-   Feature flag: n/a

## Purpose
- Address deprecation of router events found here: https://deprecations.emberjs.com/v3.x/#toc_deprecate-router-events

## Summary of Changes
- Remove usage of `willTransition` and `didTransition` in the app router
- Remove usage of private router API from app router
- Move logic that was handled in aforementioned `willTransition`, `didTransition` and other private router API calls into a new app-instance initializer `router` (The name is sort of awful, so any alternative name suggestions would be much appreciated 😬 )
  - Fetch server-side rendered page if a given waffle flag is not enabled
  - Scroll to top on page change, except in cases of query-param only route changes

## Screenshot(s)
- NA

## Side Effects
- None I think

## QA Notes
- This PR impacts how our app handles route changes (including query param only changes like `registries/my-registrations?tab=submitted` -> `registries/my-registrations?tab=draft`). The behavior of route changes should be exactly the same, so I think just navigating the app (going from emberized pages and non-emberized pages) should be enough.
- A small corner case to check is when going to a potentially waffled off page. If the page is waffled off, it should serve up the legacy page


[ENG-4010]: https://openscience.atlassian.net/browse/ENG-4010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ