### PR TITLE
Let subjects widget save

### DIFF
--- a/lib/osf-components/addon/components/node-metadata-form/template.hbs
+++ b/lib/osf-components/addon/components/node-metadata-form/template.hbs
@@ -195,7 +195,7 @@
         <Subjects::Manager
             @model={{@manager.node}}
             @provider={{@manager.node.provider}}
-            @doesAutosave={{false}}
+            @doesAutosave={{true}}
             as |subjectsManager|
         >
             <Subjects::Widget


### PR DESCRIPTION
-   Ticket :n/a
-   Feature flag: n/a

## Purpose

Allow the subjects widget to save, rather than just sitting there looking pretty.

## Summary of Changes

1. Enable autosave on subjects widget.

