### PR TITLE
[ENG-4195] Hide additional fields and show state for AVOL registrations

### DIFF
--- a/lib/registries/addon/components/registries-metadata/template.hbs
+++ b/lib/registries/addon/components/registries-metadata/template.hbs
@@ -64,18 +64,21 @@
         </div>
     </div>
 
-    <div local-class='Field'>
-        <h4>{{t 'registries.registration_metadata.associated_project'}}</h4>
-        <div>
-            <OsfLink
-                data-analytics-name='Registered from'
-                @route='guid-node'
-                @models={{array this.registeredFromId}}
-            >
-                {{this.registeredFromDisplayUrl}}
-            </OsfLink>
+    {{#unless this.registration.isAnonymous}}
+        <div local-class='Field'>
+            <h4>{{t 'registries.registration_metadata.associated_project'}}</h4>
+            <div>
+                <OsfLink
+                    data-analytics-name='Registered from'
+                    @route='guid-node'
+                    @models={{array this.registeredFromId}}
+                >
+                    {{this.registeredFromDisplayUrl}}
+                </OsfLink>
+            </div>
         </div>
-    </div>
+    {{/unless}}
+
     {{#if this.registration.providerSpecificMetadata}}
         <div local-class='Field'>
             <EditableField::ProviderMetadataManager

--- a/lib/registries/addon/components/registries-states/component.ts
+++ b/lib/registries/addon/components/registries-states/component.ts
@@ -43,27 +43,31 @@ export default class RegistriesStates extends Component {
     }
 
     get stateText() {
-        if (!this.registration || !this.registration.reviewsState || !this.registration.revisionState) {
-            return undefined;
-        }
         let stateKey;
-        if (this.registration.pendingRegistrationApproval) {
-            stateKey = 'pendingRegistrationApproval';
-        } else if (this.registration.pendingEmbargoApproval) {
-            stateKey = 'pendingEmbargoApproval';
-        } else if (
-            [
-                RegistrationReviewStates.Embargo,
-                RegistrationReviewStates.Accepted,
-            ].includes(this.registration.reviewsState)
-        ) {
-            if (this.registration.revisionState !== RevisionReviewStates.Approved) {
-                stateKey = camelize(this.registration.revisionState);
+        if (!this.registration || !this.registration.reviewsState || !this.registration.revisionState) {
+            if (!this.registration.isAnonymous) {
+                return undefined;
+            }
+            stateKey = 'anonymous';
+        } else {
+            if (this.registration.pendingRegistrationApproval) {
+                stateKey = 'pendingRegistrationApproval';
+            } else if (this.registration.pendingEmbargoApproval) {
+                stateKey = 'pendingEmbargoApproval';
+            } else if (
+                [
+                    RegistrationReviewStates.Embargo,
+                    RegistrationReviewStates.Accepted,
+                ].includes(this.registration.reviewsState)
+            ) {
+                if (this.registration.revisionState !== RevisionReviewStates.Approved) {
+                    stateKey = camelize(this.registration.revisionState);
+                } else {
+                    stateKey = camelize(this.registration.reviewsState);
+                }
             } else {
                 stateKey = camelize(this.registration.reviewsState);
             }
-        } else {
-            stateKey = camelize(this.registration.reviewsState);
         }
         return {
             short: this.intl.t(`registries.overview.${stateKey}.short_description`),

--- a/lib/registries/addon/overview/-components/overview-topbar/template.hbs
+++ b/lib/registries/addon/overview/-components/overview-topbar/template.hbs
@@ -1,12 +1,10 @@
 <div local-class='LeftWrapper'>
-    {{#unless @registration.isAnonymous}}
-        <div data-test-topbar-states>
-            <RegistriesStates
-                @registration={{@registration}}
-                @isModeratorMode={{@isModeratorMode}}
-            />
-        </div>
-    {{/unless}}
+    <div data-test-topbar-states>
+        <RegistriesStates
+            @registration={{@registration}}
+            @isModeratorMode={{@isModeratorMode}}
+        />
+    </div>
 
     <Registries::UpdateDropdown
         @registration={{@registration}}

--- a/tests/engines/registries/acceptance/overview/topbar-test.ts
+++ b/tests/engines/registries/acceptance/overview/topbar-test.ts
@@ -120,7 +120,7 @@ module('Registries | Acceptance | overview.topbar', hooks => {
         assert.dom('[data-test-topbar-states]').doesNotExist();
     });
 
-    test('registration state is not visible in topbar when viewing registrations anonymously', async assert => {
+    test('registration state shown in topbar when viewing registrations anonymously', async assert => {
         const anonymousReg = server.create('registration', {
             registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
         }, 'anonymized');
@@ -129,7 +129,13 @@ module('Registries | Acceptance | overview.topbar', hooks => {
         await percySnapshot(assert);
 
         assert.dom('[data-test-topbar-share-bookmark-fork]').exists();
-        assert.dom('[data-test-topbar-states]').doesNotExist();
+        assert.dom('[data-test-topbar-states]').exists();
+        assert.dom('[data-test-state-button]').hasText('Anonymized registration');
+        await click('[data-test-state-button]');
+        assert.dom('[data-test-state-description-short]').hasText('Anonymized');
+        assert.dom('[data-test-state-description-long]').hasText(
+            'This is an anonymized view of this registration. Identifying metadata is hidden from view.',
+        );
     });
 
     test('bookmarks work', async assert => {

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1553,6 +1553,10 @@ registries:
             text: 'Update pending review'
             short_description: 'Update pending moderator approval'
             long_description: 'This registration has an update that is waiting for moderation. Updates will be made available once approved.'
+        anonymous:
+            text: 'Anonymized registration'
+            short_description: 'Anonymized'
+            long_description: 'This is an anonymized view of this registration. Identifying metadata is hidden from view.'
         bookmark:
             add:
                 text: Bookmark


### PR DESCRIPTION
-   Ticket: [ENG-4195]
-   Feature flag: n/a

## Purpose
- Add logic around showing/hiding more fields based on this [Platform PR](https://github.com/CenterForOpenScience/osf.io/pull/10343) 

## Summary of Changes
- Add conditional logic to show/hide associated project in AVOL
- Show the registries state dropdown even in AVOL, as without it, the updates dropdown floats in an odd location

## Screenshot(s)
- Overview topbar before:
![image](https://user-images.githubusercontent.com/51409893/224136879-a8d319d0-bfdf-4110-b2a5-0ca8997d80bb.png)

- Overview topbar after:
![image](https://user-images.githubusercontent.com/51409893/224136610-88dd716e-e379-4b00-80a1-75690328d983.png)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-4195]: https://openscience.atlassian.net/browse/ENG-4195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ