### PR TITLE
Fix tranlation issue on error-page

### DIFF
--- a/lib/app-components/addon/components/error-page/template.hbs
+++ b/lib/app-components/addon/components/error-page/template.hbs
@@ -5,7 +5,7 @@
         <div class='col-xs-12'>
             <h1>{{t (concat this.translateKey '.heading')}}</h1>
             <p>
-                {{t (concat this.translateKey '.message')}}
+                {{t (concat this.translateKey '.message') brand=(t 'general.services.collections')}}
                 <br>
                 <span>
                     {{t 'app_components.error_page.email_message'}}


### PR DESCRIPTION
-   Ticket: [No ticket]
-   Feature flag: n/a

## Purpose
- Fix translation issue on collections error-page
## Summary of Changes
- Add a translation argument that was missing

## Screenshot(s)
- when going to an invalid collections page like `osf.io/collections/invalid`
![image](https://user-images.githubusercontent.com/51409893/204577692-892e1915-bcd0-4970-a61f-89c93c197cfa.png)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- Not sure if this will prevent the weird reroute issue that we are seeing on staging2, but now the error page should at least show some actionable content for users.