### PR TITLE
[ENG-4196] Update submit toast message language

### DIFF
--- a/lib/collections/addon/components/collections-submission/component.ts
+++ b/lib/collections/addon/components/collections-submission/component.ts
@@ -147,9 +147,15 @@ export default class Submit extends Component {
 
             this.collectionItem.set('collectable', false);
 
-            this.toast.success(this.intl.t(`${this.intlKeyPrefix}${operation}_save_success`, {
-                title: this.collectionItem.title,
-            }));
+            if (this.provider.reviewsWorkflow === 'pre-moderation' && operation === 'add') {
+                this.toast.success(this.intl.t(`${this.intlKeyPrefix}add_premoderation_save_success`, {
+                    title: this.collectionItem.title,
+                }));
+            } else {
+                this.toast.success(this.intl.t(`${this.intlKeyPrefix}${operation}_save_success`, {
+                    title: this.collectionItem.title,
+                }));
+            }
 
             await timeout(1000);
             this.resetPageDirty();
@@ -184,8 +190,6 @@ export default class Submit extends Component {
 
         this.collectionSubmission.set('guid', this.collectionItem);
 
-        const operation = this.edit ? 'update' : 'add';
-
         try {
             if (!this.collectionItem.public) {
                 this.collectionItem.set('public', true);
@@ -200,17 +204,23 @@ export default class Submit extends Component {
             await resubmitAction.save();
 
             this.collectionItem.set('collectable', false);
+            if (this.provider.reviewsWorkflow === 'pre-moderation') {
+                this.toast.success(this.intl.t(`${this.intlKeyPrefix}resubmit_premoderation_save_success`, {
+                    title: this.collectionItem.title,
+                }));
+            } else {
+                this.toast.success(this.intl.t(`${this.intlKeyPrefix}add_save_success`, {
+                    title: this.collectionItem.title,
+                }));
+            }
 
-            this.toast.success(this.intl.t(`${this.intlKeyPrefix}${operation}_save_success`, {
-                title: this.collectionItem.title,
-            }));
 
             await timeout(1000);
             this.resetPageDirty();
             // TODO: external-link-to / waffle for project main page
             window.location.href = getHref(this.collectionItem.links.html!);
         } catch (e) {
-            const errorMessage = this.intl.t(`${this.intlKeyPrefix}${operation}_save_error`, {
+            const errorMessage = this.intl.t(`${this.intlKeyPrefix}resubmit_save_error`, {
                 title: this.collectionItem.title,
             });
             captureException(e, { errorMessage });

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -901,9 +901,12 @@ collections:
         add_button: 'Add to collection'
         update_button: Update
         add_save_success: '{title} has been added to the collection.'
+        add_premoderation_save_success: '{title} has been submitted to the collection.'
+        resubmit_premoderation_save_success: '{title} has been resubmitted to the collection.'
         update_save_success: '{title} has been updated in the collection.'
         add_save_error: 'Error adding {title} to the collection.'
         update_save_error: 'Error updating {title} in the collection.'
+        resubmit_save_error: 'Error resubmitting {title} in the collection.'
         remove_button: 'Remove from collection'
         remove_modal_title: 'Remove from collection'
         remove_modal_body: 'Are you sure you want to remove {title} from the collection?'


### PR DESCRIPTION
-   Ticket: [ENG-4196]
-   Feature flag: n/a

## Purpose
- Update toast message language when submitting or resubmitting to a collection

## Summary of Changes
- Add translation when submitting/resubmitting to moderated collection
- Add resubmit save error message

## Screenshot(s)
- this updates the toast messages on the submit page

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- the new language is only used for pre-moderated collection providers. No moderation or post-moderation should have the same language as before