### PR TITLE
[ENG-4409] Removed bootstrap css formatting from the draft-registration-card

### DIFF
--- a/lib/osf-components/addon/components/draft-registration-card/styles.scss
+++ b/lib/osf-components/addon/components/draft-registration-card/styles.scss
@@ -1,9 +1,13 @@
-.DraftRegistrationCard {
+// stylelint-disable max-nesting-depth, selector-max-compound-selectors
+.draft-registration-card {
     margin-bottom: 10px;
+    width: 100%;
+    min-width: 300px;
 
     :global(.ember-content-placeholders-text__line) {
         height: 1em;
     }
+
 
     :global(.btn) {
         margin-left: 5px;
@@ -12,53 +16,67 @@
             margin-left: 0;
         }
     }
-}
 
-.DraftRegistratrionCard__title {
-    :global(.ember-content-placeholders-text) {
-        width: 50%;
+    .title {
+        text-align: left;
+
+        :global(.ember-content-placeholders-text) {
+            width: 50%;
+        }
+    }
+
+    .body {
+        font-weight: 400;
+        line-height: 1;
+        text-align: left;
+
+        dl {
+            margin-bottom: 10px;
+        }
+
+        dt,
+        dd {
+            display: inline-block;
+        }
+
+        :global(.ember-content-placeholders-text) {
+            width: 33%;
+        }
+
+        .button-container {
+            display: flex;
+            flex-direction: row;
+            justify-content: flex-start;
+            align-items: flex-start;
+
+            .review-container {
+                flex: 1;
+                min-width: 200px; 
+            }
+
+            .delete-container {
+                width: 200px;
+                display: flex;
+                flex-direction: row;
+                justify-content: flex-end;
+                align-items: flex-end;
+
+                .delete {
+                    button {
+                        padding: 6px 12px;
+                    }
+                }
+            }
+        }
     }
 }
 
-.DraftRegistrationCard__body {
-    font-weight: 400;
-    line-height: 1;
-
-    dl {
-        margin-bottom: 10px;
-    }
-
-    dt,
-    dd {
-        display: inline-block;
-    }
-
-    :global(.ember-content-placeholders-text) {
-        width: 33%;
-    }
-}
-
-.DraftRegistrationCard__review {
+.review {
     composes: Button from '../button/styles.scss';
     composes: SecondaryButton from '../button/styles.scss';
     composes: MediumButton from '../button/styles.scss';
 
     &:hover {
         text-decoration: none !important; /* override OsfLink hover style */
-    }
-}
-
-.DraftRegistrationCard__delete {
-    button {
-        padding: 6px 12px;
-    }
-}
-
-:global(.delete_draft_registration) {
-    :global(.modal-header) {
-        h4 {
-            font-size: 24px;
-            font-weight: 400;
-        }
     }
 }

--- a/lib/osf-components/addon/components/draft-registration-card/template.hbs
+++ b/lib/osf-components/addon/components/draft-registration-card/template.hbs
@@ -1,9 +1,9 @@
 <div
     data-analytics-scope='Draft registrations'
     data-test-draft-registration-card
-    local-class='DraftRegistrationCard'
+    local-class='draft-registration-card'
 >
-    <h4 local-class='DraftRegistratrionCard__title' data-test-draft-registration-card-title>
+    <h4 local-class='title' data-test-draft-registration-card-title>
         {{#if this.draftRegistration}}
             <OsfLink
                 data-analytics-name='view_registration'
@@ -25,7 +25,7 @@
             </ContentPlaceholders>
         {{/if}}
     </h4>
-    <section local-class='DraftRegistrationCard__body' data-test-draft-registration-card-body>
+    <section local-class='body' data-test-draft-registration-card-body>
         {{#if this.draftRegistration}}
             <dl>
                 <div data-test-initiated-by>
@@ -69,12 +69,12 @@
                     </dd>
                 </div>
             </dl>
-            <div class='row'>
-                <div class='col-md-10'>
+            <div local-class='button-container'>
+                <div local-class='review-container'>
                     <OsfLink
                         data-test-draft-card-review
                         data-analytics-name='Review'
-                        local-class='DraftRegistrationCard__review'
+                        local-class='review'
                         @route='registries.drafts.draft.review'
                         @models={{array this.draftRegistration.id}}
                     >
@@ -83,7 +83,7 @@
                     {{#unless this.draftRegistration.currentUserIsReadOnly}}
                         <OsfLink
                             data-test-draft-card-edit
-                            local-class='DraftRegistrationCard__review'
+                            local-class='review'
                             data-analytics-name='Edit'
                             @route='registries.drafts.draft'
                             @models={{array this.draftRegistration.id}}
@@ -92,7 +92,7 @@
                         </OsfLink>
                     {{/unless}}
                 </div>
-                <div class='col-md-1'>
+                <div local-class='delete-container'>
                     {{#if this.draftRegistration.currentUserIsAdmin}}
                         <DeleteButton
                             data-test-draft-card-delete
@@ -101,7 +101,7 @@
                             @delete={{action this.confirmDelete}}
                             @modalTitle={{t 'general.please_confirm'}}
                             @modalBody={{t 'osf-components.draft-registration-card.delete_draft_confirm'}}
-                            local-class='DraftRegistrationCard__delete'
+                            local-class='delete'
                         />
                     {{/if}}
                 </div>


### PR DESCRIPTION
-   Ticket: [ENG-4409]
-   Feature flag: n/a

## Purpose

Remove bootstrap

## Summary of Changes

Removed bootstrap css formatting from the draft-registration-card

## Screenshot(s)
![desktop-pre](https://user-images.githubusercontent.com/113387478/226695759-474c73d8-35ab-438a-a201-6f493bdaaa39.png)
![mobile-pre](https://user-images.githubusercontent.com/113387478/226695768-410c7f86-a487-4047-9c9b-d1bc5d9478ce.png)

![desktop-post](https://user-images.githubusercontent.com/113387478/226695838-8c5b479a-9e9d-4d99-a78f-0b3170e01c33.png)
![mobile-post](https://user-images.githubusercontent.com/113387478/226695843-80c99669-5670-4b7f-aada-44bc8389440b.png)


## Side Effects

I did right justify the delete button and kept it in a row in mobile view.

## QA Notes

Look at the screen shots.

[ENG-4409]: https://openscience.atlassian.net/browse/ENG-4409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ