### PR TITLE
Guid metadata / Fix registration approval

### DIFF
--- a/lib/osf-components/addon/components/funding-metadata/component.ts
+++ b/lib/osf-components/addon/components/funding-metadata/component.ts
@@ -67,7 +67,7 @@ export default class FundingMetadata extends Component<Args> {
     @action
     selectFunder(item: FunderObjects, funder: CrossrefFunderModel) {
         item.funder_identifier = funder.uri;
-        item.funder_identifier_type = 'Crossref Funder URI';
+        item.funder_identifier_type = 'Crossref Funder ID';
         item.funder_name = funder.name;
         this.saveToChangeset();
         this.validateFunderObjects();


### PR DESCRIPTION
## Purpose

Registration approval stopped working because of the problem described by [this sentry error](https://staging-sentry.cos.io/cos/osf-back-end-77/issues/15597/).

> 'Crossref Funder URI' is not one of ['ISNI', 'GRID', 'Crossref Funder ID', 'ROR', 'Other'] Failed validating 'enum' in schema['properties']['fundingReferences']['items']['properties']['funderIdentifierType']: {'enum': ['ISNI', 'GRID', 'Crossref Funder ID', 'ROR', 'Other'], 'type': 'string'} On instance['fundingReferences'][0]['funderIdentifierType']: 'Crossref Funder URI'

## Summary of Changes

1. Change `Crossref Funder URI` to `Crossref Funder ID`

