### PR TITLE
Make fetch requests authenticated

### DIFF
--- a/app/adapters/osf-adapter.ts
+++ b/app/adapters/osf-adapter.ts
@@ -158,9 +158,7 @@ export default class OsfAdapter extends JSONAPIAdapter {
     ajaxOptions(url: string, type: RequestType, options?: { isBulk?: boolean }): object {
         const hash: any = super.ajaxOptions(url, type, options);
 
-        hash.xhrFields = {
-            withCredentials: true,
-        };
+        hash.credentials = 'include';
 
         if (options && options.isBulk) {
             hash.contentType = 'application/vnd.api+json; ext=bulk';


### PR DESCRIPTION
## Purpose

Requests made through ember-data directly were not being authenticated after switching off jQuery Integration. This fixes that.

## Summary of Changes

1. Make fetch requests authenticated

## QA Notes

This should make it possible to view draft registrations again, and probably fix some other things as well.
