### PR TITLE
[ENG-4362] Explicitly sort subjects by text

### DIFF
--- a/lib/osf-components/addon/components/subjects/browse/browse-manager/component.ts
+++ b/lib/osf-components/addon/components/subjects/browse/browse-manager/component.ts
@@ -50,6 +50,7 @@ export default class SubjectBrowserManagerComponent extends Component {
                 page: {
                     size: subjectPageSize,
                 },
+                sort: 'text',
                 related_counts: 'children',
             });
             this.setProperties({ rootSubjects });

--- a/lib/osf-components/addon/components/subjects/search/component.ts
+++ b/lib/osf-components/addon/components/subjects/search/component.ts
@@ -49,6 +49,7 @@ export default class SearchSubjects extends Component {
             page: {
                 size: 150,
             },
+            sort: 'text',
             related_counts: 'children',
             embed: 'parent',
         });


### PR DESCRIPTION
-   Ticket: [ENG-4362]
-   Feature flag: n/a

## Purpose
- Sort subjects alphabetically

## Summary of Changes
- Explicitly set a sort when fetching subjects

## Screenshot(s)
- Order of subjects in the subjects widget is fixed (registration metadata page shown)
Before:
![image](https://user-images.githubusercontent.com/51409893/219142023-47487849-fd8f-46c0-9935-d4c0275ecca4.png)
After:
![image](https://user-images.githubusercontent.com/51409893/219141726-d1ac112e-6504-40f9-9881-773d5685ac51.png)


## Side Effects
- none

## QA Notes
- there may be some other lists that are being fetched without an explicit `sort` order, so please be on the lookout for that