### PR TITLE
[ENG-4196] Fix position and scroll for mobile responsive dropdown

### DIFF
--- a/lib/osf-components/addon/components/responsive-dropdown/component.ts
+++ b/lib/osf-components/addon/components/responsive-dropdown/component.ts
@@ -56,12 +56,15 @@ export default class ResponsiveDropdown extends Component {
         document.querySelector('body')!.classList.add('modal-open');
 
         const [, content] = args;
-        const { height: dropdownHeight, width: dropdownWidth } = content.getBoundingClientRect();
-        content.style.marginLeft = `${-(dropdownWidth / 2)}px`;
-        content.style.marginTop = `${-(dropdownHeight / 2)}px`;
-        content.style.top = `${pos.style.top}px`;
-        content.style.left = '50%';
+        content.style.position = 'fixed';
+        content.style.top = '50%'; // move top of div to center of screen
+        content.style.left = '50%'; // move left of div to center of screen
+        content.style.transform = 'translate(-50%, -50%)'; // move div to top-left by -50% of its own height/width
         content.style.right = '';
+        content.style.bottom = '';
+        content.style.maxHeight = '90%';
+        content.style.maxWidth = '90%';
+        content.style.overflow = 'auto';
 
         return {
             horizontalPosition: null,


### PR DESCRIPTION
-   Ticket: [ENG-4196]
-   Feature flag: n/a

## Purpose
- Fix issue where responsive dropdown content wouldn't scroll or show up off screen on mobile (when using modal overlay)

## Summary of Changes
- Change how dropdown position is handled when using the modal overlay
- Add max-height/max-width to dropdown content and add overflow

## Screenshot(s)
Before:
- Issue where dropdown content shows up off-screen if the trigger is close to the bottom of the viewport:
![image](https://user-images.githubusercontent.com/51409893/206547550-32f36064-a71d-4479-bcb5-8c874290a69d.png)
- Prevents an issue where dropdown content is not able to be scrolled:
![image](https://user-images.githubusercontent.com/51409893/206549915-32f4bfa2-c545-4dd7-9950-d72e4f4ad490.png)


After:
- After clicking a dropdown trigger that is close to the bottom of the viewport:
![image](https://user-images.githubusercontent.com/51409893/206549279-7e0b6016-ecd0-4da6-a021-f29e6c1cf6af.png)
- Scrollable when the dropdown content is taller than the viewport height:
 
![image](https://user-images.githubusercontent.com/51409893/206549675-f6549b33-52c6-405c-8e07-7b981292dda0.png)

![image](https://user-images.githubusercontent.com/51409893/206549594-f61b3d2f-8db9-4163-8fff-6cd7c67ea27f.png)


## Side Effects
- Other instances of dropdown content being cut off the screen should be prevented with this fix

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
