### PR TITLE
Split reviews state requests into two

### DIFF
--- a/lib/collections/addon/components/collection-item-picker/component.ts
+++ b/lib/collections/addon/components/collection-item-picker/component.ts
@@ -89,15 +89,20 @@ export default class CollectionItemPicker extends Component {
 
         // Filter out nodes that are already in the current collection
         const nodeIds = nodes.mapBy('id').join();
-        const unsubmittableReviewsStates = [
-            CollectionSubmissionReviewStates.Accepted, CollectionSubmissionReviewStates.Pending,
-        ].join();
-        const cgm = await this.collection.queryHasMany('collectionSubmissions', {
+        // making two calls since the API doesn't    OR filtering yet
+        const cgmAccepted = await this.collection.queryHasMany('collectionSubmissions', {
             filter: {
                 id: nodeIds,
-                reviews_state: unsubmittableReviewsStates,
+                reviews_state: CollectionSubmissionReviewStates.Accepted,
             },
         });
+        const cgmPending = await this.collection.queryHasMany('collectionSubmissions', {
+            filter: {
+                id: nodeIds,
+                reviews_state: CollectionSubmissionReviewStates.Pending,
+            },
+        });
+        const cgm = cgmAccepted.concat(cgmPending);
 
         // Collection-submissions IDs are the same as node IDs
         const cgmCompoundIds: string[] = cgm.mapBy('id');

--- a/lib/collections/addon/components/collections-submission/component.ts
+++ b/lib/collections/addon/components/collections-submission/component.ts
@@ -82,12 +82,21 @@ export default class Submit extends Component {
     async checkForExistingSubmission(collectionItem: Node) {
         const filter = {
             id: collectionItem.id,
-            reviews_state: [CollectionSubmissionReviewStates.Rejected, CollectionSubmissionReviewStates.Removed].join(),
         };
-        const existingSubmission = await this.collection.queryHasMany('collectionSubmissions', { filter });
-        if (existingSubmission.length) {
+        // making two calls since the API doesn't support OR filtering yet
+        const existingRejectedSubmission = await this.collection.queryHasMany('collectionSubmissions', {
+            filter,
+            reviews_state: CollectionSubmissionReviewStates.Rejected,
+        });
+        const existingRemovedSubmission = await this.collection.queryHasMany('collectionSubmissions', {
+            filter,
+            reviews_state: CollectionSubmissionReviewStates.Removed,
+        });
+        if (existingRejectedSubmission.length || existingRemovedSubmission.length) {
+            const existingSubmission = existingRejectedSubmission.length ? existingRejectedSubmission[0] :
+                existingRemovedSubmission[0];
             this.collectionSubmission.deleteRecord();
-            this.set('collectionSubmission', existingSubmission[0]);
+            this.set('collectionSubmission', existingSubmission);
             this.set('showResubmitModal', true);
         } else {
             // No existing submission

--- a/lib/collections/addon/components/collections-submission/component.ts
+++ b/lib/collections/addon/components/collections-submission/component.ts
@@ -80,17 +80,18 @@ export default class Submit extends Component {
     @dropTask
     @waitFor
     async checkForExistingSubmission(collectionItem: Node) {
-        const filter = {
-            id: collectionItem.id,
-        };
         // making two calls since the API doesn't support OR filtering yet
         const existingRejectedSubmission = await this.collection.queryHasMany('collectionSubmissions', {
-            filter,
-            reviews_state: CollectionSubmissionReviewStates.Rejected,
+            filter: {
+                id: collectionItem.id,
+                reviews_state: CollectionSubmissionReviewStates.Rejected,
+            },
         });
         const existingRemovedSubmission = await this.collection.queryHasMany('collectionSubmissions', {
-            filter,
-            reviews_state: CollectionSubmissionReviewStates.Removed,
+            filter: {
+                id: collectionItem.id,
+                reviews_state: CollectionSubmissionReviewStates.Removed,
+            },
         });
         if (existingRejectedSubmission.length || existingRemovedSubmission.length) {
             const existingSubmission = existingRejectedSubmission.length ? existingRejectedSubmission[0] :


### PR DESCRIPTION
-   Ticket: [ENG-4224]
-   Feature flag: n/a

## Purpose
- Avoid API requests to `/v2/collections/ru4bv/collection_submissions/` with `filter[reviews_state]=a,b` as the API doesn't support this yet

## Summary of Changes
- Split up requests to `/v2/collections/ru4bv/collection_submissions/` to limit `filter[reviews_state]` to just one review state at a time

## Screenshot(s)
- NA
## Side Effects
- potentially slower to find nodes on the submit page, and slower to move to the next section after selecting node

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-4224]: https://openscience.atlassian.net/browse/ENG-4224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ