### PR TITLE
[ENG-4186] Add styling to file detail page view section

### DIFF
--- a/app/guid-file/-components/file-detail-layout/styles.scss
+++ b/app/guid-file/-components/file-detail-layout/styles.scss
@@ -7,6 +7,7 @@
 .main-column {
     flex-grow: 3;
     z-index: 1;
+    margin-top: 1.4vh;
 
     h3 {
         text-overflow: ellipsis;
@@ -22,7 +23,6 @@
     flex-basis: 300px;
     flex-direction: column;
     flex-grow: 1;
-    margin-top: 1.4vh;
 
     &.is-closed {
         display: none;
@@ -48,7 +48,7 @@
     z-index: 1;
 }
 
-.slider {
+.lider {
     position: absolute;
     width: 100%;
     height: 100%;

--- a/app/guid-file/-components/file-detail-layout/styles.scss
+++ b/app/guid-file/-components/file-detail-layout/styles.scss
@@ -7,6 +7,7 @@
 .MainColumn {
     flex-grow: 3;
     z-index: 1;
+    margin-top: 1.4vh;
 
     h3 {
         text-overflow: ellipsis;
@@ -20,9 +21,22 @@
     flex-grow: 1;
     border-left: 1px solid #ddd;
     flex-basis: 300px;
+    display: inline-flex;
+    flex-direction: column;
+    margin-top: 1.4vh;
 
     &.is-closed {
         display: none;
+    }
+
+    h2 {
+        font-weight: 700;
+        font-size: 22px;
+    }
+
+    h2:nth-of-type(2) {
+        border-top: 2px solid rgb(221, 221, 221);
+        padding-top: 4vh;
     }
 }
 

--- a/app/guid-file/-components/file-detail-layout/styles.scss
+++ b/app/guid-file/-components/file-detail-layout/styles.scss
@@ -22,6 +22,7 @@
     flex-basis: 300px;
     flex-direction: column;
     flex-grow: 1;
+    width: 28vw;
 
     &.is-closed {
         display: none;

--- a/app/guid-file/-components/file-detail-layout/styles.scss
+++ b/app/guid-file/-components/file-detail-layout/styles.scss
@@ -1,10 +1,10 @@
-.Container {
+.container {
     display: flex;
     flex-direction: row;
     flex-grow: 1;
 }
 
-.MainColumn {
+.main-column {
     flex-grow: 3;
     z-index: 1;
     margin-top: 1.4vh;
@@ -17,7 +17,7 @@
     }
 }
 
-.RightColumn {
+.right-column {
     border-left: 1px solid #ddd;
     display: inline-flex;
     flex-basis: 300px;
@@ -35,7 +35,7 @@
     }
 }
 
-.RightButtons {
+.right-buttons {
     @media (max-width: 767px) {
         display: flex;
         flex-direction: row;
@@ -49,7 +49,7 @@
     z-index: 1;
 }
 
-.Slider {
+.slider {
     position: absolute;
     width: 100%;
     height: 100%;

--- a/app/guid-file/-components/file-detail-layout/styles.scss
+++ b/app/guid-file/-components/file-detail-layout/styles.scss
@@ -27,11 +27,6 @@
     &.is-closed {
         display: none;
     }
-
-    h2:nth-of-type(2) {
-        border-top: 2px solid rgb(221, 221, 221);
-        padding-top: 4vh;
-    }
 }
 
 .right-buttons {

--- a/app/guid-file/-components/file-detail-layout/styles.scss
+++ b/app/guid-file/-components/file-detail-layout/styles.scss
@@ -18,20 +18,15 @@
 }
 
 .RightColumn {
-    flex-grow: 1;
     border-left: 1px solid #ddd;
-    flex-basis: 300px;
     display: inline-flex;
+    flex-basis: 300px;
     flex-direction: column;
+    flex-grow: 1;
     margin-top: 1.4vh;
 
     &.is-closed {
         display: none;
-    }
-
-    h2 {
-        font-weight: 700;
-        font-size: 22px;
     }
 
     h2:nth-of-type(2) {

--- a/app/guid-file/-components/file-detail-layout/styles.scss
+++ b/app/guid-file/-components/file-detail-layout/styles.scss
@@ -43,13 +43,6 @@
     z-index: 1;
 }
 
-.lider {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    transform: translateX(-100%);
-}
-
 .slide-in {
     animation: slide-in 0.5s forwards;
 }

--- a/app/guid-file/-components/file-detail-layout/styles.scss
+++ b/app/guid-file/-components/file-detail-layout/styles.scss
@@ -7,7 +7,6 @@
 .main-column {
     flex-grow: 3;
     z-index: 1;
-    margin-top: 1.4vh;
 
     h3 {
         text-overflow: ellipsis;

--- a/app/guid-file/-components/file-detail-layout/template.hbs
+++ b/app/guid-file/-components/file-detail-layout/template.hbs
@@ -1,8 +1,8 @@
-<div local-class='Container'>
+<div local-class='container'>
     {{#if @isMobile}}
-        <div local-class='MainColumn'>
+        <div local-class='main-column'>
             {{yield to='header'}}
-            <div local-class='RightButtons'>
+            <div local-class='right-buttons'>
                 {{yield to='rightButtons'}}
             </div>
             <div>
@@ -14,14 +14,14 @@
             </div>
         </div>
     {{else}}
-        <div local-class='MainColumn'>
+        <div local-class='main-column'>
             {{yield to='header'}}
             {{yield to='body'}}
         </div>
-        <div local-class='RightColumn {{if @rightColumnClosed 'is-closed'}}'>
+        <div local-class='right-column {{if @rightColumnClosed 'is-closed'}}'>
             {{yield to='right'}}
         </div>
-        <div local-class='RightButtons'>
+        <div local-class='right-buttons'>
             {{yield to='rightButtons'}}
         </div>
     {{/if}}

--- a/app/guid-file/styles.scss
+++ b/app/guid-file/styles.scss
@@ -72,6 +72,10 @@
     height: 95%;
     margin: 0 20px;
 
+    &.Mobile {
+        width: 90vw;
+    }
+
     dt {
         font-size: 17px;
         font-weight: 600;

--- a/app/guid-file/styles.scss
+++ b/app/guid-file/styles.scss
@@ -140,8 +140,9 @@
 .metadata-form-and-buttons {
     display: flex;
     flex-direction: column;
+    grid-gap: 20px;
     height: 100%;
-    justify-content: space-between;
+    justify-content: flex-start;
 }
 
 .edit-metadata-form {

--- a/app/guid-file/styles.scss
+++ b/app/guid-file/styles.scss
@@ -90,20 +90,6 @@
         line-height: 1.1;
         margin-bottom: 20px;
     }
-
-    span:nth-of-type(1) {
-        padding-bottom: 1vh;
-
-        a:nth-of-type(n+2),
-        span {
-            margin-left: -0.7vw;
-            padding-left: 0;
-        }
-
-        span:last-of-type() {
-            padding-left: 0.7vw;
-        }
-    }
 }
 
 .metadata-heading {
@@ -112,7 +98,6 @@
 
 .node-type-heading {
     border-top: 2px solid #ddd;
-    margin-top: 40px;
     border-top: 2px solid rgb(221, 221, 221);
     padding-top: 30px;
 }
@@ -189,11 +174,6 @@
     font-weight: 600;
 }
 
-.contributor-list {
-    display: inline-flex;
-    flex-direction: row;
-    overflow-x: scroll;
-    text-align: left;
-    white-space: pre;
-    width: 100%;
+.affiliated-institutions {
+    margin-top: 14px;
 }

--- a/app/guid-file/styles.scss
+++ b/app/guid-file/styles.scss
@@ -115,7 +115,8 @@
     border-top: 2px solid #ddd;
     padding-top: 3vh;
     margin-top: 4vh;
-
+    border-top: 2px solid rgb(221, 221, 221);
+    padding-top: 4vh;
 }
 
 .metadata-title-edit-download {
@@ -145,8 +146,10 @@
 
     button:active,
     button:focus,
+    button:hover,
     a:active,
-    a:focus {
+    a:focus,
+    a:hover {
         background: #efefef;
     }
 }

--- a/app/guid-file/styles.scss
+++ b/app/guid-file/styles.scss
@@ -17,6 +17,7 @@
     align-items: end;
     justify-content: space-between;
     padding: 0 20px 20px;
+    align-items: center;
 }
 
 .FlexContainerRow > h2 {
@@ -78,7 +79,47 @@
 .RightContainer {
     margin: 0 20px;
     
+    h2:nth-of-type(2) {
+        margin-bottom: 1vh;
+    }
+
+    h3 {
+        font-weight: 800;
+        font-size: 15px;
+        margin-top: 4px;
+    }
+
     h2 {
-        margin-bottom: 20px;
+        padding-bottom: 1vh;
+    }
+
+    div {
+        margin-bottom: 2vh;
+    }
+
+    div:nth-of-type(1) {
+        margin-bottom: 0;
+    }
+
+    span:nth-of-type(1) {
+        display: block;
+        padding-bottom: 1vh;
+    }
+}
+
+.metadata-title-edit-download {
+    display: inline-flex;
+    flex-direction: row;
+    width: 100%;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0;
+
+    button {
+        margin-left: 12vw;
+    }
+
+    svg {
+        height: 1.4em;
     }
 }

--- a/app/guid-file/styles.scss
+++ b/app/guid-file/styles.scss
@@ -1,24 +1,16 @@
-.ContentBackground {
-    display: flex;
-    flex-grow: 1;
-    justify-content: center;
-    position: relative;
-    z-index: 1;
-}
-
-.MainColumn {
+.main-column {
     display: flex;
     flex-direction: column;
 }
 
-.FlexContainerRow {
+.flex-container-row {
     display: flex;
     flex-direction: row;
     justify-content: space-between;
     padding: 0 20px 20px;
 }
 
-.FlexContainerRow > h2 {
+.flex-container-row > h2 {
     height: 40px;
     max-width: 70vw;
     overflow: hidden;
@@ -26,17 +18,17 @@
     white-space: nowrap;
 }
 
-.ProjectLink {
+.project-link {
     margin: 20px;
 }
 
-.FileRenderer {
+.file-renderer {
     height: 90vh;
     margin-bottom: 15px;
     padding: 0 20px 20px;
 }
 
-.SlideButtons {
+.slide-buttons {
     background-color: $color-bg-white;
     border: 0;
     color: $color-link-dark;
@@ -46,7 +38,7 @@
         margin: 0;
     }
 
-    &.Active {
+    &.active {
         @media (max-width: 767px) {
             background-color: $color-bg-white;
             color: $color-bg-black;
@@ -55,42 +47,42 @@
     }
 }
 
-.FileDetail__revisions {
+.file-detail-revisions {
     max-height: 100vh;
     overflow-y: auto;
 }
 
-.FileDetail__right-section-heading {
+.file-detail-right-section-heading {
     margin-left: 20px;
 }
 
-.FileDetail__revision-list {
+.file-detail-revision-list {
     list-style-position: inside;
     padding-inline: 20px;
 }
 
-.FileDetail__no-revisions {
+.file-detail-no-revisions {
     padding: 20px;
     text-align: center;
 }
 
-.RightContainer {
+.right-container {
+    display: inline-flex;
+    flex-direction: column;
+    height: 95%;
     margin: 0 20px;
     width: 28vw;
+
+    dt {
+        font-size: 17px;
+        font-weight: 600;
+    }
 
     dt,
     dd {
         background-color: #fff;
         color: #000;
-        margin-bottom: 1vh;
-
-        dt {
-            font-size: 17px;
-        }
-    }
-
-    h2:nth-of-type(2) {
-        margin-bottom: 1vh;
+        margin-bottom: 1.5vh;
     }
 
     h2 {
@@ -98,20 +90,7 @@
         font-weight: 300;
         line-height: 1.1;
         padding-bottom: 1vh;
-    }
-
-    dl > h2 {
-        border-top: 2px solid #ddd;
-        padding-top: 3vh;
-        margin-top: 4vh;
-    }
-
-    div {
         margin-bottom: 2vh;
-    }
-
-    div:nth-of-type(1) {
-        margin-bottom: 0;
     }
 
     span:nth-of-type(1) {
@@ -129,6 +108,71 @@
     }
 }
 
+.metadata-heading {
+    margin-bottom: 0;
+}
+
+.node-type-heading {
+    border-top: 2px solid #ddd;
+    padding-top: 3vh;
+    margin-top: 4vh;
+
+}
+
+.metadata-title-edit-download {
+    align-items: baseline;
+    display: inline-flex;
+    flex-direction: row;
+    justify-content: space-between;
+    white-space: nowrap;
+    width: 100%;
+
+    button {
+        margin: 0 2vw 0 12vw;
+    }
+
+    svg {
+        height: 1.4em;
+    }
+}
+
+.metadata-form-and-buttons {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    justify-content: space-between;
+}
+
+.edit-metadata-form {
+    display: inline-flex;
+    flex-direction: column;
+}
+
+.edit-metadata-save-cancel-buttons {
+    display: inline-flex;
+    flex-direction: row;
+    font-size: 14px;
+    grid-gap: 1vw;
+    justify-content: flex-end;
+
+    button {
+        border: 1px solid rgba(140, 140, 140, 0.7);
+        border-radius: 2px;
+    }
+}
+
+.cancel-edit-button {
+    background-color: #fff;
+    color: #337ab7;
+    font-weight: 100;
+}
+
+.save-edit-button {
+    background-color: #337ab7;
+    color: #fff;
+    font-weight: 600;
+}
+
 .contributor-list {
     display: inline-flex;
     flex-direction: row;
@@ -136,21 +180,4 @@
     text-align: left;
     white-space: pre;
     width: 100%;
-}
-
-.metadata-title-edit-download {
-    align-items: center;
-    display: inline-flex;
-    flex-direction: row;
-    justify-content: space-between;
-    margin-bottom: 0;
-    width: 100%;
-
-    button {
-        margin-left: 12vw;
-    }
-
-    svg {
-        height: 1.4em;
-    }
 }

--- a/app/guid-file/styles.scss
+++ b/app/guid-file/styles.scss
@@ -71,7 +71,6 @@
     flex-direction: column;
     height: 95%;
     margin: 0 20px;
-    width: 28vw;
 
     dt {
         font-size: 17px;
@@ -127,12 +126,28 @@
     white-space: nowrap;
     width: 100%;
 
+    svg {
+        height: 1.5em;
+    }
+}
+
+.edit-download-buttons {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    margin-right: 1vw;
+    grid-gap: 2vw;
+
+    a,
     button {
-        margin: 0 2vw 0 12vw;
+        padding: 0.7vw 1.1vw;
     }
 
-    svg {
-        height: 1.4em;
+    button:active,
+    button:focus,
+    a:active,
+    a:focus {
+        background: #efefef;
     }
 }
 

--- a/app/guid-file/styles.scss
+++ b/app/guid-file/styles.scss
@@ -160,23 +160,6 @@
     font-size: 14px;
     grid-gap: 1vw;
     justify-content: flex-end;
-
-    button {
-        border: 1px solid rgba(140, 140, 140, 0.7);
-        border-radius: 2px;
-    }
-}
-
-.cancel-edit-button {
-    background-color: #fff;
-    color: #337ab7;
-    font-weight: 100;
-}
-
-.save-edit-button {
-    background-color: #337ab7;
-    color: #fff;
-    font-weight: 600;
 }
 
 .affiliated-institutions {

--- a/app/guid-file/styles.scss
+++ b/app/guid-file/styles.scss
@@ -1,9 +1,9 @@
 .ContentBackground {
     display: flex;
     flex-grow: 1;
-    z-index: 1;
     justify-content: center;
     position: relative;
+    z-index: 1;
 }
 
 .MainColumn {
@@ -14,18 +14,16 @@
 .FlexContainerRow {
     display: flex;
     flex-direction: row;
-    align-items: end;
     justify-content: space-between;
     padding: 0 20px 20px;
-    align-items: center;
 }
 
 .FlexContainerRow > h2 {
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
-    max-width: 70vw;
     height: 40px;
+    max-width: 70vw;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .ProjectLink {
@@ -33,16 +31,16 @@
 }
 
 .FileRenderer {
-    padding: 0 20px 20px;
     height: 90vh;
     margin-bottom: 15px;
+    padding: 0 20px 20px;
 }
 
 .SlideButtons {
-    margin: 20px 20px 0;
+    background-color: $color-bg-white;
     border: 0;
     color: $color-link-dark;
-    background-color: $color-bg-white;
+    margin: 20px 20px 0;
 
     @media (max-width: 767px) {
         margin: 0;
@@ -78,19 +76,34 @@
 
 .RightContainer {
     margin: 0 20px;
-    
+    width: 28vw;
+
+    dt,
+    dd {
+        background-color: #fff;
+        color: #000;
+        margin-bottom: 1vh;
+
+        dt {
+            font-size: 17px;
+        }
+    }
+
     h2:nth-of-type(2) {
         margin-bottom: 1vh;
     }
 
-    h3 {
-        font-weight: 800;
-        font-size: 15px;
-        margin-top: 4px;
+    h2 {
+        font-size: 31.5px;
+        font-weight: 300;
+        line-height: 1.1;
+        padding-bottom: 1vh;
     }
 
-    h2 {
-        padding-bottom: 1vh;
+    dl > h2 {
+        border-top: 2px solid #ddd;
+        padding-top: 3vh;
+        margin-top: 4vh;
     }
 
     div {
@@ -102,18 +115,36 @@
     }
 
     span:nth-of-type(1) {
-        display: block;
         padding-bottom: 1vh;
+
+        a:nth-of-type(n+2),
+        span {
+            margin-left: -0.7vw;
+            padding-left: 0;
+        }
+
+        span:last-of-type() {
+            padding-left: 0.7vw;
+        }
     }
 }
 
-.metadata-title-edit-download {
+.contributor-list {
     display: inline-flex;
     flex-direction: row;
+    overflow-x: scroll;
+    text-align: left;
+    white-space: pre;
     width: 100%;
-    justify-content: space-between;
+}
+
+.metadata-title-edit-download {
     align-items: center;
+    display: inline-flex;
+    flex-direction: row;
+    justify-content: space-between;
     margin-bottom: 0;
+    width: 100%;
 
     button {
         margin-left: 12vw;

--- a/app/guid-file/styles.scss
+++ b/app/guid-file/styles.scss
@@ -81,15 +81,14 @@
     dd {
         background-color: #fff;
         color: #000;
-        margin-bottom: 1.5vh;
+        margin-bottom: 14px;
     }
 
     h2 {
         font-size: 31.5px;
         font-weight: 300;
         line-height: 1.1;
-        padding-bottom: 1vh;
-        margin-bottom: 2vh;
+        margin-bottom: 20px;
     }
 
     span:nth-of-type(1) {
@@ -113,10 +112,9 @@
 
 .node-type-heading {
     border-top: 2px solid #ddd;
-    padding-top: 3vh;
-    margin-top: 4vh;
+    margin-top: 40px;
     border-top: 2px solid rgb(221, 221, 221);
-    padding-top: 4vh;
+    padding-top: 30px;
 }
 
 .metadata-title-edit-download {

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -7,14 +7,14 @@
             <OsfLink
                 data-test-project-link
                 data-analytics-name='Linked project'
-                local-class='ProjectLink'
+                local-class='project-link'
                 @route={{if (eq this.model.fileModel.target.type 'registrations') 'guid-registration' 'guid-node'}}
                 @models={{array this.model.fileModel.target.id}}
             >
                 {{this.model.fileModel.target.title}}
             </OsfLink>
         </h3>
-        <div local-class='FlexContainerRow'>
+        <div local-class='flex-container-row'>
             <h2 data-test-filename>
                 {{this.model.displayName}}
                 {{#if this.viewedVersion}}
@@ -25,7 +25,7 @@
         </div>
     </:header>
     <:body>
-        <div data-test-file-renderer id='mfrIframeParent' local-class='FileRenderer'>
+        <div data-test-file-renderer id='mfrIframeParent' local-class='file-renderer'>
             <FileRenderer
                 @download={{this.model.links.download}}
                 @version={{this.viewedVersion}}
@@ -35,9 +35,9 @@
     <:right>
         {{#if (or this.model.shouldShowTags this.model.shouldShowRevisions) }}
             {{#if this.revisionsOpened}}
-                <section data-test-revisions-tab local-class='FileDetail__revisions'>
-                    <h2 local-class='FileDetail__right-section-heading'>{{t 'general.revisions'}}</h2>
-                    <ol local-class='FileDetail__revision-list' reversed>
+                <section data-test-revisions-tab local-class='file-detail-revisions'>
+                    <h2 local-class='file-detail-right-section-heading'>{{t 'general.revisions'}}</h2>
+                    <ol local-class='file-detail-revision-list' reversed>
                         <hr aria-hidden='true'>
                         {{#if this.model.getRevisions.isRunning}}
                             <LoadingIndicator @dark={{true}} />
@@ -57,7 +57,7 @@
                 </section>
             {{/if}}
             {{#if this.tagsOpened}}
-                <div local-class='RightContainer'>
+                <div local-class='right-container'>
                     <h2>{{t 'general.tags'}}</h2>
                     <TagsWidget
                         @taggable={{this.model.fileModel}}
@@ -67,10 +67,10 @@
                 </div>
             {{/if}}
             {{#if this.metadataOpened}}
-                <div local-class='RightContainer'>
+                <div local-class='right-container'>
                     <FileMetadataManager @file={{this.model.fileModel}} as |manager|>
                         <div local-class='metadata-title-edit-download'>
-                            <h2>
+                            <h2 local-class='metadata-heading'>
                                 {{t 'file_detail.file_metadata'}}
                             </h2>
                             {{#unless manager.inEditMode}}
@@ -98,55 +98,63 @@
                             <LoadingIndicator @dark={{true}} />
                         {{else}}
                             {{#if manager.inEditMode}}
-                                <FormControls @changeset={{manager.changeset}} as |form|>
-                                    <form.textarea
-                                        data-test-title-field
-                                        @valuePath='title'
-                                        @label={{t 'file_detail.title'}}
-                                    />
-                                    <form.textarea
-                                        data-test-description-field
-                                        @valuePath='description'
-                                        @label={{t 'file_detail.description'}}
-                                    />
-                                    <form.select
-                                        data-test-select-resource-type
-                                        @options={{manager.resourceTypeGeneralOptions}}
-                                        @label={{t 'file_detail.resource_type_general'}}
-                                        @valuePath='resourceTypeGeneral'
-                                        as |option|
-                                    >
-                                        {{option}}
-                                    </form.select>
-                                    <form.select
-                                        data-test-select-resource-language
-                                        @options={{manager.languageCodes}}
-                                        @label={{t 'file_detail.language'}}
-                                        @onchange={{manager.changeLanguage}}
-                                        @valuePath='languageObject'
-                                        as |option|
-                                    >
-                                        {{option.name}}
-                                    </form.select>
-                                </FormControls>
-                                <Button
-                                    data-test-cancel-editing-metadata-button
-                                    aria-label={{t 'general.cancel'}}
-                                    data-analytics-name='Cancel editing metadata'
-                                    @layout='fake-link'
-                                    {{on 'click' manager.cancel}}
-                                >
-                                    {{t 'general.cancel'}}
-                                </Button>
-                                <Button
-                                    data-test-save-metadata-button
-                                    aria-label={{t 'general.save'}}
-                                    data-analytics-name='Save metadata'
-                                    @layout='fake-link'
-                                    {{on 'click' manager.save}}
-                                >
-                                    {{t 'general.save'}}
-                                </Button>
+                                <div local-class='metadata-form-and-buttons'>
+                                    <div local-class='edit-metadata-form'>
+                                        <FormControls @changeset={{manager.changeset}} as |form|>
+                                            <form.textarea
+                                                data-test-title-field
+                                                @valuePath='title'
+                                                @label={{t 'file_detail.title'}}
+                                            />
+                                            <form.textarea
+                                                data-test-description-field
+                                                @valuePath='description'
+                                                @label={{t 'file_detail.description'}}
+                                            />
+                                            <form.select
+                                                data-test-select-resource-type
+                                                @options={{manager.resourceTypeGeneralOptions}}
+                                                @label={{t 'file_detail.resource_type_general'}}
+                                                @valuePath='resourceTypeGeneral'
+                                                as |option|
+                                            >
+                                                {{option}}
+                                            </form.select>
+                                            <form.select
+                                                data-test-select-resource-language
+                                                @options={{manager.languageCodes}}
+                                                @label={{t 'file_detail.language'}}
+                                                @onchange={{manager.changeLanguage}}
+                                                @valuePath='languageObject'
+                                                as |option|
+                                            >
+                                                {{option.name}}
+                                            </form.select>
+                                        </FormControls>
+                                    </div>
+                                    <div local-class='edit-metadata-save-cancel-buttons'>
+                                        <Button
+                                            data-test-cancel-editing-metadata-button
+                                            aria-label={{t 'general.cancel'}}
+                                            data-analytics-name='Cancel editing metadata'
+                                            @layout='fake-link'
+                                            local-class='cancel-edit-button'
+                                            {{on 'click' manager.cancel}}
+                                        >
+                                            {{t 'general.cancel'}}
+                                        </Button>
+                                        <Button
+                                            data-test-save-metadata-button
+                                            aria-label={{t 'general.save'}}
+                                            data-analytics-name='Save metadata'
+                                            @layout='fake-link'
+                                            local-class='save-edit-button'
+                                            {{on 'click' manager.save}}
+                                        >
+                                            {{t 'general.save'}}
+                                        </Button>
+                                    </div>
+                                </div>
                             {{else}}
                                 <dl>
                                     <dt>{{t 'file_detail.title'}}</dt>
@@ -157,7 +165,7 @@
                                     <dd data-test-file-resource-type>{{manager.metadataRecord.resourceTypeGeneral}}</dd>
                                     <dt>{{t 'file_detail.language'}}</dt>
                                     <dd data-test-file-language>{{manager.languageFromCode}}</dd>
-                                    <h2>{{t (concat 'file_detail.metadata_' manager.nodeWord)}}</h2>
+                                    <h2 local-class='node-type-heading'>{{t (concat 'file_detail.metadata_' manager.nodeWord)}}</h2>
                                     <div>
                                         {{#each manager.targetMetadata.funders as |funder|}}
                                             <dt>{{t 'file_detail.funder'}}</dt>
@@ -216,7 +224,7 @@
                 <BsButton
                     data-test-file-renderer-button
                     data-analytics-name='File renderer button'
-                    local-class='SlideButtons {{if this.rightColumnClosed 'Active'}}'
+                    local-class='slide-buttons {{if this.rightColumnClosed 'active'}}'
                     @size='lg'
                     @onClick={{this.toggleFileRenderer}}
                 >
@@ -227,7 +235,7 @@
                 aria-label={{if this.metadataOpened (t 'file_detail.close_metadata') (t 'file_detail.view_metadata')}}
                 data-test-metadata-button
                 data-analytics-name='Metadata button'
-                local-class='SlideButtons {{if this.metadataOpened 'Active'}}'
+                local-class='slide-buttons {{if this.metadataOpened 'active'}}'
                 @size='lg'
                 @onClick={{this.toggleMetadata}}
             >
@@ -238,7 +246,7 @@
                     aria-label={{if this.revisionsOpened (t 'file_detail.close_revisions') (t 'file_detail.view_revisions')}}
                     data-test-versions-button
                     data-analytics-name='Versions button'
-                    local-class='SlideButtons {{if this.revisionsOpened 'Active'}}'
+                    local-class='slide-buttons {{if this.revisionsOpened 'active'}}'
                     @size='lg'
                     @onClick={{this.toggleRevisions}}
                 >
@@ -250,7 +258,7 @@
                     aria-label={{if this.tagsOpened (t 'file_detail.close_tags') (t 'file_detail.view_tags')}}
                     data-test-tags-button
                     data-analytics-name='Tags button'
-                    local-class='SlideButtons {{if this.tagsOpened 'Active'}}'
+                    local-class='slide-buttons {{if this.tagsOpened 'active'}}'
                     @size='lg'
                     @onClick={{this.toggleTags}}
                 >

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -139,7 +139,6 @@
                                             aria-label={{t 'general.cancel'}}
                                             data-analytics-name='Cancel editing metadata'
                                             data-test-cancel-editing-metadata-button
-                                            @layout='fake-link'
                                             local-class='cancel-edit-button'
                                             @type='secondary'
                                             {{on 'click' manager.cancel}}
@@ -150,7 +149,6 @@
                                             aria-label={{t 'general.save'}}
                                             data-analytics-name='Save metadata'
                                             data-test-save-metadata-button
-                                            @layout='fake-link'
                                             local-class='save-edit-button'
                                             @type='primary'
                                             {{on 'click' manager.save}}

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -69,29 +69,31 @@
             {{#if this.metadataOpened}}
                 <div local-class='RightContainer'>
                     <FileMetadataManager @file={{this.model.fileModel}} as |manager|>
-                        <h2>
-                            {{t 'file_detail.file_metadata'}}
-                        </h2>
-                        {{#unless manager.inEditMode}}
-                            {{#if manager.userCanEdit}}
-                                <Button
-                                    data-test-edit-metadata-button
-                                    aria-label={{t 'general.edit'}}
-                                    data-analytics-name='Edit metadata'
-                                    @layout='fake-link'
-                                    {{on 'click' manager.edit}}
+                        <div local-class='metadata-title-edit-download'>
+                            <h2>
+                                {{t 'file_detail.file_metadata'}}
+                            </h2>
+                            {{#unless manager.inEditMode}}
+                                {{#if manager.userCanEdit}}
+                                    <Button
+                                        data-test-edit-metadata-button
+                                        aria-label={{t 'general.edit'}}
+                                        data-analytics-name='Edit metadata'
+                                        @layout='fake-link'
+                                        {{on 'click' manager.edit}}
+                                    >
+                                        <FaIcon @icon='pencil-alt' />
+                                    </Button>
+                                {{/if}}
+                                <OsfLink
+                                    data-test-download-button
+                                    aria-label={{t 'general.download'}}
+                                    @href='#'
                                 >
-                                    <FaIcon @icon='pencil-alt' />
-                                </Button>
-                            {{/if}}
-                            <OsfLink
-                                data-test-download-button
-                                aria-label={{t 'general.download'}}
-                                @href='#'
-                            >
-                                <FaIcon @icon='download' />
-                            </OsfLink>
-                        {{/unless}}
+                                    <FaIcon @icon='download' />
+                                </OsfLink>
+                            {{/unless}}
+                        </div>
                         {{#if manager.isGatheringData}}
                             <LoadingIndicator @dark={{true}} />
                         {{else}}
@@ -146,57 +148,57 @@
                                     {{t 'general.save'}}
                                 </Button>
                             {{else}}
-                                <div>{{t 'file_detail.title'}}</div>
+                                <h3>{{t 'file_detail.title'}}</h3>
                                 <div data-test-file-title>{{manager.metadataRecord.title}}</div>
-                                <div>{{t 'file_detail.description'}}</div>
+                                <h3>{{t 'file_detail.description'}}</h3>
                                 <div data-test-file-description>{{manager.metadataRecord.description}}</div>
-                                <div>{{t 'file_detail.resource_type_general'}}</div>
+                                <h3>{{t 'file_detail.resource_type_general'}}</h3>
                                 <div data-test-file-resource-type>{{manager.metadataRecord.resourceTypeGeneral}}</div>
-                                <div>{{t 'file_detail.language'}}</div>
+                                <h3>{{t 'file_detail.language'}}</h3>
                                 <div data-test-file-language>{{manager.languageFromCode}}</div>
                                 <h2>{{t (concat 'file_detail.metadata_' manager.nodeWord)}}</h2>
                                 <div>
                                     {{#each manager.targetMetadata.funders as |funder|}}
-                                        <div>{{t 'file_detail.funder'}}</div>
+                                        <h3>{{t 'file_detail.funder'}}</h3>
                                         <div data-test-target-funder-name={{funder.funder_name}}>
                                             {{funder.funder_name}}
                                         </div>
-                                        <div>{{t 'file_detail.award_title'}}</div>
+                                        <h3>{{t 'file_detail.award_title'}}</h3>
                                         <div data-test-target-funder-award-title={{funder.funder_name}}>
                                             {{funder.award_title}}
                                         </div>
-                                        <div>{{t 'file_detail.award_uri'}}</div>
+                                        <h3>{{t 'file_detail.award_uri'}}</h3>
                                         <div data-test-target-funder-award-uri={{funder.funder_name}}>
                                             {{funder.award_uri}}
                                         </div>
-                                        <div>{{t 'file_detail.award_number'}}</div>
+                                        <h3>{{t 'file_detail.award_number'}}</h3>
                                         <div data-test-target-funder-award-number={{funder.funder_name}}>
                                             {{funder.award_number}}
                                         </div>
                                     {{/each}}
                                 </div>
-                                <div>{{t 'file_detail.title'}}</div>
+                                <h3>{{t 'file_detail.title'}}</h3>
                                 <div data-test-target-title>{{manager.target.title}}</div>
-                                <div>{{t 'file_detail.description'}}</div>
+                                <h3>{{t 'file_detail.description'}}</h3>
                                 <div data-test-target-description>{{manager.target.description}}</div>
-                                <div>{{t 'file_detail.contributors'}}</div>
+                                <h3>{{t 'file_detail.contributors'}}</h3>
                                 <ContributorList
                                     data-test-target-contributors
                                     @model={{manager.target}}
                                     @shouldLinkUsers={{true}}
                                     @shouldTruncate={{false}}
                                 />
-                                <div>{{t 'file_detail.institutions'}}</div>
+                                <h3>{{t 'file_detail.institutions'}}</h3>
                                 <div data-test-target-institutions>
                                     {{#each this.targetInstitutions as |institution|}}
                                         <div>{{institution.name}}</div>
                                     {{/each}}
                                 </div>
-                                <div>{{t 'file_detail.license'}}</div>
+                                <h3>{{t 'file_detail.license'}}</h3>
                                 <div data-test-target-license-name>{{manager.targetLicense.name}}</div>
-                                <div>{{t 'file_detail.resource_type_general'}}</div>
+                                <h3>{{t 'file_detail.resource_type_general'}}</h3>
                                 <div data-test-target-resource-type>{{manager.targetMetadata.resourceTypeGeneral}}</div>
-                                <div>{{t 'file_detail.language'}}</div>
+                                <h3>{{t 'file_detail.language'}}</h3>
                                 <div data-test-target-language>{{manager.targetMetadata.language}}</div>
                             {{/if}}
                         {{/if}}

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -136,21 +136,23 @@
                                     </div>
                                     <div local-class='edit-metadata-save-cancel-buttons'>
                                         <Button
-                                            data-test-cancel-editing-metadata-button
                                             aria-label={{t 'general.cancel'}}
                                             data-analytics-name='Cancel editing metadata'
+                                            data-test-cancel-editing-metadata-button
                                             @layout='fake-link'
                                             local-class='cancel-edit-button'
+                                            @type='secondary'
                                             {{on 'click' manager.cancel}}
                                         >
                                             {{t 'general.cancel'}}
                                         </Button>
                                         <Button
-                                            data-test-save-metadata-button
                                             aria-label={{t 'general.save'}}
                                             data-analytics-name='Save metadata'
+                                            data-test-save-metadata-button
                                             @layout='fake-link'
                                             local-class='save-edit-button'
+                                            @type='primary'
                                             {{on 'click' manager.save}}
                                         >
                                             {{t 'general.save'}}

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -139,7 +139,6 @@
                                             aria-label={{t 'general.cancel'}}
                                             data-analytics-name='Cancel editing metadata'
                                             data-test-cancel-editing-metadata-button
-                                            local-class='cancel-edit-button'
                                             @type='secondary'
                                             {{on 'click' manager.cancel}}
                                         >
@@ -149,7 +148,6 @@
                                             aria-label={{t 'general.save'}}
                                             data-analytics-name='Save metadata'
                                             data-test-save-metadata-button
-                                            local-class='save-edit-button'
                                             @type='primary'
                                             {{on 'click' manager.save}}
                                         >

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -148,58 +148,61 @@
                                     {{t 'general.save'}}
                                 </Button>
                             {{else}}
-                                <h3>{{t 'file_detail.title'}}</h3>
-                                <div data-test-file-title>{{manager.metadataRecord.title}}</div>
-                                <h3>{{t 'file_detail.description'}}</h3>
-                                <div data-test-file-description>{{manager.metadataRecord.description}}</div>
-                                <h3>{{t 'file_detail.resource_type_general'}}</h3>
-                                <div data-test-file-resource-type>{{manager.metadataRecord.resourceTypeGeneral}}</div>
-                                <h3>{{t 'file_detail.language'}}</h3>
-                                <div data-test-file-language>{{manager.languageFromCode}}</div>
-                                <h2>{{t (concat 'file_detail.metadata_' manager.nodeWord)}}</h2>
-                                <div>
-                                    {{#each manager.targetMetadata.funders as |funder|}}
-                                        <h3>{{t 'file_detail.funder'}}</h3>
-                                        <div data-test-target-funder-name={{funder.funder_name}}>
-                                            {{funder.funder_name}}
-                                        </div>
-                                        <h3>{{t 'file_detail.award_title'}}</h3>
-                                        <div data-test-target-funder-award-title={{funder.funder_name}}>
-                                            {{funder.award_title}}
-                                        </div>
-                                        <h3>{{t 'file_detail.award_uri'}}</h3>
-                                        <div data-test-target-funder-award-uri={{funder.funder_name}}>
-                                            {{funder.award_uri}}
-                                        </div>
-                                        <h3>{{t 'file_detail.award_number'}}</h3>
-                                        <div data-test-target-funder-award-number={{funder.funder_name}}>
-                                            {{funder.award_number}}
-                                        </div>
-                                    {{/each}}
-                                </div>
-                                <h3>{{t 'file_detail.title'}}</h3>
-                                <div data-test-target-title>{{manager.target.title}}</div>
-                                <h3>{{t 'file_detail.description'}}</h3>
-                                <div data-test-target-description>{{manager.target.description}}</div>
-                                <h3>{{t 'file_detail.contributors'}}</h3>
-                                <ContributorList
-                                    data-test-target-contributors
-                                    @model={{manager.target}}
-                                    @shouldLinkUsers={{true}}
-                                    @shouldTruncate={{false}}
-                                />
-                                <h3>{{t 'file_detail.institutions'}}</h3>
-                                <div data-test-target-institutions>
-                                    {{#each this.targetInstitutions as |institution|}}
-                                        <div>{{institution.name}}</div>
-                                    {{/each}}
-                                </div>
-                                <h3>{{t 'file_detail.license'}}</h3>
-                                <div data-test-target-license-name>{{manager.targetLicense.name}}</div>
-                                <h3>{{t 'file_detail.resource_type_general'}}</h3>
-                                <div data-test-target-resource-type>{{manager.targetMetadata.resourceTypeGeneral}}</div>
-                                <h3>{{t 'file_detail.language'}}</h3>
-                                <div data-test-target-language>{{manager.targetMetadata.language}}</div>
+                                <dl>
+                                    <dt>{{t 'file_detail.title'}}</dt>
+                                    <dd data-test-file-title>{{manager.metadataRecord.title}}</dd>
+                                    <dt>{{t 'file_detail.description'}}</dt>
+                                    <dd data-test-file-description>{{manager.metadataRecord.description}}</dd>
+                                    <dt>{{t 'file_detail.resource_type_general'}}</dt>
+                                    <dd data-test-file-resource-type>{{manager.metadataRecord.resourceTypeGeneral}}</dd>
+                                    <dt>{{t 'file_detail.language'}}</dt>
+                                    <dd data-test-file-language>{{manager.languageFromCode}}</dd>
+                                    <h2>{{t (concat 'file_detail.metadata_' manager.nodeWord)}}</h2>
+                                    <div>
+                                        {{#each manager.targetMetadata.funders as |funder|}}
+                                            <dt>{{t 'file_detail.funder'}}</dt>
+                                            <dd data-test-target-funder-name={{funder.funder_name}}>
+                                                {{funder.funder_name}}
+                                            </dd>
+                                            <dt>{{t 'file_detail.award_title'}}</dt>
+                                            <dd data-test-target-funder-award-title={{funder.funder_name}}>
+                                                {{funder.award_title}}
+                                            </dd>
+                                            <dt>{{t 'file_detail.award_uri'}}</dt>
+                                            <dd data-test-target-funder-award-uri={{funder.funder_name}}>
+                                                {{funder.award_uri}}
+                                            </dd>
+                                            <dt>{{t 'file_detail.award_number'}}</dt>
+                                            <dd data-test-target-funder-award-number={{funder.funder_name}}>
+                                                {{funder.award_number}}
+                                            </dd>
+                                        {{/each}}
+                                    </div>
+                                    <dt>{{t 'file_detail.title'}}</dt>
+                                    <dd data-test-target-title>{{manager.target.title}}</dd>
+                                    <dt>{{t 'file_detail.description'}}</dt>
+                                    <dd data-test-target-description>{{manager.target.description}}</dd>
+                                    <dt>{{t 'file_detail.contributors'}}</dt>
+                                    <ContributorList
+                                        data-test-target-contributors
+                                        local-class='contributor-list'
+                                        @model={{manager.target}}
+                                        @shouldLinkUsers={{true}}
+                                        @shouldTruncate={{false}}
+                                    />
+                                    <dt>{{t 'file_detail.institutions'}}</dt>
+                                    <div data-test-target-institutions>
+                                        {{#each this.targetInstitutions as |institution|}}
+                                            <dd>{{institution.name}}</dd>
+                                        {{/each}}
+                                    </div>
+                                    <dt>{{t 'file_detail.license'}}</dt>
+                                    <dd data-test-target-license-name>{{manager.targetLicense.name}}</dd>
+                                    <dt>{{t 'file_detail.resource_type_general'}}</dt>
+                                    <dd data-test-target-resource-type>{{manager.targetMetadata.resourceTypeGeneral}}</dd>
+                                    <dt>{{t 'file_detail.language'}}</dt>
+                                    <dd data-test-target-language>{{manager.targetMetadata.language}}</dd>
+                                </dl>
                             {{/if}}
                         {{/if}}
                     </FileMetadataManager>

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -73,26 +73,28 @@
                             <h2 local-class='metadata-heading'>
                                 {{t 'file_detail.file_metadata'}}
                             </h2>
-                            {{#unless manager.inEditMode}}
-                                {{#if manager.userCanEdit}}
-                                    <Button
-                                        data-test-edit-metadata-button
-                                        aria-label={{t 'general.edit'}}
-                                        data-analytics-name='Edit metadata'
-                                        @layout='fake-link'
-                                        {{on 'click' manager.edit}}
+                            <div local-class='edit-download-buttons'>
+                                {{#unless manager.inEditMode}}
+                                    {{#if manager.userCanEdit}}
+                                        <Button
+                                            data-test-edit-metadata-button
+                                            aria-label={{t 'general.edit'}}
+                                            data-analytics-name='Edit metadata'
+                                            @layout='fake-link'
+                                            {{on 'click' manager.edit}}
+                                        >
+                                            <FaIcon @icon='pencil-alt' />
+                                        </Button>
+                                    {{/if}}
+                                    <OsfLink
+                                        data-test-download-button
+                                        aria-label={{t 'general.download'}}
+                                        @href='#'
                                     >
-                                        <FaIcon @icon='pencil-alt' />
-                                    </Button>
-                                {{/if}}
-                                <OsfLink
-                                    data-test-download-button
-                                    aria-label={{t 'general.download'}}
-                                    @href='#'
-                                >
-                                    <FaIcon @icon='download' />
-                                </OsfLink>
-                            {{/unless}}
+                                        <FaIcon @icon='download' />
+                                    </OsfLink>
+                                {{/unless}}
+                            </div>
                         </div>
                         {{#if manager.isGatheringData}}
                             <LoadingIndicator @dark={{true}} />

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -167,9 +167,11 @@
                                     <dd data-test-file-resource-type>{{manager.metadataRecord.resourceTypeGeneral}}</dd>
                                     <dt>{{t 'file_detail.language'}}</dt>
                                     <dd data-test-file-language>{{manager.languageFromCode}}</dd>
-                                    <h2 local-class='node-type-heading'>{{t (concat 'file_detail.metadata_' manager.nodeWord)}}</h2>
-                                    <div>
-                                        {{#each manager.targetMetadata.funders as |funder|}}
+                                </dl>
+                                <h2 local-class='node-type-heading'>{{t (concat 'file_detail.metadata_' manager.nodeWord)}}</h2>
+                                <div>
+                                    {{#each manager.targetMetadata.funders as |funder|}}
+                                        <dl>
                                             <dt>{{t 'file_detail.funder'}}</dt>
                                             <dd data-test-target-funder-name={{funder.funder_name}}>
                                                 {{funder.funder_name}}
@@ -186,8 +188,10 @@
                                             <dd data-test-target-funder-award-number={{funder.funder_name}}>
                                                 {{funder.award_number}}
                                             </dd>
-                                        {{/each}}
-                                    </div>
+                                        </dl>
+                                    {{/each}}
+                                </div>
+                                <dl>
                                     <dt>{{t 'file_detail.title'}}</dt>
                                     <dd data-test-target-title>{{manager.target.title}}</dd>
                                     <dt>{{t 'file_detail.description'}}</dt>
@@ -200,7 +204,7 @@
                                         @shouldLinkUsers={{true}}
                                         @shouldTruncate={{false}}
                                     />
-                                    <dt>{{t 'file_detail.institutions'}}</dt>
+                                    <dt local-class='affiliated-institutions'>{{t 'file_detail.institutions'}}</dt>
                                     <div data-test-target-institutions>
                                         {{#each this.targetInstitutions as |institution|}}
                                             <dd>{{institution.name}}</dd>

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -67,7 +67,7 @@
                 </div>
             {{/if}}
             {{#if this.metadataOpened}}
-                <div local-class='right-container'>
+                <div local-class='right-container {{if this.isMobile 'Mobile'}}'>
                     <FileMetadataManager @file={{this.model.fileModel}} as |manager|>
                         <div local-class='metadata-title-edit-download'>
                             <h2 local-class='metadata-heading'>


### PR DESCRIPTION
-   Ticket: https://openscience.atlassian.net/browse/ENG-4186
-   Feature flag: feature/file-metadata-detail-styling

## Purpose

The purpose of these changes is to update the styling of the files detail metadata section for the File Metadata project.

## Summary of Changes

Changes include updating the form label <div> elements to the appropriate heading tag, updating the font weight and size, adding flex, and adding appropriate spacing between elements.

## Screenshot(s)

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/82047646/211689566-e0efb149-77cd-4145-a98a-52f8acde5ee5.png">
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/82047646/211689595-28337b47-ae3c-4bfe-8781-2430705d390c.png">
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/82047646/212129549-6a06d116-9512-4007-b64f-9a27284ce5e7.png">

## Side Effects

These changes affect the layout and sizing of the expandable panel on the right of the File Detail page. Alterations may result in text overflow, incorrect spacing for different size texts, and button formatting. Testing should include browser compatibility as well as mobile formatting.

## QA Notes

-Are the elements appropriately spaced?
-Are duplicate elements present?
-Do all buttons still work?
-Does the revision and download button align properly with the right buttons?
