### PR TITLE
Guid-Metadata / Add metadata download link to file detail page

### DIFF
--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -90,7 +90,8 @@
                                         <OsfLink
                                             data-test-download-button
                                             aria-label={{t 'general.download'}}
-                                            @href='#'
+                                            @href={{manager.metadataDownloadUrl}}
+                                            @target='_blank'
                                         >
                                             <FaIcon @icon='download' />
                                         </OsfLink>

--- a/lib/osf-components/addon/components/file-metadata-manager/template.hbs
+++ b/lib/osf-components/addon/components/file-metadata-manager/template.hbs
@@ -11,6 +11,7 @@
     isSaving=this.isSaving
     languageCodes=this.languageCodes
     languageFromCode=this.languageFromCode
+    metadataDownloadUrl=this.metadataDownloadUrl
     metadataRecord=this.metadataRecord
     nodeWord=this.nodeWord
     resourceTypeGeneralOptions=this.resourceTypeGeneralOptions


### PR DESCRIPTION
## Purpose

In anticipation of the backend having download capabilities for metadata, add the download link to the download button on the files page.

## Summary of Changes

1. Create a link builder
2. Add link getter to manager
3. Add link to download button

## QA Notes

Make sure this works properly with non-anonymous VOLs on a private project.