### PR TITLE
[WIP][ENG-4187] Test file detail view section - Updated

### DIFF
--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -66,10 +66,10 @@
             </div>
         {{/if}}
         {{#if this.metadataOpened}}
-            <div local-class='right-container {{if this.isMobile 'Mobile'}}'>
+            <div local-class='right-container {{if this.isMobile 'Mobile'}}' data-test-metadata-tab>
                 <FileMetadataManager @file={{this.model.fileModel}} as |manager|>
                     <div local-class='metadata-title-edit-download'>
-                        <h2 local-class='metadata-heading'>
+                        <h2 local-class='metadata-heading' data-test-metadata-header>
                             {{t 'file_detail.file_metadata'}}
                         </h2>
                         <div local-class='edit-download-buttons'>
@@ -175,11 +175,11 @@
                             )}}
                                 <dl>
                                     {{#if manager.metadataRecord.title}}
-                                        <dt>{{t 'file_detail.title'}}</dt>
+                                        <dt data-test-file-title-label>{{t 'file_detail.title'}}</dt>
                                         <dd data-test-file-title>{{manager.metadataRecord.title}}</dd>
                                     {{/if}}
                                     {{#if manager.metadataRecord.description}}
-                                        <dt>{{t 'file_detail.description'}}</dt>
+                                        <dt data-test-file-description-label>{{t 'file_detail.description'}}</dt>
                                         <dd data-test-file-description>
                                             <ExpandablePreview data-test-display-file-description>
                                                 {{manager.metadataRecord.description}}
@@ -187,7 +187,7 @@
                                         </dd>
                                     {{/if}}
                                     {{#if manager.metadataRecord.resourceTypeGeneral}}
-                                        <dt>
+                                        <dt data-test-file-resource-type-label>
                                             {{t 'file_detail.resource_type_general'}}
                                             <Button
                                                 aria-label={{t 'file_detail.resource_type_general_help'}}
@@ -205,7 +205,7 @@
                                         <dd data-test-file-resource-type>{{manager.metadataRecord.resourceTypeGeneral}}</dd>
                                     {{/if}}
                                     {{#if manager.languageFromCode}}
-                                        <dt>{{t 'file_detail.language'}}</dt>
+                                        <dt data-test-file-language-label>{{t 'file_detail.language'}}</dt>
                                         <dd data-test-file-language>{{manager.languageFromCode}}</dd>
                                     {{/if}}
                                 </dl>
@@ -214,31 +214,31 @@
                                     {{t 'file_detail.enter_metadata'}}
                                 {{/if}}
                             {{/if}}
-                            <h2 local-class='node-type-heading'>{{t (concat 'file_detail.metadata_' manager.nodeWord)}}</h2>
+                            <h2 local-class='node-type-heading' data-test-metadata-node>{{t (concat 'file_detail.metadata_' manager.nodeWord)}}</h2>
                             {{#unless manager.isAnonymous}}
                                 <div>
                                     {{#each manager.targetMetadata.funders as |funder|}}
                                         <dl>
                                             {{#if funder.funder_name}}
-                                                <dt>{{t 'file_detail.funder'}}</dt>
+                                                <dt data-test-target-funder-name-label>{{t 'file_detail.funder'}}</dt>
                                                 <dd data-test-target-funder-name={{funder.funder_name}}>
                                                     {{funder.funder_name}}
                                                 </dd>
                                             {{/if}}
                                             {{#if funder.award_title}}
-                                                <dt>{{t 'file_detail.award_title'}}</dt>
+                                                <dt data-test-target-funder-award-title-label>{{t 'file_detail.award_title'}}</dt>
                                                 <dd data-test-target-funder-award-title={{funder.funder_name}}>
                                                     {{funder.award_title}}
                                                 </dd>
                                             {{/if}}
                                             {{#if funder.award_uri}}
-                                                <dt>{{t 'file_detail.award_uri'}}</dt>
+                                                <dt data-test-target-funder-award-uri-label>{{t 'file_detail.award_uri'}}</dt>
                                                 <dd data-test-target-funder-award-uri={{funder.funder_name}}>
                                                     {{funder.award_uri}}
                                                 </dd>
                                             {{/if}}
                                             {{#if funder.award_number}}
-                                                <dt>{{t 'file_detail.award_number'}}</dt>
+                                                <dt data-test-target-funder-award-number-label>{{t 'file_detail.award_number'}}</dt>
                                                 <dd data-test-target-funder-award-number={{funder.funder_name}}>
                                                     {{funder.award_number}}
                                                 </dd>
@@ -248,10 +248,10 @@
                                 </div>
                             {{/unless}}
                             <dl>
-                                <dt>{{t 'file_detail.title'}}</dt>
+                                <dt data-test-target-title-label>{{t 'file_detail.title'}}</dt>
                                 <dd data-test-target-title>{{manager.target.title}}</dd>
                                 {{#if manager.target.description}}
-                                    <dt>{{t 'file_detail.description'}}</dt>
+                                    <dt data-test-target-description-label>{{t 'file_detail.description'}}</dt>
                                     <dd data-test-target-description>
                                         <ExpandablePreview data-test-display-target-description>
                                             {{manager.target.description}}
@@ -259,7 +259,7 @@
                                     </dd>
                                 {{/if}}
                                 {{#if (and manager.targetInstitutions (not manager.isAnonymous))}}
-                                    <dt local-class='affiliated-institutions'>{{t 'file_detail.institutions'}}</dt>
+                                    <dt local-class='affiliated-institutions' data-test-target-institutions-label>{{t 'file_detail.institutions'}}</dt>
                                     <div data-test-target-institutions>
                                         {{#each manager.targetInstitutions as |institution|}}
                                             <dd>{{institution.name}}</dd>
@@ -267,20 +267,20 @@
                                     </div>
                                 {{/if}}
                                 {{#if manager.targetLicense.name}}
-                                    <dt>{{t 'file_detail.license'}}</dt>
+                                    <dt data-test-target-license-name-label>{{t 'file_detail.license'}}</dt>
                                     <dd data-test-target-license-name>{{manager.targetLicense.name}}</dd>
                                 {{/if}}
                                 {{#if manager.targetMetadata.resourceTypeGeneral}}
-                                    <dt>{{t 'file_detail.resource_type_general'}}</dt>
+                                    <dt data-test-target-resource-type-label>{{t 'file_detail.resource_type_general'}}</dt>
                                     <dd data-test-target-resource-type>{{manager.targetMetadata.resourceTypeGeneral}}</dd>
                                 {{/if}}
                                 {{#if manager.targetLanguageFromCode}}
-                                    <dt>{{t 'file_detail.language'}}</dt>
+                                    <dt data-test-target-language-label>{{t 'file_detail.language'}}</dt>
                                     <dd data-test-target-language>{{manager.targetLanguageFromCode}}</dd>
                                 {{/if}}
                             </dl>
                             {{#unless manager.isAnonymous}}
-                                <h3>{{t 'file_detail.contributors'}}</h3>
+                                <h3 data-test-target-contributors-label>{{t 'file_detail.contributors'}}</h3>
                                 <ContributorList
                                     data-test-target-contributors
                                     local-class='contributor-list'

--- a/tests/acceptance/guid-file/registration-file-detail-test.ts
+++ b/tests/acceptance/guid-file/registration-file-detail-test.ts
@@ -283,18 +283,6 @@ module('Acceptance | guid file | registration files', hooks => {
         assert.dom('[data-test-metadata-tab]').exists();
     });
 
-    // Verify anonymous registrations
-    test('Anonymous registration', async function(this: ThisTestContext, assert) {
-        const node = server.create('node', {
-            isAnonymous: true,
-        });
-
-        await visit(`/--node/${node.id}`);
-        assert.equal(currentURL(), `/--node/${node.id}`);
-
-        assert.dom('[data-test-metadata-node]').doesNotExist();
-    });
-
     // Verify A11y testing
     test('A11y testing', async function(this: ThisTestContext, assert) {
         await visit(`/--file/${this.file.id}`);

--- a/tests/acceptance/guid-file/registration-file-detail-test.ts
+++ b/tests/acceptance/guid-file/registration-file-detail-test.ts
@@ -2,6 +2,7 @@ import {
     currentURL,
     visit,
 } from '@ember/test-helpers';
+
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { ModelInstance } from 'ember-cli-mirage';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -113,14 +114,14 @@ module('Acceptance | guid file | registration files', hooks => {
 
     // Test file metadata
     test('view metadata', async function(this: ThisTestContext, assert) {
-        const nodeNoun = ['Registration','Project','Component'];
+        const nodeNoun = ['Registration', 'Project', 'Component'];
         const metadataRecord = await this.owner.lookup('service:store')
             .findRecord('custom-item-metadata-record', this.registration.id);
 
         await visit(`/--file/${this.file.id}`);
         assert.equal(currentURL(), `/--file/${this.file.guid}`);
 
-        // Verify correct tab on dekstop
+        // Verify correct default tab for dekstop
         assert.dom('[data-test-metadata-tab]').exists();
         assert.dom('[data-test-revisions-tab]').doesNotExist();
         assert.dom('[data-test-tags-tab]').doesNotExist();
@@ -203,7 +204,6 @@ module('Acceptance | guid file | registration files', hooks => {
         assert.dom('[data-test-target-description-label]').hasText('Description',
             'File metadata target description text is properly set.');
         assert.dom('[data-test-target-description]').exists();
-
     });
 
     // Save and cancel buttons with write permissions

--- a/tests/acceptance/guid-file/registration-file-detail-test.ts
+++ b/tests/acceptance/guid-file/registration-file-detail-test.ts
@@ -14,6 +14,7 @@ import { TestContext } from 'ember-test-helpers';
 
 import { module, test } from 'qunit';
 
+import FileModel from 'ember-osf-web/models/file';
 import { Permission } from 'ember-osf-web/models/osf-model';
 import { click, setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
 import RegistrationModel from 'ember-osf-web/models/registration';
@@ -275,6 +276,18 @@ module('Acceptance | guid file | registration files', hooks => {
         // Verify form closes
         assert.dom('[data-test-edit-metadata-form]').doesNotExist();
         assert.dom('[data-test-metadata-tab]').exists();
+    });
+
+    // Verify anonymous registrations
+    test('anonymous registration', async function(this: ThisTestContext, assert) {
+        const node = server.create('node', {
+            isAnonymous: true,
+        });
+
+        await visit(`/--node/${node.id}`);
+        assert.equal(currentURL(), `/--node/${node.id}`);
+
+        assert.dom('[data-test-metadata-node]').doesNotExist();
     });
 
     // Verify A11y testing

--- a/tests/acceptance/guid-file/registration-file-detail-test.ts
+++ b/tests/acceptance/guid-file/registration-file-detail-test.ts
@@ -18,10 +18,12 @@ import FileModel from 'ember-osf-web/models/file';
 import { Permission } from 'ember-osf-web/models/osf-model';
 import { click, setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
 import RegistrationModel from 'ember-osf-web/models/registration';
+import User from 'ember-osf-web/models/user';
 
 interface ThisTestContext extends TestContext {
     registration: ModelInstance<RegistrationModel>;
     file: ModelInstance<FileModel>;
+    currentUser: ModelInstance<User>;
 }
 
 module('Acceptance | guid file | registration files', hooks => {
@@ -31,7 +33,9 @@ module('Acceptance | guid file | registration files', hooks => {
     hooks.beforeEach(function(this: ThisTestContext) {
         this.registration = server.create('registration', {
             currentUserPermissions: [Permission.Write],
-        });
+            isAnonymous: false,
+        }, 'withContributors', 'withAffiliatedInstitutions');
+
         this.file = server.create('file', {
             target: this.registration,
             name: 'Test File',
@@ -155,20 +159,16 @@ module('Acceptance | guid file | registration files', hooks => {
         assert.dom('[data-test-file-language-label]').hasText('Resource language',
             'File metadata resource language text is properly set.');
         assert.dom('[data-test-file-language]').exists();
-
         // Contributor metadata
-        if (!this.registration.isAnonymous && (this.registration.contributors.length !== 0)) {
-            // Target contributors
-            assert.dom('[data-test-target-contributors-label]').hasText('Contributors',
-                'File metadata contributor text is properly set.');
-            assert.dom('[data-test-target-contributors]').exists();
-            // Target institutions
-            assert.dom('[data-test-target-institutions-label]').hasText('Affiliated institutions',
-                'File affiliated institutions text is properly set.');
-            assert.dom('[data-test-target-institutions]').exists();
-        }
+        assert.dom('[data-test-target-contributors-label]').hasText('Contributors',
+            'File metadata contributor text is properly set.');
+        assert.dom('[data-test-target-contributors]').exists();
+        // Target institutions
+        assert.dom('[data-test-target-institutions-label]').hasText('Affiliated institutions',
+            'File affiliated institutions text is properly set.');
+        assert.dom('[data-test-target-institutions]').exists();
         // Funder metadata
-        if (!this.registration.isAnonymous && metadataRecord.funder) {
+        if (metadataRecord.funder) {
             assert.dom('[data-test-target-funder-div]').exists();
             for (const funder of metadataRecord.funders) {
                 // Funder name

--- a/tests/acceptance/guid-file/registration-file-detail-test.ts
+++ b/tests/acceptance/guid-file/registration-file-detail-test.ts
@@ -2,16 +2,19 @@ import {
     currentURL,
     visit,
 } from '@ember/test-helpers';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { ModelInstance } from 'ember-cli-mirage';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { t } from 'ember-intl/test-support';
 import { percySnapshot } from 'ember-percy';
+import { selectChoose } from 'ember-power-select/test-support';
 import { setBreakpoint } from 'ember-responsive/test-support';
 import { TestContext } from 'ember-test-helpers';
+
 import { module, test } from 'qunit';
 
+import { Permission } from 'ember-osf-web/models/osf-model';
 import { click, setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
-import FileModel from 'ember-osf-web/models/file';
 import RegistrationModel from 'ember-osf-web/models/registration';
 
 interface ThisTestContext extends TestContext {
@@ -58,16 +61,26 @@ module('Acceptance | guid file | registration files', hooks => {
         assert.dom('[data-test-tags-button]').exists('Tags button exists');
         await percySnapshot('Acceptance | guid file | registration files | mobile view | file renderer');
 
-        await click('[data-test-versions-button]');
-        assert.dom('[data-test-revisions-tab]').exists('Revisions shown');
-        assert.dom('[data-test-file-renderer]').doesNotExist('File renderer is hidden');
-        await percySnapshot('Acceptance | guid file | registration files | mobile view | revisions');
+        assert.dom('[data-test-file-renderer]').exists();
+        assert.dom('[data-test-metadata-tab]').doesNotExist();
+        assert.dom('[data-test-revisions-tab]').doesNotExist();
+        assert.dom('[data-test-tags-tab]').doesNotExist();
 
         // click tags and verify appropriate panels shown
+        await click('[data-test-versions-button]');
+        assert.dom('[data-test-revisions-tab]').exists('Revisions shown');
+        assert.dom('[data-test-file-renderer]').isNotVisible('File renderer is hidden');
+        await percySnapshot('Acceptance | guid file | registration files | mobile view | revisions');
 
         await click('[data-test-file-renderer-button]');
         assert.dom('[data-test-file-renderer]').exists('File renderer is shown again');
-        assert.dom('[data-test-revisions-tab]').doesNotExist('Revisions now hidden');
+        assert.dom('[data-test-revisions-tab]').isNotVisible('Revisions now hidden');
+
+        await click('[data-test-metadata-button]');
+        assert.dom('[data-test-metadata-tab]').exists('Metadata tab now visible');
+        assert.dom('[data-test-revisions-tab]').isNotVisible('Revisions now hidden');
+        assert.dom('[data-test-file-renderer]').isNotVisible('File renderer now hidden');
+        assert.dom('[data-test-tags-tab]').isNotVisible('Tags now hidden');
     });
 
     test('view revisions', async function(this: ThisTestContext, assert) {
@@ -98,7 +111,168 @@ module('Acceptance | guid file | registration files', hooks => {
             .hasAria('label', t('file_detail.view_revisions'), 'Versions button has correct label when closed');
     });
 
-    // test for tags
+    // Test file metadata
+    test('view metadata', async function(this: ThisTestContext, assert) {
+        const nodeNoun = ['Registration','Project','Component'];
+        const metadataRecord = await this.owner.lookup('service:store')
+            .findRecord('custom-item-metadata-record', this.registration.id);
 
-    // test for switching views
+        await visit(`/--file/${this.file.id}`);
+        assert.equal(currentURL(), `/--file/${this.file.guid}`);
+
+        // Verify correct tab on dekstop
+        assert.dom('[data-test-metadata-tab]').exists();
+        assert.dom('[data-test-revisions-tab]').doesNotExist();
+        assert.dom('[data-test-tags-tab]').doesNotExist();
+
+        // Verify favicon
+        assert.dom('[data-test-metadata-button]').hasAria('label', 'Close metadata',
+            'Close metadata aria should be present when metadata tab is open.');
+        assert.dom('[data-test-metadata-button] > svg').hasClass('fa-info-circle',
+            'Button should have info circle Font Awesome 5 icon present.');
+
+        // File Metadata
+        assert.dom('[data-test-metadata-header]').hasText('File Metadata',
+            'File metadata header is properly set.');
+        // Title
+        assert.dom('[data-test-file-title-label]').hasText('Title',
+            'File metadata title label text is properly set.');
+        assert.dom('[data-test-file-title]').exists();
+        // Description
+        assert.dom('[data-test-file-description-label]').hasText('Description',
+            'File metadata description label text is properly set.');
+        assert.dom('[data-test-file-description]').exists();
+        // Resource type
+        assert.dom('[data-test-file-resource-type-label]').hasText('Resource type',
+            'File metadata resource type text is properly set.');
+        assert.dom('[data-test-file-resource-type]').exists();
+        // Resource language
+        assert.dom('[data-test-file-language-label]').hasText('Resource language',
+            'File metadata resource language text is properly set.');
+        assert.dom('[data-test-file-language]').exists();
+
+        // Node metadata
+        const nodeNounElement = document.querySelectorAll('[data-test-metadata-node]')[0].textContent;
+        const nounFound = nodeNoun.some(r => nodeNounElement?.includes(r));
+        assert.equal(nounFound, true, 'Node noun properly set.');
+        if (!this.registration.isAnonymous && (this.registration.contributors.length !== 0)) {
+            // Target contributors
+            assert.dom('[data-test-target-contributors-label]').hasText('Contributors',
+                'File metadata contributor text is properly set.');
+            assert.dom('[data-test-target-contributors]').exists();
+            // Target Institutions
+            assert.dom('[data-test-target-institutions-label]').hasText('Affiliated institutions',
+                'File affiliated institutions text is properly set.');
+            assert.dom('[data-test-target-institutions]').exists();
+        }
+        // Funder metadata
+        if (!this.registration.isAnonymous && metadataRecord.funder) {
+            assert.dom('[data-test-target-funder-div]').exists();
+            for (const funder of metadataRecord.funders) {
+                // Funder name
+                assert.dom('[data-test-target-funder-name-label]').hasText('Funder',
+                    'File metadata funder text is properly set.');
+                assert.dom('[data-test-target-funder-name]').exists();
+                assert.dom(`[data-test-target-funder-name="${funder.funder_name}"]`)
+                    .containsText(funder.funder_name, `Funder name is unchanged for ${funder.funder_name}`);
+                // Award title
+                assert.dom('[data-test-target-funder-award-title-label]').hasText('Award title',
+                    'File metadata award title text is properly set.');
+                assert.dom('[data-test-target-funder-award-title]').exists();
+                assert.dom(`[data-test-target-funder-award-title="${funder.award_title}"]`)
+                    .containsText(funder.award_title, `Funder award title is unchanged for ${funder.funder_name}`);
+                // Award URI
+                assert.dom('[data-test-target-funder-award-uri-label]').hasText('Award URI',
+                    'File metadata award URI text is properly set.');
+                assert.dom('[data-test-target-funder-award-uri]').exists();
+                assert.dom(`[ data-test-target-funder-award-uri="${funder.award_uri}"]`)
+                    .containsText(funder.award_uri, `Funder award URI is unchanged for ${funder.funder_name}`);
+                // Award number
+                assert.dom('[data-test-target-funder-award-number-label]').hasText('Award number',
+                    'File metadata award number text is properly set.');
+                assert.dom('[data-test-target-funder-award-number]').exists();
+                assert.dom(`[data-test-target-funder-award-number="${funder.award_number}"`)
+                    .containsText(funder.award_number, `Funder award number is unchanged for ${funder.funder_name}`);
+            }
+        }
+        // Target title
+        assert.dom('[data-test-target-title-label]').hasText('Title',
+            'File metadata target title text is properly set.');
+        assert.dom('[data-test-target-title]').exists();
+        // Target description
+        assert.dom('[data-test-target-description-label]').hasText('Description',
+            'File metadata target description text is properly set.');
+        assert.dom('[data-test-target-description]').exists();
+
+    });
+
+    // Save and cancel buttons with write permissions
+    test('save and cancel', async function(this: ThisTestContext, assert) {
+        await visit(`/--file/${this.file.id}`);
+        assert.equal(currentURL(), `/--file/${this.file.guid}`);
+
+        // Verify download
+        if (!this.registration.isAnonymous) {
+            assert.dom('[data-test-download-button]').exists();
+        }
+
+        // Verify edit
+        if (this.file.target.currentUserPermissions.includes(Permission.Write)) {
+            await click('[data-test-edit-metadata-button]');
+            assert.dom('[data-test-title-field]').exists();
+            assert.dom('[data-test-description-field]').exists();
+            assert.dom('[data-test-select-resource-type]').exists();
+            assert.dom('[data-test-select-resource-language]').exists();
+            assert.dom('[data-test-cancel-editing-metadata-button]').exists();
+            assert.dom('[data-test-save-metadata-button]').exists();
+            await click('[data-test-cancel-editing-metadata-button]');
+            assert.dom('[data-test-edit-metadata-form]').doesNotExist();
+            await click('[data-test-edit-metadata-button]');
+
+            // Screenshot before changes
+            await percySnapshot(assert);
+            // Update Title
+            const editTitleTextArea = document.querySelectorAll('textarea')[0];
+            editTitleTextArea.textContent = 'A test title.';
+            assert.dom('[data-test-title-field]')
+                .containsText('A test title.', 'Metadata title field updates.');
+            // Update Description
+            const editDescriptionTextArea = document.querySelectorAll('textarea')[1];
+            editDescriptionTextArea.textContent = 'A test description.';
+            assert.dom('[data-test-title-field]')
+                .containsText('A test description.', 'Metadata description field updates.');
+            // Update Resource Type
+            await selectChoose('[data-test-select-resource-type]', 'InteractiveResource');
+            // Update Resource Language
+            await selectChoose('[data-test-select-resource-language]', 'InteractiveResource');
+            // Screenshot after changes
+            await percySnapshot(assert);
+            // Save changes
+            await click('[data-test-save-metadata-button]');
+        }
+        // Verify form closes
+        assert.dom('[data-test-edit-metadata-form]').doesNotExist();
+        assert.dom('[data-test-metadata-tab]').exists();
+    });
+
+    // Verify A11y testing
+    test('a11y testing', async function(this: ThisTestContext, assert) {
+        await visit(`/--file/${this.file.id}`);
+        assert.equal(currentURL(), `/--file/${this.file.guid}`);
+        await a11yAudit();
+
+        // verify metadata
+        await click('[data-test-metadata-button]');
+        await a11yAudit();
+
+        // verify versions
+        await click('[data-test-versions-button]');
+        await a11yAudit();
+
+        // verify tags
+        await click('[data-test-tags-button]');
+        await a11yAudit();
+
+        assert.ok('No A11y issues');
+    });
 });

--- a/tests/acceptance/guid-file/registration-file-detail-test.ts
+++ b/tests/acceptance/guid-file/registration-file-detail-test.ts
@@ -53,7 +53,7 @@ module('Acceptance | guid file | registration files', hooks => {
         await percySnapshot(assert);
     });
 
-    test('mobile view', async function(this: ThisTestContext, assert) {
+    test('Mobile view', async function(this: ThisTestContext, assert) {
         setBreakpoint('mobile');
         await visit(`/--file/${this.file.id}`);
         assert.equal(currentURL(), `/--file/${this.file.guid}`);
@@ -90,7 +90,7 @@ module('Acceptance | guid file | registration files', hooks => {
         assert.dom('[data-test-tags-tab]').doesNotExist('Tags now hidden');
     });
 
-    test('view revisions', async function(this: ThisTestContext, assert) {
+    test('View revisions', async function(this: ThisTestContext, assert) {
         await visit(`/--file/${this.file.id}`);
         assert.equal(currentURL(), `/--file/${this.file.guid}`);
 
@@ -118,8 +118,7 @@ module('Acceptance | guid file | registration files', hooks => {
             .hasAria('label', t('file_detail.view_revisions'), 'Versions button has correct label when closed');
     });
 
-    test('view metadata', async function(this: ThisTestContext, assert) {
-        const nodeNoun = ['Registration', 'Project', 'Component'];
+    test('View metadata', async function(this: ThisTestContext, assert) {
         const metadataRecord = await this.owner.lookup('service:store')
             .findRecord('custom-item-metadata-record', this.registration.id);
 
@@ -157,10 +156,7 @@ module('Acceptance | guid file | registration files', hooks => {
             'File metadata resource language text is properly set.');
         assert.dom('[data-test-file-language]').exists();
 
-        // Node metadata
-        const nodeNounElement = document.querySelectorAll('[data-test-metadata-node]')[0].textContent;
-        const nounFound = nodeNoun.some(r => nodeNounElement?.includes(r));
-        assert.equal(nounFound, true, 'Node noun properly set.');
+        // Contributor metadata
         if (!this.registration.isAnonymous && (this.registration.contributors.length !== 0)) {
             // Target contributors
             assert.dom('[data-test-target-contributors-label]').hasText('Contributors',
@@ -211,8 +207,17 @@ module('Acceptance | guid file | registration files', hooks => {
         assert.dom('[data-test-target-description]').exists();
     });
 
+    // Node type
+    test('Node type', async function(this: ThisTestContext, assert) {
+        await visit(`/--file/${this.file.id}`);
+        assert.equal(currentURL(), `/--file/${this.file.guid}`);
+
+        assert.dom('[data-test-metadata-node]').hasText('Registration Metadata',
+            'Node noun for registration properly set.');
+    });
+
     // Save and cancel buttons with write permissions
-    test('save and cancel', async function(this: ThisTestContext, assert) {
+    test('Save and cancel', async function(this: ThisTestContext, assert) {
         await visit(`/--file/${this.file.id}`);
         assert.equal(currentURL(), `/--file/${this.file.guid}`);
 
@@ -279,7 +284,7 @@ module('Acceptance | guid file | registration files', hooks => {
     });
 
     // Verify anonymous registrations
-    test('anonymous registration', async function(this: ThisTestContext, assert) {
+    test('Anonymous registration', async function(this: ThisTestContext, assert) {
         const node = server.create('node', {
             isAnonymous: true,
         });
@@ -291,7 +296,7 @@ module('Acceptance | guid file | registration files', hooks => {
     });
 
     // Verify A11y testing
-    test('a11y testing', async function(this: ThisTestContext, assert) {
+    test('A11y testing', async function(this: ThisTestContext, assert) {
         await visit(`/--file/${this.file.id}`);
         assert.equal(currentURL(), `/--file/${this.file.guid}`);
         await a11yAudit();


### PR DESCRIPTION
-   Ticket: https://openscience.atlassian.net/browse/ENG-4187
-   Feature flag: feature/file-metadata-mirage-tests

## Purpose

The purpose of these changes is to add tests for the ember-osf-web portion of the File Metadata project.

## Summary of Changes

Tests were added to the registration-file-detail-test.ts file to verify the functionality of metadata label and div elements, the edit metadata form and its save and cancel buttons, and the mobile default view for the application.

## Screenshot(s)

<img width="519" alt="image" src="https://user-images.githubusercontent.com/82047646/213532231-3764e167-b0f7-4521-8976-aa586edf6a72.png">

## Side Effects

There should be no unintended side effects.

## QA Notes

-Are all added components and functionalities properly tested?
-Are there any suggested tests not already covered?
-Does the default view change for tablet view? From tablet to mobile, mobile to desktop and vice versa?
-Are all elements properly rendered on the screen? Does the edit metadata button remain hidden when permissions change?
