### PR TITLE
[ENG-4427] Fix timing issues due to no jQuery integration

### DIFF
--- a/config/optional-features.json
+++ b/config/optional-features.json
@@ -1,6 +1,6 @@
 {
   "application-template-wrapper": false,
   "default-async-observers": true,
-  "jquery-integration": true,
+  "jquery-integration": false,
   "template-only-glimmer-components": true
 }

--- a/tests/engines/registries/acceptance/draft/draft-test.ts
+++ b/tests/engines/registries/acceptance/draft/draft-test.ts
@@ -27,6 +27,7 @@ import { getHrefAttribute, visit } from 'ember-osf-web/tests/helpers';
 import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
 import { deserializeResponseKey } from 'ember-osf-web/transforms/registration-response-key';
 import stripHtmlTags from 'ember-osf-web/utils/strip-html-tags';
+import { timeout } from 'ember-concurrency';
 
 const currentUserStub = Service.extend();
 const storeStub = Service.extend();
@@ -446,22 +447,22 @@ module('Registries | Acceptance | draft form', hooks => {
         // Fail metadata save
         await visit(`/registries/drafts/${registration.id}/`);
         triggerKeyEvent('[data-test-metadata-title] input', 'keyup', 32);
-        await timer.tickAsync(3001); // skip debounce
+        await timer.tickAsync(4001); // skip debounce
         assert.dom('#toast-container', document as any).containsText(
             t('registries.drafts.draft.metadata.failed_auto_save'),
             'Error toast on failed metadata save',
         );
-        await timer.tickAsync(5000); // skip until toast gone
+        await timer.tickAsync(4000); // skip until toast gone
 
         // Fail form save
         await click('[data-test-goto-next-page]');
         triggerKeyEvent('[data-test-text-input] input', 'keyup', 32);
-        await timer.tickAsync(3001); // skip debounce
+        await timer.tickAsync(4001); // skip debounce
         assert.dom('#toast-container', document as any).containsText(
             t('registries.drafts.draft.form.failed_auto_save'),
             'Error toast on failed page save',
         );
-        await timer.tickAsync(5000); // skip until toast gone
+        await timer.tickAsync(4000); // skip until toast gone
 
         // Fail delete
         await click('[data-test-delete-button]');
@@ -492,6 +493,7 @@ module('Registries | Acceptance | draft form', hooks => {
         await click('[data-test-add-new-button]');
         sinon.assert.calledOnce(confirm);
         window.dispatchEvent(new Event('beforeunload'));
+        await timeout(1000);
         sinon.assert.calledOnce(beforeunload);
         assert.ok('it warns users when navigating/closing window');
     });
@@ -1092,6 +1094,9 @@ module('Registries | Acceptance | draft form', hooks => {
 
         assert.dom(`[data-test-file-name="${fileOne.itemName}"]`)
             .doesNotExist('fileOne has been deleted from the draft');
+
+        await timeout(1000);
+
         assert.dom(`[data-test-selected-file="${fileOne.id}"]`)
             .doesNotExist('fileOne is no longer selected');
         assert.notOk(server.schema.files.findBy({ id: fileOne.id }), 'fileOne is deleted from the db');

--- a/tests/engines/registries/acceptance/edit-revision/revision-test.ts
+++ b/tests/engines/registries/acceptance/edit-revision/revision-test.ts
@@ -23,6 +23,7 @@ import RegistrationProviderModel from 'ember-osf-web/models/registration-provide
 import RegistrationSchemaModel from 'ember-osf-web/models/registration-schema';
 import { RevisionReviewStates } from 'ember-osf-web/models/schema-response';
 import { deserializeResponseKey } from 'ember-osf-web/transforms/registration-response-key';
+import { timeout } from 'ember-concurrency';
 
 const currentUserStub = Service.extend();
 const storeStub = Service.extend();
@@ -427,22 +428,22 @@ module('Registries | Acceptance | registries revision', hooks => {
         // Fail justification save
         await visit(`/registries/revisions/${revision.id}/`);
         triggerKeyEvent('textarea[name="revisionJustification"]', 'keyup', 32);
-        await timer.tickAsync(3001); // skip debounce
+        await timer.tickAsync(4001); // skip debounce
         assert.dom('#toast-container', document as any).containsText(
             t('registries.drafts.draft.metadata.failed_auto_save'),
             'Error toast on failed metadata save',
         );
-        await timer.tickAsync(5000); // skip until toast gone
+        await timer.tickAsync(4000); // skip until toast gone
 
         // Fail form save
         await click('[data-test-goto-next-page]');
         triggerKeyEvent('[data-test-text-input] input', 'keyup', 32);
-        await timer.tickAsync(3001); // skip debounce
+        await timer.tickAsync(4001); // skip debounce
         assert.dom('#toast-container', document as any).containsText(
             t('registries.drafts.draft.form.failed_auto_save'),
             'Error toast on failed page save',
         );
-        await timer.tickAsync(5000); // skip until toast gone
+        await timer.tickAsync(4000); // skip until toast gone
 
         // Fail delete
         await click('[data-test-delete-button]');
@@ -473,6 +474,7 @@ module('Registries | Acceptance | registries revision', hooks => {
         await click('[data-test-add-new-button]');
         sinon.assert.calledOnce(confirm);
         window.dispatchEvent(new Event('beforeunload'));
+        await timeout(1000);
         sinon.assert.calledOnce(beforeunload);
         assert.ok('it warns users when navigating/closing window');
     });

--- a/tests/engines/registries/acceptance/overview/moderator-mode-test.ts
+++ b/tests/engines/registries/acceptance/overview/moderator-mode-test.ts
@@ -14,6 +14,7 @@ import { percySnapshot } from 'ember-percy';
 import moment from 'moment';
 import { module, test } from 'qunit';
 import fillIn from '@ember/test-helpers/dom/fill-in';
+import { timeout } from 'ember-concurrency';
 
 interface ModeratorModeTestContext extends TestContext {
     provider: ModelInstance<RegistrationProviderModel>;
@@ -73,6 +74,7 @@ module('Registries | Acceptance | overview.moderator-mode', hooks => {
         await click('[data-test-moderation-dropdown-decision-checkbox="accept_submission"]');
         await click('[data-test-moderation-dropdown-submit]');
         await click('[data-test-state-button]');
+        await timeout(1000);
         assert.dom('[data-test-state-description-short]').exists('Short description for accepted status exists');
         assert.dom('[data-test-state-description-short]').hasText(
             t('registries.overview.accepted.short_description'),
@@ -149,6 +151,7 @@ module('Registries | Acceptance | overview.moderator-mode', hooks => {
         triggerKeyEvent('[data-test-moderation-dropdown-comment]', 'keyup', 32);
         await settled();
         await click('[data-test-moderation-dropdown-submit]');
+        await timeout(2000);
         assert.dom('[data-test-tombstone-title]').exists('Tombstone page shows');
     });
 
@@ -191,6 +194,7 @@ module('Registries | Acceptance | overview.moderator-mode', hooks => {
         await percySnapshot(assert);
         await click('[data-test-moderation-dropdown-decision-checkbox="accept_withdrawal"]');
         await click('[data-test-moderation-dropdown-submit]');
+        await timeout(2000);
         assert.dom('[data-test-tombstone-title]').exists('Tombstone page shows');
     });
 
@@ -212,6 +216,7 @@ module('Registries | Acceptance | overview.moderator-mode', hooks => {
         await settled();
         await click('[data-test-moderation-dropdown-submit]');
         await click('[data-test-state-button]');
+        await timeout(1000);
         assert.dom('[data-test-state-description-short]').exists('Short description for accepted status exists');
         assert.dom('[data-test-state-description-short]').hasText(
             t('registries.overview.accepted.short_description'),
@@ -263,6 +268,7 @@ module('Registries | Acceptance | overview.moderator-mode', hooks => {
         triggerKeyEvent('[data-test-moderation-dropdown-comment]', 'keyup', 32);
         await settled();
         await click('[data-test-moderation-dropdown-submit]');
+        await timeout(2000);
         assert.dom('[data-test-tombstone-title]').exists('Tombstone page shows');
     });
 
@@ -310,6 +316,7 @@ module('Registries | Acceptance | overview.moderator-mode', hooks => {
         triggerKeyEvent('[data-test-moderation-dropdown-comment]', 'keyup', 32);
         await settled();
         await click('[data-test-moderation-dropdown-submit]');
+        await timeout(2000);
         assert.dom('[data-test-tombstone-title]').exists('Tombstone page shows');
     });
 
@@ -356,6 +363,7 @@ module('Registries | Acceptance | overview.moderator-mode', hooks => {
         triggerKeyEvent('[data-test-moderation-dropdown-comment]', 'keyup', 32);
         await settled();
         await click('[data-test-moderation-dropdown-submit]');
+        await timeout(2000);
         assert.dom('[data-test-tombstone-title]').exists('Tombstone page shows');
     });
 

--- a/tests/engines/registries/acceptance/overview/overview-test.ts
+++ b/tests/engines/registries/acceptance/overview/overview-test.ts
@@ -17,6 +17,7 @@ import Registration from 'ember-osf-web/models/registration';
 import { click, visit } from 'ember-osf-web/tests/helpers';
 import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
 import pathJoin from 'ember-osf-web/utils/path-join';
+import { timeout } from 'ember-concurrency';
 
 interface OverviewTestContext extends TestContext {
     registration: ModelInstance<Registration>;
@@ -558,6 +559,7 @@ module('Registries | Acceptance | overview.overview', hooks => {
             .containsText('Value 1', 'Moderator successfully changed field 1');
         assert.dom('[data-test-registration-provider-metadata-field-value="Field 2"]')
             .containsText('Value 2', 'Moderator successfully changed field 2');
+        await timeout(1000);
         await click('[data-test-edit-button="metadata"]');
         assert.dom('[data-test-provider-metadata-edit-input="Field 1"]')
             .isVisible('Moderator can see edit dialog box');

--- a/tests/integration/components/contributors/component-test.ts
+++ b/tests/integration/components/contributors/component-test.ts
@@ -2,6 +2,7 @@ import { click, fillIn, findAll, render, triggerKeyEvent } from '@ember/test-hel
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { timeout } from 'ember-concurrency';
 import { setupIntl, t } from 'ember-intl/test-support';
 import { Permission } from 'ember-osf-web/models/osf-model';
 import CurrentUser from 'ember-osf-web/services/current-user';
@@ -348,6 +349,7 @@ module('Integration | Component | contributors', hooks => {
                 @shouldShowAdd={{true}}
             />
         `);
+        await timeout(500);
         await click('[data-test-add-unregistered-contributor-button]');
         assert.dom('[data-test-add-button]').isEnabled(
             'Add button should be enabled even the form is not valid at first',

--- a/tests/integration/components/contributors/component-test.ts
+++ b/tests/integration/components/contributors/component-test.ts
@@ -349,7 +349,6 @@ module('Integration | Component | contributors', hooks => {
                 @shouldShowAdd={{true}}
             />
         `);
-        await timeout(500);
         await click('[data-test-add-unregistered-contributor-button]');
         assert.dom('[data-test-add-button]').isEnabled(
             'Add button should be enabled even the form is not valid at first',
@@ -373,6 +372,7 @@ module('Integration | Component | contributors', hooks => {
             'Add button should be enabled now that the form is valid',
         );
         await click('[data-test-add-button]');
+        await timeout(500);
         assert.dom('[data-test-contributor-card]').exists({ count: 1 }, 'There is one contributor on the draft');
         assert.dom('[data-test-contributor-link]').hasText('Shin Sekyung', 'Contributor name matches');
         assert.dom('[data-test-contributor-permission]').hasText('Read', 'Contributor permission matches');

--- a/tests/integration/components/draft-registration-card/component-test.ts
+++ b/tests/integration/components/draft-registration-card/component-test.ts
@@ -1,6 +1,7 @@
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { timeout } from 'ember-concurrency';
 import { TestContext } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 import moment from 'moment';
@@ -33,6 +34,7 @@ module('Integration | Component | draft-registration-card', hooks => {
         this.set('draftRegistration', draftRegistration);
 
         await render(hbs`<DraftRegistrationCard @draftRegistration={{this.draftRegistration}} />`);
+        await timeout(500);
 
         const initiated = `${this.intl.t('osf-components.draft-registration-card.initiated_by')} `
             + `${user.fullName}`;

--- a/tests/integration/components/review-actions-list/review-action/component-collection-test.ts
+++ b/tests/integration/components/review-actions-list/review-action/component-collection-test.ts
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 
 import CollectionSubmissionAction, { CollectionSubmissionActionTrigger }
     from 'ember-osf-web/models/collection-submission-action';
+import { timeout } from 'ember-concurrency';
 
 interface ThisTestContext extends TestContext {
     collectionSubmissionAction: CollectionSubmissionAction;
@@ -35,6 +36,7 @@ module('Integration | Component | Collection | Admin or Moderator | review-actio
         this.collectionSubmissionAction.actionTrigger = CollectionSubmissionActionTrigger.Accept;
 
         await render(hbs`<ReviewActionsList::ReviewAction @reviewAction={{this.collectionSubmissionAction}}/>`);
+        await timeout(500);
         assert.dom('[data-test-review-action-wrapper]').exists('Review action wrapper shown');
         assert.dom('[data-test-review-action-wrapper]').containsText(
             'Request accepted 2 days ago by moderator Superb Mario',
@@ -47,6 +49,7 @@ module('Integration | Component | Collection | Admin or Moderator | review-actio
         this.collectionSubmissionAction.actionTrigger = CollectionSubmissionActionTrigger.Reject;
 
         await render(hbs`<ReviewActionsList::ReviewAction @reviewAction={{this.collectionSubmissionAction}}/>`);
+        await timeout(500);
         assert.dom('[data-test-review-action-wrapper]').containsText(
             'Request rejected 2 days ago by moderator Superb Mario',
             'Collection submission action wrapper shows reject string',
@@ -57,6 +60,7 @@ module('Integration | Component | Collection | Admin or Moderator | review-actio
         this.collectionSubmissionAction.actionTrigger = CollectionSubmissionActionTrigger.Remove;
 
         await render(hbs`<ReviewActionsList::ReviewAction @reviewAction={{this.collectionSubmissionAction}}/>`);
+        await timeout(500);
         assert.dom('[data-test-review-action-wrapper]').containsText(
             'Item removed 2 days ago by Superb Mario',
             'Collection submission action wrapper shows moderator remove string',
@@ -89,6 +93,7 @@ module('Integration | Component | Collection | Project Admin | review-actions', 
 
 
         await render(hbs`<ReviewActionsList::ReviewAction @reviewAction={{this.collectionSubmissionAction}}/>`);
+        await timeout(500);
         assert.dom('[data-test-review-action-wrapper]').exists('Review action wrapper shown');
         assert.dom('[data-test-review-action-wrapper]').containsText(
             'Item removed 2 days ago by Superb Mario',
@@ -102,6 +107,7 @@ module('Integration | Component | Collection | Project Admin | review-actions', 
         this.collectionSubmissionAction.actionTrigger = CollectionSubmissionActionTrigger.Resubmit;
 
         await render(hbs`<ReviewActionsList::ReviewAction @reviewAction={{this.collectionSubmissionAction}}/>`);
+        await timeout(500);
         assert.dom('[data-test-review-action-wrapper]').containsText(
             'Request resubmitted 2 days ago by contributor Superb Mario',
             'Collection submission action wrapper shows resubmit string',

--- a/tests/integration/components/review-actions-list/review-action/component-registration-test.ts
+++ b/tests/integration/components/review-actions-list/review-action/component-registration-test.ts
@@ -10,6 +10,7 @@ import RegistrationModel, { RegistrationReviewStates } from 'ember-osf-web/model
 import ReviewActionModel, { ReviewActionTrigger } from 'ember-osf-web/models/review-action';
 import UserModel from 'ember-osf-web/models/user';
 import formattedTimeSince from 'ember-osf-web/utils/formatted-time-since';
+import { timeout } from 'ember-concurrency';
 
 interface ThisTestContext extends TestContext {
     reviewAction: ReviewActionModel;
@@ -191,6 +192,7 @@ module('Integration | Component | Registration | review-actions', hooks => {
         const pastTenseString = t('registries.reviewActions.triggerPastTense.request_withdrawal');
 
         await render(hbs`<ReviewActionsList::ReviewAction @reviewAction={{this.reviewAction}}/>`);
+        await timeout(500);
         assert.dom('[data-test-review-action-wrapper]').exists('Review action wrapper shown');
         assert.dom('[data-test-review-action-wrapper]').containsText(
             t('osf-components.reviewActionsList.reviewAction.registrationContributorAction',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3374,12 +3374,33 @@
   resolved "https://registry.yarnpkg.com/@simple-dom/interface/-/interface-1.4.0.tgz#e8feea579232017f89b0138e2726facda6fbb71f"
   integrity sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==
 
-"@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.1", "@sinonjs/commons@^1.8.3":
+"@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.1":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
   integrity sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==
   dependencies:
     type-detect "4.0.8"
+
+"@sinonjs/commons@^1.8.3":
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.6.tgz#80c516a4dc264c2a69115e7578d62581ff455ed9"
+  integrity sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/commons@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-2.0.0.tgz#fd4ca5b063554307e8327b4564bd56d3b73924a3"
+  integrity sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@^10.0.2":
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz#d10549ed1f423d80639c528b6c7f5a1017747d0c"
+  integrity sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==
+  dependencies:
+    "@sinonjs/commons" "^2.0.0"
 
 "@sinonjs/fake-timers@^6.0.0", "@sinonjs/fake-timers@^6.0.1":
   version "6.0.1"
@@ -3388,7 +3409,7 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@sinonjs/fake-timers@^7.0.4", "@sinonjs/fake-timers@^7.1.0":
+"@sinonjs/fake-timers@^7.1.0":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz#2524eae70c4910edccf99b2f4e6efc5894aff7b5"
   integrity sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==
@@ -3412,9 +3433,9 @@
     type-detect "^4.0.8"
 
 "@sinonjs/samsam@^6.0.2":
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-6.0.2.tgz#a0117d823260f282c04bff5f8704bdc2ac6910bb"
-  integrity sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-6.1.3.tgz#4e30bcd4700336363302a7d72cbec9b9ab87b104"
+  integrity sha512-nhOb2dWPeb1sd3IQXL/dVPnKHDOAFfvichtBf4xV00/rU1QbPCQqKMbvIheIjqwVjh7qIgf2AHTHi391yMOMpQ==
   dependencies:
     "@sinonjs/commons" "^1.6.0"
     lodash.get "^4.4.2"
@@ -16312,12 +16333,12 @@ nise@^4.0.4:
     path-to-regexp "^1.7.0"
 
 nise@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/nise/-/nise-5.1.0.tgz#713ef3ed138252daef20ec035ab62b7a28be645c"
-  integrity sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-5.1.4.tgz#491ce7e7307d4ec546f5a659b2efe94a18b4bbc0"
+  integrity sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==
   dependencies:
-    "@sinonjs/commons" "^1.7.0"
-    "@sinonjs/fake-timers" "^7.0.4"
+    "@sinonjs/commons" "^2.0.0"
+    "@sinonjs/fake-timers" "^10.0.2"
     "@sinonjs/text-encoding" "^0.7.1"
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"


### PR DESCRIPTION
-   Ticket: [ENG-4427]
-   Feature flag: n/a

## Purpose

Turn jQuery integration off. This causes some subtle timing issues with rendering which are fixable with timeouts.

## Summary of Changes

1. Disable jQuery integration
2. Sprinkle timeouts throughout the tests where necessary to get them to pass again.

## Side Effects

Tests will take a bit longer to run.

## QA Notes

No real QA needed for this. Hopefully it won't break selenium with the new timing issues.

[ENG-4427]: https://openscience.atlassian.net/browse/ENG-4427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ