### PR TITLE
[ENG-4196] Reload provider permissions after self-remove

### DIFF
--- a/app/models/provider.ts
+++ b/app/models/provider.ts
@@ -1,4 +1,5 @@
 import { attr, hasMany, SyncHasMany, AsyncHasMany } from '@ember-data/model';
+import { computed } from '@ember/object';
 
 import LicenseModel from './license';
 import ModeratorModel from './moderator';
@@ -69,6 +70,7 @@ export default abstract class ProviderModel extends OsfModel {
     @hasMany('moderator', { inverse: 'provider' })
     moderators!: AsyncHasMany<ModeratorModel> | ModeratorModel[];
 
+    @computed('permissions')
     get currentUserCanReview() {
         if (this.permissions) {
             return this.permissions.includes(ReviewPermissions.ViewSubmissions);

--- a/lib/collections/addon/provider/moderation/moderators/controller.ts
+++ b/lib/collections/addon/provider/moderation/moderators/controller.ts
@@ -1,20 +1,13 @@
 import Controller from '@ember/controller';
-import { action } from '@ember/object';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 import Store from '@ember-data/store';
 import { waitFor } from '@ember/test-waiters';
 import { task } from 'ember-concurrency';
-import { taskFor } from 'ember-concurrency-ts';
 
 export default class CollectionsModerationModeratorsController extends Controller {
     @service router!: RouterService;
     @service store!: Store;
-
-    @action
-    afterSelfRemoval() {
-        taskFor(this.refetchProvider).perform(this.model.id);
-    }
 
     @task
     @waitFor

--- a/lib/collections/addon/provider/moderation/moderators/controller.ts
+++ b/lib/collections/addon/provider/moderation/moderators/controller.ts
@@ -2,12 +2,24 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
+import Store from '@ember-data/store';
+import { waitFor } from '@ember/test-waiters';
+import { task } from 'ember-concurrency';
+import { taskFor } from 'ember-concurrency-ts';
 
 export default class CollectionsModerationModeratorsController extends Controller {
     @service router!: RouterService;
+    @service store!: Store;
 
     @action
     afterSelfRemoval() {
-        this.transitionToRoute('provider.discover', this.model.id);
+        taskFor(this.refetchProvider).perform(this.model.id);
+    }
+
+    @task
+    @waitFor
+    async refetchProvider(id: string) {
+        await this.store.findRecord('collection-provider', id, { reload: true });
+        this.router.transitionTo('collections.provider.discover', id);
     }
 }

--- a/lib/collections/addon/provider/moderation/moderators/template.hbs
+++ b/lib/collections/addon/provider/moderation/moderators/template.hbs
@@ -1,6 +1,6 @@
 <Moderators::Manager
     @provider={{this.model}}
-    @afterSelfRemoval={{this.afterSelfRemoval}}
+    @afterSelfRemoval={{perform this.refetchProvider this.model.id}}
     as |moderatorManager|
 >
     <Moderators::List

--- a/lib/osf-components/addon/components/moderators/manager/component.ts
+++ b/lib/osf-components/addon/components/moderators/manager/component.ts
@@ -77,6 +77,7 @@ export default class ModeratorManagerComponent extends Component {
     @task
     @waitFor
     async removeModeratorTask(moderator: ModeratorModel) {
+        const isSelfRemoval = moderator.id === this.currentUser.currentUserId;
         try {
             await moderator.destroyRecord();
 
@@ -84,7 +85,7 @@ export default class ModeratorManagerComponent extends Component {
                 'osf-components.moderators.removedModeratorSuccess',
                 { userName: moderator.fullName },
             ));
-            if (moderator.id === this.currentUser.currentUserId && this.afterSelfRemoval) {
+            if (isSelfRemoval && this.afterSelfRemoval) {
                 this.afterSelfRemoval();
             }
         } catch (e) {
@@ -95,7 +96,7 @@ export default class ModeratorManagerComponent extends Component {
             captureException(e, { errorMessage });
             this.toast.error(getApiErrorMessage(e), errorMessage);
         } finally {
-            if (this.reloadModeratorList) {
+            if (this.reloadModeratorList && !isSelfRemoval) {
                 this.reloadModeratorList();
             }
         }

--- a/lib/registries/addon/branded/moderation/moderators/controller.ts
+++ b/lib/registries/addon/branded/moderation/moderators/controller.ts
@@ -2,12 +2,23 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
-
+import Store from '@ember-data/store';
+import { waitFor } from '@ember/test-waiters';
+import { task } from 'ember-concurrency';
+import { taskFor } from 'ember-concurrency-ts';
 export default class BrandedModerationModeratorsController extends Controller {
     @service router!: RouterService;
+    @service store!: Store;
 
     @action
     afterSelfRemoval() {
-        this.transitionToRoute('branded.discover', this.model.id);
+        taskFor(this.refetchProvider).perform(this.model.id);
+    }
+
+    @task
+    @waitFor
+    async refetchProvider(id: string) {
+        await this.store.findRecord('registration-provider', id, { reload: true });
+        this.router.transitionTo('registries.branded.discover', id);
     }
 }

--- a/lib/registries/addon/branded/moderation/moderators/controller.ts
+++ b/lib/registries/addon/branded/moderation/moderators/controller.ts
@@ -1,19 +1,12 @@
 import Controller from '@ember/controller';
-import { action } from '@ember/object';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 import Store from '@ember-data/store';
 import { waitFor } from '@ember/test-waiters';
 import { task } from 'ember-concurrency';
-import { taskFor } from 'ember-concurrency-ts';
 export default class BrandedModerationModeratorsController extends Controller {
     @service router!: RouterService;
     @service store!: Store;
-
-    @action
-    afterSelfRemoval() {
-        taskFor(this.refetchProvider).perform(this.model.id);
-    }
 
     @task
     @waitFor

--- a/lib/registries/addon/branded/moderation/moderators/template.hbs
+++ b/lib/registries/addon/branded/moderation/moderators/template.hbs
@@ -2,7 +2,7 @@
  
 <Moderators::Manager
     @provider={{this.model}}
-    @afterSelfRemoval={{this.afterSelfRemoval}}
+    @afterSelfRemoval={{perform this.refetchProvider this.model.id}}
     as |moderatorManager|
 >
     <Moderators::List


### PR DESCRIPTION
-   Ticket: [ENG-4196]
-   Feature flag: n/a

## Purpose
- Hide "Moderation" button in navbar if you removed yourself as a moderator

## Summary of Changes
- Reload provider after removing yourself as a moderator
- Make `currentUserCanReview` a computed property

## Screenshot(s)
NA
## Side Effects

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-4196]: https://openscience.atlassian.net/browse/ENG-4196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ