### PR TITLE
[ENG-4312] Visual fixes for Guid Metadata

### DIFF
--- a/app/guid-file/styles.scss
+++ b/app/guid-file/styles.scss
@@ -170,6 +170,7 @@
 .edit-metadata-form {
     display: inline-flex;
     flex-direction: column;
+    max-width: 100%;
 }
 
 .edit-metadata-save-cancel-buttons {

--- a/app/guid-file/styles.scss
+++ b/app/guid-file/styles.scss
@@ -18,6 +18,10 @@
     white-space: nowrap;
 }
 
+.project-link-header {
+    padding-bottom: 5px;
+}
+
 .project-link {
     margin: 20px;
 }

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -3,7 +3,7 @@
     @isMobile={{this.media.isMobile}}
 >
     <:header>
-        <h3>
+        <h3 local-class='project-link-header'>
             <OsfLink
                 data-test-project-link
                 data-analytics-name='Linked project'

--- a/app/router.ts
+++ b/app/router.ts
@@ -54,6 +54,8 @@ Router.map(function() {
         this.mount('registries', { path: '--registries' });
     }
 
+    this.route('guid-file', { path: '--file/:guid' });
+
     this.route('guid-node', { path: '--node/:guid' }, function() {
         this.mount('analytics-page', { as: 'analytics' });
         this.route('forks');

--- a/app/router.ts
+++ b/app/router.ts
@@ -54,7 +54,9 @@ Router.map(function() {
         this.mount('registries', { path: '--registries' });
     }
 
-    this.route('guid-file', { path: '--file/:guid' });
+    this.route('guid-file', { path: '--file/:guid' }, function() {
+        this.route('metadata');
+    });
 
     this.route('guid-node', { path: '--node/:guid' }, function() {
         this.mount('analytics-page', { as: 'analytics' });

--- a/app/router.ts
+++ b/app/router.ts
@@ -54,10 +54,6 @@ Router.map(function() {
         this.mount('registries', { path: '--registries' });
     }
 
-    this.route('guid-file', { path: '--file/:guid' }, function() {
-        this.route('metadata');
-    });
-
     this.route('guid-node', { path: '--node/:guid' }, function() {
         this.mount('analytics-page', { as: 'analytics' });
         this.route('forks');

--- a/lib/osf-components/addon/components/node-metadata-form/styles.scss
+++ b/lib/osf-components/addon/components/node-metadata-form/styles.scss
@@ -11,8 +11,7 @@
         color: $color-link-black;
     }
 
-    div:not(.resource-edit),
-    div:not(.metadata-description-field) {
+    > div {
         justify-content: space-between;
         margin: 5px 0 15px;
     }
@@ -154,15 +153,10 @@
 
 .resource-edit div {
     display: block;
+    margin: 5px 0 15px;
 
     div {
         max-width: 100%;
     }
 }
 
-/* stylelint-disable selector-no-qualifying-type */
-.metadata-description-field div {
-    &[data-test-collapse-overlay] {
-        margin-bottom: 0;
-    }
-}

--- a/lib/osf-components/addon/components/node-metadata-form/styles.scss
+++ b/lib/osf-components/addon/components/node-metadata-form/styles.scss
@@ -14,7 +14,7 @@
     div:not(.resource-edit),
     div:not(.metadata-description-field) {
         justify-content: space-between;
-        margin: 5px 0;
+        margin: 5px 0 15px;
     }
 
     dd {
@@ -152,8 +152,12 @@
     }
 }
 
-.resource-edit > div {
+.resource-edit div {
     display: block;
+
+    div {
+        max-width: 100%;
+    }
 }
 
 /* stylelint-disable selector-no-qualifying-type */

--- a/lib/osf-components/addon/components/node-metadata-form/styles.scss
+++ b/lib/osf-components/addon/components/node-metadata-form/styles.scss
@@ -11,7 +11,8 @@
         color: $color-link-black;
     }
 
-    div:not(.resource-edit) {
+    div:not(.resource-edit),
+    div:not(.metadata-description-field) {
         justify-content: space-between;
         margin: 5px 0;
     }
@@ -153,4 +154,11 @@
 
 .resource-edit > div {
     display: block;
+}
+
+/* stylelint-disable selector-no-qualifying-type */
+.metadata-description-field div {
+    &[data-test-collapse-overlay] {
+        margin-bottom: 0;
+    }
 }

--- a/lib/osf-components/addon/components/node-metadata-form/template.hbs
+++ b/lib/osf-components/addon/components/node-metadata-form/template.hbs
@@ -47,7 +47,9 @@
                         </Button>
                     {{/if}}
                 </dt>
-                <dd>
+                <dd
+                    local-class='metadata-description-field'
+                >
                     <ExpandablePreview data-test-display-node-description>
                         {{@manager.node.description}}
                     </ExpandablePreview>

--- a/lib/osf-components/addon/components/registries/version-metadata/styles.scss
+++ b/lib/osf-components/addon/components/registries/version-metadata/styles.scss
@@ -1,6 +1,7 @@
 .versionMetadata {
     border: 3px solid $brand-warning;
     padding: 10px;
+    margin-top: 28px;
 }
 
 .versionMetadata-title {

--- a/tests/acceptance/resolve-guid-test.ts
+++ b/tests/acceptance/resolve-guid-test.ts
@@ -47,10 +47,12 @@ module('Acceptance | resolve-guid', hooks => {
     });
 
     module('File', __ => {
-        test('Index', async () => {
+        test('Index', async assert => {
             const file = server.create('file', { target: server.create('registration') });
 
             await visit(`/${file.id}`);
+
+            routingAssertions(assert, '--file', `/${file.id}`, 'guid-file');
         });
     });
 

--- a/tests/acceptance/resolve-guid-test.ts
+++ b/tests/acceptance/resolve-guid-test.ts
@@ -47,22 +47,12 @@ module('Acceptance | resolve-guid', hooks => {
     });
 
     module('File', __ => {
-        test('Index', async assert => {
+        test('Index', async () => {
             const file = server.create('file', { target: server.create('registration') });
 
             await visit(`/${file.id}`);
-
-            routingAssertions(assert, '--file', `/${file.id}`, 'guid-file.index');
-        });
-        test('Metadata', async assert => {
-            const file = server.create('file', { target: server.create('registration') });
-
-            await visit(`/${file.id}/metadata`);
-
-            routingAssertions(assert, '--file', `/${file.id}/metadata`, 'guid-file.metadata');
         });
     });
-
 
     module('Node', mhooks => {
         mhooks.beforeEach(async () => {

--- a/tests/acceptance/resolve-guid-test.ts
+++ b/tests/acceptance/resolve-guid-test.ts
@@ -52,7 +52,14 @@ module('Acceptance | resolve-guid', hooks => {
 
             await visit(`/${file.id}`);
 
-            routingAssertions(assert, '--file', `/${file.id}`, 'guid-file');
+            routingAssertions(assert, '--file', `/${file.id}`, 'guid-file.index');
+        });
+        test('Metadata', async assert => {
+            const file = server.create('file', { target: server.create('registration') });
+
+            await visit(`/${file.id}/metadata`);
+
+            routingAssertions(assert, '--file', `/${file.id}/metadata`, 'guid-file.metadata');
         });
     });
 


### PR DESCRIPTION
-   Ticket: https://openscience.atlassian.net/browse/ENG-4312
-   Feature flag: n/a

## Purpose

The purpose of these changes is to fix any remaining visual changes affected by the Files Metadata project following post-release.

## Summary of Changes

Issue 1: File Name is cut off for lower case (descending) letters. Add a `padding-bottom: 5px;` to the h3 that holds the title to fix. 
-> Padding has been added to the h3 title.

Issue 2: Fade clip for very long text area descriptions. Take off the 5px margin to the div that holds the description to fix (or possibly change the 5px margin added to all divs into padding instead)
-> Margin has been set to 0 for the div nested in the edit metadata description text area.

Issue 3. Resource Dropdowns overflow in mobile view
-> Issues were not reproducible when testing on Edge and Chrome respectively however a maximum width has been added to the edit metadata form to help prevent any unwanted divider spillage.

Issue 4. Add top margin back to registration update messages
-> Margin has been added to the top of the divider containing the notification.

## Screenshot(s) below are rendered on Google Chrome Version 109.0.5414.119 (Official Build) (arm64)

1. Visible descending characters in file name 
<img width="1574" alt="image" src="https://user-images.githubusercontent.com/82047646/216188063-ad0ce14b-8dd6-443c-8ba8-ea8946e130cf.png">

2. Fade clip removed
<img width="1575" alt="image" src="https://user-images.githubusercontent.com/82047646/216188297-5744c85b-6ee7-4193-8d0c-908bd09bcdf7.png">

3. No overflow of resources present
<img width="418" alt="Pending Penguins" src="https://user-images.githubusercontent.com/82047646/216188526-d4ce48f9-fc3b-4ae6-a959-9921ac394d54.png">
<img width="411" alt="File Metadata" src="https://user-images.githubusercontent.com/82047646/216188539-15eb10c6-c15f-4e52-b940-dfa8fe2ec2cd.png">

4. Margin added to the top of the revision metadata notification divider
<img width="1573" alt="image" src="https://user-images.githubusercontent.com/82047646/216187501-5acec1fd-3c5f-49a7-a4d9-bc450c396f6e.png">

## Side Effects

Changes to the UI especially of height and width to include padding and margin will trigger the DOM to reposition other neighboring elements. Testing should ensure both on desktop and mobile that all text is readily visible, it is visually engaging, and that no overflow occurs.

## QA Notes

-Do elements look as expected?
-Did changes affect other views to include anonymized, embargoed and revised projects, components, and registrations?