### PR TITLE
[Eng-4051] Fixed the CSS for cutting off a button on the mobile view

### DIFF
--- a/lib/analytics-page/addon/application/styles.scss
+++ b/lib/analytics-page/addon/application/styles.scss
@@ -1,15 +1,3 @@
-@media (min-width: 768px) {
-    .Counts {
-        display: flex;
-    }
-}
-
-@media (max-width: 767px) {
-    .CountBox:global(.panel) {
-        margin-left: 15px;
-        margin-right: 15px;
-    }
-}
 
 .Counts {
     margin-top: 20px;
@@ -63,4 +51,25 @@
     padding: 0;
     margin: 0;
     border: 0;
+}
+
+@media (min-width: 768px) {
+    .Counts {
+        display: flex;
+    }
+}
+
+@media (max-width: 768px) {
+    .CountBox:global(.panel) {
+        margin-left: 15px;
+        margin-right: 15px;
+    }
+}
+
+@media screen and (max-device-height: 500px) {
+    :global(.modal-body) {
+        max-height: 60vh;
+        padding: 0;
+        margin-bottom: 0;
+    }
 }

--- a/lib/analytics-page/addon/application/template.hbs
+++ b/lib/analytics-page/addon/application/template.hbs
@@ -18,57 +18,55 @@
                 {{/if}}
             </div>
         </div>
-        <div class='col-sm-4' local-class='CountBox'>
-            <div class='panel panel-default'>
-                <div class='panel-body'>
-                    <h3>{{t 'analytics.links'}}</h3>
-                    {{#if this.loading}}
-                        {{loading-indicator dark=true}}
-                    {{else}}
-                        <h2>{{this.linkedByCount}}</h2>
-                        <button
-                            type='button'
-                            class='btn btn-link'
-                            local-class='button-link'
-                            {{on 'click' this.showLinksModal}}
-                        >
-                            {{t 'analytics.viewLinks'}}
-                        </button>
-                        {{#if this.linksModalShown}}
-                            {{#bs-modal-simple
-                                title=(t 'analytics.links')
-                                closeTitle=(t 'general.close')
-                                onHide=(action 'hideLinksModal')
-                            }}
-                                {{#if this.node}}
-                                    <ul class='list-group'>
-                                        {{#paginated-list/has-many
-                                            model=this.node
-                                            relationshipName='linkedByNodes'
-                                            query=this.linkedByQueryParams
-                                            analyticsScope='Project Analytics - Links'
-                                            as |list|
-                                        }}
-                                            <list.item as |node|>
-                                                <NodeCard
-                                                    @node={{node}}
-                                                    @readOnly={{true}}
-                                                    @analyticsScope='Project Analytics - Links'
-                                                />
-                                            </list.item>
+        <div class='col-sm-4 panel panel-default' local-class='CountBox'>
+            <div class='panel-body'>
+                <h3>{{t 'analytics.links'}}</h3>
+                {{#if this.loading}}
+                    {{loading-indicator dark=true}}
+                {{else}}
+                    <h2>{{this.linkedByCount}}</h2>
+                    <button
+                        type='button'
+                        class='btn btn-link'
+                        local-class='button-link'
+                        {{on 'click' this.showLinksModal}}
+                    >
+                        {{t 'analytics.viewLinks'}}
+                    </button>
+                    {{#if this.linksModalShown}}
+                        {{#bs-modal-simple
+                            title=(t 'analytics.links')
+                            closeTitle=(t 'general.close')
+                            onHide=(action 'hideLinksModal')
+                        }}
+                            {{#if this.node}}
+                                <ul class='list-group'>
+                                    {{#paginated-list/has-many
+                                        model=this.node
+                                        relationshipName='linkedByNodes'
+                                        query=this.linkedByQueryParams
+                                        analyticsScope='Project Analytics - Links'
+                                        as |list|
+                                    }}
+                                        <list.item as |node|>
+                                            <NodeCard
+                                                @node={{node}}
+                                                @readOnly={{true}}
+                                                @analyticsScope='Project Analytics - Links'
+                                            />
+                                        </list.item>
 
-                                            <list.empty>
-                                                {{t 'analytics.noLinks'}}
-                                            </list.empty>
-                                        {{/paginated-list/has-many}}
-                                    </ul>
-                                {{else}}
-                                    <LoadingIndicator @dark={{true}} />
-                                {{/if}}
-                            {{/bs-modal-simple}}
-                        {{/if}}
+                                        <list.empty>
+                                            {{t 'analytics.noLinks'}}
+                                        </list.empty>
+                                    {{/paginated-list/has-many}}
+                                </ul>
+                            {{else}}
+                                <LoadingIndicator @dark={{true}} />
+                            {{/if}}
+                        {{/bs-modal-simple}}
                     {{/if}}
-                </div>
+                {{/if}}
             </div>
         </div>
         <div class='col-sm-4 panel panel-default' local-class='CountBox'>


### PR DESCRIPTION
Fixed the CSS for cutting off a button on the mobile view on the Project Analytics Page > Linked Projects

-   Ticket: [ENG-4051]
-   Feature flag: No

## Purpose

Fixed the CSS for cutting off a button on the mobile view on the Project Analytics Page > Linked Projects

## Summary of Changes

Updated the analytics-page/andon/application/template.hbs to be the same dom structure and css.

Updated the analytics-page/andon/application/styles.scss to have a @media screen and (max-device-height: 500px) attribute to change the max-height, padding and margin-bottom.

## Screenshot(s)

Non-mobile view
![Screen Shot 2022-09-26 at 2 21 26 PM](https://user-images.githubusercontent.com/113387478/192372456-21f44e99-df0a-45f4-9d57-1283e5

Mobile View
![Screen Shot 2022-09-26 at 2 22 17 PM](https://user-images.githubusercontent.com/113387478/192372592-4d770032-4b88-4be3-b44c-c0ec95b4d725.png)
041537.png)

## Side Effects


A rouge phone with a super small screen?

## QA Notes

The test requires to Projects with a file being shared between the two project.

On the `shared with` project do the following steps

1. Click on the project
2. Click on Analytics
3. Click on View Links
4. Change the view port to be a phone in landscape mode.
5. Verify the button is clickable


[ENG-4051]: https://openscience.atlassian.net/browse/ENG-4051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ