### PR TITLE
[ENG-4196] Fix long titles in collection-submission-card

### DIFF
--- a/lib/osf-components/addon/components/collection-submission-card/styles.scss
+++ b/lib/osf-components/addon/components/collection-submission-card/styles.scss
@@ -21,6 +21,7 @@
         flex-direction: column;
         align-items: flex-start;
         justify-content: center;
+        overflow: hidden;
     }
 
     .button-container {
@@ -36,6 +37,7 @@
 
 .project-title {
     height: 25px;
+    max-width: 100%;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
-   Ticket: [ENG-4196]
-   Feature flag: n/a

## Purpose
- Prevent long titles from pushing the make-decision-dropdown outside of the collection-submission-card

## Summary of Changes
- Add ellipsis text-truncation to title

## Screenshot(s)
- Before
Mobile:
![image](https://user-images.githubusercontent.com/51409893/205345750-c37ecc6d-6e4e-45b5-a313-2e6d25778306.png)

Desktop:
![image](https://user-images.githubusercontent.com/51409893/205345706-81a7cc83-1be0-4c99-8b8a-bc4e02783657.png)


- After
Mobile:
![image](https://user-images.githubusercontent.com/51409893/205345399-75d34029-8f3c-4252-afd3-5092ae9c2e99.png)
Desktop:
![image](https://user-images.githubusercontent.com/51409893/205345567-f4ba18f4-1be7-4dbe-9a48-db93f2ea1021.png)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-4196]: https://openscience.atlassian.net/browse/ENG-4196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ