### PR TITLE
Guid metadata/node a11y fixes

### DIFF
--- a/lib/osf-components/addon/components/funding-metadata/template.hbs
+++ b/lib/osf-components/addon/components/funding-metadata/template.hbs
@@ -60,7 +60,7 @@
                 @type='destroy'
                 {{on 'click' (fn this.delete item)}}
             >
-                {{t 'general.delete'}}
+                {{t 'osf-components.funding-metadata.delete'}}
             </Button>
         {{/each}}
         <Button

--- a/lib/osf-components/addon/components/node-metadata-form/styles.scss
+++ b/lib/osf-components/addon/components/node-metadata-form/styles.scss
@@ -45,6 +45,13 @@
             margin: 14px 0;
         }
     }
+    
+    .metadata-header {
+        align-items: flex-end;
+        display: flex;
+        font-weight: 700;
+        margin: 14px 0;
+    }
 }
 
 .edit-metadata-description {

--- a/lib/osf-components/addon/components/node-metadata-form/styles.scss
+++ b/lib/osf-components/addon/components/node-metadata-form/styles.scss
@@ -36,6 +36,15 @@
         font-size: 30px;
         color: $color-text-gray-blue;
     }
+
+    div {
+        .metadata-header {
+            align-items: flex-end;
+            display: flex;
+            font-weight: 700;
+            margin: 14px 0;
+        }
+    }
 }
 
 .edit-metadata-description {

--- a/lib/osf-components/addon/components/node-metadata-form/styles.scss
+++ b/lib/osf-components/addon/components/node-metadata-form/styles.scss
@@ -39,18 +39,14 @@
 
     div {
         .metadata-header {
-            align-items: flex-end;
-            display: flex;
-            font-weight: 700;
             margin: 14px 0;
         }
     }
-    
+
     .metadata-header {
         align-items: flex-end;
         display: flex;
         font-weight: 700;
-        margin: 14px 0;
     }
 }
 

--- a/lib/osf-components/addon/components/node-metadata-form/template.hbs
+++ b/lib/osf-components/addon/components/node-metadata-form/template.hbs
@@ -90,6 +90,7 @@
                     local-class='resource-select'
                     @options={{@manager.resourceTypeGeneralOptions}}
                     @valuePath='resourceTypeGeneral'
+                    @placeholder={{t 'osf-components.node-metadata-form.choose-resource-type-general'}}
                     as |option|
                 >
                     {{option}}
@@ -102,6 +103,7 @@
                     @valuePath='languageObject'
                     @searchField='name'
                     @searchEnabled={{true}}
+                    @placeholder={{t 'osf-components.node-metadata-form.choose-language'}}
                     as |option|
                 >
                     {{option.name}}
@@ -151,6 +153,9 @@
         {{/if}}
         {{#unless @manager.node.isAnonymous}}
             {{#if @manager.isEditingFunding}}
+                <div local-class='metadata-header'>
+                    {{t 'osf-components.node-metadata-form.funding-information'}}
+                </div>
                 <FundingMetadata @changeset={{@manager.changeset}} as |funding|>
                     <Button
                         data-test-cancel-editing-funding-metadata-button
@@ -178,8 +183,31 @@
                 </FundingMetadata>
             {{else}}
                 <div local-class='funders'>
-                    <dl>
-                        <dt>
+                    {{#if @manager.metadataRecord.funders}}
+                        <dl>
+                            <dt>
+                                {{t 'osf-components.node-metadata-form.funding-information'}}
+                                {{#if (and @manager.userCanEdit (not @manager.inEditMode))}}
+                                    <Button
+                                        data-test-edit-funding-metadata-button
+                                        data-analytics-name='Edit Funding Metadata'
+                                        aria-label={{t 'osf-components.node-metadata-form.edit-button'}}
+                                        {{on 'click' @manager.editFunding}}
+                                        @layout='fake-link'
+                                    >
+                                        <FaIcon @icon='pencil-alt' />
+                                    </Button>
+                                {{/if}}
+                            </dt>
+                            {{#each @manager.metadataRecord.funders as |funder|}}
+                                <dd data-test-display-funder-name={{funder.funder_name}}>{{t 'osf-components.node-metadata-form.funder'}} {{funder.funder_name}}</dd>
+                                <dd data-test-display-funder-award-title={{funder.funder_name}}>{{t 'osf-components.node-metadata-form.award-title'}} {{funder.award_title}}</dd>
+                                <dd data-test-display-funder-award-uri={{funder.funder_name}}>{{t 'osf-components.node-metadata-form.award-info-uri'}} {{funder.award_uri}}</dd>
+                                <dd data-test-display-funder-award-number={{funder.funder_name}}>{{t 'osf-components.node-metadata-form.award-number'}} {{funder.award_number}}</dd>
+                            {{/each}}
+                        </dl>
+                    {{else}}
+                        <div local-class='metadata-header'>
                             {{t 'osf-components.node-metadata-form.funding-information'}}
                             {{#if (and @manager.userCanEdit (not @manager.inEditMode))}}
                                 <Button
@@ -191,15 +219,9 @@
                                 >
                                     <FaIcon @icon='pencil-alt' />
                                 </Button>
-                            {{/if}}
-                        </dt>
-                        {{#each @manager.metadataRecord.funders as |funder|}}
-                            <dd data-test-display-funder-name={{funder.funder_name}}>{{t 'osf-components.node-metadata-form.funder'}} {{funder.funder_name}}</dd>
-                            <dd data-test-display-funder-award-title={{funder.funder_name}}>{{t 'osf-components.node-metadata-form.award-title'}} {{funder.award_title}}</dd>
-                            <dd data-test-display-funder-award-uri={{funder.funder_name}}>{{t 'osf-components.node-metadata-form.award-info-uri'}} {{funder.award_uri}}</dd>
-                            <dd data-test-display-funder-award-number={{funder.funder_name}}>{{t 'osf-components.node-metadata-form.award-number'}} {{funder.award_number}}</dd>
-                        {{/each}}
-                    </dl>
+                            {{/if}} 
+                        </div>
+                    {{/if}}
                 </div>
             {{/if}}
         {{/unless}}

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1872,6 +1872,8 @@ osf-components:
         award-title: 'Award title:'
         award-info-uri: 'Award info URI:'
         award-number: 'Award number:'
+        choose-resource-type-general: 'Choose a resource type'
+        choose-language: 'Choose a language'
     open-badges-list:
         title: 'Open resources'
         open-data: 'Data'
@@ -1940,7 +1942,8 @@ osf-components:
         award_title: 'Award title'
         award_info_uri: 'Award info URI'
         award_number: 'Award number'
-        add_another: 'Add another'
+        add_another: 'Add funder'
+        delete: 'Delete funder'
         error: '"Funder name", "Award title" ,"Award info URI" or "Award number" has to be specified.'
     move_file_modal:
         move_header: 'Move {itemCount, plural, one {# item} other {# items}}'


### PR DESCRIPTION
## Purpose

Fix a number of small issues including accessibility problems.

## Summary of Changes

1. Rename funding widget's buttons to be a bit clearer
2. Ensure funding widget header remains when editing funding info
3. Add placeholder onto resource type power select
4. Fix accessibility on funding display to not have a dt without a dd
5. Add more space between funding widget and subjects widget


## Screenshot(s)
<img width="598" alt="Screenshot 2023-01-26 at 11 46 30 AM" src="https://user-images.githubusercontent.com/6599111/214897008-ae1fbe6f-f029-4cff-a64a-f14a040ff4ad.png">

<img width="320" alt="Screenshot 2023-01-26 at 11 46 46 AM" src="https://user-images.githubusercontent.com/6599111/214897013-8055172c-e68c-46eb-b2c5-b24176a5687d.png">

## QA Notes

As with files, the two search power select widgets will still fail accessibility and will be hopefully fixed shortly after release.
