### PR TITLE
[ENG-4231] Prevent users from continuing submission when license is invalid

### DIFF
--- a/lib/app-components/addon/components/project-metadata/component.ts
+++ b/lib/app-components/addon/components/project-metadata/component.ts
@@ -4,15 +4,34 @@ import Component from '@ember/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { waitFor } from '@ember/test-waiters';
+import { validatePresence } from 'ember-changeset-validations/validators';
 import { task } from 'ember-concurrency';
 import Intl from 'ember-intl/services/intl';
 import Toast from 'ember-toastr/services/toast';
+import { BufferedChangeset } from 'validated-changeset';
 
 import { layout, requiredAction } from 'ember-osf-web/decorators/component';
 import Node from 'ember-osf-web/models/node';
+import { validateNodeLicense } from 'ember-osf-web/packages/registration-schema/validations';
 import Analytics from 'ember-osf-web/services/analytics';
+import buildChangeset from 'ember-osf-web/utils/build-changeset';
 import styles from './styles';
 import template from './template';
+
+const nodeValidations = {
+    title: [
+        validatePresence({ presence: true, ignoreBlank: true, type: 'empty' }),
+    ],
+    description: [
+        validatePresence({ presence: true, ignoreBlank: true, type: 'empty' }),
+    ],
+    license: [
+        validatePresence({ presence: true, ignoreBlank: true, type: 'mustSelect' }),
+    ],
+    nodeLicense: [
+        validateNodeLicense(),
+    ],
+};
 
 @layout(template, styles)
 @tagName('')
@@ -23,14 +42,36 @@ export default class ProjectMetadata extends Component {
     @service toast!: Toast;
 
     node!: Node;
+    changeset!: BufferedChangeset;
 
     @requiredAction continue!: () => void;
+
+    init() {
+        super.init();
+        this.changeset = buildChangeset(this.node, nodeValidations);
+    }
 
     @task
     @waitFor
     async reset() {
         this.node.rollbackAttributes();
         await this.node.reload();
+    }
+
+    @task
+    @waitFor
+    async save() {
+        this.changeset.validate();
+        if (this.changeset.isValid) {
+            try {
+                await this.changeset.save();
+                this.onSave();
+            } catch (e) {
+                this.onError();
+            }
+        } else {
+            this.toast.error(this.intl.t('app_components.project_metadata.save_error'));
+        }
     }
 
     @action
@@ -44,6 +85,7 @@ export default class ProjectMetadata extends Component {
         this.analytics.click('button', 'Collections - Submit - Remove tag');
         this.node.set('tags', this.node.tags.slice().removeAt(index));
     }
+
 
     @action
     onSave() {

--- a/lib/app-components/addon/components/project-metadata/template.hbs
+++ b/lib/app-components/addon/components/project-metadata/template.hbs
@@ -1,7 +1,5 @@
-<ValidatedModelForm
-    @onSave={{action this.onSave}}
-    @onError={{action this.onError}}
-    @model={{this.node}}
+<FormControls
+    @changeset={{this.changeset}}
     as |form|
 >
     <div class='col-md-6'>
@@ -73,10 +71,11 @@
             data-test-project-metadata-save-button
             data-analytics-name='Save metadata'
             disabled={{form.submitting}}
+            @onClick={{perform this.save}}
             @buttonType='submit'
             @type='primary'
         >
             {{t 'app_components.submit_section.save'}}
         </BsButton>
     </div>
-</ValidatedModelForm>
+</FormControls>

--- a/lib/osf-components/addon/components/form-controls/template.hbs
+++ b/lib/osf-components/addon/components/form-controls/template.hbs
@@ -1,4 +1,5 @@
 {{yield (hash
+    changeset=@changeset
     checkboxes=(
         component
         'validated-input/checkboxes'

--- a/lib/osf-components/addon/components/license-picker/template.hbs
+++ b/lib/osf-components/addon/components/license-picker/template.hbs
@@ -1,19 +1,24 @@
 <label>
     {{yield}}
 </label>
-<this.form.select
-    @model={{this.node}}
-    @valuePath='license'
-    @search={{perform this.queryLicenses}}
-    @options={{this.licensesAcceptable}}
-    @onchange={{action this.changeLicense}}
-    @noMatchesMessage={{t 'new_project.no_matches'}}
-    @placeholder={{this.placeholder}}
-    @searchEnabled={{true}}
-    as |license|
->
-    {{license.name}}
-</this.form.select>
+{{#if this.licensesAcceptable}}
+    <this.form.select
+        @model={{this.node}}
+        @valuePath='license'
+        @options={{this.licensesAcceptable}}
+        @onchange={{action this.changeLicense}}
+        @searchField='name'
+        @noMatchesMessage={{t 'new_project.no_matches'}}
+        @placeholder={{this.placeholder}}
+        @searchEnabled={{true}}
+        as |license|
+    >
+        {{license.name}}
+    </this.form.select>
+{{else}}
+    <LoadingIndicator @dark={{true}} />
+{{/if}}
+
 <small>
     <a
         target='_blank'
@@ -38,7 +43,7 @@
             <Input
                 @class='form-control'
                 @id={{concat 'nodeLicense-' key}}
-                @value={{readonly (get this.node.nodeLicense key)}}
+                @value={{readonly (get this.form.changeset.nodeLicense key)}}
                 @change={{fn this.updateNodeLicense key}}
                 @placeholder={{t 'general.required'}}
             />


### PR DESCRIPTION
-   Ticket: [ENG-4231]
-   Feature flag: n/a

## Purpose
- Prevent users from continuing a submission if the license is not valid
## Summary of Changes
- Switched `ProjectMetadata` component away from `ValidatedModelForm` to `FormControls`
- Prevent users from moving forward if validation issues exist in project metadata
- Show toast message letting users know some fields are invalid

## Screenshot(s)


## Side Effects
- None?

## QA Notes
- This should prevent users from moving onto the next section of the collection-submission if the license is not set (dropdown says `Required`), or if the node license fields (Year and Copyright Holder) are invalid