### PR TITLE
[ENG-4196] Hide remove button unless submission is accepted

### DIFF
--- a/lib/collections/addon/components/collections-submission/component.ts
+++ b/lib/collections/addon/components/collections-submission/component.ts
@@ -46,7 +46,8 @@ export default class Submit extends Component {
     readonly provider!: CollectionProvider;
     readonly collection!: Collection;
 
-    collectionSubmission!: CollectionSubmission;
+    @tracked collectionSubmission!: CollectionSubmission;
+
     collectionItem: Node | null = null;
     isProjectSelectorValid = false;
     sections = Section;
@@ -58,7 +59,7 @@ export default class Submit extends Component {
     @tracked showResubmitModal = false;
 
     @bool('provider.reviewsWorkflow') collectionIsModerated!: boolean;
-    @computed('collectionSubmission.reviewsState')
+
     get isAccepted() {
         return this.collectionSubmission.reviewsState === CollectionSubmissionReviewStates.Accepted;
     }

--- a/lib/collections/addon/components/collections-submission/component.ts
+++ b/lib/collections/addon/components/collections-submission/component.ts
@@ -58,6 +58,10 @@ export default class Submit extends Component {
     @tracked showResubmitModal = false;
 
     @bool('provider.reviewsWorkflow') collectionIsModerated!: boolean;
+    @computed('collectionSubmission.reviewsState')
+    get isAccepted() {
+        return this.collectionSubmission.reviewsState === CollectionSubmissionReviewStates.Accepted;
+    }
 
     /**
      * Leaves the current route for the discover route (currently home for collections)

--- a/lib/collections/addon/components/collections-submission/template.hbs
+++ b/lib/collections/addon/components/collections-submission/template.hbs
@@ -175,7 +175,7 @@
             local-class='last-buttons'
         >
             <div class='col-xs-12'>
-                {{#if this.edit}}
+                {{#if (and this.edit this.isAccepted)}}
                     <DeleteButton
                         data-test-collections-remove-button
                         local-class='remove-button'


### PR DESCRIPTION
-   Ticket: [ENG-4196]
-   Feature flag: n/a

## Purpose
- Hide option to `Remove` a submission in `osf.io/collections/providerId/submissionId/edit` if the submission is not accepted

## Summary of Changes
- Only show "Remove" button if the submission is accepted

## Screenshot(s)
- This button should only be visible on a route like https://staging2.osf.io/collections/postmod/nhrqd/edit if the submission is public

![image](https://user-images.githubusercontent.com/51409893/206303392-8bb14f24-d2b4-41bd-a1e5-54624b18bd8e.png)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- Currently we don't support users removing a submission if it is still pending. That workflow is something we will need to visit in a future improvement


[ENG-4196]: https://openscience.atlassian.net/browse/ENG-4196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ