### PR TITLE
Guid metadata/remove file metadata route

### DIFF
--- a/app/router.ts
+++ b/app/router.ts
@@ -54,9 +54,7 @@ Router.map(function() {
         this.mount('registries', { path: '--registries' });
     }
 
-    this.route('guid-file', { path: '--file/:guid' }, function() {
-        this.route('metadata');
-    });
+    this.route('guid-file', { path: '--file/:guid' });
 
     this.route('guid-node', { path: '--node/:guid' }, function() {
         this.mount('analytics-page', { as: 'analytics' });

--- a/tests/acceptance/resolve-guid-test.ts
+++ b/tests/acceptance/resolve-guid-test.ts
@@ -52,14 +52,7 @@ module('Acceptance | resolve-guid', hooks => {
 
             await visit(`/${file.id}`);
 
-            routingAssertions(assert, '--file', `/${file.id}`, 'guid-file.index');
-        });
-        test('Metadata', async assert => {
-            const file = server.create('file', { target: server.create('registration') });
-
-            await visit(`/${file.id}/metadata`);
-
-            routingAssertions(assert, '--file', `/${file.id}/metadata`, 'guid-file.metadata');
+            routingAssertions(assert, '--file', `/${file.id}`, 'guid-file');
         });
     });
 


### PR DESCRIPTION
-   Ticket: N/A

## Purpose

Design changes caused us to no longer need the metadata route under guid-file, so this pulls that out.

## Summary of Changes

1. Remove route
2. Remove template
3. Fix tests

## Side Effects

No
