### PR TITLE
Remove keen config from metrics

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -119,13 +119,6 @@ module.exports = function(environment) {
                     version: 'dimension5',
                 },
             },
-            {
-                name: 'Keen',
-                environments: keenConfig ? ['all'] : [],
-                config: {
-                    ...keenConfig,
-                },
-            },
         ],
         FB_APP_ID,
         OSF: {


### PR DESCRIPTION
## Purpose

Make metrics track GA events again. I removed the keen metrics adapter from the codebase, but it's still being called by the configuration, which is probably the thing breaking the metrics service right now.

## Summary of Changes

1. Removed unused and now missing keen adapter from configuration

