### PR TITLE
[ENG-4176] Add functionality for all submissions page

### DIFF
--- a/app/models/collection-submission.ts
+++ b/app/models/collection-submission.ts
@@ -31,6 +31,14 @@ export enum CollectionSubmissionReviewStates {
     Rejected = 'rejected',
 }
 
+export const SubmissionIconMap = {
+    [CollectionSubmissionReviewStates.Pending]: 'clock',
+    [CollectionSubmissionReviewStates.Accepted]: 'check',
+    [CollectionSubmissionReviewStates.Removed]: 'trash',
+    [CollectionSubmissionReviewStates.Rejected]: 'times',
+    [CollectionSubmissionReviewStates.InProgress]: 'times',
+};
+
 export type ActionableCollectionSubmissionStates =
     CollectionSubmissionReviewStates.Accepted | CollectionSubmissionReviewStates.Pending;
 

--- a/lib/collections/addon/provider/moderation/all/controller.ts
+++ b/lib/collections/addon/provider/moderation/all/controller.ts
@@ -1,0 +1,39 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import Media from 'ember-responsive';
+
+import { CollectionSubmissionReviewStates, SubmissionIconMap } from 'ember-osf-web/models/collection-submission';
+
+
+export default class CollectionsModerationAllController extends Controller {
+    @service media!: Media;
+
+    queryParams = ['state'];
+
+    @tracked state?: CollectionSubmissionReviewStates;
+    @tracked sort = '-date_created';
+
+    submissionIconMap = SubmissionIconMap;
+    reloadSubmissionList?: (page?: number) => void; // bound by paginated-list
+
+    get isMobile() {
+        return this.media.isMobile;
+    }
+
+    get query() {
+        return {
+            filter: {
+                reviews_state: [this.state],
+            },
+            // TBD: '-modified'?? Check if API has dateModified based on actions
+            sort: '-date_registered',
+        };
+    }
+
+    @action
+    changeTab(tab: CollectionSubmissionReviewStates) {
+        this.state = tab;
+    }
+}

--- a/lib/collections/addon/provider/moderation/all/route.ts
+++ b/lib/collections/addon/provider/moderation/all/route.ts
@@ -1,11 +1,37 @@
-import Store from '@ember-data/store';
+import Transition from '@ember/routing/-private/transition';
 import Route from '@ember/routing/route';
+import Store from '@ember-data/store';
 import { inject as service } from '@ember/service';
 
-export default class ModerationAll extends Route {
-  @service store!: Store;
+import CollectionProviderModel from 'ember-osf-web/models/collection-provider';
+import CollectionSubmissionModel,
+{ CollectionSubmissionReviewStates } from 'ember-osf-web/models/collection-submission';
+import Theme from 'ember-osf-web/services/theme';
 
-  model() {
-      return this.store.findAll('collection-submission');
-  }
+import CollectionsModerationAllController from './controller';
+
+export default class ModerationAll extends Route {
+    @service store!: Store;
+    @service theme!: Theme;
+
+    model() {
+        const provider = this.theme.provider as CollectionProviderModel;
+        return provider.primaryCollection;
+
+    }
+
+    setupController(
+        controller: CollectionsModerationAllController,
+        model: CollectionSubmissionModel,
+        transition: Transition,
+    ) {
+        super.setupController(controller, model, transition);
+        const { state } = controller;
+        if (!state || ![CollectionSubmissionReviewStates.Accepted,
+            CollectionSubmissionReviewStates.Pending,
+            CollectionSubmissionReviewStates.Rejected,
+            CollectionSubmissionReviewStates.Removed].includes(state)) {
+            controller.set('state', CollectionSubmissionReviewStates.Pending);
+        }
+    }
 }

--- a/lib/collections/addon/provider/moderation/all/styles.scss
+++ b/lib/collections/addon/provider/moderation/all/styles.scss
@@ -1,4 +1,43 @@
-hr {
-    margin-top: 5px;
-    margin-bottom: 5px;
+.tab-wrapper {
+    font-size: 15px;
+    background-color: $color-bg-gray-light;
+    border-bottom: 1px solid $color-border-gray;
+    padding: 10px 20px;
+}
+
+.tab {
+    padding-right: 15px;
+
+    &.selected {
+        font-weight: 700;
+        position: relative;
+    }
+}
+
+.sort-button {
+    margin-right: 15px;
+}
+
+.list {
+    ul {
+        margin: 0;
+    }
+}
+
+.empty {
+    border: 1px solid $color-border-gray;
+    padding: 15px;
+}
+
+.pending {
+    color: $color-text-black;
+}
+
+.accepted {
+    color: $brand-success;
+}
+
+.rejected,
+.removed {
+    color: $brand-danger;
 }

--- a/lib/collections/addon/provider/moderation/all/template.hbs
+++ b/lib/collections/addon/provider/moderation/all/template.hbs
@@ -1,9 +1,41 @@
-{{#each this.model as |collectionSubmission|}}
-    <CollectionSubmissionCard
-        @submission={{collectionSubmission}}
-    >
-    </CollectionSubmissionCard>
-    <hr aria-hidden='true'>
-{{else}}
-    {{t 'osf-components.moderators.all.noModerationSubmissions' }}
-{{/each}}
+<nav local-class='tab-wrapper'>
+    {{#each (array 'pending' 'accepted' 'rejected' 'removed') as |state| }}
+        {{#let (eq this.state state) as |selected| }}
+            <a
+                data-test-submissions-type={{state}}
+                data-test-is-selected={{if selected 'true' 'false'}}
+                aria-label={{t (concat 'collections.moderation.all.tabLabel.' state)}}
+                href='#'
+                {{on 'click' (fn this.changeTab state)}}
+                local-class='tab {{if selected 'selected'}}'
+            >
+                <FaIcon local-class='{{state}}' @icon={{get this.submissionIconMap state}} />
+                {{#if (or (not this.isMobile) selected)}}
+                    {{t (concat 'collections.moderation.all.' state)}}
+                {{/if}}
+            </a>
+        {{/let}}
+    {{/each}}
+</nav>
+<PaginatedList::HasMany
+    @model={{this.model}}
+    @relationshipName='collectionSubmissions'
+    @query={{this.query}}
+    @usePlaceholders={{false}}
+    @bindReload={{mut this.reloadSubmissionList}}
+    local-class='list'
+    as |list|
+>
+    <list.item as |submission|>
+        {{#if submission}}
+            <CollectionSubmissionCard
+                @submission={{submission}}
+            />
+        {{else}}
+            <LoadingIndicator @dark={{true}} @inline={{true}} />
+        {{/if}}
+    </list.item>
+    <list.empty>
+        <p local-class='empty' data-test-moderation-submissions-empty>{{t 'collections.moderation.all.noSubmissions'}}</p>
+    </list.empty>
+</PaginatedList::HasMany>

--- a/lib/osf-components/addon/components/collection-submission-card/styles.scss
+++ b/lib/osf-components/addon/components/collection-submission-card/styles.scss
@@ -1,8 +1,5 @@
-$container-height: 105px;
-
 .page-container {
     width: 100%;
-    height: $container-height;
     display: flex;
     flex-direction: row;
     align-items: flex-end;
@@ -11,7 +8,7 @@ $container-height: 105px;
     .icon-container {
         width: 55px;
         min-width: 55px;
-        height: $container-height;
+        margin: auto;
         display: flex;
         flex-direction: row;
         align-items: center;
@@ -19,55 +16,50 @@ $container-height: 105px;
     }
 
     .text-container {
-        height: $container-height;
         display: flex;
         flex-grow: 1;
-        min-width: 500px;
         flex-direction: column;
         align-items: flex-start;
         justify-content: center;
-
-        .project-title {
-            height: 25px;
-            width: 100%;
-            min-width: 500px;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            font-size: 18px;
-            font-weight: bold;
-            margin-bottom: 10px;
-        }
-
-        .moderation-details {
-            height: 19px;
-            width: 100%;
-            min-width: 500px;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            font-size: 14px;
-        }
-
-        .project-metadata {
-            height: fit-content;
-            width: calc(100% - 5px);
-            min-width: 500px;
-            overflow: hidden;
-            word-break: break-all;
-            font-size: 14px;
-            margin-bottom: 5px;
-            padding-right: 5px;
-        }
     }
 
     .button-container {
         width: 150px;
         min-width: 150px;
-        height: $container-height;
+        margin: auto;
         display: flex;
         flex-direction: row;
         align-items: center;
         justify-content: center;
+    }
+}
+
+.project-title {
+    height: 25px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 18px;
+    font-weight: bold;
+    margin-bottom: 10px;
+}
+
+.project-metadata {
+    display: inline-flex;
+    flex-wrap: wrap;
+    height: fit-content;
+    overflow: hidden;
+    word-break: break-all;
+    font-size: 14px;
+    margin-bottom: 5px;
+    padding-right: 5px;
+
+    .metadata-field-label:not(:first-of-type)::before {
+        content: '|';
+        margin-left: 5px;
+    }
+
+    .metadata-field-value {
+        margin-left: 5px;
     }
 }

--- a/lib/osf-components/addon/components/collection-submission-card/template.hbs
+++ b/lib/osf-components/addon/components/collection-submission-card/template.hbs
@@ -1,25 +1,44 @@
 <div local-class='page-container'>
-    <div local-class='icon-container'>
-        <FaIcon @icon='clock' @prefix='far' />
+    <div local-class='icon-container {{this.iconClass}}'>
+        <FaIcon data-test-submission-card-icon @icon={{this.icon}} @size='2x'/>
     </div>
     <div local-class='text-container'>
         <div local-class='project-title'>
-            {{ this.project.title }}
+            {{#if this.project}}
+                <OsfLink
+                    data-test-submission-card-title
+                    @route='resolve-guid'
+                    @models={{array this.project.id}}
+                >
+                    {{this.project.title}}
+                </OsfLink>
+            {{/if}}
         </div>
-        <div local-class='project-metadata'>
-            {{ this.projectMetadata }}
-        </div>
-        <div local-class='moderation-details'>
-            {{ this.moderationDetails }}
-        </div>
+        <dl local-class='project-metadata'>
+            {{#each this.projectMetadata as |metadataField|}}
+                <dt local-class='metadata-field-label'>
+                    {{t metadataField.label}}
+                </dt>
+                <dd local-class='metadata-field-value'>
+                    {{metadataField.value}}
+                </dd>
+            {{/each}}
+        </dl>
+        {{#if this.fetchActions.isRunning}}
+            <LoadingIndicator />
+        {{else}}
+            <div data-test-submission-card-latest-action local-class='moderation-details'>
+                <ReviewActionsList::ReviewAction
+                    @reviewAction={{this.latestAction}}
+                />
+            </div>
+        {{/if}}
     </div>
-    <div local-class='button-container'>
-        <Button
-            @type='create'
-            data-test-moderator-make-decision-button
-        >
-            {{t 'osf-components.moderators.all.button'}}
-            <FaIcon @icon='caret-down' />
-        </Button>
-    </div>
+    {{#if this.showDecisionDropdown}}
+        <div local-class='button-container'>
+            <MakeDecisionDropdown
+                @collectionSubmission={{@submission}}
+            />
+        </div>
+    {{/if}}
 </div>

--- a/lib/osf-components/addon/components/responsive-dropdown/component.ts
+++ b/lib/osf-components/addon/components/responsive-dropdown/component.ts
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 import Component from '@ember/component';
 import { action, computed } from '@ember/object';
-import { not } from '@ember/object/computed';
+import { or } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import calculatePosition from 'ember-basic-dropdown/utils/calculate-position';
 import Media from 'ember-responsive';
@@ -16,7 +16,7 @@ import template from './template';
 export default class ResponsiveDropdown extends Component {
     @service media!: Media;
 
-    @not('media.isDesktop') useOverlay!: boolean;
+    @or('media.isMobile', 'media.isTablet') useOverlay!: boolean;
 
     // eslint-disable-next-line ember/no-ember-testing-in-module-scope
     inTestMode = Ember.testing;

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -4,6 +4,7 @@ import config from 'ember-get-config';
 import { createReviewAction } from 'ember-osf-web/mirage/views/review-action';
 import { createResource, updateResource } from 'ember-osf-web/mirage/views/resource';
 import { getCitation } from './views/citation';
+import { createSubmissionAction } from './views/collection-submission-action';
 import { searchCollections } from './views/collection-search';
 import { reportDelete } from './views/comment';
 import { addContributor, createBibliographicContributor } from './views/contributor';
@@ -332,10 +333,10 @@ export default function(this: Server) {
         path: '/collection_submissions/:parentID/actions',
         relatedModelName: 'collection-submission-action',
     });
+    this.post('/collection_submissions/:submissionID/actions/', createSubmissionAction);
     osfResource(this, 'collection-submission-action', {
         only: ['show'],
     });
-    // this.post('/collection_submission_actions', someModerationThing);
 
     osfResource(this, 'resource', { except: ['index', 'update', 'create'] });
     this.patch('/resources/:id', updateResource);

--- a/mirage/factories/collection-submission-action.ts
+++ b/mirage/factories/collection-submission-action.ts
@@ -189,7 +189,7 @@ declare module 'ember-cli-mirage/types/registries/model' {
 
 declare module 'ember-cli-mirage/types/registries/schema' {
     export default interface MirageSchemaRegistry {
-        'collection-submission-action': MirageCollectionSubmissionAction;
+        collectionSubmissionActions: MirageCollectionSubmissionAction;
     } // eslint-disable-line semi
 }
 

--- a/mirage/serializers/collection.ts
+++ b/mirage/serializers/collection.ts
@@ -41,6 +41,7 @@ export default class CollectionSerializer extends ApplicationSerializer<Collecti
                 links: {
                     related: {
                         href: `${apiUrl}/v2/collections/${model.id}/collection_submissions/`,
+                        meta: this.buildRelatedLinkMeta(model, 'collectionSubmissions'),
                     },
                 },
             };

--- a/mirage/views/collection-submission-action.ts
+++ b/mirage/views/collection-submission-action.ts
@@ -1,0 +1,40 @@
+import { HandlerContext, NormalizedRequestAttrs, Request, Schema } from 'ember-cli-mirage';
+import CollectionSubmissionAction,
+{ CollectionSubmissionActionTrigger } from 'ember-osf-web/models/collection-submission-action';
+import { CollectionSubmissionReviewStates } from 'ember-osf-web/models/collection-submission';
+
+export function createSubmissionAction(this: HandlerContext, schema: Schema, request: Request) {
+    const attrs = this.normalizedRequestAttrs('collection-submission-action') as
+        Partial<NormalizedRequestAttrs<CollectionSubmissionAction>>;
+    const submissionId = request.params.submissionID;
+    const userId = schema.roots.first().currentUserId;
+    let collectionSubmissionAction;
+    if (userId && submissionId) {
+        const currentUser = schema.users.find(userId);
+        const submission = schema.collectionSubmissions.find(submissionId);
+        const { trigger, comment } = attrs as any; // cast attrs to any because `actionTrigger` does not exist on type
+        collectionSubmissionAction = schema.collectionSubmissionActions.create({
+            creator: currentUser,
+            target: submission,
+            dateCreated: new Date(),
+            dateModified: new Date(),
+            actionTrigger: trigger,
+            comment,
+        });
+        switch (trigger) {
+        case CollectionSubmissionActionTrigger.Accept:
+            submission.reviewsState = CollectionSubmissionReviewStates.Accepted;
+            break;
+        case CollectionSubmissionActionTrigger.ModeratorRemove:
+            submission.reviewsState = CollectionSubmissionReviewStates.Removed;
+            break;
+        case CollectionSubmissionActionTrigger.Reject:
+            submission.reviewsState = CollectionSubmissionReviewStates.Rejected;
+            break;
+        default:
+            break;
+        }
+        submission.save();
+    }
+    return collectionSubmissionAction;
+}

--- a/tests/engines/collections/acceptance/moderation/all-submissions-test.ts
+++ b/tests/engines/collections/acceptance/moderation/all-submissions-test.ts
@@ -1,0 +1,151 @@
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { percySnapshot } from 'ember-percy';
+import { module, test } from 'qunit';
+
+import { visit } from 'ember-osf-web/tests/helpers';
+import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
+import { currentRouteName } from '@ember/test-helpers/setup-application-context';
+
+import { CollectionSubmissionReviewStates } from 'ember-osf-web/models/collection-submission';
+import click from '@ember/test-helpers/dom/click';
+
+module('Collections | Acceptance | moderation | all', hooks => {
+    setupEngineApplicationTest(hooks, 'collections');
+    setupMirage(hooks);
+
+    test('it defaults to pending and changes tabs', async assert => {
+        server.create('user', 'loggedIn');
+        const primaryCollection = server.create('collection');
+        server.create('collection-submission', {
+            creator: server.create('user'),
+            reviewsState: CollectionSubmissionReviewStates.Pending,
+            collection: primaryCollection,
+            guid: server.create('node'),
+        });
+        server.create('collection-submission', {
+            creator: server.create('user'),
+            reviewsState: CollectionSubmissionReviewStates.Accepted,
+            collection: primaryCollection,
+            guid: server.create('node'),
+        });
+        server.create('collection-submission', {
+            creator: server.create('user'),
+            reviewsState: CollectionSubmissionReviewStates.Rejected,
+            collection: primaryCollection,
+            guid: server.create('node'),
+        });
+        const provider = server.create('collection-provider', {
+            id: 'studyswap',
+            primaryCollection,
+        }, 'currentUserIsAdmin');
+        await visit(`/collections/${provider.id}/moderation/`);
+        assert.equal(currentRouteName(), 'collections.provider.moderation.all');
+        assert.dom('[data-test-collections-moderation-all-tab]').hasClass('active', 'all submissions is active tab');
+
+        assert.dom('[data-test-submissions-type="pending"][data-test-is-selected="true"]')
+            .exists('pending is selected by default');
+        assert.dom('[data-test-submission-card-icon]').exists({ count: 1 }, 'has one pending submission');
+
+        await click('[data-test-submissions-type="accepted"]');
+        assert.dom('[data-test-submissions-type="accepted"][data-test-is-selected="true"]')
+            .exists('accepted is selected');
+        assert.dom('[data-test-submission-card-icon]').exists({ count: 1 }, 'has one accepted submission');
+
+        await click('[data-test-submissions-type="rejected"]');
+        assert.dom('[data-test-submissions-type="rejected"][data-test-is-selected="true"]')
+            .exists('rejected is selected');
+        assert.dom('[data-test-submission-card-icon]').exists({ count: 1 }, 'has one rejected submission');
+
+        await click('[data-test-submissions-type="removed"]');
+        assert.dom('[data-test-submissions-type="removed"][data-test-is-selected="true"]')
+            .exists('removed is selected');
+        assert.dom('[data-test-moderation-submissions-empty]').exists('no removed submssions are shown');
+        await percySnapshot(assert);
+    });
+
+    test('it moderates pending submissions', async assert => {
+        server.create('user', 'loggedIn');
+        const primaryCollection = server.create('collection');
+        server.create('collection-submission', {
+            creator: server.create('user'),
+            reviewsState: CollectionSubmissionReviewStates.Pending,
+            collection: primaryCollection,
+            guid: server.create('node', {title: 'To be accepted'}),
+        });
+        server.create('collection-submission', {
+            creator: server.create('user'),
+            reviewsState: CollectionSubmissionReviewStates.Pending,
+            collection: primaryCollection,
+            guid: server.create('node', {title: 'To be rejected'}),
+        });
+        const provider = server.create('collection-provider', {
+            id: 'studyswap',
+            primaryCollection,
+        }, 'currentUserIsAdmin');
+        await visit(`/collections/${provider.id}/moderation/`);
+        assert.dom('[data-test-moderation-dropdown-button]').exists({ count: 2 }, 'has two moderation dropdowns');
+        // check accepted and rejected tab
+        await click('[data-test-submissions-type="accepted"]');
+        assert.dom('[data-test-moderation-dropdown-button]').doesNotExist('no accepted submissions');
+        await click('[data-test-submissions-type="rejected"]');
+        assert.dom('[data-test-moderation-dropdown-button]').doesNotExist('no rejected submissions');
+
+        // Accept first submission
+        await click('[data-test-submissions-type="pending"]');
+        await click('[data-test-moderation-dropdown-button]');
+        assert.dom('[data-test-moderation-dropdown-submit]').isDisabled('submit button is disabled');
+        await click('[data-test-moderation-dropdown-decision-label="accept"]');
+        await click('[data-test-moderation-dropdown-submit]');
+        // TODO: need to reload automatically
+        await click('[data-test-submissions-type="pending"]');
+        assert.dom('[data-test-moderation-dropdown-button]').exists({ count: 1 }, 'has one moderation dropdown');
+        await click('[data-test-submissions-type="accepted"]');
+        assert.dom('[data-test-submission-card-title]').containsText('To be accepted', 'has one accepted submission');
+
+        // Reject second submission
+        await click('[data-test-submissions-type="pending"]');
+        await click('[data-test-moderation-dropdown-button]');
+        assert.dom('[data-test-moderation-dropdown-submit]').isDisabled('submit button is disabled');
+        await click('[data-test-moderation-dropdown-decision-label="reject"]');
+        await click('[data-test-moderation-dropdown-submit]');
+        // TODO: need to reload automatically
+        await click('[data-test-submissions-type="pending"]');
+        assert.dom('[data-test-moderation-dropdown-button]').doesNotExist('No more pending submisisons');
+        assert.dom('[data-test-moderation-submissions-empty]').exists('no pending submssions message shown');
+        await click('[data-test-submissions-type="rejected"]');
+        assert.dom('[data-test-submission-card-title]').containsText('To be rejected', 'has one rejected submission');
+    });
+
+    // 1 accepted -> 1 removed
+    test('it moderates accepted submissions', async assert => {
+        server.create('user', 'loggedIn');
+        const primaryCollection = server.create('collection');
+        server.create('collection-submission', {
+            creator: server.create('user'),
+            reviewsState: CollectionSubmissionReviewStates.Accepted,
+            collection: primaryCollection,
+            guid: server.create('node', {title: 'To be removed'}),
+        });
+        const provider = server.create('collection-provider', {
+            id: 'studyswap',
+            primaryCollection,
+        }, 'currentUserIsAdmin');
+        await visit(`/collections/${provider.id}/moderation/all?state=accepted`);
+        assert.dom('[data-test-moderation-dropdown-button]').exists({ count: 1 }, 'has 1 pending submission');
+        // check removed tab
+        await click('[data-test-submissions-type="removed"]');
+        assert.dom('[data-test-moderation-dropdown-button]').doesNotExist('no removed submissions');
+
+        // Remove submission
+        await click('[data-test-submissions-type="accepted"]');
+        await click('[data-test-moderation-dropdown-button]');
+        assert.dom('[data-test-moderation-dropdown-submit]').isDisabled('submit button is disabled');
+        await click('[data-test-moderation-dropdown-decision-label="moderator_remove"]');
+        await click('[data-test-moderation-dropdown-submit]');
+        // TODO: need to reload automatically
+        await click('[data-test-submissions-type="accepted"]');
+        assert.dom('[data-test-moderation-dropdown-button]').doesNotExist('No more pending submisisons');
+        await click('[data-test-submissions-type="removed"]');
+        assert.dom('[data-test-submission-card-title]').containsText('To be removed', 'has one removed submission');
+    });
+});

--- a/tests/integration/components/collection-submission-card/component-test.ts
+++ b/tests/integration/components/collection-submission-card/component-test.ts
@@ -1,0 +1,94 @@
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { TestContext } from 'ember-test-helpers';
+
+import CollectionModel from 'ember-osf-web/models/collection';
+import CollectionSubmissionModel,{ CollectionSubmissionReviewStates } from 'ember-osf-web/models/collection-submission';
+import { CollectionSubmissionActionTrigger } from 'ember-osf-web/models/collection-submission-action';
+import NodeModel from 'ember-osf-web/models/node';
+
+import { OsfLinkRouterStub } from '../../helpers/osf-link-router-stub';
+
+interface ThisTestContext extends TestContext {
+    collection: CollectionModel;
+    node: NodeModel;
+    submission: CollectionSubmissionModel;
+}
+
+module('Integration | Component | collection-submission-card', hooks => {
+    setupRenderingTest(hooks);
+    setupMirage(hooks);
+
+    hooks.beforeEach(async function(this: ThisTestContext) {
+        this.owner.unregister('service:router');
+        this.owner.register('service:router', OsfLinkRouterStub);
+        const store = this.owner.lookup('service:store');
+        const collection = server.create('collection');
+        this.collection = await store.findRecord('collection', collection.id);
+        const mirageNode = server.create('node');
+        this.node = await store.findRecord('node', mirageNode.id);
+        const submissionId = `${collection.id}-${mirageNode.id}`;
+
+        const currentUser = server.create('user', 'loggedIn');
+        const mirageSubmission = server.create('collection-submission', {
+            creator: currentUser,
+            guid: mirageNode,
+            id: mirageNode.id,
+            collection,
+        });
+        server.create('collection-submission-action', {
+            creator: currentUser,
+            target: mirageSubmission,
+            actionTrigger: CollectionSubmissionActionTrigger.Accept,
+            fromState: CollectionSubmissionReviewStates.Pending,
+            toState: CollectionSubmissionReviewStates.Accepted,
+        });
+        this.submission = await store.findRecord('collection-submission', submissionId);
+    });
+
+    test('it renders accepted submission', async function(this: ThisTestContext, assert) {
+        this.submission.reviewsState = CollectionSubmissionReviewStates.Accepted;
+        await render(hbs`
+        <CollectionSubmissionCard
+            @submission={{this.submission}}
+        />`);
+        assert.dom('[data-test-submission-card-icon]').hasAttribute('data-icon', 'check', 'Accepted icon shown');
+        assert.dom('[data-test-submission-card-title]').containsText(this.node.title, 'Node title shown');
+        assert.dom('[data-test-submission-card-latest-action]')
+            .containsText('Submission accepted', 'Latest action shown');
+        await click('[data-test-moderation-dropdown-button]');
+        assert.dom('[data-test-moderation-dropdown-submit]').isDisabled('Submit button is disabled');
+        assert.dom('[data-test-moderation-dropdown-decision-label="moderator_remove"]').exists('Accept option shown');
+        await click('[data-test-moderation-dropdown-button]');
+
+        this.submission.reviewsState = CollectionSubmissionReviewStates.Pending;
+        await render(hbs`
+        <CollectionSubmissionCard
+            @submission={{this.submission}}
+        />`);
+        assert.dom('[data-test-submission-card-icon]').hasAttribute('data-icon', 'clock', 'Pending icon shown');
+        await click('[data-test-moderation-dropdown-button]');
+        assert.dom('[data-test-moderation-dropdown-decision-label="accept"]').exists('Accept trigger shown');
+        assert.dom('[data-test-moderation-dropdown-decision-label="reject"]').exists('Reject trigger shown');
+        await click('[data-test-moderation-dropdown-button]');
+
+        this.submission.reviewsState = CollectionSubmissionReviewStates.Rejected;
+        await render(hbs`
+        <CollectionSubmissionCard
+            @submission={{this.submission}}
+        />`);
+        assert.dom('[data-test-submission-card-icon]').hasAttribute('data-icon', 'times', 'Rejected icon shown');
+        assert.dom('[data-test-moderation-dropdown-button]').doesNotExist('No moderation dropdown for rejected');
+
+        this.submission.reviewsState = CollectionSubmissionReviewStates.Removed;
+        await render(hbs`
+        <CollectionSubmissionCard
+            @submission={{this.submission}}
+        />`);
+        assert.dom('[data-test-submission-card-icon]').hasAttribute('data-icon', 'trash', 'Removed icon shown');
+        assert.dom('[data-test-moderation-dropdown-button]').doesNotExist('No moderation dropdown for removed');
+    });
+});

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -963,6 +963,16 @@ collections:
         header: 'Collections Moderation'
         all:
             title: 'All Items'
+            tabLabel:
+                pending: 'View pending submissions'
+                accepted: 'View accepted submissions'
+                rejected: 'View rejected submissions'
+                removed: 'View removed submissions'
+            pending: 'Pending'
+            accepted: 'Accepted'
+            rejected: 'Rejected'
+            removed: 'Removed'
+            noSubmissions: 'No submissions'
         moderators:
             title: 'Moderators'
         settings:
@@ -2146,11 +2156,6 @@ osf-components:
                 inviteByEmail: 'Invite user by email'
                 email: 'Email'
                 fullName: 'Full name'
-        all:
-            button: 'Make decision'
-            moderationDetails: 'Project {status} into collection on {date} by {moderator}'
-            noModerationSubmissions: 'There are no active moderation submissions.'
-            projectMetadataDisplay: '{metadataType}: {metadata}, '
     makeDecisionDropdown:
         makeDecision: 'Make Decision'
         acceptSubmission: 'Accept submission'


### PR DESCRIPTION
-   Ticket: [ENG-4176] 
-   Feature flag: n/a

## Purpose
- Create collection-submission cards to allow for moderation

## Summary of Changes
- Modify collection moderation's all-submissions page to fetch submissions based on current tab
- Update collection-submission-card 
  - use ReviewActionList::ReviewAction to show latest review-action
  - Use MakeDecisionDropdown
- Tests

## Screenshot(s)
- Pending:
![image](https://user-images.githubusercontent.com/51409893/203169885-0daaaff4-a646-486d-ab10-3c6fab2e57d3.png)

- Accepted:
![image](https://user-images.githubusercontent.com/51409893/203169794-4ac8c143-da72-4bd1-beec-49b8eaa1d29a.png)

- Rejected:
![image](https://user-images.githubusercontent.com/51409893/203169932-370bdcb9-4357-4db8-9b47-bf8a87563e0a.png)

- Removed:
![image](https://user-images.githubusercontent.com/51409893/203169953-f7304de2-a375-4294-9cfe-5359cbf51de5.png)


## Side Effects
- None

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
