### PR TITLE
[Hotfix] Update dockerfile to use node 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ### App code
-FROM quay.io/centerforopenscience/ember-base-10 AS app
+FROM quay.io/centerforopenscience/ember-base-14 AS app
 
 COPY ./package.json ./yarn.lock ./.yarnrc ./
 RUN yarn --frozen-lockfile
@@ -17,7 +17,7 @@ RUN git clone https://github.com/CenterForOpenScience/osf-assets.git ./public/as
     && yarn build --environment=production
 
 ### Dist
-FROM node:8-alpine AS dist
+FROM node:14-alpine AS dist
 
 RUN mkdir -p /code
 WORKDIR /code


### PR DESCRIPTION
## Purpose
Fix CI/CD pipelines

## Summary of Changes
- Created `ember-base-14` image, available in quay: https://quay.io/repository/centerforopenscience/ember-base-14
- Tested resulting EOW image via `docker run --rm --env 'CI=true' ember-osf-web yarn test:ember` with these changes in a cloud shell

## Side Effects
Ember tests only go so far, **should be verified on staging before production deploy**
