### PR TITLE
Guid metadata/file a11y fixes 1

### DIFF
--- a/app/guid-file/styles.scss
+++ b/app/guid-file/styles.scss
@@ -94,6 +94,16 @@
         line-height: 1.1;
         margin-bottom: 20px;
     }
+
+    dl {
+        margin-bottom: 0;
+    }
+
+    h3 {
+        font-size: 17px;
+        font-weight: 600;
+        margin-top: 10px;
+    }
 }
 
 .metadata-heading {

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -121,6 +121,7 @@
                                                 @options={{manager.resourceTypeGeneralOptions}}
                                                 @label={{t 'file_detail.resource_type_general'}}
                                                 @valuePath='resourceTypeGeneral'
+                                                @placeholder={{t 'file_detail.choose_resource_type_general'}}
                                                 as |option|
                                             >
                                                 {{option}}
@@ -132,7 +133,8 @@
                                                 @onchange={{manager.changeLanguage}}
                                                 @valuePath='languageObject'
                                                 @searchField='name'
-                                                @searchEnabled=true
+                                                @searchEnabled={{true}}
+                                                @searchPlaceholder={{t 'file_detail.choose_language'}}
                                                 as |option|
                                             >
                                                 {{option.name}}
@@ -161,69 +163,111 @@
                                     </div>
                                 </div>
                             {{else}}
-                                <dl>
-                                    <dt>{{t 'file_detail.title'}}</dt>
-                                    <dd data-test-file-title>{{manager.metadataRecord.title}}</dd>
-                                    <dt>{{t 'file_detail.description'}}</dt>
-                                    <dd data-test-file-description>{{manager.metadataRecord.description}}</dd>
-                                    <dt>{{t 'file_detail.resource_type_general'}}</dt>
-                                    <dd data-test-file-resource-type>{{manager.metadataRecord.resourceTypeGeneral}}</dd>
-                                    <dt>{{t 'file_detail.language'}}</dt>
-                                    <dd data-test-file-language>{{manager.languageFromCode}}</dd>
-                                </dl>
+                                {{#if (or
+                                    manager.metadataRecord.title
+                                    manager.metadataRecord.description
+                                    manager.metadataRecord.resourceTypeGeneral
+                                    manager.languageFromCode
+                                )}}
+                                    <dl>
+                                        {{#if manager.metadataRecord.title}}
+                                            <dt>{{t 'file_detail.title'}}</dt>
+                                            <dd data-test-file-title>{{manager.metadataRecord.title}}</dd>
+                                        {{/if}}
+                                        {{#if manager.metadataRecord.description}}
+                                            <dt>{{t 'file_detail.description'}}</dt>
+                                            <dd data-test-file-description>{{manager.metadataRecord.description}}</dd>
+                                        {{/if}}
+                                        {{#if manager.metadataRecord.resourceTypeGeneral}}
+                                            <dt>{{t 'file_detail.resource_type_general'}}</dt>
+                                            <dd data-test-file-resource-type>{{manager.metadataRecord.resourceTypeGeneral}}</dd>
+                                        {{/if}}
+                                        {{#if manager.languageFromCode}}
+                                            <dt>{{t 'file_detail.language'}}</dt>
+                                            <dd data-test-file-language>{{manager.languageFromCode}}</dd>
+                                        {{/if}}
+                                    </dl>
+                                {{else}}
+                                    {{t 'file_detail.enter_metadata'}}
+                                {{/if}}
                                 <h2 local-class='node-type-heading'>{{t (concat 'file_detail.metadata_' manager.nodeWord)}}</h2>
                                 {{#unless manager.isAnonymous}}
                                     <div>
                                         {{#each manager.targetMetadata.funders as |funder|}}
-                                            <dl>
-                                                <dt>{{t 'file_detail.funder'}}</dt>
-                                                <dd data-test-target-funder-name={{funder.funder_name}}>
-                                                    {{funder.funder_name}}
-                                                </dd>
-                                                <dt>{{t 'file_detail.award_title'}}</dt>
-                                                <dd data-test-target-funder-award-title={{funder.funder_name}}>
-                                                    {{funder.award_title}}
-                                                </dd>
-                                                <dt>{{t 'file_detail.award_uri'}}</dt>
-                                                <dd data-test-target-funder-award-uri={{funder.funder_name}}>
-                                                    {{funder.award_uri}}
-                                                </dd>
-                                                <dt>{{t 'file_detail.award_number'}}</dt>
-                                                <dd data-test-target-funder-award-number={{funder.funder_name}}>
-                                                    {{funder.award_number}}
-                                                </dd>
-                                            </dl>
+                                            {{#if (or 
+                                                funder.funder_name
+                                                funder.award_title
+                                                funder.award_uri
+                                                funder.award_number
+                                            )}}
+                                                <dl>
+                                                    {{#if funder.funder_name}}
+                                                        <dt>{{t 'file_detail.funder'}}</dt>
+                                                        <dd data-test-target-funder-name={{funder.funder_name}}>
+                                                            {{funder.funder_name}}
+                                                        </dd>
+                                                    {{/if}}
+                                                    {{#if funder.award_title}}
+                                                        <dt>{{t 'file_detail.award_title'}}</dt>
+                                                        <dd data-test-target-funder-award-title={{funder.funder_name}}>
+                                                            {{funder.award_title}}
+                                                        </dd>
+                                                    {{/if}}
+                                                    {{#if funder.award_uri}}
+                                                        <dt>{{t 'file_detail.award_uri'}}</dt>
+                                                        <dd data-test-target-funder-award-uri={{funder.funder_name}}>
+                                                            {{funder.award_uri}}
+                                                        </dd>
+                                                    {{/if}}
+                                                    {{#if funder.award_number}}
+                                                        <dt>{{t 'file_detail.award_number'}}</dt>
+                                                        <dd data-test-target-funder-award-number={{funder.funder_name}}>
+                                                            {{funder.award_number}}
+                                                        </dd>
+                                                    {{/if}}
+                                                </dl>
+                                            {{/if}}
                                         {{/each}}
                                     </div>
                                 {{/unless}}
                                 <dl>
                                     <dt>{{t 'file_detail.title'}}</dt>
                                     <dd data-test-target-title>{{manager.target.title}}</dd>
-                                    <dt>{{t 'file_detail.description'}}</dt>
-                                    <dd data-test-target-description>{{manager.target.description}}</dd>
-                                    {{#unless manager.isAnonymous}}
-                                        <dt>{{t 'file_detail.contributors'}}</dt>
-                                        <ContributorList
-                                            data-test-target-contributors
-                                            local-class='contributor-list'
-                                            @model={{manager.target}}
-                                            @shouldLinkUsers={{true}}
-                                            @shouldTruncate={{false}}
-                                        />
+                                    {{#if manager.target.description}}
+                                        <dt>{{t 'file_detail.description'}}</dt>
+                                        <dd data-test-target-description>{{manager.target.description}}</dd>
+                                    {{/if}}
+                                    {{#if (and this.targetInstitutions (not manager.isAnonymous))}}
                                         <dt local-class='affiliated-institutions'>{{t 'file_detail.institutions'}}</dt>
                                         <div data-test-target-institutions>
                                             {{#each this.targetInstitutions as |institution|}}
                                                 <dd>{{institution.name}}</dd>
                                             {{/each}}
                                         </div>
-                                    {{/unless}}
-                                    <dt>{{t 'file_detail.license'}}</dt>
-                                    <dd data-test-target-license-name>{{manager.targetLicense.name}}</dd>
-                                    <dt>{{t 'file_detail.resource_type_general'}}</dt>
-                                    <dd data-test-target-resource-type>{{manager.targetMetadata.resourceTypeGeneral}}</dd>
-                                    <dt>{{t 'file_detail.language'}}</dt>
-                                    <dd data-test-target-language>{{manager.targetLanguageFromCode}}</dd>
+                                    {{/if}}
+                                    {{#if manager.targetLicense.name}}
+                                        <dt>{{t 'file_detail.license'}}</dt>
+                                        <dd data-test-target-license-name>{{manager.targetLicense.name}}</dd>
+                                    {{/if}}
+                                    {{#if manager.targetMetadata.resourceTypeGeneral}}
+                                        <dt>{{t 'file_detail.resource_type_general'}}</dt>
+                                        <dd data-test-target-resource-type>{{manager.targetMetadata.resourceTypeGeneral}}</dd>
+                                    {{/if}}
+                                    {{#if manager.targetLanguageFromCode}}
+                                        <dt>{{t 'file_detail.language'}}</dt>
+                                        <dd data-test-target-language>{{manager.targetLanguageFromCode}}</dd>
+                                    {{/if}}
                                 </dl>
+                                {{#unless manager.isAnonymous}}
+                                    <h3>{{t 'file_detail.contributors'}}</h3>
+                                    <ContributorList
+                                        data-test-target-contributors
+                                        local-class='contributor-list'
+                                        @model={{manager.target}}
+                                        @shouldLinkUsers={{true}}
+                                        @shouldTruncate={{false}}
+                                    />
+                                {{/unless}}
                             {{/if}}
                         {{/if}}
                     </FileMetadataManager>

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -134,7 +134,7 @@
                                                 @valuePath='languageObject'
                                                 @searchField='name'
                                                 @searchEnabled={{true}}
-                                                @searchPlaceholder={{t 'file_detail.choose_language'}}
+                                                @placeholder={{t 'file_detail.choose_language'}}
                                                 as |option|
                                             >
                                                 {{option.name}}
@@ -188,7 +188,9 @@
                                         {{/if}}
                                     </dl>
                                 {{else}}
-                                    {{t 'file_detail.enter_metadata'}}
+                                    {{#if manager.userCanEdit}}
+                                        {{t 'file_detail.enter_metadata'}}
+                                    {{/if}}
                                 {{/if}}
                                 <h2 local-class='node-type-heading'>{{t (concat 'file_detail.metadata_' manager.nodeWord)}}</h2>
                                 {{#unless manager.isAnonymous}}

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -196,39 +196,32 @@
                                 {{#unless manager.isAnonymous}}
                                     <div>
                                         {{#each manager.targetMetadata.funders as |funder|}}
-                                            {{#if (or 
-                                                funder.funder_name
-                                                funder.award_title
-                                                funder.award_uri
-                                                funder.award_number
-                                            )}}
-                                                <dl>
-                                                    {{#if funder.funder_name}}
-                                                        <dt>{{t 'file_detail.funder'}}</dt>
-                                                        <dd data-test-target-funder-name={{funder.funder_name}}>
-                                                            {{funder.funder_name}}
-                                                        </dd>
-                                                    {{/if}}
-                                                    {{#if funder.award_title}}
-                                                        <dt>{{t 'file_detail.award_title'}}</dt>
-                                                        <dd data-test-target-funder-award-title={{funder.funder_name}}>
-                                                            {{funder.award_title}}
-                                                        </dd>
-                                                    {{/if}}
-                                                    {{#if funder.award_uri}}
-                                                        <dt>{{t 'file_detail.award_uri'}}</dt>
-                                                        <dd data-test-target-funder-award-uri={{funder.funder_name}}>
-                                                            {{funder.award_uri}}
-                                                        </dd>
-                                                    {{/if}}
-                                                    {{#if funder.award_number}}
-                                                        <dt>{{t 'file_detail.award_number'}}</dt>
-                                                        <dd data-test-target-funder-award-number={{funder.funder_name}}>
-                                                            {{funder.award_number}}
-                                                        </dd>
-                                                    {{/if}}
-                                                </dl>
-                                            {{/if}}
+                                            <dl>
+                                                {{#if funder.funder_name}}
+                                                    <dt>{{t 'file_detail.funder'}}</dt>
+                                                    <dd data-test-target-funder-name={{funder.funder_name}}>
+                                                        {{funder.funder_name}}
+                                                    </dd>
+                                                {{/if}}
+                                                {{#if funder.award_title}}
+                                                    <dt>{{t 'file_detail.award_title'}}</dt>
+                                                    <dd data-test-target-funder-award-title={{funder.funder_name}}>
+                                                        {{funder.award_title}}
+                                                    </dd>
+                                                {{/if}}
+                                                {{#if funder.award_uri}}
+                                                    <dt>{{t 'file_detail.award_uri'}}</dt>
+                                                    <dd data-test-target-funder-award-uri={{funder.funder_name}}>
+                                                        {{funder.award_uri}}
+                                                    </dd>
+                                                {{/if}}
+                                                {{#if funder.award_number}}
+                                                    <dt>{{t 'file_detail.award_number'}}</dt>
+                                                    <dd data-test-target-funder-award-number={{funder.funder_name}}>
+                                                        {{funder.award_number}}
+                                                    </dd>
+                                                {{/if}}
+                                            </dl>
                                         {{/each}}
                                     </div>
                                 {{/unless}}

--- a/lib/osf-components/addon/components/file-metadata-manager/component.ts
+++ b/lib/osf-components/addon/components/file-metadata-manager/component.ts
@@ -48,7 +48,6 @@ export interface FileMetadataManager {
     isDirty: boolean;
     isGatheringData: boolean;
     metadataDownloadUrl: string;
-    selectedLanguage: string;
 }
 
 export function languageFromLanguageCode(languageCode: string){

--- a/lib/osf-components/addon/components/file-metadata-manager/component.ts
+++ b/lib/osf-components/addon/components/file-metadata-manager/component.ts
@@ -48,6 +48,7 @@ export interface FileMetadataManager {
     isDirty: boolean;
     isGatheringData: boolean;
     metadataDownloadUrl: string;
+    selectedLanguage: string;
 }
 
 export function languageFromLanguageCode(languageCode: string){

--- a/lib/osf-components/addon/components/node-metadata-form/template.hbs
+++ b/lib/osf-components/addon/components/node-metadata-form/template.hbs
@@ -101,7 +101,7 @@
                     @onchange={{@manager.changeLanguage}}
                     @valuePath='languageObject'
                     @searchField='name'
-                    @searchEnabled=true
+                    @searchEnabled={{true}}
                     as |option|
                 >
                     {{option.name}}

--- a/mirage/scenarios/dashboard.ts
+++ b/mirage/scenarios/dashboard.ts
@@ -45,11 +45,17 @@ export function dashboardScenario(server: Server, currentUser: ModelInstance<Use
         server.create('contributor', { node, users: currentUser, index: 11 });
     }
 
-    server.create('node', {
+    const filesNode = server.create('node', {
         id: 'file5',
         title: 'With some files',
         currentUserPermissions: [Permission.Read, Permission.Write],
-    }, 'withFiles', 'withStorage');
+    }, 'withFiles', 'withStorage', 'withContributors');
+    server.create('contributor', {
+        node: filesNode,
+        users: currentUser,
+        permission: Permission.Write,
+        index: 0,
+    });
 
     // NOTE: Some institutions are already created by this point
     server.createList('institution', 20);

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -143,7 +143,9 @@ file_detail:
     title: 'Title'
     description: 'Description'
     resource_type_general: 'Resource type'
+    choose_resource_type_general: 'Choose a resource type'
     language: 'Resource language'
+    choose_language: 'Choose a language'
     funder: 'Funder'
     award_title: 'Award title'
     award_uri: 'Award URI'
@@ -153,6 +155,7 @@ file_detail:
     contributors: 'Contributors'
     osf_map: 'OSF-MAP'
     schema: 'Schema'
+    enter_metadata: 'Press the edit button to add metadata to this file.'
 dashboard:
     page_title: Home
     title: Dashboard


### PR DESCRIPTION
## Purpose

Fix some a11y problems and some potential a11y problems. Note: There was a weird merge conflict, so hopefully I put everything back right? The diff isn't looking exactly right though, so I'm a bit concerned.

## Summary of Changes

1. Move contributors outside of data-list and make the h3 heading match the dt styling
2. Put placeholders on the power selects (note: this will only affect the resource type widget until we upgrade ember power select)
3. Hide fields in a data list unless they will be filled out with information to prevent having a dt without a dd
4. Add in mirage contributors to the file5 node for better testing


## Screenshot(s)

No metadata, write access:

<img width="506" alt="Screenshot 2023-01-25 at 11 30 57 AM" src="https://user-images.githubusercontent.com/6599111/214680895-2a64099c-d0a3-4a12-a25f-eb432c0da352.png">

No metadata, no write access:

<img width="605" alt="Screenshot 2023-01-25 at 2 01 10 PM" src="https://user-images.githubusercontent.com/6599111/214680792-25e1b999-f660-4a65-82b3-0098c56aa6e0.png">

Some metadata:

<img width="373" alt="Screenshot 2023-01-25 at 2 01 20 PM" src="https://user-images.githubusercontent.com/6599111/214680852-45aac68a-841c-4c99-aa02-933febbaafb1.png">

New contributors placement:
<img width="354" alt="Screenshot 2023-01-25 at 2 14 48 PM" src="https://user-images.githubusercontent.com/6599111/214680982-8b764c76-f125-4609-8412-12226f8898b2.png">


## QA Notes

I didn't do anything to explicitly fix the contributor contrast, but I wasn't getting the error in my local setup after these changes, so if it shows up still on staging2 we'll have to re-visit. This also won't fix the Language chooser's problems as noted above. That will have to wait until post-release.