### PR TITLE
[ENG-4318] Move sorting dropdown on mobile

### DIFF
--- a/lib/collections/addon/provider/moderation/all/styles.scss
+++ b/lib/collections/addon/provider/moderation/all/styles.scss
@@ -18,6 +18,11 @@
 .sort-wrapper {
     width: 155px;
     float: right;
+
+    &.mobile {
+        float: none;
+        margin-top: 10px;
+    }
 }
 
 .list {

--- a/lib/collections/addon/provider/moderation/all/template.hbs
+++ b/lib/collections/addon/provider/moderation/all/template.hbs
@@ -16,7 +16,7 @@
             </a>
         {{/let}}
     {{/each}}
-    <div data-test-submission-sort local-class='sort-wrapper'>
+    <div data-test-submission-sort local-class='sort-wrapper {{if this.isMobile 'mobile'}}'>
         <PowerSelect
             @options={{this.sortOptions}}
             @selected={{this.sort}}


### PR DESCRIPTION
-   Ticket: [ENG-4318]
-   Feature flag: n/a

## Purpose
- Address a visual bug in mobile view for collection moderation's submission view

## Summary of Changes
- Move sorting dropdown to next line for mobile view

## Screenshot(s)
- Before:
![image](https://user-images.githubusercontent.com/51409893/216423492-27163519-bfb2-422f-a67e-a33325cbc8fe.png)


- After:
![image](https://user-images.githubusercontent.com/51409893/216422252-41c1f4a2-454a-4215-b475-3782ca6fc621.png)


## Side Effects
- None

## QA Notes
- The dropdown should only be moved for mobile view and should no longer be obscured as it was before

[ENG-4318]: https://openscience.atlassian.net/browse/ENG-4318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ