### PR TITLE
Guid metadata/misc updates

### DIFF
--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -128,6 +128,8 @@
                                                 @label={{t 'file_detail.language'}}
                                                 @onchange={{manager.changeLanguage}}
                                                 @valuePath='languageObject'
+                                                @searchField='name'
+                                                @searchEnabled=true
                                                 as |option|
                                             >
                                                 {{option.name}}
@@ -167,41 +169,45 @@
                                     <dd data-test-file-language>{{manager.languageFromCode}}</dd>
                                 </dl>
                                 <h2 local-class='node-type-heading'>{{t (concat 'file_detail.metadata_' manager.nodeWord)}}</h2>
-                                <div>
-                                    {{#each manager.targetMetadata.funders as |funder|}}
-                                        <dl>
-                                            <dt>{{t 'file_detail.funder'}}</dt>
-                                            <dd data-test-target-funder-name={{funder.funder_name}}>
-                                                {{funder.funder_name}}
-                                            </dd>
-                                            <dt>{{t 'file_detail.award_title'}}</dt>
-                                            <dd data-test-target-funder-award-title={{funder.funder_name}}>
-                                                {{funder.award_title}}
-                                            </dd>
-                                            <dt>{{t 'file_detail.award_uri'}}</dt>
-                                            <dd data-test-target-funder-award-uri={{funder.funder_name}}>
-                                                {{funder.award_uri}}
-                                            </dd>
-                                            <dt>{{t 'file_detail.award_number'}}</dt>
-                                            <dd data-test-target-funder-award-number={{funder.funder_name}}>
-                                                {{funder.award_number}}
-                                            </dd>
-                                        </dl>
-                                    {{/each}}
-                                </div>
+                                {{#unless manager.isAnonymous}}
+                                    <div>
+                                        {{#each manager.targetMetadata.funders as |funder|}}
+                                            <dl>
+                                                <dt>{{t 'file_detail.funder'}}</dt>
+                                                <dd data-test-target-funder-name={{funder.funder_name}}>
+                                                    {{funder.funder_name}}
+                                                </dd>
+                                                <dt>{{t 'file_detail.award_title'}}</dt>
+                                                <dd data-test-target-funder-award-title={{funder.funder_name}}>
+                                                    {{funder.award_title}}
+                                                </dd>
+                                                <dt>{{t 'file_detail.award_uri'}}</dt>
+                                                <dd data-test-target-funder-award-uri={{funder.funder_name}}>
+                                                    {{funder.award_uri}}
+                                                </dd>
+                                                <dt>{{t 'file_detail.award_number'}}</dt>
+                                                <dd data-test-target-funder-award-number={{funder.funder_name}}>
+                                                    {{funder.award_number}}
+                                                </dd>
+                                            </dl>
+                                        {{/each}}
+                                    </div>
+                                {{/unless}}
                                 <dl>
                                     <dt>{{t 'file_detail.title'}}</dt>
                                     <dd data-test-target-title>{{manager.target.title}}</dd>
                                     <dt>{{t 'file_detail.description'}}</dt>
                                     <dd data-test-target-description>{{manager.target.description}}</dd>
-                                    <dt>{{t 'file_detail.contributors'}}</dt>
-                                    <ContributorList
-                                        data-test-target-contributors
-                                        local-class='contributor-list'
-                                        @model={{manager.target}}
-                                        @shouldLinkUsers={{true}}
-                                        @shouldTruncate={{false}}
-                                    />
+                                    {{#unless manager.isAnonymous}}
+                                        <dt>{{t 'file_detail.contributors'}}</dt>
+                                        <ContributorList
+                                            data-test-target-contributors
+                                            local-class='contributor-list'
+                                            @model={{manager.target}}
+                                            @shouldLinkUsers={{true}}
+                                            @shouldTruncate={{false}}
+                                        />
+                                    {{/unless}}
                                     <dt local-class='affiliated-institutions'>{{t 'file_detail.institutions'}}</dt>
                                     <div data-test-target-institutions>
                                         {{#each this.targetInstitutions as |institution|}}
@@ -213,7 +219,7 @@
                                     <dt>{{t 'file_detail.resource_type_general'}}</dt>
                                     <dd data-test-target-resource-type>{{manager.targetMetadata.resourceTypeGeneral}}</dd>
                                     <dt>{{t 'file_detail.language'}}</dt>
-                                    <dd data-test-target-language>{{manager.targetMetadata.language}}</dd>
+                                    <dd data-test-target-language>{{manager.targetLanguageFromCode}}</dd>
                                 </dl>
                             {{/if}}
                         {{/if}}

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -207,13 +207,13 @@
                                             @shouldLinkUsers={{true}}
                                             @shouldTruncate={{false}}
                                         />
+                                        <dt local-class='affiliated-institutions'>{{t 'file_detail.institutions'}}</dt>
+                                        <div data-test-target-institutions>
+                                            {{#each this.targetInstitutions as |institution|}}
+                                                <dd>{{institution.name}}</dd>
+                                            {{/each}}
+                                        </div>
                                     {{/unless}}
-                                    <dt local-class='affiliated-institutions'>{{t 'file_detail.institutions'}}</dt>
-                                    <div data-test-target-institutions>
-                                        {{#each this.targetInstitutions as |institution|}}
-                                            <dd>{{institution.name}}</dd>
-                                        {{/each}}
-                                    </div>
                                     <dt>{{t 'file_detail.license'}}</dt>
                                     <dd data-test-target-license-name>{{manager.targetLicense.name}}</dd>
                                     <dt>{{t 'file_detail.resource_type_general'}}</dt>

--- a/app/guid-node/styles.scss
+++ b/app/guid-node/styles.scss
@@ -29,7 +29,6 @@
     position: relative;
     background: url('images/default-brand/bg-dark.jpg');
     background-size: cover;
-    display: block;
     align-items: center;
 
 

--- a/lib/osf-components/addon/components/file-metadata-manager/component.ts
+++ b/lib/osf-components/addon/components/file-metadata-manager/component.ts
@@ -47,6 +47,14 @@ export interface FileMetadataManager {
     isGatheringData: boolean;
 }
 
+export function languageFromLanguageCode(languageCode: string){
+    const language = languageCodes.find(item => item.code === languageCode);
+    if(language){
+        return language.name;
+    }
+    return '';
+}
+
 export default class FileMetadataManagerComponent extends Component<Args> {
     @service store!: Store;
     @service intl!: Intl;
@@ -90,23 +98,13 @@ export default class FileMetadataManagerComponent extends Component<Args> {
     }
 
     get languageFromCode(){
-        if (this.metadataRecord?.language){
-            const language = this.languageCodes.find(item => item.code === this.metadataRecord.language);
-            if(language){
-                return language.name;
-            }
-        }
-        return '';
+        const languageCode = this.metadataRecord?.language || '';
+        return languageFromLanguageCode(languageCode);
     }
 
     get targetLanguageFromCode(){
-        if (this.targetMetadata?.language){
-            const language = this.languageCodes.find(item => item.code === this.targetMetadata.language);
-            if(language){
-                return language.name;
-            }
-        }
-        return '';
+        const languageCode = this.targetMetadata?.language || '';
+        return languageFromLanguageCode(languageCode);
     }
 
     @task

--- a/lib/osf-components/addon/components/file-metadata-manager/component.ts
+++ b/lib/osf-components/addon/components/file-metadata-manager/component.ts
@@ -71,6 +71,7 @@ export default class FileMetadataManagerComponent extends Component<Args> {
     isGatheringData!: boolean;
     @alias('changeset.isDirty') isDirty!: boolean;
     @alias('save.isRunning') isSaving!: boolean;
+    @alias('file.apiMeta.isAnonymous') isAnonymous!: boolean;
 
     constructor(owner: unknown, args: Args) {
         super(owner, args);
@@ -90,6 +91,16 @@ export default class FileMetadataManagerComponent extends Component<Args> {
     get languageFromCode(){
         if (this.metadataRecord?.language){
             const language = this.languageCodes.find(item => item.code === this.metadataRecord.language);
+            if(language){
+                return language.name;
+            }
+        }
+        return '';
+    }
+
+    get targetLanguageFromCode(){
+        if (this.targetMetadata?.language){
+            const language = this.languageCodes.find(item => item.code === this.targetMetadata.language);
             if(language){
                 return language.name;
             }

--- a/lib/osf-components/addon/components/file-metadata-manager/component.ts
+++ b/lib/osf-components/addon/components/file-metadata-manager/component.ts
@@ -56,6 +56,7 @@ export default class FileMetadataManagerComponent extends Component<Args> {
     @tracked targetMetadata!: CustomItemMetadataRecordModel;
     file: FileModel = this.args.file;
     @tracked target!: (NodeModel | RegistrationModel);
+    @tracked targetParent!: (NodeModel | RegistrationModel);
     @tracked targetInstitutions!: InstitutionModel[];
     @tracked targetLicense!: LicenseModel;
     @tracked changeset!: BufferedChangeset;
@@ -112,6 +113,7 @@ export default class FileMetadataManagerComponent extends Component<Args> {
     @waitFor
     async getTarget() {
         this.target = await this.file.target as NodeModel;
+        this.targetParent = await this.target.get('parent');
         this.targetLicense = await this.target.license;
         this.targetInstitutions = await this.target.affiliatedInstitutions as InstitutionModel[];
         this.userCanEdit = this.target.currentUserPermissions.includes(Permission.Write);
@@ -190,7 +192,7 @@ export default class FileMetadataManagerComponent extends Component<Args> {
             if (this.target.isRegistration) {
                 return 'registration';
             }
-            if (this.target.parent.id) {
+            if (this.targetParent) {
                 return 'component';
             }
         }

--- a/lib/osf-components/addon/components/file-metadata-manager/template.hbs
+++ b/lib/osf-components/addon/components/file-metadata-manager/template.hbs
@@ -5,6 +5,7 @@
     edit=(action this.edit)
     file=this.file
     inEditMode=this.inEditMode
+    isAnonymous=this.isAnonymous
     isDirty=this.isDirty
     isGatheringData=this.isGatheringData
     isSaving=this.isSaving
@@ -16,6 +17,7 @@
     save=(perform this.save)
     target=this.target
     targetInstitutions=this.targetInstitutions
+    targetLanguageFromCode=this.targetLanguageFromCode
     targetLicense=this.targetLicense
     targetMetadata=this.targetMetadata
     userCanEdit=this.userCanEdit

--- a/lib/osf-components/addon/components/node-metadata-form/template.hbs
+++ b/lib/osf-components/addon/components/node-metadata-form/template.hbs
@@ -89,6 +89,8 @@
             @label={{t 'osf-components.node-metadata-form.resource-language'}}
             @onchange={{@manager.changeLanguage}}
             @valuePath='languageObject'
+            @searchField='name'
+            @searchEnabled=true
             as |option|
         >
             {{option.name}}

--- a/lib/osf-components/addon/components/node-metadata-manager/component.ts
+++ b/lib/osf-components/addon/components/node-metadata-manager/component.ts
@@ -20,6 +20,8 @@ import { languageCodes, LanguageCode } from 'ember-osf-web/utils/languages';
 import buildChangeset from 'ember-osf-web/utils/build-changeset';
 import { tracked } from '@glimmer/tracking';
 
+import { languageFromLanguageCode } from 'osf-components/components/file-metadata-manager/component';
+
 interface Args {
     node: (AbstractNodeModel);
 }
@@ -107,13 +109,8 @@ export default class NodeMetadataManagerComponent extends Component<Args> {
     }
 
     get languageFromCode(){
-        if (this.metadata?.language){
-            const language = this.languageCodes.find(item => item.code === this.metadata.language);
-            if(language){
-                return language.name;
-            }
-        }
-        return '';
+        const languageCode = this.metadata?.language || '';
+        return languageFromLanguageCode(languageCode);
     }
 
     @action

--- a/mirage/scenarios/dashboard.ts
+++ b/mirage/scenarios/dashboard.ts
@@ -15,6 +15,8 @@ export function dashboardScenario(server: Server, currentUser: ModelInstance<Use
     server.create('user-setting', { user: currentUser });
     const firstNode = server.create('node', 'withAffiliatedInstitutions');
     server.create('contributor', { node: firstNode, users: currentUser, index: 0 });
+    const component = server.create('node', {id: 'cmpnt', parent: firstNode}, 'withFiles', 'withStorage');
+    server.create('contributor', { node: component, users: currentUser, index: 0, permission: Permission.Admin });
     const nodes = server.createList('node', 10, {
         currentUserPermissions: Object.values(Permission),
     }, 'withContributors');

--- a/tests/acceptance/guid-node/metadata-test.ts
+++ b/tests/acceptance/guid-node/metadata-test.ts
@@ -5,19 +5,11 @@ import { selectChoose } from 'ember-power-select/test-support';
 import { module, test } from 'qunit';
 
 import { click, currentURL, setupOSFApplicationTest, visit } from 'ember-osf-web/tests/helpers';
-import { languageCodes } from 'ember-osf-web/utils/languages';
 import { TestContext } from 'ember-test-helpers';
 import { Permission } from 'ember-osf-web/models/osf-model';
 import fillIn from '@ember/test-helpers/dom/fill-in';
 
-
-function languageFromCode(languageCode: string){
-    const language = languageCodes.find(item => item.code === languageCode);
-    if(language){
-        return language.name;
-    }
-    return '';
-}
+import { languageFromLanguageCode } from 'osf-components/components/file-metadata-manager/component';
 
 module('Acceptance | guid-node/metadata', hooks => {
     setupOSFApplicationTest(hooks);
@@ -36,7 +28,7 @@ module('Acceptance | guid-node/metadata', hooks => {
         assert.equal(currentURL(), url, `We are on ${url}`);
         assert.equal(currentRouteName(), 'guid-node.metadata', 'We are at guid-node.metadata');
         assert.dom('[data-test-display-resource-language]')
-            .containsText(languageFromCode(metadataRecord.language), 'Language is correct');
+            .containsText(languageFromLanguageCode(metadataRecord.language), 'Language is correct');
         assert.dom('[data-test-display-resource-type-general]')
             .containsText(metadataRecord.resourceTypeGeneral, 'Resource type is correct');
         assert.dom('[data-test-display-node-description]')
@@ -77,7 +69,7 @@ module('Acceptance | guid-node/metadata', hooks => {
         assert.equal(currentURL(), url, `We are on ${url}`);
         assert.equal(currentRouteName(), 'guid-node.metadata', 'We are at guid-node.metadata');
         assert.dom('[data-test-display-resource-language]')
-            .containsText(languageFromCode(metadataRecord.language), 'Language is correct');
+            .containsText(languageFromLanguageCode(metadataRecord.language), 'Language is correct');
         assert.dom('[data-test-display-resource-type-general]')
             .containsText(metadataRecord.resourceTypeGeneral, 'Resource type is correct');
         assert.dom('[data-test-display-node-description]')
@@ -114,7 +106,7 @@ module('Acceptance | guid-node/metadata', hooks => {
         assert.equal(currentURL(), url, `We are on ${url}`);
         assert.equal(currentRouteName(), 'guid-node.metadata', 'We are at guid-node.metadata');
         assert.dom('[data-test-display-resource-language]')
-            .containsText(languageFromCode(metadataRecord.language), 'Language is correct');
+            .containsText(languageFromLanguageCode(metadataRecord.language), 'Language is correct');
         assert.dom('[data-test-display-resource-type-general]')
             .containsText(metadataRecord.resourceTypeGeneral, 'Resource type is correct');
         assert.dom('[data-test-display-node-description]')
@@ -152,7 +144,7 @@ module('Acceptance | guid-node/metadata', hooks => {
         await selectChoose('[data-test-select-resource-language]', 'Esperanto');
         await click('[data-test-cancel-editing-resource-metadata-button]');
         assert.dom('[data-test-display-resource-language]')
-            .containsText(languageFromCode(metadataLanguageOriginal), 'Language is unchanged');
+            .containsText(languageFromLanguageCode(metadataLanguageOriginal), 'Language is unchanged');
         assert.dom('[data-test-display-resource-type-general]')
             .containsText(metadataResourceTypeOriginal, 'Resource type is unchanged');
         await click('[data-test-edit-resource-metadata-button]');


### PR DESCRIPTION
## Purpose

Fix and improve a few small things.

## Summary of Changes

1. Add search to power select for languages on files and nodes
2. Show the language name on the files node metadata section
3. Remove duplicate 'display' property on CSS for node hero
4. Properly detect if a node is a component or not
5. Hide appropriate info on file display for AVOLs
6. Add a component to the default mirage scenario for the dashboard

## Screenshot(s)

<img width="1670" alt="Screenshot 2023-01-20 at 9 43 51 AM" src="https://user-images.githubusercontent.com/6599111/213726642-e0989b0d-6c24-4b87-b543-4562b43b597e.png">
<img width="1568" alt="Screenshot 2023-01-20 at 9 44 01 AM" src="https://user-images.githubusercontent.com/6599111/213726645-be694a68-7bdc-487c-99fa-f18074ebefaa.png">


## Side Effects

The node title is centered in the hero now like it is on registries rather than being pulled to the left.

## QA Notes

Language selection should be easier now. If you're on a file that's on a component of a project, it should say that the node's metadata is "Component metadata" rather than "Project metadata" or "Registration metadata".