### PR TITLE
Redirect out of moderation app after removing self as moderator

### DIFF
--- a/lib/collections/addon/provider/moderation/moderators/controller.ts
+++ b/lib/collections/addon/provider/moderation/moderators/controller.ts
@@ -1,0 +1,13 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import RouterService from '@ember/routing/router-service';
+import { inject as service } from '@ember/service';
+
+export default class CollectionsModerationModeratorsController extends Controller {
+    @service router!: RouterService;
+
+    @action
+    afterSelfRemoval() {
+        this.transitionToRoute('provider.discover', this.model.id);
+    }
+}

--- a/lib/collections/addon/provider/moderation/moderators/template.hbs
+++ b/lib/collections/addon/provider/moderation/moderators/template.hbs
@@ -1,5 +1,6 @@
 <Moderators::Manager
     @provider={{this.model}}
+    @afterSelfRemoval={{this.afterSelfRemoval}}
     as |moderatorManager|
 >
     <Moderators::List

--- a/lib/osf-components/addon/components/moderators/manager/component.ts
+++ b/lib/osf-components/addon/components/moderators/manager/component.ts
@@ -41,6 +41,7 @@ export default class ModeratorManagerComponent extends Component {
     provider!: ProviderModel;
     permissionOptions = Object.values(PermissionGroup);
     reloadModeratorList?: () => void;
+    afterSelfRemoval?: () => void;
 
     @tracked currentModerator?: ModeratorModel;
 
@@ -83,6 +84,9 @@ export default class ModeratorManagerComponent extends Component {
                 'osf-components.moderators.removedModeratorSuccess',
                 { userName: moderator.fullName },
             ));
+            if (moderator.id === this.currentUser.currentUserId && this.afterSelfRemoval) {
+                this.afterSelfRemoval();
+            }
         } catch (e) {
             const errorMessage = this.intl.t(
                 'osf-components.moderators.removedModeratorError',

--- a/lib/registries/addon/branded/moderation/moderators/controller.ts
+++ b/lib/registries/addon/branded/moderation/moderators/controller.ts
@@ -1,0 +1,13 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import RouterService from '@ember/routing/router-service';
+import { inject as service } from '@ember/service';
+
+export default class BrandedModerationModeratorsController extends Controller {
+    @service router!: RouterService;
+
+    @action
+    afterSelfRemoval() {
+        this.transitionToRoute('branded.discover', this.model.id);
+    }
+}

--- a/lib/registries/addon/branded/moderation/moderators/template.hbs
+++ b/lib/registries/addon/branded/moderation/moderators/template.hbs
@@ -2,6 +2,7 @@
  
 <Moderators::Manager
     @provider={{this.model}}
+    @afterSelfRemoval={{this.afterSelfRemoval}}
     as |moderatorManager|
 >
     <Moderators::List


### PR DESCRIPTION
-   Ticket: [ENG-4196]
-   Feature flag: n/a

## Purpose
- Redirect users out of moderation app after they remove themselves as a moderator

## Summary of Changes
- Add an optional `@afterSelfRemoval` argument to `Moderators::Manager` component to be called if you remove yourself as a moderator

## Screenshot(s)
NA
<!-- Attach screenshots if applicable. -->

## Side Effects
NA
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- This is implemented for both collections and registries moderators

[ENG-4196]: https://openscience.atlassian.net/browse/ENG-4196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ