### PR TITLE
[ENG-4243] Add optional removal message

### DIFF
--- a/lib/collections/addon/components/collections-submission/component.ts
+++ b/lib/collections/addon/components/collections-submission/component.ts
@@ -57,6 +57,7 @@ export default class Submit extends Component {
     intlKeyPrefix = 'collections.collections_submission.';
     showSubmitModal = false;
     @tracked showResubmitModal = false;
+    @tracked removeReason = '';
 
     @bool('provider.reviewsWorkflow') collectionIsModerated!: boolean;
 
@@ -239,7 +240,9 @@ export default class Submit extends Component {
             const newAction = this.store.createRecord('collection-submission-action', {
                 actionTrigger: CollectionSubmissionActionTrigger.Remove,
                 target: this.collectionSubmission,
+                comment: this.removeReason,
             });
+
             await newAction.save();
 
             this.toast.success(this.intl.t(`${this.intlKeyPrefix}remove_success`, {

--- a/lib/collections/addon/components/collections-submission/styles.scss
+++ b/lib/collections/addon/components/collections-submission/styles.scss
@@ -51,3 +51,9 @@
 .remove-button {
     float: left;
 }
+
+.remove-textarea {
+    margin-top: 12px;
+    max-width: 100%;
+    width: 100%;
+}

--- a/lib/collections/addon/components/collections-submission/template.hbs
+++ b/lib/collections/addon/components/collections-submission/template.hbs
@@ -183,9 +183,17 @@
                         @disabled={{this.removeSubmission.isRunning}}
                         @buttonLabel={{t (concat this.intlKeyPrefix 'remove_button')}}
                         @modalTitle={{t (concat this.intlKeyPrefix 'remove_modal_title')}}
-                        @modalBody={{t (concat this.intlKeyPrefix 'remove_modal_body') title=this.collectionItem.title}}
                         @confirmButtonText={{t (concat this.intlKeyPrefix 'remove_button')}}
-                    />
+                    >
+                        {{t (concat this.intlKeyPrefix 'remove_modal_body') title=this.collectionItem.title}}
+                        <div>
+                            <Textarea
+                                local-class='remove-textarea'
+                                @placeholder={{t (concat this.intlKeyPrefix 'remove_reason_placeholder')}}
+                                @value={{this.removeReason}}
+                            />
+                        </div>
+                    </DeleteButton>
                 {{/if}}
                 <div class='text-right'>
                     <button

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -910,6 +910,7 @@ collections:
         remove_button: 'Remove from collection'
         remove_modal_title: 'Remove from collection'
         remove_modal_body: 'Are you sure you want to remove {title} from the collection?'
+        remove_reason_placeholder: 'Optional reason for removal'
         remove_success: '{title} has been removed from the collection.'
         remove_error: 'Error removing {title} from the collection.'
         warning_body: 'Are you sure you want to discard changes to the submission? Changes saved to the project will persist.'


### PR DESCRIPTION
-   Ticket: [ENG-4243]
-   Feature flag: n/a

## Purpose
- Allow users to give a reason why they are removing a submission from the collection

## Summary of Changes
- Add text-area when removing a submission via the collection edit page (osf.io/collections/provider-name/submission-id/edit)

## Screenshot(s)
- After clicking "Remove from collection" button:
![image](https://user-images.githubusercontent.com/51409893/210643018-6b6c2888-10bf-4a3b-9794-59a582063450.png)

## Side Effects
- None

## QA Notes
- Users will be able to add a reason for removal when removing via this page osf.io/collections/provider-name/submission-id/edit (default privacy message should show up if a user changes the privacy setting)