### PR TITLE
[ENG-4261] License validation

### DIFF
--- a/app/packages/registration-schema/validations.ts
+++ b/app/packages/registration-schema/validations.ts
@@ -95,6 +95,19 @@ export function validateNodeLicense() {
         if (!validateLicenseTarget || validateLicenseTarget?.requiredFields?.length === 0) {
             return true;
         }
+
+        if (validateLicenseTarget.requiredFields?.includes('year')) {
+            const year = validateNodeLicenseTarget?.year;
+            const regex = /^((?!(0))[0-9]{4})$/;
+            if (year && !regex.test(year)) {
+                return {
+                    context: {
+                        type: 'year_format',
+                    },
+                };
+            }
+        }
+
         const missingFieldsList: Array<keyof NodeLicense> = [];
         for (const item of validateLicenseTarget.requiredFields) {
             if (!validateNodeLicenseTarget || !validateNodeLicenseTarget[item]) {

--- a/lib/app-components/addon/components/project-metadata/component.ts
+++ b/lib/app-components/addon/components/project-metadata/component.ts
@@ -14,7 +14,7 @@ import { layout, requiredAction } from 'ember-osf-web/decorators/component';
 import CollectionProviderModel from 'ember-osf-web/models/collection-provider';
 import LicenseModel from 'ember-osf-web/models/license';
 import Node from 'ember-osf-web/models/node';
-import { validateNodeLicense, validateNodeLicenseYear } from 'ember-osf-web/packages/registration-schema/validations';
+import { validateNodeLicense } from 'ember-osf-web/packages/registration-schema/validations';
 import Analytics from 'ember-osf-web/services/analytics';
 import buildChangeset from 'ember-osf-web/utils/build-changeset';
 import captureException from 'ember-osf-web/utils/capture-exception';
@@ -45,7 +45,6 @@ export default class ProjectMetadata extends Component {
         ],
         nodeLicense: [
             validateNodeLicense(),
-            validateNodeLicenseYear(),
         ],
     };
 

--- a/lib/app-components/addon/components/project-metadata/component.ts
+++ b/lib/app-components/addon/components/project-metadata/component.ts
@@ -81,8 +81,9 @@ export default class ProjectMetadata extends Component {
     validateCollectionLicense() {
         return async (_: unknown, newValue: LicenseModel, oldValue: Promise<LicenseModel>, changes: Partial<Node>) => {
             // if the license has not changed, use the old value to validate
+            // changes.license may exist even if the license has not changed
             let currentLicense = newValue;
-            if (!changes.license) {
+            if (!changes.license || !changes.license.id) {
                 currentLicense = await oldValue;
             }
             if (!currentLicense) {


### PR DESCRIPTION

-   Ticket: [ENG-4261]
-   Feature flag: n/a

## Purpose
- Address some issues discovered when validating collection submission licenses

## Summary of Changes
- Fixed an issue where Year validation errors were being shown, even when the license did not require a year
- Fixed an issue where a validation error for an unacceptable license was showing up when a user didn't change the license, but changed a different field in the Project Metadata section.
  - `changes.license` would be set to an empty object after changing other metadata fields, so checking to see if the `currentLicense` was acceptable by the provider would be false

## Screenshot(s)
- On `collections/providerId/submit`
![image](https://user-images.githubusercontent.com/51409893/212994760-8c1561ab-b898-481b-acea-8ccfc431859b.png)


## Side Effects
- Registration License validation should now also check the year format

## QA Notes
- Please check that the license validation works properly when submitting to a collection. Particulary when the license is already set to one that the provider doesn't accept, when it is changed to one that requires a year and copyright holder and when the year format is incorrect.