### PR TITLE
[ENG-4004] Unsilence ember.globals-resolver deprecation

### DIFF
--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -1,7 +1,6 @@
 self.deprecationWorkflow = self.deprecationWorkflow || {};
 self.deprecationWorkflow.config = {
     workflow: [
-        { handler: 'silence', matchId: 'ember.globals-resolver' },
         { handler: 'silence', matchId: 'ember-inflector.globals' },
         { handler: 'silence', matchId: 'ember-metal.get-with-default' },
         { handler: 'silence', matchId: 'computed-property.volatile' },

--- a/package.json
+++ b/package.json
@@ -138,7 +138,6 @@
     "ember-cli-release": "^1.0.0-beta.2",
     "ember-cli-sanitize-html": "^2.0.3",
     "ember-cli-sass": "^10.0.0",
-    "ember-cli-shims": "^1.2.0",
     "ember-cli-showdown": "^4.4.4",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-string-helpers": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9279,17 +9279,6 @@ ember-cli-sass@^10.0.0:
     broccoli-sass-source-maps "^4.0.0"
     ember-cli-version-checker "^2.1.0"
 
-ember-cli-shims@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-shims/-/ember-cli-shims-1.2.0.tgz#0f53aff0aab80b5f29da3a9731bac56169dd941f"
-  integrity sha1-D1Ov8Kq4C18p2jqXMbrFYWndlB8=
-  dependencies:
-    broccoli-file-creator "^1.1.1"
-    broccoli-merge-trees "^2.0.0"
-    ember-cli-version-checker "^2.0.0"
-    ember-rfc176-data "^0.3.1"
-    silent-error "^1.0.1"
-
 ember-cli-showdown@^4.4.4:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/ember-cli-showdown/-/ember-cli-showdown-4.5.0.tgz#6ea0d28ced62fd5feb92799bc90d6a4857ceb5a7"
@@ -9488,7 +9477,7 @@ ember-cli-version-checker@^1.0.2:
   dependencies:
     semver "^5.3.0"
 
-ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0, ember-cli-version-checker@^2.1.2:
+ember-cli-version-checker@^2.1.0, ember-cli-version-checker@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz#47771b731fe0962705e27c8199a9e3825709f3b3"
   integrity sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==
@@ -10345,7 +10334,7 @@ ember-responsive@^3.0.0:
   dependencies:
     ember-cli-babel "^7.19.0"
 
-ember-rfc176-data@^0.3.1, ember-rfc176-data@^0.3.12, ember-rfc176-data@^0.3.13, ember-rfc176-data@^0.3.15, ember-rfc176-data@^0.3.17:
+ember-rfc176-data@^0.3.12, ember-rfc176-data@^0.3.13, ember-rfc176-data@^0.3.15, ember-rfc176-data@^0.3.17:
   version "0.3.17"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.17.tgz#d4fc6c33abd6ef7b3440c107a28e04417b49860a"
   integrity sha512-EVzTTKqxv9FZbEh6Ktw56YyWRAA0MijKvl7H8C06wVF+8f/cRRz3dXxa4nkwjzyVwx4rzKGuIGq77hxJAQhWWw==


### PR DESCRIPTION
-   Ticket: [ENG-4004]

## Purpose

Stop tripping the warning for ember.globals-resolver deprecation.

## Summary of Changes

1. Stop using ember-cli-shims, which we don't _seem_ to need anymore.
2. Update the prerender instance initializer test to prevent a future problem when upgrading to 4.0 that wasn't caught by the deprecation.

## Side Effects

ember-cli-shims has been removed and re-added before, and I'm not sure why it was re-added. But everything builds, and tests run, so as long as selenium and percy does fine, we're probably okay.

## QA Notes

I don't have anything specific to look out for with this PR.

[ENG-4004]: https://openscience.atlassian.net/browse/ENG-4004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ