### PR TITLE
Guid metadata/re-add search language for nodes

### DIFF
--- a/lib/osf-components/addon/components/node-metadata-form/template.hbs
+++ b/lib/osf-components/addon/components/node-metadata-form/template.hbs
@@ -100,6 +100,8 @@
                     @label={{t 'osf-components.node-metadata-form.resource-language'}}
                     @onchange={{@manager.changeLanguage}}
                     @valuePath='languageObject'
+                    @searchField='name'
+                    @searchEnabled=true
                     as |option|
                 >
                     {{option.name}}


### PR DESCRIPTION
## Purpose

Searching for a language on the node metadata form's resources section was lost during a merge conflict resolution. This returns it. 

## Summary of Changes

1. Make the ember-power-select widget search again.

## Screenshot(s)
<img width="610" alt="Screenshot 2023-01-23 at 1 37 57 PM" src="https://user-images.githubusercontent.com/6599111/214122039-e8c0681d-6e65-47c5-a6fc-eb6977c3f483.png">
