### PR TITLE
[ENG-4149] Add controls to file item menu to go to metadata page 

### DIFF
--- a/lib/osf-components/addon/components/file-actions-menu/styles.scss
+++ b/lib/osf-components/addon/components/file-actions-menu/styles.scss
@@ -25,4 +25,12 @@
 .DropdownItem {
     composes: FakeLink from '../button/styles.scss';
     padding: 8px 0 0;
+
+    div:nth-of-type(3) {
+        padding-left: 2px;
+    }
+}
+
+.metadata-link {
+    padding-top: 6px;
 }

--- a/lib/osf-components/addon/components/file-actions-menu/template.hbs
+++ b/lib/osf-components/addon/components/file-actions-menu/template.hbs
@@ -60,6 +60,16 @@
             </dd.trigger>
         </SharingIcons::Dropdown>
         {{#if @manager}}
+            <OsfLink
+                data-test-metadata-link
+                data-analytics-name='File metadata link'
+                local-class='metadata-link'
+                @href='#'
+                aria-label={{t 'file_actions_menu.metadata_aria'}}
+            >
+                <FaIcon @icon='question-circle' />
+                {{t 'file_actions_menu.metadata'}}
+            </OsfLink>
             {{#if @item.currentUserCanDelete}}
                 {{#if @allowRename}}
                     <Button

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -109,6 +109,8 @@ file_actions_menu:
     error_message: 'Could not copy to clipboard'
     rename: 'Rename'
     rename_aria: 'Open rename link'
+    metadata: 'Metadata'
+    metadata_aria: 'Redirect to file metadata.'
 node_categories:
     analysis: Analysis
     communication: Communication


### PR DESCRIPTION
-   Ticket: https://openscience.atlassian.net/browse/ENG-4149
-   Feature flag: feature/file-action-list-metadata 

## Purpose

The purpose of these changes is to add a link to file metadata on the file list view.

## Summary of Changes

A link for file metadata was added to the file list view and some styling was added to ensure it was properly formatted.

## Screenshot(s)

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/82047646/199987808-89d3cefc-5535-4f5e-9669-d072f61e65b6.png">
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/82047646/199987854-b92b935f-aa69-4f4b-b4f6-d9343dec4ea8.png">


## Side Effects

This change will affect the file actions menu on the file list view. The actions menu will contain an additional link. Testing should include ensuring a proper redirect as well as making sure the expanded element does not obscure other elements on the page.

## QA Notes

-Does the link work? Is the user properly redirected?
-Does the link look all right or could more styling be applied?
-When the link is hovered upon, does it visually indicate such to the user?