### PR TITLE
Fix page-change scroll behavior

### DIFF
--- a/lib/collections/addon/components/discover-page/component.ts
+++ b/lib/collections/addon/components/discover-page/component.ts
@@ -11,7 +11,6 @@ import { waitFor } from '@ember/test-waiters';
 import { keepLatestTask, timeout } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 import config from 'ember-get-config';
-import $ from 'jquery';
 
 import { layout } from 'ember-osf-web/decorators/component';
 import Analytics from 'ember-osf-web/services/analytics';
@@ -309,7 +308,7 @@ export default class DiscoverPage extends Component {
 
     scrollToResults() {
         // Scrolls to top of search results
-        $('html, body').scrollTop($('.results-top').position().top);
+        document.querySelector('.results-top')?.scrollIntoView({ behavior: 'smooth' });
     }
 
     search(): void {

--- a/lib/collections/addon/components/discover-page/template.hbs
+++ b/lib/collections/addon/components/discover-page/template.hbs
@@ -109,7 +109,7 @@
                 <BsDropdown class='dropdown pull-right' as |dd|>
                     <dd.button
                         data-test-sort-by-button
-                        class='btn btn-default'
+                        class='btn btn-default results-top'
                     >
                         {{t 'collections.discover_page.sortBy'}}:
                         {{this.sortDisplay}}
@@ -183,7 +183,7 @@
                 {{else}}
                     {{#if this.numberOfResults}}
                         {{!RESULTS FOUND}}
-                        <div class='results-top'>
+                        <div>
                             {{#each this.results as |result|}}
                                 {{component
                                     this.searchResultComponent


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: []
-   Feature flag: n/a

## Purpose
- Fix scroll-to-top behavior when changing pages on collection discover page

## Summary of Changes
- Moved `.results-top` to a different element as navbar's positioning covers up the first search result's title
- Use vanilla js `Element.scrollIntoView` instead of jquery

## Screenshot(s)
NA

## Side Effects
None

## QA Notes
Page should scroll to the top of the first search result when changing pages on pages like https://staging2.osf.io/collections/colmod/discover?page=2