### PR TITLE
[ENG-4196] Lower navbar z-index below modals

### DIFF
--- a/lib/app-components/addon/components/branded-navbar/styles.scss
+++ b/lib/app-components/addon/components/branded-navbar/styles.scss
@@ -1,6 +1,10 @@
 @import 'app/styles/layout';
 
 .branded-nav-wrapper {
+    .branded-nav {
+        z-index: 999;
+    }
+
     :global(.navbar) {
         box-shadow: 2px 1px 4px rgba(82, 81, 81, 0.7);
     }


### PR DESCRIPTION
-   Ticket: [ENG-4196]
-   Feature flag: n/a

## Purpose
- Lower the navbar's z-index to be below modals

## Summary of Changes
- Override the `z-index: 1030` of BsNav class `.navbar-fixed-top` to be below `.ember-basic-dropdown-content` class's `z-index: 1000`

## Screenshot(s)
- Prevents:
![image](https://user-images.githubusercontent.com/51409893/207130330-4cc42615-f51e-43d8-ace9-41e2b18dd94b.png)

- New:
![image](https://user-images.githubusercontent.com/51409893/207130503-7db78c7b-d759-4a98-8723-d9fd50639a7c.png)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-4196]: https://openscience.atlassian.net/browse/ENG-4196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ