### PR TITLE
[ENG-4223] Test node-metadata-form

### DIFF
--- a/app/models/custom-metadata.ts
+++ b/app/models/custom-metadata.ts
@@ -35,7 +35,7 @@ export const resourceTypeGeneralOptions = [
 ];
 
 export default class CustomMetadataModel extends OsfModel {
-    @attr('fixstring') resourceTypeGeneral?: string;
+    @attr('fixstring') resourceTypeGeneral?: typeof resourceTypeGeneralOptions[number];
 
     @belongsTo('guid', { inverse: 'customMetadata' })
     guid!: AsyncBelongsTo<GuidModel> & GuidModel;

--- a/app/models/custom-metadata.ts
+++ b/app/models/custom-metadata.ts
@@ -35,7 +35,7 @@ export const resourceTypeGeneralOptions = [
 ];
 
 export default class CustomMetadataModel extends OsfModel {
-    @attr('fixstring') resourceTypeGeneral?: typeof resourceTypeGeneralOptions;
+    @attr('fixstring') resourceTypeGeneral?: string;
 
     @belongsTo('guid', { inverse: 'customMetadata' })
     guid!: AsyncBelongsTo<GuidModel> & GuidModel;

--- a/lib/osf-components/addon/components/node-metadata-form/template.hbs
+++ b/lib/osf-components/addon/components/node-metadata-form/template.hbs
@@ -21,7 +21,7 @@
             data-test-save-node-description-button
             aria-label={{t 'general.save'}}
             data-analytics-name='Save node description'
-            disabled={{@manager.isSaving}}
+            disabled={{or (not @manager.nodeChangeset.isDirty) @manager.isSaving}}
             {{on 'click' @manager.saveNode}}
         >
             {{t 'general.save'}}
@@ -40,9 +40,37 @@
                 </Button>
             {{/if}}
         </div>
-        <div>{{@manager.node.description}}</div>
+        <ExpandablePreview data-test-display-node-description>
+            {{@manager.node.description}}
+        </ExpandablePreview>
     {{/if}}
 </FormControls>
+
+{{#unless @manager.node.isAnonymous}}
+    <div  data-test-contributors-list>
+        <div>
+            {{t 'osf-components.node-metadata-form.contributors'}}
+            {{#if (and @manager.userCanEdit (not @manager.inEditMode))}}
+                <a
+                    data-test-edit-contributors
+                    aria-label={{t 'osf-components.node-metadata-form.edit-button'}}
+                    href={{concat '/' @manager.nodeId '/contributors/'}}
+                >
+                    <FaIcon @icon='pencil-alt' />
+                </a>
+            {{/if}}
+        </div>
+        <div>
+            <ContributorList
+                data-test-target-contributors
+                @model={{@manager.node}}
+                @shouldLinkUsers={{true}}
+                @shouldTruncate={{false}}
+            />
+        </div>
+    </div>
+{{/unless}}
+
 <FormControls @changeset={{@manager.changeset}} as |form|>
     {{#if @manager.isEditingResources}}
         <form.select
@@ -78,7 +106,7 @@
             data-test-save-resource-metadata-button
             aria-label={{t 'general.save'}}
             data-analytics-name='Save resource metadata'
-            disabled={{@manager.isSaving}}
+            disabled={{or (not @manager.changeset.isDirty) @manager.isSaving}}
             {{on 'click' @manager.saveMetadata}}
         >
             {{t 'general.save'}}
@@ -100,90 +128,69 @@
             </div>
             <dl>
                 <dt>{{t 'osf-components.node-metadata-form.resource-type'}}</dt>
-                <dd>{{@manager.metadataRecord.resourceTypeGeneral}}</dd>
+                <dd data-test-display-resource-type-general>{{@manager.metadataRecord.resourceTypeGeneral}}</dd>
                 <dt>{{t 'osf-components.node-metadata-form.resource-language'}}</dt>
-                <dd>{{@manager.languageFromCode}}</dd>
+                <dd data-test-display-resource-language>{{@manager.languageFromCode}}</dd>
             </dl>
         </div>
     {{/if}}
-    {{#if @manager.isEditingFunding}}
-        <Button
-            data-test-cancel-editing-funding-metadata-button
-            aria-label={{t 'general.cancel'}}
-            data-analytics-name='Cancel editing funding metadata'
-            disabled={{@manager.isSaving}}
-            {{on 'click' @manager.cancelMetadata}}
-        >
-            {{t 'general.cancel'}}
-        </Button>
-        <Button
-            data-test-save-funding-metadata-button
-            aria-label={{t 'general.save'}}
-            data-analytics-name='Save funding metadata'
-            disabled={{@manager.isSaving}}
-            {{on 'click' @manager.saveMetadata}}
-        >
-            {{t 'general.save'}}
-        </Button>
-
-    {{else}}
-        <div>
+    {{#unless @manager.node.isAnonymous}}
+        {{#if @manager.isEditingFunding}}
+            <Button
+                data-test-cancel-editing-funding-metadata-button
+                aria-label={{t 'general.cancel'}}
+                data-analytics-name='Cancel editing funding metadata'
+                disabled={{@manager.isSaving}}
+                {{on 'click' @manager.cancelMetadata}}
+            >
+                {{t 'general.cancel'}}
+            </Button>
+            <Button
+                data-test-save-funding-metadata-button
+                aria-label={{t 'general.save'}}
+                data-analytics-name='Save funding metadata'
+                disabled={{or (not @manager.changeset.isDirty) @manager.isSaving}}
+                {{on 'click' @manager.saveMetadata}}
+            >
+                {{t 'general.save'}}
+            </Button>
+        {{else}}
             <div>
-                {{t 'osf-components.node-metadata-form.funding-information'}}
-                {{#if (and @manager.userCanEdit (not @manager.inEditMode))}}
-                    <Button
-                        data-test-edit-funding-metadata-button
-                        data-analytics-name='Edit Funding Metadata'
-                        aria-label={{t 'osf-components.node-metadata-form.edit-button'}}
-                        {{on 'click' @manager.editFunding}}
-                    >
-                        <FaIcon @icon='pencil-alt' />
-                    </Button>
-                {{/if}}
+                <div>
+                    {{t 'osf-components.node-metadata-form.funding-information'}}
+                    {{#if (and @manager.userCanEdit (not @manager.inEditMode))}}
+                        <Button
+                            data-test-edit-funding-metadata-button
+                            data-analytics-name='Edit Funding Metadata'
+                            aria-label={{t 'osf-components.node-metadata-form.edit-button'}}
+                            {{on 'click' @manager.editFunding}}
+                        >
+                            <FaIcon @icon='pencil-alt' />
+                        </Button>
+                    {{/if}}
+                </div>
+                {{#each @manager.metadataRecord.funders as |funder|}}
+                    <dl>
+                        <dt>{{t 'osf-components.node-metadata-form.funder'}}</dt>
+                        <dd data-test-display-funder-name={{funder.funder_name}}>{{funder.funder_name}}</dd>
+                        <dt>{{t 'osf-components.node-metadata-form.award-title'}}</dt>
+                        <dd data-test-display-funder-award-title={{funder.funder_name}}>{{funder.award_title}}</dd>
+
+                        <dt>{{t 'osf-components.node-metadata-form.award-info-uri'}}</dt>
+                        <dd data-test-display-funder-award-uri={{funder.funder_name}}>{{funder.award_uri}}</dd>
+
+                        <dt>{{t 'osf-components.node-metadata-form.award-number'}}</dt>
+                        <dd data-test-display-funder-award-number={{funder.funder_name}}>{{funder.award_number}}</dd>
+                    </dl>
+                {{/each}}
             </div>
-            {{#each @manager.metadataRecord.funders as |funder|}}
-                <dl>
-                    <dt>{{t 'osf-components.node-metadata-form.funder'}}</dt>
-                    <dd>{{funder.funder_name}}</dd>
+        {{/if}}
+    {{/unless}}
 
-                    <dt>{{t 'osf-components.node-metadata-form.award-title'}}</dt>
-                    <dd>{{funder.award_title}}</dd>
-
-                    <dt>{{t 'osf-components.node-metadata-form.award-info-uri'}}</dt>
-                    <dd>{{funder.award_uri}}</dd>
-
-                    <dt>{{t 'osf-components.node-metadata-form.award-number'}}</dt>
-                    <dd>{{funder.award_number}}</dd>
-                </dl>
-            {{/each}}
-        </div>
-    {{/if}}
 </FormControls>
 
-<div>
-    <div>
-        {{t 'osf-components.node-metadata-form.contributors'}}
-        {{#unless @manager.inEditMode}}
-            <a
-                data-test-edit-contributors
-                aria-label={{t 'osf-components.node-metadata-form.edit-button'}}
-                href={{concat '/' @manager.nodeId '/contributors/'}}
-            >
-                <FaIcon @icon='pencil-alt' />
-            </a>
-        {{/unless}}
-    </div>
-    <div>
-        <ContributorList
-            data-test-target-contributors
-            @model={{@manager.node}}
-            @shouldLinkUsers={{true}}
-            @shouldTruncate={{false}}
-        />
-    </div>
-</div>
 {{#if @manager.node.isRegistration}}
-    <div>
+    <div data-test-subjects-list>
         <div>{{t 'osf-components.node-metadata-form.subjects'}}</div>
         <Subjects::Manager
             @model={{@manager.node}}
@@ -197,6 +204,7 @@
         </Subjects::Manager>
     </div>
 {{/if}}
+
 <div>
     <div>{{t 'osf-components.node-metadata-form.tags'}}</div>
     <TagsWidget

--- a/lib/osf-components/addon/components/node-metadata-manager/component.ts
+++ b/lib/osf-components/addon/components/node-metadata-manager/component.ts
@@ -151,7 +151,7 @@ export default class NodeMetadataManagerComponent extends Component<Args> {
     @task
     @waitFor
     async cancelNode(){
-        if (this.saveErrored){
+        if (this.saveNodeErrored){
             await this.node.reload();
             this.saveNodeErrored = false;
         }

--- a/tests/acceptance/guid-node/metadata-test.ts
+++ b/tests/acceptance/guid-node/metadata-test.ts
@@ -1,0 +1,237 @@
+import { currentRouteName, resetOnerror, setupOnerror } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { percySnapshot } from 'ember-percy';
+import { selectChoose } from 'ember-power-select/test-support';
+import { module, test } from 'qunit';
+
+import { click, currentURL, setupOSFApplicationTest, visit } from 'ember-osf-web/tests/helpers';
+import { languageCodes } from 'ember-osf-web/utils/languages';
+import { TestContext } from 'ember-test-helpers';
+import { Permission } from 'ember-osf-web/models/osf-model';
+import fillIn from '@ember/test-helpers/dom/fill-in';
+
+
+function languageFromCode(languageCode: string){
+    const language = languageCodes.find(item => item.code === languageCode);
+    if(language){
+        return language.name;
+    }
+    return '';
+}
+
+module('Acceptance | guid-node/metadata', hooks => {
+    setupOSFApplicationTest(hooks);
+    setupMirage(hooks);
+
+    test('logged out', async function(this: TestContext, assert) {
+        const node = server.create('node', {
+            id: 'mtadt',
+            currentUserPermissions: [],
+        });
+        const url = `/${node.id}/metadata`;
+
+        await visit(url);
+        const metadataRecord = await this.owner.lookup('service:store')
+            .findRecord('custom-item-metadata-record', node.id);
+        assert.equal(currentURL(), url, `We are on ${url}`);
+        assert.equal(currentRouteName(), 'guid-node.metadata', 'We are at guid-node.metadata');
+        assert.dom('[data-test-display-resource-language]')
+            .containsText(languageFromCode(metadataRecord.language), 'Language is correct');
+        assert.dom('[data-test-display-resource-type-general]')
+            .containsText(metadataRecord.resourceTypeGeneral, 'Resource type is correct');
+        assert.dom('[data-test-display-node-description]')
+            .containsText(node.description, 'Description is correct');
+        for (const funder of metadataRecord.funders) {
+            assert.dom(`[data-test-display-funder-name="${funder.funder_name}"]`)
+                .containsText(funder.funder_name, `Funder name is correct for ${funder.funder_name}`);
+            assert.dom(`[data-test-display-funder-award-title="${funder.funder_name}"]`)
+                .containsText(funder.award_title, `Funder award title is correct for ${funder.funder_name}`);
+            assert.dom(`[data-test-display-funder-award-uri="${funder.funder_name}"]`)
+                .containsText(funder.award_uri,  `Funder award URI is correct for ${funder.funder_name}`);
+            assert.dom(`[data-test-display-funder-award-number="${funder.funder_name}"`)
+                .containsText(funder.award_number,  `Funder award number is correct for ${funder.funder_name}`);
+        }
+        assert.dom('[data-test-contributors-list]').exists();
+        assert.dom('[data-test-subjects-list]').doesNotExist('There are no subjects for projects');
+
+        assert.dom('[data-test-edit-node-description-button]').doesNotExist();
+        assert.dom('[data-test-edit-resource-metadata-button]').doesNotExist();
+        assert.dom('[data-test-edit-funding-metadata-button]').doesNotExist();
+        assert.dom('[data-test-edit-contributors]').doesNotExist();
+    });
+
+    test('AVOL', async function(this: TestContext, assert) {
+        const node = server.create('node', {
+            id: 'mtadt',
+            currentUserPermissions: [],
+            apiMeta: {
+                anonymous: true,
+                version: '2.20',
+            },
+        });
+        const url = `/${node.id}/metadata`;
+
+        await visit(url);
+        const metadataRecord = await this.owner.lookup('service:store')
+            .findRecord('custom-item-metadata-record', node.id);
+        assert.equal(currentURL(), url, `We are on ${url}`);
+        assert.equal(currentRouteName(), 'guid-node.metadata', 'We are at guid-node.metadata');
+        assert.dom('[data-test-display-resource-language]')
+            .containsText(languageFromCode(metadataRecord.language), 'Language is correct');
+        assert.dom('[data-test-display-resource-type-general]')
+            .containsText(metadataRecord.resourceTypeGeneral, 'Resource type is correct');
+        assert.dom('[data-test-display-node-description]')
+            .containsText(node.description, 'Description is correct');
+        for (const funder of metadataRecord.funders) {
+            assert.dom(`[data-test-display-funder-name="${funder.funder_name}"]`)
+                .doesNotExist(`Funder name does not exist for ${funder.funder_name}`);
+            assert.dom(`[data-test-display-funder-award-title="${funder.funder_name}"]`)
+                .doesNotExist(`Funder award title does not exist for ${funder.funder_name}`);
+            assert.dom(`[data-test-display-funder-award-uri="${funder.funder_name}"]`)
+                .doesNotExist(`Funder award URI does not exist for ${funder.funder_name}`);
+            assert.dom(`[data-test-display-funder-award-number="${funder.funder_name}"`)
+                .doesNotExist(`Funder award number does not exist for ${funder.funder_name}`);
+        }
+        assert.dom('[data-test-contributors-list]').doesNotExist('There are no contributors for AVOL');
+        assert.dom('[data-test-subjects-list]').doesNotExist('There are no subjects for projects');
+
+        assert.dom('[data-test-edit-node-description-button]').doesNotExist();
+        assert.dom('[data-test-edit-resource-metadata-button]').doesNotExist();
+        assert.dom('[data-test-edit-funding-metadata-button]').doesNotExist();
+        assert.dom('[data-test-edit-contributors]').doesNotExist();
+    });
+
+    test('Editable', async function(this: TestContext, assert) {
+        const node = server.create('node', {
+            id: 'mtadt',
+            currentUserPermissions: [Permission.Read, Permission.Write],
+        });
+        const url = `/${node.id}/metadata`;
+
+        await visit(url);
+        const metadataRecord = await this.owner.lookup('service:store')
+            .findRecord('custom-item-metadata-record', node.id);
+        assert.equal(currentURL(), url, `We are on ${url}`);
+        assert.equal(currentRouteName(), 'guid-node.metadata', 'We are at guid-node.metadata');
+        assert.dom('[data-test-display-resource-language]')
+            .containsText(languageFromCode(metadataRecord.language), 'Language is correct');
+        assert.dom('[data-test-display-resource-type-general]')
+            .containsText(metadataRecord.resourceTypeGeneral, 'Resource type is correct');
+        assert.dom('[data-test-display-node-description]')
+            .containsText(node.description, 'Description is correct');
+        for (const funder of metadataRecord.funders) {
+            assert.dom(`[data-test-display-funder-name="${funder.funder_name}"]`)
+                .containsText(funder.funder_name, `Funder name is correct for ${funder.funder_name}`);
+            assert.dom(`[data-test-display-funder-award-title="${funder.funder_name}"]`)
+                .containsText(funder.award_title, `Funder award title is correct for ${funder.funder_name}`);
+            assert.dom(`[data-test-display-funder-award-uri="${funder.funder_name}"]`)
+                .containsText(funder.award_uri,  `Funder award URI is correct for ${funder.funder_name}`);
+            assert.dom(`[data-test-display-funder-award-number="${funder.funder_name}"`)
+                .containsText(funder.award_number,  `Funder award number is correct for ${funder.funder_name}`);
+        }
+        assert.dom('[data-test-contributors-list]').exists();
+        assert.dom('[data-test-subjects-list]').doesNotExist('There are no subjects for projects');
+
+        assert.dom('[data-test-edit-node-description-button]').exists();
+        await click('[data-test-edit-node-description-button]');
+        await fillIn('[data-test-description-field] textarea', 'New description');
+        await click('[data-test-cancel-editing-node-description-button]');
+        assert.dom('[data-test-display-node-description]')
+            .doesNotContainText('New description', 'Description is not incorrect after cancelling edit');
+        await click('[data-test-edit-node-description-button]');
+        await fillIn('[data-test-description-field] textarea', 'New description');
+        await click('[data-test-save-node-description-button]');
+        assert.dom('[data-test-display-node-description]')
+            .containsText('New description', 'Description is changed');
+
+        assert.dom('[data-test-edit-resource-metadata-button]').exists();
+        const metadataLanguageOriginal = metadataRecord.language;
+        const metadataResourceTypeOriginal = metadataRecord.resourceTypeGeneral;
+        await click('[data-test-edit-resource-metadata-button]');
+        await selectChoose('[data-test-select-resource-type]', 'InteractiveResource');
+        await selectChoose('[data-test-select-resource-language]', 'Esperanto');
+        await click('[data-test-cancel-editing-resource-metadata-button]');
+        assert.dom('[data-test-display-resource-language]')
+            .containsText(languageFromCode(metadataLanguageOriginal), 'Language is unchanged');
+        assert.dom('[data-test-display-resource-type-general]')
+            .containsText(metadataResourceTypeOriginal, 'Resource type is unchanged');
+        await click('[data-test-edit-resource-metadata-button]');
+        await selectChoose('[data-test-select-resource-type]', 'InteractiveResource');
+        await selectChoose('[data-test-select-resource-language]', 'Esperanto');
+        await click('[data-test-save-resource-metadata-button]');
+        assert.dom('[data-test-display-resource-language]')
+            .containsText('Esperanto', 'Language is changed');
+        assert.dom('[data-test-display-resource-type-general]')
+            .containsText('InteractiveResource', 'Resource type is changed');
+
+        assert.dom('[data-test-edit-funding-metadata-button]').exists();
+        await click('[data-test-edit-funding-metadata-button]');
+        // TODO: Make some changes here with the new funding widget when it's in
+        await click('[data-test-cancel-editing-funding-metadata-button]');
+        const originalFunders = metadataRecord.funders;
+        for (const funder of originalFunders) {
+            assert.dom(`[data-test-display-funder-name="${funder.funder_name}"]`)
+                .containsText(funder.funder_name, `Funder name is unchanged for ${funder.funder_name}`);
+            assert.dom(`[data-test-display-funder-award-title="${funder.funder_name}"]`)
+                .containsText(funder.award_title, `Funder award title is unchanged for ${funder.funder_name}`);
+            assert.dom(`[data-test-display-funder-award-uri="${funder.funder_name}"]`)
+                .containsText(funder.award_uri,  `Funder award URI is unchanged for ${funder.funder_name}`);
+            assert.dom(`[data-test-display-funder-award-number="${funder.funder_name}"`)
+                .containsText(funder.award_number,  `Funder award number is unchanged for ${funder.funder_name}`);
+        }
+        // TODO: Test the edit-save flow with the new funding widget when it's in
+
+        assert.dom('[data-test-edit-contributors]').exists();
+        assert.dom('[data-test-edit-contributors]').hasAttribute('href', '/mtadt/contributors/');
+        await percySnapshot(assert);
+    });
+
+    test('Error handling: metadata', async function(this: TestContext, assert) {
+        setupOnerror((e: any) => assert.ok(e, 'Error is handled'));
+        const node = server.create('node', {
+            id: 'mtadt',
+            currentUserPermissions: [Permission.Read, Permission.Write],
+        });
+        const url = `/${node.id}/metadata`;
+        server.namespace = '/v2';
+        server.patch('/custom_item_metadata_records/:id', () => ({
+            errors: [{ detail: 'Could not patch metadata' }],
+        }), 400);
+        await visit(url);
+
+        await click('[data-test-edit-resource-metadata-button]');
+        await selectChoose('[data-test-select-resource-type]', 'InteractiveResource');
+        await selectChoose('[data-test-select-resource-language]', 'Esperanto');
+        await click('[data-test-save-resource-metadata-button]');
+        assert.dom('#toast-container', document as any).hasTextContaining('Could not patch metadata',
+            'Toast error shown after failing to update metadata');
+        await click('[data-test-cancel-editing-resource-metadata-button]');
+
+        resetOnerror();
+    });
+
+    test('Error handling: node', async function(this: TestContext, assert) {
+        setupOnerror((e: any) => assert.ok(e, 'Error is handled'));
+        const node = server.create('node', {
+            id: 'mtadt',
+            currentUserPermissions: [Permission.Read, Permission.Write],
+        });
+        const url = `/${node.id}/metadata`;
+        server.namespace = '/v2';
+        server.patch('/nodes/:id', () => ({
+            errors: [{ detail: 'Could not patch node' }],
+        }), 400);
+        await visit(url);
+
+        assert.dom('[data-test-display-node-description]')
+            .containsText(node.description, 'Description is correct');
+        await click('[data-test-edit-node-description-button]');
+        await fillIn('[data-test-description-field] textarea', 'New description');
+        await click('[data-test-save-node-description-button]');
+        assert.dom('#toast-container', document as any).hasTextContaining('Could not patch node',
+            'Toast error shown after failing to update node');
+        await click('[data-test-cancel-editing-node-description-button]');
+
+        resetOnerror();
+    });
+});

--- a/tests/engines/registries/acceptance/overview/metadata-test.ts
+++ b/tests/engines/registries/acceptance/overview/metadata-test.ts
@@ -1,0 +1,60 @@
+import { currentRouteName } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { percySnapshot } from 'ember-percy';
+import { module, test } from 'qunit';
+
+import { currentURL, setupOSFApplicationTest, visit } from 'ember-osf-web/tests/helpers';
+import { languageCodes } from 'ember-osf-web/utils/languages';
+import { TestContext } from 'ember-test-helpers';
+
+
+function languageFromCode(languageCode: string){
+    const language = languageCodes.find(item => item.code === languageCode);
+    if(language){
+        return language.name;
+    }
+    return '';
+}
+
+module('Registries | Acceptance | overview/metadata', hooks => {
+    setupOSFApplicationTest(hooks);
+    setupMirage(hooks);
+
+    test('logged out', async function(this: TestContext, assert) {
+        const node = server.create('registration', {
+            id: 'mtadt',
+            currentUserPermissions: [],
+        });
+        const url = `/${node.id}/metadata`;
+
+        await visit(url);
+        const metadataRecord = await this.owner.lookup('service:store')
+            .findRecord('custom-item-metadata-record', node.id);
+        assert.equal(currentURL(), url, `We are on ${url}`);
+        assert.equal(currentRouteName(), 'registries.overview.metadata', 'We are at registries.overview.metadata');
+        assert.dom('[data-test-display-resource-language]')
+            .containsText(languageFromCode(metadataRecord.language), 'Language is correct');
+        assert.dom('[data-test-display-resource-type-general]')
+            .containsText(metadataRecord.resourceTypeGeneral, 'Resource type is correct');
+        assert.dom('[data-test-display-node-description]')
+            .containsText(node.description, 'Description is correct');
+        for (const funder of metadataRecord.funders) {
+            assert.dom(`[data-test-display-funder-name="${funder.funder_name}"]`)
+                .containsText(funder.funder_name, `Funder name is correct for ${funder.funder_name}`);
+            assert.dom(`[data-test-display-funder-award-title="${funder.funder_name}"]`)
+                .containsText(funder.award_title, `Funder award title is correct for ${funder.funder_name}`);
+            assert.dom(`[data-test-display-funder-award-uri="${funder.funder_name}"]`)
+                .containsText(funder.award_uri,  `Funder award URI is correct for ${funder.funder_name}`);
+            assert.dom(`[data-test-display-funder-award-number="${funder.funder_name}"`)
+                .containsText(funder.award_number,  `Funder award number is correct for ${funder.funder_name}`);
+        }
+        assert.dom('[data-test-contributors-list]').exists();
+        assert.dom('[data-test-subjects-list]').exists('There are subjects for registrations');
+
+        assert.dom('[data-test-edit-node-description-button]').doesNotExist();
+        assert.dom('[data-test-edit-resource-metadata-button]').doesNotExist();
+        assert.dom('[data-test-edit-funding-metadata-button]').doesNotExist();
+        assert.dom('[data-test-edit-contributors]').doesNotExist();
+        await percySnapshot(assert);
+    });
+});


### PR DESCRIPTION
-   Ticket: [ENG-4223]

## Purpose

Test the NodeMetadataForm component and its corresponding manager component.

## Summary of Changes

1. Add guid-node tests for everything
2. Add registries-overview tests for mainly making sure the subjects picker shows up
3. Disable save buttons when changeset isn't dirty
4. Limit display of long descriptions
5. Move contributors list up
6. Add more data-test selectors
7. Hide things in AVOLs

## Side Effects

Tests take about six seconds longer to run.



[ENG-4223]: https://openscience.atlassian.net/browse/ENG-4223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ