### PR TITLE
[ENG-4009] Remove use of volatile computed property

### DIFF
--- a/app/models/user-registration.ts
+++ b/app/models/user-registration.ts
@@ -1,5 +1,5 @@
+import { alias } from '@ember/object/computed';
 import Model, { attr } from '@ember-data/model';
-import { computed } from '@ember/object';
 import { buildValidations, validator } from 'ember-cp-validations';
 import config from 'ember-get-config';
 
@@ -11,18 +11,12 @@ const Validations = buildValidations({
         validator('format', { type: 'email' }),
         validator('exclusion', {
             messageKey: 'validationErrors.email_registered',
-            in: computed('model.existingEmails', function(): string[] {
-                return [...this.model.existingEmails];
-            // eslint-disable-next-line ember/no-volatile-computed-properties
-            }).volatile(),
+            in: alias('model.existingEmailsArray'),
         }),
         validator('exclusion', {
             messageKey: 'validationErrors.email_invalid',
             supportEmail,
-            in: computed('model.invalidEmails', function(): string[] {
-                return [...this.model.invalidEmails];
-            // eslint-disable-next-line ember/no-volatile-computed-properties
-            }).volatile(),
+            in: alias('model.invalidEmailsArray'),
         }),
         validator('length', {
             max: 255,
@@ -82,6 +76,14 @@ export default class UserRegistrationModel extends Model.extend(Validations) {
 
     existingEmails: Set<string> = new Set();
     invalidEmails: Set<string> = new Set();
+
+    get existingEmailsArray(): string[] {
+        return [...this.existingEmails];
+    }
+
+    get invalidEmailsArray(): string[] {
+        return [...this.invalidEmails];
+    }
 
     addExistingEmail(email?: string) {
         this.existingEmails.add(email || this.email1);

--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -2,7 +2,6 @@ self.deprecationWorkflow = self.deprecationWorkflow || {};
 self.deprecationWorkflow.config = {
     workflow: [
         { handler: 'silence', matchId: 'ember-inflector.globals' },
-        { handler: 'silence', matchId: 'computed-property.volatile' },
         { handler: 'silence', matchId: 'implicit-injections' },
         { handler: 'silence', matchId: 'manager-capabilities.modifiers-3-13' },
         { handler: 'silence', matchId: 'this-property-fallback' },


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-4009]
-   Feature flag: n/a

## Purpose
- Remove [deprecated volatile computed properties](https://deprecations.emberjs.com/v3.x/#toc_computed-property-volatile) 

## Summary of Changes
- Change how we fetch the `existingEmails` and `invalidEmails` when validating a new user registration

## Screenshot(s)
- when visiting `osf.io/register` and trying to sign up with an email already in use by another user
![image](https://user-images.githubusercontent.com/51409893/218211480-8969f533-644a-4a3a-b734-46c42350ed9f.png)


## Side Effects
- There should be no side-effects

## QA Notes
- Please verify that the register page works properly and users get a meaningful message when they try to sign up using an email that is already in use by another account, and also when they try to use an email domain that is forbidden (`danger@forbiddendomain.com`)

[ENG-4009]: https://openscience.atlassian.net/browse/ENG-4009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ