### PR TITLE
[ENG-4307][ENG-4309] Add placeholders to power selects

### DIFF
--- a/app/guid-file/styles.scss
+++ b/app/guid-file/styles.scss
@@ -28,6 +28,10 @@
     padding: 0 20px 20px;
 }
 
+.placeholder {
+    color: #555;
+}
+
 .slide-buttons {
     background-color: $color-bg-white;
     border: 0;

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -133,10 +133,15 @@
                                             @valuePath='languageObject'
                                             @searchField='name'
                                             @searchEnabled={{true}}
-                                            @placeholder={{t 'file_detail.choose_language'}}
                                             as |option|
                                         >
-                                            {{option.name}}
+                                            {{#if option.name}}
+                                                {{option.name}}
+                                            {{else}}
+                                                <span local-class='placeholder'>
+                                                    {{t 'file_detail.choose_language'}}
+                                                </span>
+                                            {{/if}}
                                         </form.select>
                                     </FormControls>
                                 </div>

--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -82,7 +82,7 @@ declare const config: {
             keenSessionId: string;
             analyticsDismissAdblock: string;
             cookieConsent: string;
-            outputFeaturePopover: string;
+            newFeaturePopover: string;
             maintenance: string;
             csrf: string;
             authSession: string;

--- a/config/environment.js
+++ b/config/environment.js
@@ -156,7 +156,7 @@ module.exports = function(environment) {
                 keenSessionId: 'keenSessionId',
                 analyticsDismissAdblock: 'adBlockDismiss',
                 cookieConsent: 'osf_cookieconsent',
-                outputFeaturePopover: 'outputFeaturePopover',
+                newFeaturePopover: 'metadataFeaturePopover',
                 maintenance: 'maintenance',
                 csrf: 'api-csrf',
                 authSession: 'embosf-auth-session',

--- a/lib/osf-components/addon/components/funding-metadata/template.hbs
+++ b/lib/osf-components/addon/components/funding-metadata/template.hbs
@@ -17,10 +17,14 @@
                         @selected={{item}}
                         as |options|
                     >
-                        {{#if options.name}}
-                            {{options.name}}    
+                        {{#if (or options.name options.funder_name)}}
+                            {{#if options.name}}
+                                {{options.name}}    
+                            {{else}}
+                                {{options.funder_name}}
+                            {{/if}}
                         {{else}}
-                            {{options.funder_name}}
+                            {{t 'osf-components.funding-metadata.funder_placeholder'}}
                         {{/if}}
                     </PowerSelect>
                 </label>

--- a/lib/osf-components/addon/components/node-metadata-form/styles.scss
+++ b/lib/osf-components/addon/components/node-metadata-form/styles.scss
@@ -92,6 +92,10 @@
     }
 }
 
+.placeholder {
+    color: #555;
+}
+
 .resource-select {
     div {
         width: 250px;

--- a/lib/osf-components/addon/components/node-metadata-form/template.hbs
+++ b/lib/osf-components/addon/components/node-metadata-form/template.hbs
@@ -103,10 +103,15 @@
                     @valuePath='languageObject'
                     @searchField='name'
                     @searchEnabled={{true}}
-                    @placeholder={{t 'osf-components.node-metadata-form.choose-language'}}
                     as |option|
                 >
-                    {{option.name}}
+                    {{#if option.name}}
+                        {{option.name}}
+                    {{else}}
+                        <span local-class='placeholder'>
+                            {{t 'osf-components.node-metadata-form.choose-language'}}
+                        </span>
+                    {{/if}}
                 </form.select>
                 <Button
                     aria-label={{t 'general.cancel'}}

--- a/lib/registries/addon/overview/controller.ts
+++ b/lib/registries/addon/overview/controller.ts
@@ -24,7 +24,7 @@ const {
     },
     OSF: {
         cookies: {
-            outputFeaturePopover,
+            newFeaturePopover,
         },
     },
 } = config;
@@ -41,7 +41,7 @@ export default class Overview extends Controller {
 
     queryParams = ['mode', 'revisionId'];
     supportEmail = supportEmail;
-    outputFeaturePopoverCookie = outputFeaturePopover;
+    newFeaturePopoverCookie = newFeaturePopover;
 
     @tracked mode = '';
     @tracked revisionId = '';

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -62,8 +62,29 @@
                 <layout.leftNavOld as |leftNav|>
                     <leftNav.link data-analytics-name='Overview' @route='registries.overview.index'
                         @models={{array this.registration.id}} @icon='home' @label={{t 'registries.overview.title'}} />
-                    <leftNav.link data-analytics-name='Metadata' @route='registries.overview.metadata'
-                        @models={{array this.registration.id}} @icon='info-circle' @label={{t 'registries.overview.metadata'}} />
+                    {{#let (unique-id 'metadata-link') as |id|}}
+                        <leftNav.link
+                            data-analytics-name='Metadata'
+                            @route='registries.overview.metadata'
+                            @models={{array this.registration.id}}
+                            @icon='info-circle'
+                            @label={{t 'registries.overview.metadata'}}
+                            id={{id}}
+                        />
+                        {{#if this.showNewFeaturePopover}}
+                            <NewFeaturePopover
+                                @triggerElement={{concat '#' id}}
+                                @featureCookie={{this.newFeaturePopoverCookie}}
+                            >
+                                <:header>
+                                    {{t 'general.newFeaturePopoverHeading'}}
+                                </:header>
+                                <:body>
+                                    {{t 'general.newFeaturePopoverBody'}}
+                                </:body>
+                            </NewFeaturePopover>
+                        {{/if}}
+                    {{/let}}
                     <leftNav.link data-analytics-name='Files' 
                         @route='registries.overview.files'
                         @models={{array this.registration.id}}
@@ -99,30 +120,14 @@
                         </div>
                     {{/if}}
                     {{#if this.registration.resourcesVisible}}
-                        {{#let (unique-id 'resource-link') as |id|}}
-                            <leftNav.link 
-                                data-test-resource-link
-                                data-analytics-name='Resources'
-                                @route='registries.overview.resources'
-                                @models={{array this.registration.id}}
-                                @icon='archive'
-                                @label={{t 'registries.overview.resources.title'}}
-                                id={{id}}
-                            />
-                            {{#if this.showNewFeaturePopover}}
-                                <NewFeaturePopover
-                                    @triggerElement={{concat '#' id}}
-                                    @featureCookie={{this.outputFeaturePopoverCookie}}
-                                >
-                                    <:header>
-                                        {{t 'registries.overview.files.outputFeaturePopoverHeading'}}
-                                    </:header>
-                                    <:body>
-                                        {{t 'registries.overview.files.outputFeaturePopoverBody'}}
-                                    </:body>
-                                </NewFeaturePopover>
-                            {{/if}}
-                        {{/let}}
+                        <leftNav.link 
+                            data-test-resource-link
+                            data-analytics-name='Resources'
+                            @route='registries.overview.resources'
+                            @models={{array this.registration.id}}
+                            @icon='archive'
+                            @label={{t 'registries.overview.resources.title'}}
+                        />
                     {{/if}}
                     {{#if this.registration.wikiEnabled}}
                         <leftNav.link

--- a/mirage/factories/draft-node.ts
+++ b/mirage/factories/draft-node.ts
@@ -1,5 +1,4 @@
 import { Factory, trait, Trait } from 'ember-cli-mirage';
-import faker from 'faker';
 
 import DraftNode from 'ember-osf-web/models/draft-node';
 import { guid } from './utils';
@@ -13,7 +12,7 @@ export default Factory.extend <DraftNode & DraftNodeTraits>({
 
     withFiles: trait<DraftNode>({
         afterCreate(draftNode, server) {
-            const count = faker.random.number({ min: 1, max: 5 });
+            const count = 3;
             const osfstorage = server.create('file-provider', { target: draftNode });
             const files = server.createList('file', count, { target: draftNode });
             osfstorage.rootFolder.update({ files, target: draftNode });

--- a/mirage/factories/node.ts
+++ b/mirage/factories/node.ts
@@ -155,7 +155,7 @@ export default Factory.extend<MirageNode & NodeTraits>({
 
     withFiles: trait<MirageNode>({
         afterCreate(node, server) {
-            const count = faker.random.number({ min: 1, max: 5 });
+            const count = 3;
             const providerId = node.id + ':osfstorage';
             const osfstorage = server.create('file-provider', { id: providerId, target: node });
             const files = server.createList('file', count, { target: node });

--- a/mirage/factories/registration.ts
+++ b/mirage/factories/registration.ts
@@ -283,7 +283,7 @@ export default NodeFactory.extend<MirageRegistration & RegistrationTraits>({
     }),
     withFiles: trait<MirageRegistration>({
         afterCreate(registration, server) {
-            const count = faker.random.number({ min: 1, max: 5 });
+            const count = 3;
             const osfstorage = registration.files.filter(file => file.name === 'osfstorage').models[0];
             const files = server.createList('file', count, {
                 target: registration,

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "ember-page-title": "^6.2.1",
     "ember-parachute": "^1.0.2",
     "ember-percy": "^1.5.0",
-    "ember-power-select": "^4.1.3",
+    "ember-power-select": "^4.1.7",
     "ember-promise-helpers": "^1.0.4",
     "ember-qrcode-shim": "^0.4.0",
     "ember-qunit": "^5.1.4",

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -103,6 +103,9 @@ general:
     tags: 'Tags'
     science: 'science'
     engineering: 'engineering'
+    newFeaturePopoverHeading: 'New feature!'
+    newFeaturePopoverBody: 'You can now add funder information, resource types, and more enhanced metadata to your registration.'
+
 file_actions_menu:
     actions: '{filename} actions'
     copy_js: 'Copy dynamic JS iFrame'
@@ -1399,8 +1402,6 @@ registries:
         none_selected: 'None selected'
     overview:
         files:
-            outputFeaturePopoverHeading: 'New feature!'
-            outputFeaturePopoverBody: 'You can now add DOIs for resources (ex. data, code, papers, etc.) to your registration.'
             title: Files
             storage_providers:
                 invalidProviderDetails: 'Could not find the requested file provider.'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1967,6 +1967,7 @@ osf-components:
         add_another: 'Add funder'
         delete: 'Delete funder'
         funder_name_required: 'Funder name is required'
+        funder_placeholder: 'Choose your funder'
         award_uri_format_error: 'Award info URI has to be a URI'
         api_uri_validation_error: 'Award URI is not a full URI. Did you remember the "https://"?'
     move_file_modal:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2616,6 +2616,15 @@
     ember-cli-babel "^7.10.0"
     ember-modifier-manager-polyfill "^1.1.0"
 
+"@ember/render-modifiers@^2.0.0":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@ember/render-modifiers/-/render-modifiers-2.0.5.tgz#4b1d9496a82ca471aeaa3ecddd94ef089450f415"
+  integrity sha512-5cJ1niIdOJC6k6KtIn9HGbr1DATJQp4ZqMv1vbi6LKQWbVCQ3byvKONtUEi3H0wcewlrcaWCqXOgm0nACzCOQA==
+  dependencies:
+    "@embroider/macros" "^1.0.0"
+    ember-cli-babel "^7.26.11"
+    ember-modifier-manager-polyfill "^1.2.0"
+
 "@ember/string@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@ember/string/-/string-1.0.0.tgz#3a2254caedacb95e09071204d36cad49e0f8b855"
@@ -2685,7 +2694,7 @@
     walk-sync "^1.1.3"
     wrap-legacy-hbs-plugin-if-needed "^1.0.1"
 
-"@embroider/macros@0.33.0", "@embroider/macros@0.41.0", "@embroider/macros@1.8.3", "@embroider/macros@^0.36.0", "@embroider/macros@^0.39.0 || ^0.40.0 || ^0.41.0", "@embroider/macros@^0.41.0", "@embroider/macros@^0.50.0 || ^1.0.0", "@embroider/macros@^1.0.0":
+"@embroider/macros@0.33.0", "@embroider/macros@0.47.2", "@embroider/macros@1.8.3", "@embroider/macros@^0.36.0", "@embroider/macros@^0.41.0", "@embroider/macros@^0.47.2", "@embroider/macros@^0.50.0 || ^1.0.0", "@embroider/macros@^1.0.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-1.8.3.tgz#2f0961ab8871f6ad819630208031d705b357757e"
   integrity sha512-gnIOfTL/pUkoD6oI7JyWOqXlVIUgZM+CnbH10/YNtZr2K0hij9eZQMdgjOZZVgN0rKOFw9dIREqc1ygrJHRYQA==
@@ -2713,21 +2722,21 @@
     semver "^7.3.5"
     typescript-memoize "^1.0.1"
 
-"@embroider/util@^0.39.0 || ^0.40.0 || ^0.41.0":
-  version "0.41.0"
-  resolved "https://registry.yarnpkg.com/@embroider/util/-/util-0.41.0.tgz#5324cb4742aa4ed8d613c4f88a466f73e4e6acc1"
-  integrity sha512-ytA3J/YfQh7FEUEBwz3ezTqQNm/S5et5rZw3INBIy4Ak4x0NXV/VXLjyL8mv3txL8fGknZTBdXEhDsHUKIq8SQ==
-  dependencies:
-    "@embroider/macros" "0.41.0"
-    broccoli-funnel "^3.0.5"
-    ember-cli-babel "^7.23.1"
-
 "@embroider/util@^0.39.1 || ^0.40.0 || ^0.41.0 || ^1.0.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@embroider/util/-/util-1.8.3.tgz#7267a2b6fcbf3e56712711441159ab373f9bee7a"
   integrity sha512-FvsPzsb9rNeveSnIGnsfLkWWBdSM5QIA9lDVtckUktRnRnBWZHm5jDxU/ST//pWMhZ8F0DucRlFWE149MTLtuQ==
   dependencies:
     "@embroider/macros" "1.8.3"
+    broccoli-funnel "^3.0.5"
+    ember-cli-babel "^7.23.1"
+
+"@embroider/util@^0.47.2":
+  version "0.47.2"
+  resolved "https://registry.yarnpkg.com/@embroider/util/-/util-0.47.2.tgz#d06497b4b84c07ed9c7b628293bb019c533f4556"
+  integrity sha512-g9OqnFJPktGu9NS0Ug3Pxz1JE3jeDceeVE4IrlxDrVmBXMA/GrBvpwjolWgl6jh97cMJyExdz62jIvPHV4256Q==
+  dependencies:
+    "@embroider/macros" "0.47.2"
     broccoli-funnel "^3.0.5"
     ember-cli-babel "^7.23.1"
 
@@ -2851,7 +2860,7 @@
     "@glimmer/wire-format" "^0.27.0"
     simple-html-tokenizer "^0.3.0"
 
-"@glimmer/component@^1.0.2", "@glimmer/component@^1.0.3", "@glimmer/component@^1.0.4":
+"@glimmer/component@^1.0.3", "@glimmer/component@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@glimmer/component/-/component-1.0.4.tgz#1c85a5181615a6647f6acfaaed68e28ad7e9626e"
   integrity sha512-sS4N8wtcKfYdUJ6O3m8nbTut6NjErdz94Ap8VB1ekcg4WSD+7sI7Nmv6kt2rdPoe363nUdjUbRBzHNWhLzraBw==
@@ -4785,6 +4794,11 @@ babel-import-util@^1.1.0, babel-import-util@^1.2.0:
   resolved "https://registry.yarnpkg.com/babel-import-util/-/babel-import-util-1.2.2.tgz#1027560e143a4a68b1758e71d4fadc661614e495"
   integrity sha512-8HgkHWt5WawRFukO30TuaL9EiDUOdvyKtDwLma4uBNeUSDbOO0/hiPfavrOWxSS6J6TKXfukWHZ3wiqZhJ8ONQ==
 
+babel-import-util@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/babel-import-util/-/babel-import-util-1.3.0.tgz#dc9251ea39a7747bd586c1c13b8d785a42797f8e"
+  integrity sha512-PPzUT17eAI18zn6ek1R3sB4Krc/MbnmT1MkZQFmyhjoaEGBVwNABhfVU9+EKcDSKrrOm9OIpGhjxukx1GCiy1g==
+
 babel-loader@^8.0.6:
   version "8.2.2"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.2.2.tgz#9363ce84c10c9a40e6c753748e1441b60c8a0b81"
@@ -4865,6 +4879,13 @@ babel-plugin-ember-template-compilation@^1.0.0:
     line-column "^1.0.2"
     magic-string "^0.26.0"
     string.prototype.matchall "^4.0.5"
+
+babel-plugin-ember-template-compilation@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-2.0.0.tgz#41d895874ba6119dd461f61993c16d1154bf8a57"
+  integrity sha512-d+4jaB2ik0rt9TH0K9kOlKJeRBHEb373FgFMcU9ZaJL2zYuVXe19bqy+cWlLpLf1tpOBcBG9QTlFBCoImlOt1g==
+  dependencies:
+    babel-import-util "^1.3.0"
 
 babel-plugin-filter-imports@^4.0.0:
   version "4.0.0"
@@ -8635,22 +8656,22 @@ ember-auto-import@^1.12.0:
     walk-sync "^0.3.3"
     webpack "^4.43.0"
 
-ember-basic-dropdown@^3.0.18:
-  version "3.0.19"
-  resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-3.0.19.tgz#e15e71097cbcbc585e85c2c5cf677a6434edb1d5"
-  integrity sha512-5mZ4hbfGLd+TrFAp0JsfcpIb10zqF60SorKc1Bsm29kJF2wy8p0JUXMb21VVF7+phkrRFYbcXy5enFc8qdm4xw==
+ember-basic-dropdown@^3.0.21:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-3.1.0.tgz#47c292de890d1958057736c00b8eb2b8017d530b"
+  integrity sha512-UISvgJHfiJ8FeXqH8ZN+NmoImN8p6Sb+85qlEv853hLuEfEYnFUqLNhea8nNl9CpFqcD3yU4dKbhYtc6nB39aQ==
   dependencies:
-    "@ember/render-modifiers" "^1.0.2"
-    "@embroider/macros" "^0.39.0 || ^0.40.0 || ^0.41.0"
-    "@embroider/util" "^0.39.0 || ^0.40.0 || ^0.41.0"
+    "@ember/render-modifiers" "^2.0.0"
+    "@embroider/macros" "^0.47.2"
+    "@embroider/util" "^0.47.2"
     "@glimmer/component" "^1.0.4"
     "@glimmer/tracking" "^1.0.4"
-    ember-cli-babel "^7.23.1"
-    ember-cli-htmlbars "^5.7.0"
-    ember-cli-typescript "^4.1.0"
-    ember-element-helper "^0.5.2"
-    ember-maybe-in-element "^2.0.2"
-    ember-style-modifier "^0.6.0"
+    ember-cli-babel "^7.26.6"
+    ember-cli-htmlbars "^6.0.0"
+    ember-cli-typescript "^4.2.1"
+    ember-element-helper "^0.5.5"
+    ember-maybe-in-element "^2.0.3"
+    ember-style-modifier "^0.7.0"
     ember-truth-helpers "^2.1.0 || ^3.0.0"
 
 ember-bootstrap-datepicker@^2.0.9:
@@ -8874,7 +8895,7 @@ ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cl
     rimraf "^3.0.1"
     semver "^5.5.0"
 
-ember-cli-babel@^7.26.10, ember-cli-babel@^7.26.11:
+ember-cli-babel@^7.26.0, ember-cli-babel@^7.26.10, ember-cli-babel@^7.26.11:
   version "7.26.11"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz#50da0fe4dcd99aada499843940fec75076249a9f"
   integrity sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==
@@ -9064,7 +9085,7 @@ ember-cli-htmlbars@^4.0.5, ember-cli-htmlbars@^4.0.8, ember-cli-htmlbars@^4.2.0,
     strip-bom "^4.0.0"
     walk-sync "^2.0.2"
 
-ember-cli-htmlbars@^5.0.0, ember-cli-htmlbars@^5.1.2, ember-cli-htmlbars@^5.2.0, ember-cli-htmlbars@^5.3.1, ember-cli-htmlbars@^5.3.2, ember-cli-htmlbars@^5.6.3, ember-cli-htmlbars@^5.7.0, ember-cli-htmlbars@^5.7.1:
+ember-cli-htmlbars@^5.0.0, ember-cli-htmlbars@^5.1.2, ember-cli-htmlbars@^5.2.0, ember-cli-htmlbars@^5.3.1, ember-cli-htmlbars@^5.3.2, ember-cli-htmlbars@^5.6.3, ember-cli-htmlbars@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.1.tgz#eb5b88c7d9083bc27665fb5447a9b7503b32ce4f"
   integrity sha512-9laCgL4tSy48orNoQgQKEHp93MaqAs9ZOl7or5q+8iyGGJHW6sVXIYrVv5/5O9HfV6Ts8/pW1rSoaeKyLUE+oA==
@@ -9084,6 +9105,26 @@ ember-cli-htmlbars@^5.0.0, ember-cli-htmlbars@^5.1.2, ember-cli-htmlbars@^5.2.0,
     semver "^7.3.4"
     silent-error "^1.1.1"
     strip-bom "^4.0.0"
+    walk-sync "^2.2.0"
+
+ember-cli-htmlbars@^6.0.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-6.2.0.tgz#18ec48ee1c93f9eed862a64eb24a9d14604f1dfc"
+  integrity sha512-j5EGixjGau23HrqRiW/JjoAovg5UBHfjbyN7wX5ekE90knIEqUUj1z/Mo/cTx/J2VepQ2lE6HdXW9LWQ/WdMtw==
+  dependencies:
+    "@ember/edition-utils" "^1.2.0"
+    babel-plugin-ember-template-compilation "^2.0.0"
+    babel-plugin-htmlbars-inline-precompile "^5.3.0"
+    broccoli-debug "^0.6.5"
+    broccoli-persistent-filter "^3.1.2"
+    broccoli-plugin "^4.0.3"
+    ember-cli-version-checker "^5.1.2"
+    fs-tree-diff "^2.0.1"
+    hash-for-dep "^1.5.1"
+    heimdalljs-logger "^0.1.10"
+    js-string-escape "^1.0.1"
+    semver "^7.3.4"
+    silent-error "^1.1.1"
     walk-sync "^2.2.0"
 
 ember-cli-htmlbars@^6.0.1:
@@ -9447,6 +9488,38 @@ ember-cli-typescript@^4.0.0, ember-cli-typescript@^4.1.0:
     stagehand "^1.0.0"
     walk-sync "^2.2.0"
 
+ember-cli-typescript@^4.2.0, ember-cli-typescript@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz#54d08fc90318cc986f3ea562f93ce58a6cc4c24d"
+  integrity sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==
+  dependencies:
+    ansi-to-html "^0.6.15"
+    broccoli-stew "^3.0.0"
+    debug "^4.0.0"
+    execa "^4.0.0"
+    fs-extra "^9.0.1"
+    resolve "^1.5.0"
+    rsvp "^4.8.1"
+    semver "^7.3.2"
+    stagehand "^1.0.0"
+    walk-sync "^2.2.0"
+
+ember-cli-typescript@^5.0.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz#553030f1ce3e8958b8e4fc34909acd1218cb35f2"
+  integrity sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==
+  dependencies:
+    ansi-to-html "^0.6.15"
+    broccoli-stew "^3.0.0"
+    debug "^4.0.0"
+    execa "^4.0.0"
+    fs-extra "^9.0.1"
+    resolve "^1.5.0"
+    rsvp "^4.8.1"
+    semver "^7.3.2"
+    stagehand "^1.0.0"
+    walk-sync "^2.2.0"
+
 ember-cli-typescript@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-5.1.0.tgz#460eb848564e29d64f2b36b2a75bbe98172b72a4"
@@ -9636,6 +9709,17 @@ ember-compatibility-helpers@^1.0.2, ember-compatibility-helpers@^1.1.1, ember-co
   dependencies:
     babel-plugin-debug-macros "^0.2.0"
     ember-cli-version-checker "^5.1.1"
+    fs-extra "^9.1.0"
+    semver "^5.4.1"
+
+ember-compatibility-helpers@^1.2.5:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.6.tgz#603579ab2fb14be567ef944da3fc2d355f779cd8"
+  integrity sha512-2UBUa5SAuPg8/kRVaiOfTwlXdeVweal1zdNPibwItrhR0IvPrXpaqwJDlEZnWKEoB+h33V0JIfiWleSG6hGkkA==
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-version-checker "^5.1.1"
+    find-up "^5.0.0"
     fs-extra "^9.1.0"
     semver "^5.4.1"
 
@@ -9836,7 +9920,7 @@ ember-diff-attrs@^0.2.1, ember-diff-attrs@^0.2.2:
   dependencies:
     ember-cli-babel "^7.0.0"
 
-ember-element-helper@^0.3.1, ember-element-helper@^0.5.0, ember-element-helper@^0.5.2, ember-element-helper@^0.6.1:
+ember-element-helper@^0.3.1, ember-element-helper@^0.5.0, ember-element-helper@^0.5.5, ember-element-helper@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/ember-element-helper/-/ember-element-helper-0.6.1.tgz#a6fbc5be5f875b5c864ae61bf5c5f81d6de6d936"
   integrity sha512-YiOdAMlzYul4ulkIoNp8z7iHDfbT1fbut/9xGFRfxDwU/FmF8HtAUB2f1veu/w50HTeZNopa1OV2PCloZ76XlQ==
@@ -10100,10 +10184,10 @@ ember-maybe-import-regenerator@^1.0.0:
     ember-cli-babel "^7.26.6"
     regenerator-runtime "^0.13.2"
 
-ember-maybe-in-element@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/ember-maybe-in-element/-/ember-maybe-in-element-2.0.2.tgz#93e503fb0655b65cc822e4040e51e13814b5f648"
-  integrity sha512-NyZNEGsdUHKUbpeZV0U6fbs0KaRKaa6O6E3RP3TMoqUA/NI3Fhha28kZ38aPe21KMgN4I1NHicgSHf4ijuHFsA==
+ember-maybe-in-element@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/ember-maybe-in-element/-/ember-maybe-in-element-2.0.3.tgz#640ea56b492bdacd1c41c128c2163d933c18c3ec"
+  integrity sha512-XKuBYPYELwsEmDnJXI7aNSZtt/SKGgRZNMFhASODLz7j0OHSNrcJtjo5Wam/alxIjUIYVjEnMnOzqBLMfJnQkQ==
   dependencies:
     ember-cli-babel "^7.21.0"
     ember-cli-htmlbars "^5.2.0"
@@ -10147,6 +10231,17 @@ ember-modifier@^2.1.0, ember-modifier@^2.1.1:
     ember-cli-typescript "^3.1.3"
     ember-destroyable-polyfill "^2.0.2"
     ember-modifier-manager-polyfill "^1.2.0"
+
+ember-modifier@^3.0.0:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-3.2.7.tgz#f2d35b7c867cbfc549e1acd8d8903c5ecd02ea4b"
+  integrity sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==
+  dependencies:
+    ember-cli-babel "^7.26.6"
+    ember-cli-normalize-entity-name "^1.0.0"
+    ember-cli-string-utils "^1.1.0"
+    ember-cli-typescript "^5.0.0"
+    ember-compatibility-helpers "^1.2.5"
 
 ember-moment@^7.7.0:
   version "7.8.1"
@@ -10227,18 +10322,18 @@ ember-popper@^0.11.3:
     fastboot-transform "^0.1.0"
     popper.js "^1.14.1"
 
-ember-power-select@^4.1.3:
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/ember-power-select/-/ember-power-select-4.1.6.tgz#03e767a8e9d5d2fc301bec35644d15f53c006d79"
-  integrity sha512-dumnieoQrU7PvNhVQBn67ZqbbuotWPFHNdhm3wNBVQvkCndLE6WkRwRElGffMLnF4KGbqGCQyIUsxBUi/nM0wQ==
+ember-power-select@^4.1.7:
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/ember-power-select/-/ember-power-select-4.1.7.tgz#eb547dd37448357d8f3fa789db18ddbba43fb8ca"
+  integrity sha512-Q4cjUudWb7JA6q7qe0jhcpLsipuFUHMwkYC05HxST5qm3MRMEzs6KfZ3Xd/TcrjBLSoWniw3Q61Quwcb41w5Jw==
   dependencies:
-    "@glimmer/component" "^1.0.2"
-    "@glimmer/tracking" "^1.0.2"
+    "@glimmer/component" "^1.0.4"
+    "@glimmer/tracking" "^1.0.4"
     ember-assign-helper "^0.3.0"
-    ember-basic-dropdown "^3.0.18"
-    ember-cli-babel "^7.23.0"
-    ember-cli-htmlbars "^5.3.1"
-    ember-cli-typescript "^4.1.0"
+    ember-basic-dropdown "^3.0.21"
+    ember-cli-babel "^7.26.0"
+    ember-cli-htmlbars "^6.0.0"
+    ember-cli-typescript "^4.2.0"
     ember-concurrency ">=1.0.0 <3"
     ember-concurrency-decorators "^2.0.0"
     ember-text-measurer "^0.6.0"
@@ -10438,6 +10533,14 @@ ember-style-modifier@^0.6.0:
   dependencies:
     ember-cli-babel "^7.21.0"
     ember-modifier "^2.1.0"
+
+ember-style-modifier@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/ember-style-modifier/-/ember-style-modifier-0.7.0.tgz#85b3dfd7e4bc2bd546df595f2dab4fb141cf7d87"
+  integrity sha512-iDzffiwJcb9j6gu3g8CxzZOTvRZ0BmLMEFl+uyqjiaj72VVND9+HbLyQRw1/ewPAtinhSktxxTTdwU/JO+stLw==
+  dependencies:
+    ember-cli-babel "^7.26.6"
+    ember-modifier "^3.0.0"
 
 ember-tag-input@^2.0.3:
   version "2.0.3"


### PR DESCRIPTION
Tickets:
- [ENG-4307]
- [ENG-4309]

## Purpose

There were three power select widgets that didn't have placeholders, because their selections were objects rather than a simple type, so it couldn't tell when the object was empty. 

Also, this moves the new feature popover to the metadata tab.

## Summary of Changes

1. Upgrade ember-power-select to 4.1.7
2. Add manual placeholders to power select widgets
3. Stop using random numbers for count of files created by mirage, because that caused different nodes to have different file guids associated with them every time you reloaded the page, so it was impossible to consistently know what permissions any given file was going to have or even if a given file guid was going to exist or not.
4. Generalize the new feature popover and move it to the metadata tab

## Screenshot(s)

<img width="585" alt="Screenshot 2023-02-01 at 3 47 08 PM" src="https://user-images.githubusercontent.com/6599111/216161162-b189e52e-c11a-4306-bc33-b14b63a2829d.png">
<img width="406" alt="Screenshot 2023-02-01 at 3 22 01 PM" src="https://user-images.githubusercontent.com/6599111/216161164-abd77179-2516-44e6-9f18-47f65b9bb502.png">
<img width="499" alt="Screenshot 2023-02-02 at 4 01 42 PM" src="https://user-images.githubusercontent.com/6599111/216448848-1c6bbd1e-4cc3-4635-9bf3-bae8a9511ae5.png">


## Side Effects

Shouldn't be. I didn't do any major upgrades, just a minor bump, so _should_ be fine.

## QA Notes

This should allow us to pass accessibility testing for the last items from guid-metadata.


[ENG-4307]: https://openscience.atlassian.net/browse/ENG-4307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ENG-4309]: https://openscience.atlassian.net/browse/ENG-4309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ