### PR TITLE
Guid-Metadata / Unconstrain metadata container

### DIFF
--- a/lib/osf-components/addon/components/node-metadata-form/styles.scss
+++ b/lib/osf-components/addon/components/node-metadata-form/styles.scss
@@ -1,6 +1,5 @@
 .container {
     background-color: $color-bg-white;
-    display: inline-flex;
     flex-direction: column;
 
     svg {


### PR DESCRIPTION
## Purpose

On staging, not local (or maybe on Safari, not Chrome), the metadata container was being constrained to be smaller than it needed to be. This corrects that problem.

## Summary of Changes

1. Remove what seemed to be an unnecessary display directive

## Screenshot(s)

Before:

<img width="1164" alt="Screenshot 2023-01-23 at 11 17 25 AM" src="https://user-images.githubusercontent.com/6599111/214092620-8fd56a92-9801-406a-a2f4-f17dfd6a4fc5.png">


After:
<img width="1165" alt="Screenshot 2023-01-23 at 11 17 34 AM" src="https://user-images.githubusercontent.com/6599111/214092645-c229a985-ee11-4a82-8646-af05de29adce.png">
