### PR TITLE
[ENG-4266] Add menuitem role to dropdown direct descendants

### DIFF
--- a/lib/osf-components/addon/components/osf-navbar/auth-dropdown/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/auth-dropdown/template.hbs
@@ -25,52 +25,48 @@
                     {{@headline}}
                 </ddm.item>
             {{/if}}
-            <ddm.item>
+            <li role='menuitem'>
                 <OsfLink
                     data-test-ad-my-profile
                     data-analytics-name='MyProfile'
                     @href={{this.profileURL}}
-                    role='menuitem'
                 >
                     <FaIcon @icon='user' class='fa-lg p-r-xs' />
                     {{t 'auth_dropdown.my_profile'}}
                 </OsfLink>
-            </ddm.item>
-            <ddm.item>
+            </li>
+            <li role='menuitem'>
                 <OsfLink
                     data-test-ad-support
                     data-analytics-name='Support'
                     @href={{this.supportURL}}
-                    role='menuitem'
                 >
                     <FaIcon @icon='life-ring' class='fa-lg p-r-xs' />
                     {{t 'auth_dropdown.osf_support'}}
                 </OsfLink>
-            </ddm.item>
-            <ddm.item>
+            </li>
+            <li role='menuitem'>
                 <OsfLink
                     data-test-ad-settings
                     data-analytics-name='Settings'
                     @href={{this.settingsURL}}
-                    role='menuitem'
                 >
                     <FaIcon @icon='cog' class='fa-lg p-r-xs' />
                     {{t 'general.settings'}}
                 </OsfLink>
-            </ddm.item>
-            <ddm.item>
+            </li>
+            <li role='menuitem'>
                 <BsButton
                     data-test-ad-logout
                     data-analytics-name='Logout'
                     class='logoutLink'
                     @type='link'
                     @onClick={{action this.currentUser.logout}}
-                    role='menuitem'
                 >
                     <FaIcon @icon='sign-out-alt' class='fa-lg p-r-xs' />
                     {{t 'auth_dropdown.log_out'}}
                 </BsButton>
-            </ddm.item>
+            </li>
         </dd.menu>
     </BsDropdown>
 {{else}}


### PR DESCRIPTION

-   Ticket: [ENG-4266]
-   Feature flag: n/a

## Purpose
- Address a11y issue in navbar's auth dropdown

## Summary of Changes
- Move `role='menuitem'` to direct descendant of `role='menu'`
  - Use vanilla `<li>` instead of `<DropdownMenu.item>` as `<ddm.item>` doesn't has splattributes


## Screenshot(s)
- check the `role`s of the `<ul>` and `<li>`s
![image](https://user-images.githubusercontent.com/51409893/213577963-2863d6bb-3b45-4a4e-be5b-fc1b4c2237c8.png)

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-4266]: https://openscience.atlassian.net/browse/ENG-4266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ