### PR TITLE
Guid-Metadata / Hide download button in AVOL

### DIFF
--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -86,13 +86,15 @@
                                             <FaIcon @icon='pencil-alt' />
                                         </Button>
                                     {{/if}}
-                                    <OsfLink
-                                        data-test-download-button
-                                        aria-label={{t 'general.download'}}
-                                        @href='#'
-                                    >
-                                        <FaIcon @icon='download' />
-                                    </OsfLink>
+                                    {{#unless manager.isAnonymous}}
+                                        <OsfLink
+                                            data-test-download-button
+                                            aria-label={{t 'general.download'}}
+                                            @href='#'
+                                        >
+                                            <FaIcon @icon='download' />
+                                        </OsfLink>
+                                    {{/unless}}
                                 {{/unless}}
                             </div>
                         </div>


### PR DESCRIPTION
## Purpose

Certain fields of the metadata shouldn't be accessible while viewing with an AVOL. Rather than complicating server-side logic, let's hide the download button if viewing through an AVOL.

## Summary of Changes

1. Hide download button for AVOLs

