### PR TITLE
Guid-Metadata / Use proper property for anonymous views

### DIFF
--- a/lib/osf-components/addon/components/file-metadata-manager/component.ts
+++ b/lib/osf-components/addon/components/file-metadata-manager/component.ts
@@ -80,7 +80,7 @@ export default class FileMetadataManagerComponent extends Component<Args> {
     isGatheringData!: boolean;
     @alias('changeset.isDirty') isDirty!: boolean;
     @alias('save.isRunning') isSaving!: boolean;
-    @alias('file.apiMeta.isAnonymous') isAnonymous!: boolean;
+    @alias('file.apiMeta.anonymous') isAnonymous!: boolean;
 
     constructor(owner: unknown, args: Args) {
         super(owner, args);


### PR DESCRIPTION
## Purpose

Make AVOLs behave on file detail page

## Summary of Changes

1. Use `apiMeta.anonymous`, which should exist, instead of `apiMeta.isAnonymous`, which doesn't