### PR TITLE
guid metadata / Fix a bunch of things found during QA

### DIFF
--- a/app/guid-file/styles.scss
+++ b/app/guid-file/styles.scss
@@ -70,7 +70,7 @@
     display: inline-flex;
     flex-direction: column;
     height: 95%;
-    margin: 0 20px;
+    margin: 0 20px 20px;
 
     &.Mobile {
         width: 90vw;

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -176,7 +176,11 @@
                                         {{/if}}
                                         {{#if manager.metadataRecord.description}}
                                             <dt>{{t 'file_detail.description'}}</dt>
-                                            <dd data-test-file-description>{{manager.metadataRecord.description}}</dd>
+                                            <dd data-test-file-description>
+                                                <ExpandablePreview data-test-display-file-description>
+                                                    {{manager.metadataRecord.description}}
+                                                </ExpandablePreview>
+                                            </dd>
                                         {{/if}}
                                         {{#if manager.metadataRecord.resourceTypeGeneral}}
                                             <dt>{{t 'file_detail.resource_type_general'}}</dt>
@@ -230,12 +234,16 @@
                                     <dd data-test-target-title>{{manager.target.title}}</dd>
                                     {{#if manager.target.description}}
                                         <dt>{{t 'file_detail.description'}}</dt>
-                                        <dd data-test-target-description>{{manager.target.description}}</dd>
+                                        <dd data-test-target-description>
+                                            <ExpandablePreview data-test-display-target-description>
+                                                {{manager.target.description}}
+                                            </ExpandablePreview>
+                                        </dd>
                                     {{/if}}
-                                    {{#if (and this.targetInstitutions (not manager.isAnonymous))}}
+                                    {{#if (and manager.targetInstitutions (not manager.isAnonymous))}}
                                         <dt local-class='affiliated-institutions'>{{t 'file_detail.institutions'}}</dt>
                                         <div data-test-target-institutions>
-                                            {{#each this.targetInstitutions as |institution|}}
+                                            {{#each manager.targetInstitutions as |institution|}}
                                                 <dd>{{institution.name}}</dd>
                                             {{/each}}
                                         </div>

--- a/app/guid-node/styles.scss
+++ b/app/guid-node/styles.scss
@@ -40,6 +40,10 @@
         margin-bottom: 0;
         padding: 20px;
     }
+    
+    .NavButton {
+        width: 100%;
+    }
 }
 
 .FileProviders {

--- a/app/guid-node/template.hbs
+++ b/app/guid-node/template.hbs
@@ -10,14 +10,16 @@
         <layout.heading local-class='Hero'>
             <h1>{{this.model.taskInstance.value.title}}</h1>
             {{#unless this.isDesktop}}
-                <nav>
-                    <Button
-                        aria-label={{t 'node.left_nav.toggle'}}
-                        {{on 'click' layout.toggleSidenav}}
-                    >
-                        <FaIcon @icon='bars' />
-                    </Button>
-                </nav>
+                <div local-class='NavButton'>
+                    <nav>
+                        <Button
+                            aria-label={{t 'node.left_nav.toggle'}}
+                            {{on 'click' layout.toggleSidenav}}
+                        >
+                            <FaIcon @icon='bars' />
+                        </Button>
+                    </nav>
+                </div>
             {{/unless}}
         </layout.heading>
         <layout.leftNavOld as |leftNav|>

--- a/lib/osf-components/addon/components/file-metadata-manager/component.ts
+++ b/lib/osf-components/addon/components/file-metadata-manager/component.ts
@@ -131,7 +131,11 @@ export default class FileMetadataManagerComponent extends Component<Args> {
         this.target = await this.file.target as NodeModel;
         this.targetParent = await this.target.get('parent');
         this.targetLicense = await this.target.license;
-        this.targetInstitutions = await this.target.affiliatedInstitutions as InstitutionModel[];
+        this.targetInstitutions = await this.target.queryHasMany(
+            'affiliatedInstitutions', {
+                pageSize: 100,
+            },
+        );
         this.userCanEdit = this.target.currentUserPermissions.includes(Permission.Write);
         await taskFor(this.getTargetMetadata).perform();
     }

--- a/lib/osf-components/addon/components/node-metadata-form/template.hbs
+++ b/lib/osf-components/addon/components/node-metadata-form/template.hbs
@@ -224,6 +224,22 @@
                     {{/if}}
                 </div>
             {{/if}}
+            {{#if @manager.license.name}}
+                <dl>
+                    <dt>{{t 'osf-components.node-metadata-form.license'}}</dt>
+                    <dd data-test-target-license-name>{{@manager.license.name}}</dd>
+                </dl>
+            {{/if}}
+            {{#if (and @manager.institutions (not @manager.isAnonymous))}}
+                <dl>
+                    <dt local-class='affiliated-institutions'>{{t 'osf-components.node-metadata-form.institutions'}}</dt>
+                    <div data-test-target-institutions>
+                        {{#each @manager.institutions as |institution|}}
+                            <dd>{{institution.name}}</dd>
+                        {{/each}}
+                    </div>
+                </dl>
+            {{/if}}
         {{/unless}}
     </FormControls>
     {{#if @manager.node.isRegistration}}

--- a/lib/osf-components/addon/components/node-metadata-manager/template.hbs
+++ b/lib/osf-components/addon/components/node-metadata-manager/template.hbs
@@ -7,6 +7,7 @@
     editFunding=(action this.editFunding)
     editResources=(action this.editResources)
     inEditMode=this.inEditMode
+    institutions=this.institutions
     isDirty=this.isDirty
     isEditingDescription=this.isEditingDescription
     isEditingFunding=this.isEditingFunding
@@ -15,6 +16,7 @@
     isSaving=this.isSaving
     languageCodes=this.languageCodes
     languageFromCode=this.languageFromCode
+    license=this.license
     metadataRecord=this.metadata
     node=this.node
     nodeChangeset=this.nodeChangeset

--- a/mirage/scenarios/dashboard.ts
+++ b/mirage/scenarios/dashboard.ts
@@ -49,7 +49,7 @@ export function dashboardScenario(server: Server, currentUser: ModelInstance<Use
         id: 'file5',
         title: 'With some files',
         currentUserPermissions: [Permission.Read, Permission.Write],
-    }, 'withFiles', 'withStorage', 'withContributors');
+    }, 'withFiles', 'withStorage', 'withContributors', 'withAffiliatedInstitutions');
     server.create('contributor', {
         node: filesNode,
         users: currentUser,

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1877,6 +1877,8 @@ osf-components:
         award-number: 'Award number:'
         choose-resource-type-general: 'Choose a resource type'
         choose-language: 'Choose a language'
+        license: 'License'
+        institutions: 'Affiliated institutions'
     open-badges-list:
         title: 'Open resources'
         open-data: 'Data'


### PR DESCRIPTION
## Purpose

A smorgasbord of fixes for guid-metadata.

## Summary of Changes

1. Put some space between contributors and the footer on the guid-file page
2. Add expandable previews to descriptions on guid-file page
3. Fix institutions on guid-file page
4. Make mobile nav toggle left aligned rather than center aligned
5. Add license and institutions to node metadata component
6. Give file5 in mirage some institutions
