### PR TITLE
[ENG-4196] A11y fixes for collection moderation

### DIFF
--- a/lib/collections/addon/provider/moderation/all/controller.ts
+++ b/lib/collections/addon/provider/moderation/all/controller.ts
@@ -15,6 +15,12 @@ export default class CollectionsModerationAllController extends Controller {
     @tracked state?: CollectionSubmissionReviewStates;
     @tracked sort = '-date_created';
 
+    states = [
+        CollectionSubmissionReviewStates.Pending,
+        CollectionSubmissionReviewStates.Accepted,
+        CollectionSubmissionReviewStates.Rejected,
+        CollectionSubmissionReviewStates.Removed,
+    ];
     submissionIconMap = SubmissionIconMap;
     reloadSubmissionList?: (page?: number) => void; // bound by paginated-list
 

--- a/lib/collections/addon/provider/moderation/all/styles.scss
+++ b/lib/collections/addon/provider/moderation/all/styles.scss
@@ -7,6 +7,7 @@
 
 .tab {
     padding-right: 15px;
+    color: $color-link-dark;
 
     &.selected {
         font-weight: 700;

--- a/lib/collections/addon/provider/moderation/all/template.hbs
+++ b/lib/collections/addon/provider/moderation/all/template.hbs
@@ -1,5 +1,5 @@
 <nav local-class='tab-wrapper'>
-    {{#each (array 'pending' 'accepted' 'rejected' 'removed') as |state| }}
+    {{#each this.states as |state| }}
         {{#let (eq this.state state) as |selected| }}
             <a
                 data-test-submissions-type={{state}}

--- a/lib/osf-components/addon/components/form-controls/power-select/template.hbs
+++ b/lib/osf-components/addon/components/form-controls/power-select/template.hbs
@@ -16,6 +16,8 @@
         <PowerSelect
             @options={{this.options}}
             @onChange={{this.updateChangeset}}
+            @placeholder={{@placeholder}}
+            @searchPlaceholder={{@searchPlaceholder}}
             @searchField={{@searchField}}
             @searchEnabled={{@searchEnabled}}
             @selected={{or (get @changeset this.valuePath) null}}

--- a/lib/osf-components/addon/components/form-controls/template.hbs
+++ b/lib/osf-components/addon/components/form-controls/template.hbs
@@ -42,6 +42,8 @@
         'form-controls/power-select'
         changeset=@changeset
         shouldShowMessages=this.shouldShowMessages
+        placeholder=@placeholder
+        searchPlaceholder=@searchPlaceholder
         disabled=this.disabled
         onchange=@onchange
         searchField=@searchField

--- a/lib/osf-components/addon/components/make-decision-dropdown/styles.scss
+++ b/lib/osf-components/addon/components/make-decision-dropdown/styles.scss
@@ -1,10 +1,6 @@
 .TriggerDiv {
     height: 100%;
-}
-
-.TriggerButton {
-    height: 100%;
-    vertical-align: top;
+    composes: CreateButton from '../button/styles.scss';
 }
 
 .Dropdown {

--- a/lib/osf-components/addon/components/make-decision-dropdown/template.hbs
+++ b/lib/osf-components/addon/components/make-decision-dropdown/template.hbs
@@ -1,17 +1,15 @@
 <ResponsiveDropdown
     @horizontalPosition='right'
+    @buttonStyling={{true}}
     as |dd|
 >
-    <dd.trigger local-class='TriggerDiv'>
-        <Button
-            data-test-moderation-dropdown-button
-            data-analytics-name='Display Moderation Actions'
-            local-class='TriggerButton'
-            @type='create'
-        >
-            {{t 'osf-components.makeDecisionDropdown.makeDecision'}}
-            <FaIcon @icon='caret-down' />
-        </Button>
+    <dd.trigger
+        local-class='TriggerDiv'
+        data-test-moderation-dropdown-button
+        data-analytics-name='Display Moderation Actions'
+    >
+        {{t 'osf-components.makeDecisionDropdown.makeDecision'}}
+        <FaIcon @icon='caret-down' />
     </dd.trigger>
     <dd.content local-class='Dropdown'>
         {{#if @collectionSubmission}}

--- a/lib/osf-components/addon/components/moderators/add-modal/styles.scss
+++ b/lib/osf-components/addon/components/moderators/add-modal/styles.scss
@@ -12,6 +12,7 @@
     :global(.cp-Panel-toggle) {
         display: block;
         padding: 1em;
+        color: $color-link-dark;
 
         &:global(.cp-is-open),
         &:hover {

--- a/lib/osf-components/addon/components/moderators/add-modal/template.hbs
+++ b/lib/osf-components/addon/components/moderators/add-modal/template.hbs
@@ -36,6 +36,7 @@
                         as |form|
                     >
                         <form.select
+                            @placeholder={{t 'osf-components.moderators.add.modal.findUserByName'}}
                             @search={{perform this.searchUser}}
                             @valuePath={{'user'}}
                             @label={{t 'osf-components.moderators.add.modal.selectUser'}}

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -2161,6 +2161,7 @@ osf-components:
                 heading: 'Add a moderator'
                 add: 'Add'
                 selectUser: 'Select user'
+                findUserByName: 'Find user by name'
                 selectPermission: 'Select permission'
                 cancel: 'Cancel'
                 searchByName: 'Search user by name'


### PR DESCRIPTION
-   Ticket: [ENG-4196]
-   Feature flag: n/a

## Purpose
- A11y fixes
## Summary of Changes
- Use darker color for links and interactable elements
- Un-nest make-decision-dropdown's toggle button
- Add text-content to "Search user" dropdown when adding moderators by name

## Screenshot(s)
- Add moderator modal with accessible text for dropdown, and darker blue for "Search user by name" and "Invite user by email" panels
![image](https://user-images.githubusercontent.com/51409893/206269767-56067070-4fa4-40ca-9a20-eeecd9d27444.png)

- All submissions state names are slightly darker
![image](https://user-images.githubusercontent.com/51409893/206269935-f2e1e992-abc7-47a8-9d1e-769593956fb8.png)



## Side Effects
- Neigh, said the horse

## QA Notes
- This should fix the same A11y issues on the registries moderation workflows for the "Make decision" dropdown, as well as the "Add moderator" modals


[ENG-4196]: https://openscience.atlassian.net/browse/ENG-4196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ