### PR TITLE
[ENG-4187] Test file detail view section - Updated

### DIFF
--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -3,7 +3,7 @@
     @isMobile={{this.media.isMobile}}
 >
     <:header>
-        <h3>
+        <h3 local-class='project-link-header>
             <OsfLink
                 data-test-project-link
                 data-analytics-name='Linked project'

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -70,7 +70,7 @@
                 <FileMetadataManager @file={{this.model.fileModel}} as |manager|>
                     <div local-class='metadata-title-edit-download'>
                         <h2 local-class='metadata-heading' data-test-metadata-header>
-                            {{t 'file_detail.file_metadata'}}
+                            {{t 'file-detail.file-metadata'}}
                         </h2>
                         <div local-class='edit-download-buttons'>
                             {{#unless manager.inEditMode}}
@@ -175,11 +175,11 @@
                             )}}
                                 <dl>
                                     {{#if manager.metadataRecord.title}}
-                                        <dt data-test-file-title-label>{{t 'file_detail.title'}}</dt>
+                                        <dt data-test-file-title-label>{{t 'file-detail.title'}}</dt>
                                         <dd data-test-file-title>{{manager.metadataRecord.title}}</dd>
                                     {{/if}}
                                     {{#if manager.metadataRecord.description}}
-                                        <dt data-test-file-description-label>{{t 'file_detail.description'}}</dt>
+                                        <dt data-test-file-description-label>{{t 'file-detail.description'}}</dt>
                                         <dd data-test-file-description>
                                             <ExpandablePreview data-test-display-file-description>
                                                 {{manager.metadataRecord.description}}
@@ -188,7 +188,7 @@
                                     {{/if}}
                                     {{#if manager.metadataRecord.resourceTypeGeneral}}
                                         <dt data-test-file-resource-type-label>
-                                            {{t 'file_detail.resource_type_general'}}
+                                            {{t 'file-detail.resource-type-general'}}
                                             <Button
                                                 aria-label={{t 'file-detail.resource-type-general-help'}}
                                                 @layout='fake-link'
@@ -205,7 +205,7 @@
                                         <dd data-test-file-resource-type>{{manager.metadataRecord.resourceTypeGeneral}}</dd>
                                     {{/if}}
                                     {{#if manager.languageFromCode}}
-                                        <dt data-test-file-language-label>{{t 'file_detail.language'}}</dt>
+                                        <dt data-test-file-language-label>{{t 'file-detail.language'}}</dt>
                                         <dd data-test-file-language>{{manager.languageFromCode}}</dd>
                                     {{/if}}
                                 </dl>
@@ -214,31 +214,31 @@
                                     {{t 'file-detail.enter-metadata'}}
                                 {{/if}}
                             {{/if}}
-                            <h2 local-class='node-type-heading' data-test-metadata-node>{{t (concat 'file_detail.metadata_' manager.nodeWord)}}</h2>
+                            <h2 local-class='node-type-heading' data-test-metadata-node>{{t (concat 'file-detail.metadata-' manager.nodeWord)}}</h2>
                             {{#unless manager.isAnonymous}}
                                 <div data-test-target-funder-div>
                                     {{#each manager.targetMetadata.funders as |funder|}}
                                         <dl>
                                             {{#if funder.funder_name}}
-                                                <dt data-test-target-funder-name-label>{{t 'file_detail.funder'}}</dt>
+                                                <dt data-test-target-funder-name-label>{{t 'file-detail.funder'}}</dt>
                                                 <dd data-test-target-funder-name={{funder.funder_name}}>
                                                     {{funder.funder_name}}
                                                 </dd>
                                             {{/if}}
                                             {{#if funder.award_title}}
-                                                <dt data-test-target-funder-award-title-label>{{t 'file_detail.award_title'}}</dt>
+                                                <dt data-test-target-funder-award-title-label>{{t 'file-detail.award-title'}}</dt>
                                                 <dd data-test-target-funder-award-title={{funder.funder_name}}>
                                                     {{funder.award_title}}
                                                 </dd>
                                             {{/if}}
                                             {{#if funder.award_uri}}
-                                                <dt data-test-target-funder-award-uri-label>{{t 'file_detail.award_uri'}}</dt>
+                                                <dt data-test-target-funder-award-uri-label>{{t 'file-detail.award-uri'}}</dt>
                                                 <dd data-test-target-funder-award-uri={{funder.funder_name}}>
                                                     {{funder.award_uri}}
                                                 </dd>
                                             {{/if}}
                                             {{#if funder.award_number}}
-                                                <dt data-test-target-funder-award-number-label>{{t 'file_detail.award_number'}}</dt>
+                                                <dt data-test-target-funder-award-number-label>{{t 'file-detail.award-number'}}</dt>
                                                 <dd data-test-target-funder-award-number={{funder.funder_name}}>
                                                     {{funder.award_number}}
                                                 </dd>
@@ -248,10 +248,10 @@
                                 </div>
                             {{/unless}}
                             <dl>
-                                <dt data-test-target-title-label>{{t 'file_detail.title'}}</dt>
+                                <dt data-test-target-title-label>{{t 'file-detail.title'}}</dt>
                                 <dd data-test-target-title>{{manager.target.title}}</dd>
                                 {{#if manager.target.description}}
-                                    <dt data-test-target-description-label>{{t 'file_detail.description'}}</dt>
+                                    <dt data-test-target-description-label>{{t 'file-detail.description'}}</dt>
                                     <dd data-test-target-description>
                                         <ExpandablePreview data-test-display-target-description>
                                             {{manager.target.description}}
@@ -259,7 +259,7 @@
                                     </dd>
                                 {{/if}}
                                 {{#if (and manager.targetInstitutions (not manager.isAnonymous))}}
-                                    <dt local-class='affiliated-institutions' data-test-target-institutions-label>{{t 'file_detail.institutions'}}</dt>
+                                    <dt local-class='affiliated-institutions' data-test-target-institutions-label>{{t 'file-detail.institutions'}}</dt>
                                     <div data-test-target-institutions>
                                         {{#each manager.targetInstitutions as |institution|}}
                                             <dd>{{institution.name}}</dd>
@@ -267,15 +267,15 @@
                                     </div>
                                 {{/if}}
                                 {{#if manager.targetLicense.name}}
-                                    <dt data-test-target-license-name-label>{{t 'file_detail.license'}}</dt>
+                                    <dt data-test-target-license-name-label>{{t 'file-detail.license'}}</dt>
                                     <dd data-test-target-license-name>{{manager.targetLicense.name}}</dd>
                                 {{/if}}
                                 {{#if manager.targetMetadata.resourceTypeGeneral}}
-                                    <dt data-test-target-resource-type-label>{{t 'file_detail.resource_type_general'}}</dt>
+                                    <dt data-test-target-resource-type-label>{{t 'file-detail.resource_type_general'}}</dt>
                                     <dd data-test-target-resource-type>{{manager.targetMetadata.resourceTypeGeneral}}</dd>
                                 {{/if}}
                                 {{#if manager.targetLanguageFromCode}}
-                                    <dt data-test-target-language-label>{{t 'file_detail.language'}}</dt>
+                                    <dt data-test-target-language-label>{{t 'file-detail.language'}}</dt>
                                     <dd data-test-target-language>{{manager.targetLanguageFromCode}}</dd>
                                 {{/if}}
                                 <dt>{{t 'file-detail.creation-date'}}</dt>
@@ -310,7 +310,7 @@
                                 {{/if}}
                             </dl>
                             {{#unless manager.isAnonymous}}
-                                <h3 data-test-target-contributors-label>{{t 'file_detail.contributors'}}</h3>
+                                <h3 data-test-target-contributors-label>{{t 'file-detail.contributors'}}</h3>
                                 <ContributorList
                                     data-test-target-contributors
                                     local-class='contributor-list'

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -3,7 +3,7 @@
     @isMobile={{this.media.isMobile}}
 >
     <:header>
-        <h3 local-class='project-link-header'>
+        <h3>
             <OsfLink
                 data-test-project-link
                 data-analytics-name='Linked project'
@@ -66,11 +66,11 @@
             </div>
         {{/if}}
         {{#if this.metadataOpened}}
-            <div local-class='right-container {{if this.isMobile 'Mobile'}}'>
+            <div local-class='right-container {{if this.isMobile 'Mobile'}}' data-test-metadata-tab>
                 <FileMetadataManager @file={{this.model.fileModel}} as |manager|>
                     <div local-class='metadata-title-edit-download'>
-                        <h2 local-class='metadata-heading'>
-                            {{t 'file-detail.file-metadata'}}
+                        <h2 local-class='metadata-heading' data-test-metadata-header>
+                            {{t 'file_detail.file_metadata'}}
                         </h2>
                         <div local-class='edit-download-buttons'>
                             {{#unless manager.inEditMode}}
@@ -175,11 +175,11 @@
                             )}}
                                 <dl>
                                     {{#if manager.metadataRecord.title}}
-                                        <dt>{{t 'file-detail.title'}}</dt>
+                                        <dt data-test-file-title-label>{{t 'file_detail.title'}}</dt>
                                         <dd data-test-file-title>{{manager.metadataRecord.title}}</dd>
                                     {{/if}}
                                     {{#if manager.metadataRecord.description}}
-                                        <dt>{{t 'file-detail.description'}}</dt>
+                                        <dt data-test-file-description-label>{{t 'file_detail.description'}}</dt>
                                         <dd data-test-file-description>
                                             <ExpandablePreview data-test-display-file-description>
                                                 {{manager.metadataRecord.description}}
@@ -187,8 +187,8 @@
                                         </dd>
                                     {{/if}}
                                     {{#if manager.metadataRecord.resourceTypeGeneral}}
-                                        <dt>
-                                            {{t 'file-detail.resource-type-general'}}
+                                        <dt data-test-file-resource-type-label>
+                                            {{t 'file_detail.resource_type_general'}}
                                             <Button
                                                 aria-label={{t 'file-detail.resource-type-general-help'}}
                                                 @layout='fake-link'
@@ -205,7 +205,7 @@
                                         <dd data-test-file-resource-type>{{manager.metadataRecord.resourceTypeGeneral}}</dd>
                                     {{/if}}
                                     {{#if manager.languageFromCode}}
-                                        <dt>{{t 'file-detail.language'}}</dt>
+                                        <dt data-test-file-language-label>{{t 'file_detail.language'}}</dt>
                                         <dd data-test-file-language>{{manager.languageFromCode}}</dd>
                                     {{/if}}
                                 </dl>
@@ -214,31 +214,31 @@
                                     {{t 'file-detail.enter-metadata'}}
                                 {{/if}}
                             {{/if}}
-                            <h2 local-class='node-type-heading'>{{t (concat 'file-detail.metadata-' manager.nodeWord)}}</h2>
+                            <h2 local-class='node-type-heading' data-test-metadata-node>{{t (concat 'file_detail.metadata_' manager.nodeWord)}}</h2>
                             {{#unless manager.isAnonymous}}
-                                <div>
+                                <div data-test-target-funder-div>
                                     {{#each manager.targetMetadata.funders as |funder|}}
                                         <dl>
                                             {{#if funder.funder_name}}
-                                                <dt>{{t 'file-detail.funder'}}</dt>
+                                                <dt data-test-target-funder-name-label>{{t 'file_detail.funder'}}</dt>
                                                 <dd data-test-target-funder-name={{funder.funder_name}}>
                                                     {{funder.funder_name}}
                                                 </dd>
                                             {{/if}}
                                             {{#if funder.award_title}}
-                                                <dt>{{t 'file-detail.award-title'}}</dt>
+                                                <dt data-test-target-funder-award-title-label>{{t 'file_detail.award_title'}}</dt>
                                                 <dd data-test-target-funder-award-title={{funder.funder_name}}>
                                                     {{funder.award_title}}
                                                 </dd>
                                             {{/if}}
                                             {{#if funder.award_uri}}
-                                                <dt>{{t 'file-detail.award-uri'}}</dt>
+                                                <dt data-test-target-funder-award-uri-label>{{t 'file_detail.award_uri'}}</dt>
                                                 <dd data-test-target-funder-award-uri={{funder.funder_name}}>
                                                     {{funder.award_uri}}
                                                 </dd>
                                             {{/if}}
                                             {{#if funder.award_number}}
-                                                <dt>{{t 'file-detail.award-number'}}</dt>
+                                                <dt data-test-target-funder-award-number-label>{{t 'file_detail.award_number'}}</dt>
                                                 <dd data-test-target-funder-award-number={{funder.funder_name}}>
                                                     {{funder.award_number}}
                                                 </dd>
@@ -248,10 +248,10 @@
                                 </div>
                             {{/unless}}
                             <dl>
-                                <dt>{{t 'file-detail.title'}}</dt>
+                                <dt data-test-target-title-label>{{t 'file_detail.title'}}</dt>
                                 <dd data-test-target-title>{{manager.target.title}}</dd>
                                 {{#if manager.target.description}}
-                                    <dt>{{t 'file-detail.description'}}</dt>
+                                    <dt data-test-target-description-label>{{t 'file_detail.description'}}</dt>
                                     <dd data-test-target-description>
                                         <ExpandablePreview data-test-display-target-description>
                                             {{manager.target.description}}
@@ -259,7 +259,7 @@
                                     </dd>
                                 {{/if}}
                                 {{#if (and manager.targetInstitutions (not manager.isAnonymous))}}
-                                    <dt local-class='affiliated-institutions'>{{t 'file-detail.institutions'}}</dt>
+                                    <dt local-class='affiliated-institutions' data-test-target-institutions-label>{{t 'file_detail.institutions'}}</dt>
                                     <div data-test-target-institutions>
                                         {{#each manager.targetInstitutions as |institution|}}
                                             <dd>{{institution.name}}</dd>
@@ -267,15 +267,15 @@
                                     </div>
                                 {{/if}}
                                 {{#if manager.targetLicense.name}}
-                                    <dt>{{t 'file-detail.license'}}</dt>
+                                    <dt data-test-target-license-name-label>{{t 'file_detail.license'}}</dt>
                                     <dd data-test-target-license-name>{{manager.targetLicense.name}}</dd>
                                 {{/if}}
                                 {{#if manager.targetMetadata.resourceTypeGeneral}}
-                                    <dt>{{t 'file-detail.resource-type-general'}}</dt>
+                                    <dt data-test-target-resource-type-label>{{t 'file_detail.resource_type_general'}}</dt>
                                     <dd data-test-target-resource-type>{{manager.targetMetadata.resourceTypeGeneral}}</dd>
                                 {{/if}}
                                 {{#if manager.targetLanguageFromCode}}
-                                    <dt>{{t 'file-detail.language'}}</dt>
+                                    <dt data-test-target-language-label>{{t 'file_detail.language'}}</dt>
                                     <dd data-test-target-language>{{manager.targetLanguageFromCode}}</dd>
                                 {{/if}}
                                 <dt>{{t 'file-detail.creation-date'}}</dt>
@@ -310,7 +310,7 @@
                                 {{/if}}
                             </dl>
                             {{#unless manager.isAnonymous}}
-                                <h3>{{t 'file-detail.contributors'}}</h3>
+                                <h3 data-test-target-contributors-label>{{t 'file_detail.contributors'}}</h3>
                                 <ContributorList
                                     data-test-target-contributors
                                     local-class='contributor-list'

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -3,7 +3,7 @@
     @isMobile={{this.media.isMobile}}
 >
     <:header>
-        <h3 local-class='project-link-header>
+        <h3 local-class='project-link-header'>
             <OsfLink
                 data-test-project-link
                 data-analytics-name='Linked project'

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -271,7 +271,7 @@
                                     <dd data-test-target-license-name>{{manager.targetLicense.name}}</dd>
                                 {{/if}}
                                 {{#if manager.targetMetadata.resourceTypeGeneral}}
-                                    <dt data-test-target-resource-type-label>{{t 'file-detail.resource_type_general'}}</dt>
+                                    <dt data-test-target-resource-type-label>{{t 'file-detail.resource-type-general'}}</dt>
                                     <dd data-test-target-resource-type>{{manager.targetMetadata.resourceTypeGeneral}}</dd>
                                 {{/if}}
                                 {{#if manager.targetLanguageFromCode}}

--- a/tests/acceptance/guid-file/registration-file-detail-test.ts
+++ b/tests/acceptance/guid-file/registration-file-detail-test.ts
@@ -12,7 +12,7 @@ import { selectChoose } from 'ember-power-select/test-support';
 import { setBreakpoint } from 'ember-responsive/test-support';
 import { TestContext } from 'ember-test-helpers';
 
-import { module, skip, test } from 'qunit';
+import { module, test } from 'qunit';
 
 import FileModel from 'ember-osf-web/models/file';
 import { Permission } from 'ember-osf-web/models/osf-model';
@@ -32,17 +32,15 @@ module('Acceptance | guid file | registration files', hooks => {
 
     hooks.beforeEach(function(this: ThisTestContext) {
         this.registration = server.create('registration', {
-            currentUserPermissions: [Permission.Write],
-            isAnonymous: false,
-        }, 'withContributors', 'withAffiliatedInstitutions', 'withFiles', 'isPublic');
-
+            currentUserPermissions: [Permission.Read, Permission.Write],
+        }, 'withContributors', 'withAffiliatedInstitutions', 'withFiles');
         this.file = server.create('file', {
             target: this.registration,
             name: 'Test File',
         });
     });
 
-    skip('Desktop view', async function(this: ThisTestContext, assert) {
+    test('Desktop view', async function(this: ThisTestContext, assert) {
         await visit(`/--file/${this.file.id}`);
         assert.equal(currentURL(), `/--file/${this.file.guid}`);
         assert.dom('[data-test-filename]')

--- a/tests/acceptance/guid-file/registration-file-detail-test.ts
+++ b/tests/acceptance/guid-file/registration-file-detail-test.ts
@@ -2,21 +2,28 @@ import {
     currentURL,
     visit,
 } from '@ember/test-helpers';
+
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { ModelInstance } from 'ember-cli-mirage';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { t } from 'ember-intl/test-support';
 import { percySnapshot } from 'ember-percy';
+import { selectChoose } from 'ember-power-select/test-support';
 import { setBreakpoint } from 'ember-responsive/test-support';
 import { TestContext } from 'ember-test-helpers';
-import { module, test } from 'qunit';
 
-import { click, setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
+import { module, skip, test } from 'qunit';
+
 import FileModel from 'ember-osf-web/models/file';
+import { Permission } from 'ember-osf-web/models/osf-model';
+import { click, setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
 import RegistrationModel from 'ember-osf-web/models/registration';
+import User from 'ember-osf-web/models/user';
 
 interface ThisTestContext extends TestContext {
     registration: ModelInstance<RegistrationModel>;
     file: ModelInstance<FileModel>;
+    currentUser: ModelInstance<User>;
 }
 
 module('Acceptance | guid file | registration files', hooks => {
@@ -24,11 +31,18 @@ module('Acceptance | guid file | registration files', hooks => {
     setupMirage(hooks);
 
     hooks.beforeEach(function(this: ThisTestContext) {
-        this.registration = server.create('registration');
-        this.file = server.create('file', { target: this.registration, name: 'Test File' });
+        this.registration = server.create('registration', {
+            currentUserPermissions: [Permission.Write],
+            isAnonymous: false,
+        }, 'withContributors', 'withAffiliatedInstitutions', 'withFiles', 'isPublic');
+
+        this.file = server.create('file', {
+            target: this.registration,
+            name: 'Test File',
+        });
     });
 
-    test('Desktop view', async function(this: ThisTestContext, assert) {
+    skip('Desktop view', async function(this: ThisTestContext, assert) {
         await visit(`/--file/${this.file.id}`);
         assert.equal(currentURL(), `/--file/${this.file.guid}`);
         assert.dom('[data-test-filename]')
@@ -43,7 +57,7 @@ module('Acceptance | guid file | registration files', hooks => {
         await percySnapshot(assert);
     });
 
-    test('mobile view', async function(this: ThisTestContext, assert) {
+    test('Mobile view', async function(this: ThisTestContext, assert) {
         setBreakpoint('mobile');
         await visit(`/--file/${this.file.id}`);
         assert.equal(currentURL(), `/--file/${this.file.guid}`);
@@ -58,19 +72,29 @@ module('Acceptance | guid file | registration files', hooks => {
         assert.dom('[data-test-tags-button]').exists('Tags button exists');
         await percySnapshot('Acceptance | guid file | registration files | mobile view | file renderer');
 
+        assert.dom('[data-test-file-renderer]').exists();
+        assert.dom('[data-test-metadata-tab]').doesNotExist();
+        assert.dom('[data-test-revisions-tab]').doesNotExist();
+        assert.dom('[data-test-tags-tab]').doesNotExist();
+
+        // click versions and verify appropriate panels shown
         await click('[data-test-versions-button]');
         assert.dom('[data-test-revisions-tab]').exists('Revisions shown');
         assert.dom('[data-test-file-renderer]').doesNotExist('File renderer is hidden');
         await percySnapshot('Acceptance | guid file | registration files | mobile view | revisions');
 
-        // click tags and verify appropriate panels shown
-
         await click('[data-test-file-renderer-button]');
         assert.dom('[data-test-file-renderer]').exists('File renderer is shown again');
         assert.dom('[data-test-revisions-tab]').doesNotExist('Revisions now hidden');
+
+        await click('[data-test-metadata-button]');
+        assert.dom('[data-test-metadata-tab]').exists('Metadata tab now visible');
+        assert.dom('[data-test-revisions-tab]').doesNotExist('Revisions now hidden');
+        assert.dom('[data-test-file-renderer]').doesNotExist('File renderer now hidden');
+        assert.dom('[data-test-tags-tab]').doesNotExist('Tags now hidden');
     });
 
-    test('view revisions', async function(this: ThisTestContext, assert) {
+    test('View revisions', async function(this: ThisTestContext, assert) {
         await visit(`/--file/${this.file.id}`);
         assert.equal(currentURL(), `/--file/${this.file.guid}`);
 
@@ -98,7 +122,162 @@ module('Acceptance | guid file | registration files', hooks => {
             .hasAria('label', t('file-detail.view-revisions'), 'Versions button has correct label when closed');
     });
 
-    // test for tags
+    test('View metadata', async function(this: ThisTestContext, assert) {
+        const node = server.create('node', {
+            id: 'mtadt',
+        }, 'currentUserAdmin', 'withContributors', 'withAffiliatedInstitutions', 'withFiles');
 
-    // test for switching views
+        const file = server.create('file', { target: node });
+        const metadataRecord = await this.owner.lookup('service:store')
+            .findRecord('custom-item-metadata-record', node.id);
+
+        await visit(`/--file/${file.id}`);
+        assert.equal(currentURL(), `/--file/${file.guid}`);
+
+        // Default desktop tab
+        assert.dom('[data-test-metadata-tab]').exists();
+        assert.dom('[data-test-revisions-tab]').doesNotExist();
+        assert.dom('[data-test-tags-tab]').doesNotExist();
+
+        // Favicon
+        assert.dom('[data-test-metadata-button]').hasAria('label', 'Close metadata',
+            'Close metadata aria should be present when metadata tab is open.');
+        assert.dom('[data-test-metadata-button] > svg').hasClass('fa-info-circle',
+            'SVG info-circle is correct.');
+
+        // File metadata
+        assert.dom('[data-test-metadata-header]').hasText('File Metadata',
+            'File metadata header is properly set.');
+        // Title
+        assert.dom('[data-test-file-title-label]').hasText('Title',
+            'File metadata title label is properly set.');
+        assert.dom('[data-test-file-title]').exists();
+        // Description
+        assert.dom('[data-test-file-description-label]').hasText('Description',
+            'File metadata description label is properly set.');
+        assert.dom('[data-test-file-description]').exists();
+        // Resource type
+        assert.dom('[data-test-file-resource-type-label]').hasText('Resource type',
+            'File metadata resource type label is properly set.');
+        assert.dom('[data-test-file-resource-type]').exists();
+        // Resource language
+        assert.dom('[data-test-file-language-label]').hasText('Resource language',
+            'File metadata resource language label is properly set.');
+        assert.dom('[data-test-file-language]').exists();
+        // Contributors
+        assert.dom('[data-test-target-contributors-label]').hasText('Contributors',
+            'File metadata contributor label is properly set.');
+        assert.dom('[data-test-target-contributors]').exists();
+        // Affiliated institutions
+        assert.dom('[data-test-target-institutions-label]').hasText('Affiliated institutions',
+            'File metadata affiliated institutions label is properly set.');
+        assert.dom('[data-test-target-institutions]').exists();
+        // Funder metadata
+        assert.dom('[data-test-target-funder-div]').exists();
+        for (const funder of metadataRecord.funders) {
+            // Funder name
+            assert.dom('[data-test-target-funder-name-label]').hasText('Funder',
+                'Funder name label is properly set.');
+            assert.dom(`[data-test-target-funder-name="${funder.funder_name}"]`)
+                .containsText(funder.funder_name, `Funder name is unchanged for ${funder.funder_name}.`);
+            // Award title
+            assert.dom('[data-test-target-funder-award-title-label]').hasText('Award title',
+                'Funder award title label is properly set.');
+            assert.dom(`[data-test-target-funder-award-title="${funder.funder_name}"]`)
+                .containsText(funder.award_title, `Funder award title is unchanged for ${funder.funder_name}.`);
+            // Award URI
+            assert.dom('[data-test-target-funder-award-uri-label]').hasText('Award URI',
+                'Funder award URI label is properly set.');
+            assert.dom(`[data-test-target-funder-award-uri="${funder.funder_name}"]`)
+                .containsText(funder.award_uri, `Funder award URI is unchanged for ${funder.funder_name}.`);
+            // Award number
+            assert.dom('[data-test-target-funder-award-number-label]').hasText('Award number',
+                'Funder award number label is properly set.');
+            assert.dom(`[data-test-target-funder-award-number="${funder.funder_name}"]`)
+                .hasText(funder.award_number, `Funder award number is unchanged for ${funder.funder_name}`);
+        }
+        // Target title
+        assert.dom('[data-test-target-title-label]').hasText('Title',
+            'File metadata target title text is properly set.');
+        assert.dom('[data-test-target-title]').exists();
+        // Target description
+        assert.dom('[data-test-target-description-label]').hasText('Description',
+            'File metadata target description text is properly set.');
+        assert.dom('[data-test-target-description]').exists();
+    });
+
+    // Node type
+    test('Node type', async function(this: ThisTestContext, assert) {
+        await visit(`/--file/${this.file.id}`);
+        assert.equal(currentURL(), `/--file/${this.file.guid}`);
+
+        assert.dom('[data-test-metadata-node]').hasText('Registration Metadata',
+            'Node noun for registration properly set.');
+    });
+
+    // Save and cancel buttons with write permissions
+    test('Save and cancel', async function(this: ThisTestContext, assert) {
+        await visit(`/--file/${this.file.id}`);
+        assert.equal(currentURL(), `/--file/${this.file.guid}`);
+
+        // Verify download
+        assert.dom('[data-test-download-button]').exists();
+
+        // Verify edit form
+        await click('[data-test-edit-metadata-button]');
+        assert.dom('[data-test-title-field]').exists();
+        assert.dom('[data-test-description-field]').exists();
+        assert.dom('[data-test-select-resource-type]').exists();
+        assert.dom('[data-test-select-resource-language]').exists();
+        assert.dom('[data-test-cancel-editing-metadata-button]').exists();
+        assert.dom('[data-test-save-metadata-button]').exists();
+        await click('[data-test-cancel-editing-metadata-button]');
+        assert.dom('[data-test-edit-metadata-form]').doesNotExist();
+        await click('[data-test-edit-metadata-button]');
+
+        // Screenshot before changes
+        await percySnapshot(assert);
+        // Update title
+        const editTitleTextArea = document.querySelectorAll('textarea')[0];
+        editTitleTextArea.textContent = 'A test title.';
+        assert.dom('[data-test-title-field]')
+            .containsText('A test title.', 'Metadata title field updates.');
+        // Update description
+        const editDescriptionTextArea = document.querySelectorAll('textarea')[1];
+        editDescriptionTextArea.textContent = 'A test description.';
+        assert.dom('[data-test-description-field]')
+            .containsText('A test description.', 'Metadata description field updates.');
+        // Update resource type
+        await selectChoose('[data-test-select-resource-type]', 'InteractiveResource');
+        // Update resource language
+        await selectChoose('[data-test-select-resource-language]', 'English');
+        // Screenshot after changes
+        await percySnapshot(assert);
+        // Save changes
+        await click('[data-test-save-metadata-button]');
+        // Verify form closes
+        assert.dom('[data-test-edit-metadata-form]').doesNotExist();
+        assert.dom('[data-test-metadata-tab]').exists();
+    });
+
+    // Verify A11y testing
+    test('A11y testing', async function(this: ThisTestContext, assert) {
+        await visit(`/--file/${this.file.id}`);
+        assert.equal(currentURL(), `/--file/${this.file.guid}`);
+        await a11yAudit();
+
+        // verify metadata
+        await click('[data-test-metadata-button]');
+        await a11yAudit();
+
+        // verify versions
+        await click('[data-test-versions-button]');
+        await a11yAudit();
+
+        // verify tags
+        await click('[data-test-tags-button]');
+        await a11yAudit();
+
+        assert.ok('No A11y issues');
+    });
 });

--- a/tests/acceptance/guid-file/registration-file-detail-test.ts
+++ b/tests/acceptance/guid-file/registration-file-detail-test.ts
@@ -208,11 +208,27 @@ module('Acceptance | guid file | registration files', hooks => {
 
     // Node type
     test('Node type', async function(this: ThisTestContext, assert) {
-        await visit(`/--file/${this.file.id}`);
-        assert.equal(currentURL(), `/--file/${this.file.guid}`);
+        const project = server.create('node', 'currentUserAdmin', 'withAffiliatedInstitutions');
+        const registration = server.schema.registrationSchemas.find('open_ended_registration');
+        const component = server.create('node', {id: 'cmpnt', parent: project}, 'withFiles', 'withStorage');
 
+        // Registration metadata
+        await visit(`/--file/${registration.id}`);
+        assert.equal(currentURL(), `/--file/${registration.id}`);
         assert.dom('[data-test-metadata-node]').hasText('Registration Metadata',
             'Node noun for registration properly set.');
+
+        // Project metadata
+        await visit(`/--file/${project.id}`);
+        assert.equal(currentURL(), `/${project.id}/metadata`);
+        assert.dom('[data-test-metadata-node]').hasText('Project Metadata',
+            'Node noun for project properly set.');
+
+        // Component metadata
+        await visit(`/--file/${component.id}`);
+        assert.equal(currentURL(), `/${component.id}/metadata`);
+        assert.dom('[data-test-metadata-node]').hasText('Component Metadata',
+            'Node noun for component properly set.');
     });
 
     // Save and cancel buttons with write permissions
@@ -233,10 +249,10 @@ module('Acceptance | guid file | registration files', hooks => {
         assert.dom('[data-test-save-metadata-button]').exists();
         await click('[data-test-cancel-editing-metadata-button]');
         assert.dom('[data-test-edit-metadata-form]').doesNotExist();
-        await click('[data-test-edit-metadata-button]');
 
         // Screenshot before changes
         await percySnapshot(assert);
+        await click('[data-test-edit-metadata-button]');
         // Update title
         const editTitleTextArea = document.querySelectorAll('textarea')[0];
         editTitleTextArea.textContent = 'A test title.';


### PR DESCRIPTION
-   Ticket: https://openscience.atlassian.net/browse/ENG-4187
-   Branch: feature/file-metadata-mirage-tests

## Purpose

The purpose of these changes is to add tests to ember-osf-web for the File Metadata project.

## Summary of Changes

Tests were added to the registration-file-detail-test.ts file to verify the functionality of metadata label and div elements, the edit metadata form and its save and cancel buttons, and the mobile default view for the application.

## Screenshot(s)

<img width="1200" alt="Pasted Graphic 29" src="https://user-images.githubusercontent.com/82047646/219084844-13411076-da2c-4369-a116-498be8ea6ccf.png">

## Side Effects

There should be no unintended side effects.

## QA Notes

-This PR references the following PRs that were revised: https://github.com/CenterForOpenScience/ember-osf-web/pull/1756 && https://github.com/CenterForOpenScience/ember-osf-web/pull/1793. Any changes reflected here should also include changes referenced in them.
-Are all added components and functionalities properly tested?
-Are there any suggested tests not already covered?
-Does the default view change for tablet view? From tablet to mobile, mobile to desktop and vice versa?
-Are all elements properly rendered on the screen? Does the edit metadata button remain hidden when permissions change?
