### PR TITLE
[ENG-4333] Test file detail editing

### DIFF
--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -149,7 +149,7 @@
                                     <Button
                                         aria-label={{t 'general.cancel'}}
                                         data-analytics-name='Cancel editing metadata'
-                                        data-test-cancel-metadata-button
+                                        data-test-cancel-editing-metadata-button
                                         @type='secondary'
                                         {{on 'click' manager.cancel}}
                                     >

--- a/app/guid-file/template.hbs
+++ b/app/guid-file/template.hbs
@@ -149,7 +149,7 @@
                                     <Button
                                         aria-label={{t 'general.cancel'}}
                                         data-analytics-name='Cancel editing metadata'
-                                        data-test-cancel-editing-metadata-button
+                                        data-test-cancel-metadata-button
                                         @type='secondary'
                                         {{on 'click' manager.cancel}}
                                     >

--- a/lib/osf-components/addon/components/file-metadata-manager/component.ts
+++ b/lib/osf-components/addon/components/file-metadata-manager/component.ts
@@ -181,14 +181,20 @@ export default class FileMetadataManagerComponent extends Component<Args> {
         this.inEditMode = true;
     }
 
+    @action
+    rollback() {
+        this.changeset.rollback();
+    }
+
     @task
     @waitFor
     async cancel(){
         if (this.saveErrored){
             await this.metadataRecord.reload();
+            this.metadataRecord.rollbackAttributes();
             this.saveErrored = false;
         }
-        this.changeset.rollback();
+        this.rollback();
         this.changeset.languageObject = {
             code: this.metadataRecord.language,
             name: this.languageFromCode,

--- a/tests/acceptance/guid-file/registration-file-detail-test.ts
+++ b/tests/acceptance/guid-file/registration-file-detail-test.ts
@@ -17,6 +17,7 @@ import { Permission } from 'ember-osf-web/models/osf-model';
 import RegistrationModel from 'ember-osf-web/models/registration';
 import User from 'ember-osf-web/models/user';
 import { click, setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
+import sinon from 'sinon';
 
 interface ThisTestContext extends TestContext {
     currentUser: ModelInstance<User>;
@@ -368,6 +369,8 @@ module('Acceptance | guid file | registration files', hooks => {
             }],
         }), 400);
 
+        const timer = sinon.useFakeTimers({ shouldAdvanceTime: true });
+
         await visit(url);
 
         await click('[data-test-edit-metadata-button]');
@@ -376,11 +379,9 @@ module('Acceptance | guid file | registration files', hooks => {
         assert.dom('#toast-container', document as any)
             .hasTextContaining(t('osf-components.file-metadata-manager.error-saving-metadata'));
         await click('[data-test-cancel-metadata-button]');
+        await timer.tickAsync(5000); // skip until toast is gone
 
-        server.get('/custom_file_metadata_records/:id', _ => {
-            assert.dom('[data-test-file-title]').doesNotHaveTextContaining('A New Title',
-                'Canceling edit after server error working properly.');
-        });
+        assert.dom('[data-test-file-title]').doesNotIncludeText('A New Title');
     });
 
     test('No edit permission', async function(this: ThisTestContext, assert) {

--- a/tests/acceptance/guid-file/registration-file-detail-test.ts
+++ b/tests/acceptance/guid-file/registration-file-detail-test.ts
@@ -1,4 +1,4 @@
-import { currentURL, fillIn, setupOnerror, visit } from '@ember/test-helpers';
+import { currentURL, fillIn, resetOnerror, setupOnerror, visit } from '@ember/test-helpers';
 
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { ModelInstance } from 'ember-cli-mirage';
@@ -382,6 +382,8 @@ module('Acceptance | guid file | registration files', hooks => {
         await timer.tickAsync(5000); // skip until toast is gone
 
         assert.dom('[data-test-file-title]').doesNotIncludeText('A New Title');
+
+        resetOnerror();
     });
 
     test('No edit permission', async function(this: ThisTestContext, assert) {

--- a/tests/acceptance/guid-file/registration-file-detail-test.ts
+++ b/tests/acceptance/guid-file/registration-file-detail-test.ts
@@ -259,7 +259,7 @@ module('Acceptance | guid file | registration files', hooks => {
         await click('[data-test-edit-metadata-button]');
         // Update title
         await fillIn('[data-test-title-field] > div > textarea', 'A New Title');
-        // // Update description
+        // Update description
         await fillIn('[data-test-description-field] > div > textarea', 'A New Description');
         // Update resource type
         await selectChoose('[data-test-select-resource-type]', 'InteractiveResource');
@@ -293,5 +293,31 @@ module('Acceptance | guid file | registration files', hooks => {
         await a11yAudit();
 
         assert.ok('No A11y issues');
+    });
+
+    // View-only section
+    test('View-only section updates', async function(this: ThisTestContext, assert) {
+        await visit(`/--file/${this.file.id}`);
+
+        await click('[data-test-edit-metadata-button]');
+        // Update title
+        await fillIn('[data-test-title-field] > div > textarea', 'A New Title');
+        // Update description
+        await fillIn('[data-test-description-field] > div > textarea', 'A New Description');
+        // Update resource type
+        await selectChoose('[data-test-select-resource-type]', 'InteractiveResource');
+        // Update resource language
+        await selectChoose('[data-test-select-resource-language]', 'English');
+        // Save changes
+        await click('[data-test-save-metadata-button]');
+
+        assert.dom('[data-test-file-title]').hasText('A New Title',
+            'File metadata file title is properly updated.');
+        assert.dom('[data-test-file-description]').hasText('A New Description',
+            'File metadata file description is properly updated.');
+        assert.dom('[data-test-file-resource-type]').hasText('InteractiveResource',
+            'File metadata resource type is properly updated.');
+        assert.dom('[data-test-file-language]').hasText('English',
+            'File metadata resource language is properly updated.');
     });
 });

--- a/tests/acceptance/guid-file/registration-file-detail-test.ts
+++ b/tests/acceptance/guid-file/registration-file-detail-test.ts
@@ -275,7 +275,7 @@ module('Acceptance | guid file | registration files', hooks => {
     });
 
     // Verify A11y testing
-    test('A11y testing', async function(this: ThisTestContext, assert) {
+    test('Accessibility', async function(this: ThisTestContext, assert) {
         await visit(`/--file/${this.file.id}`);
         assert.equal(currentURL(), `/--file/${this.file.guid}`);
         await a11yAudit();

--- a/tests/acceptance/guid-file/registration-file-detail-test.ts
+++ b/tests/acceptance/guid-file/registration-file-detail-test.ts
@@ -345,4 +345,22 @@ module('Acceptance | guid file | registration files', hooks => {
         assert.dom('[data-test-file-language]').doesNotHaveTextContaining('Latin',
             'Cancel metadata edit button properly working for resource language.');
     });
+
+    test('No edit permission', async function(this: ThisTestContext, assert) {
+        const noEditRegistration = server.create('registration', {
+            currentUserPermissions: [Permission.Read],
+        }, 'withContributors', 'withFiles');
+
+        const noEditFile = server.create('file', {
+            target: noEditRegistration,
+            name: 'Test File',
+        });
+
+        await visit(`/--file/${noEditFile.id}`);
+
+        assert.dom('[data-test-edit-metadata-button]').doesNotExist();
+        assert.dom('[data-test-edit-metadata-form]').doesNotExist();
+        assert.dom('[data-test-save-metadata-button]').doesNotExist();
+        assert.dom('[data-test-cancel-metadata-button]').doesNotExist();
+    });
 });

--- a/tests/acceptance/guid-file/registration-file-detail-test.ts
+++ b/tests/acceptance/guid-file/registration-file-detail-test.ts
@@ -17,7 +17,6 @@ import { Permission } from 'ember-osf-web/models/osf-model';
 import RegistrationModel from 'ember-osf-web/models/registration';
 import User from 'ember-osf-web/models/user';
 import { click, setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
-import sinon from 'sinon';
 
 interface ThisTestContext extends TestContext {
     currentUser: ModelInstance<User>;
@@ -252,9 +251,9 @@ module('Acceptance | guid file | registration files', hooks => {
         assert.dom('[data-test-description-field]').exists();
         assert.dom('[data-test-select-resource-type]').exists();
         assert.dom('[data-test-select-resource-language]').exists();
-        assert.dom('[data-test-cancel-metadata-button]').exists();
+        assert.dom('[data-test-cancel-editing-metadata-button]').exists();
         assert.dom('[data-test-save-metadata-button]').exists();
-        await click('[data-test-cancel-metadata-button]');
+        await click('[data-test-cancel-editing-metadata-button]');
         assert.dom('[data-test-edit-metadata-form]').doesNotExist();
         // Screenshot before changes
         await percySnapshot(assert);
@@ -336,7 +335,7 @@ module('Acceptance | guid file | registration files', hooks => {
         // Update resource language
         await selectChoose('[data-test-select-resource-language]', 'Latin');
         // Cancel changes
-        await click('[data-test-cancel-metadata-button]');
+        await click('[data-test-cancel-editing-metadata-button]');
 
         assert.dom('[data-test-file-title]').doesNotHaveTextContaining('A New Title',
             'Cancel metadata edit button properly working for title.');
@@ -369,8 +368,6 @@ module('Acceptance | guid file | registration files', hooks => {
             }],
         }), 400);
 
-        const timer = sinon.useFakeTimers({ shouldAdvanceTime: true });
-
         await visit(url);
 
         await click('[data-test-edit-metadata-button]');
@@ -378,8 +375,7 @@ module('Acceptance | guid file | registration files', hooks => {
         await click('[data-test-save-metadata-button]');
         assert.dom('#toast-container', document as any)
             .hasTextContaining(t('osf-components.file-metadata-manager.error-saving-metadata'));
-        await click('[data-test-cancel-metadata-button]');
-        await timer.tickAsync(5000); // skip until toast is gone
+        await click('[data-test-cancel-editing-metadata-button]');
 
         assert.dom('[data-test-file-title]').doesNotIncludeText('A New Title');
 
@@ -401,6 +397,6 @@ module('Acceptance | guid file | registration files', hooks => {
         assert.dom('[data-test-edit-metadata-button]').doesNotExist();
         assert.dom('[data-test-edit-metadata-form]').doesNotExist();
         assert.dom('[data-test-save-metadata-button]').doesNotExist();
-        assert.dom('[data-test-cancel-metadata-button]').doesNotExist();
+        assert.dom('[data-test-cancel-editing-metadata-button]').doesNotExist();
     });
 });

--- a/tests/acceptance/guid-file/registration-file-detail-test.ts
+++ b/tests/acceptance/guid-file/registration-file-detail-test.ts
@@ -376,6 +376,11 @@ module('Acceptance | guid file | registration files', hooks => {
         assert.dom('#toast-container', document as any)
             .hasTextContaining(t('osf-components.file-metadata-manager.error-saving-metadata'));
         await click('[data-test-cancel-metadata-button]');
+
+        server.get('/custom_file_metadata_records/:id', _ => {
+            assert.dom('[data-test-file-title]').doesNotHaveTextContaining('A New Title',
+                'Canceling edit after server error working properly.');
+        });
     });
 
     test('No edit permission', async function(this: ThisTestContext, assert) {

--- a/tests/acceptance/guid-file/registration-file-detail-test.ts
+++ b/tests/acceptance/guid-file/registration-file-detail-test.ts
@@ -9,6 +9,7 @@ import { selectChoose } from 'ember-power-select/test-support';
 import { setBreakpoint } from 'ember-responsive/test-support';
 import { TestContext } from 'ember-test-helpers';
 
+
 import { module, test } from 'qunit';
 
 import FileModel from 'ember-osf-web/models/file';
@@ -344,6 +345,19 @@ module('Acceptance | guid file | registration files', hooks => {
             'Cancel metadata edit button properly working for resource type.');
         assert.dom('[data-test-file-language]').doesNotHaveTextContaining('Latin',
             'Cancel metadata edit button properly working for resource language.');
+    });
+
+    test('Error and canceling edit', async function(this: ThisTestContext, assert) {
+        await visit(`/--file/${this.file.id}`);
+
+        await click('[data-test-edit-metadata-button]');
+        await fillIn('[data-test-title-field] > div > textarea', 'A New Title');
+        await server.get(`/--file/${this.file.id}`, {}, 500);
+        await server.get(`/--file/${this.file.id}`, {}, 200);
+        assert.dom('[data-test-cancel-metadata-button]').exists();
+        await click('[data-test-cancel-metadata-button]');
+        assert.dom('[data-test-file-title]').doesNotHaveTextContaining('A New Title',
+            'Canceling edit after server error working properly.');
     });
 
     test('No edit permission', async function(this: ThisTestContext, assert) {

--- a/tests/acceptance/guid-file/registration-file-detail-test.ts
+++ b/tests/acceptance/guid-file/registration-file-detail-test.ts
@@ -250,9 +250,9 @@ module('Acceptance | guid file | registration files', hooks => {
         assert.dom('[data-test-description-field]').exists();
         assert.dom('[data-test-select-resource-type]').exists();
         assert.dom('[data-test-select-resource-language]').exists();
-        assert.dom('[data-test-cancel-editing-metadata-button]').exists();
+        assert.dom('[data-test-cancel-metadata-button]').exists();
         assert.dom('[data-test-save-metadata-button]').exists();
-        await click('[data-test-cancel-editing-metadata-button]');
+        await click('[data-test-cancel-metadata-button]');
         assert.dom('[data-test-edit-metadata-form]').doesNotExist();
         // Screenshot before changes
         await percySnapshot(assert);
@@ -319,5 +319,30 @@ module('Acceptance | guid file | registration files', hooks => {
             'File metadata resource type is properly updated.');
         assert.dom('[data-test-file-language]').hasText('English',
             'File metadata resource language is properly updated.');
+    });
+
+    test('View-only section does not update', async function(this: ThisTestContext, assert) {
+        await visit(`/--file/${this.file.id}`);
+
+        await click('[data-test-edit-metadata-button]');
+        // Update title
+        await fillIn('[data-test-title-field] > div > textarea', 'A New Title');
+        // Update description
+        await fillIn('[data-test-description-field] > div > textarea', 'A New Description');
+        // Update resource type
+        await selectChoose('[data-test-select-resource-type]', 'InteractiveResource');
+        // Update resource language
+        await selectChoose('[data-test-select-resource-language]', 'Latin');
+        // Cancel changes
+        await click('[data-test-cancel-metadata-button]');
+
+        assert.dom('[data-test-file-title]').doesNotHaveTextContaining('A New Title',
+            'Cancel metadata edit button properly working for title.');
+        assert.dom('[data-test-file-description]').doesNotHaveTextContaining('A New Description',
+            'Cancel metadata edit button properly working for description.');
+        assert.dom('[data-test-file-resource-type]').doesNotHaveTextContaining('InteractiveResource',
+            'Cancel metadata edit button properly working for resource type.');
+        assert.dom('[data-test-file-language]').doesNotHaveTextContaining('Latin',
+            'Cancel metadata edit button properly working for resource language.');
     });
 });


### PR DESCRIPTION
-   Ticket: https://openscience.atlassian.net/browse/ENG-4333
-   Branch: feature/test-file-detail-view-only

## Purpose

The purpose of these changes is to test the edit functionality of the file detail page.

## Summary of Changes

-A test has been added to verify that changing the values and saving will result in appropriate changes in the view-only section for the file title, description, resource type, and resource language.

-A test has been added to verify that changing those fields and canceling the edit will result in the values not changing in the view-only section.

-A test has been added to verify that trying to save, getting an error, and canceling the save causes the values not to change for the view-only section.

- A test has been added to verify that, if you don’t have permission to edit, the edit capability is disabled.

## Screenshot(s)

<img width="1204" alt="Pasted Graphic 11" src="https://user-images.githubusercontent.com/82047646/220147801-8caa2770-ece0-4ad8-96c0-1135d100716c.png">

## Side Effects

There should not be any side effects unless tests are not passing.

## QA Notes

-Do all tests pass?
-Are tests working as intended?
-Are there any other fields/views that have not been tested?