### PR TITLE
[ENG-4021] Deprecation/computed property override

### DIFF
--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -6,7 +6,6 @@ self.deprecationWorkflow.config = {
         { handler: 'silence', matchId: 'ember-bootstrap.subclassing#Alert' },
         { handler: 'silence', matchId: 'routing.transition-methods' },
         { handler: 'silence', matchId: 'autotracking.mutation-after-consumption' },
-        { handler: 'silence', matchId: 'computed-property.override' },
         { handler: 'silence', matchId: 'ember-utils.try-invoke' },
         { handler: 'silence', matchId: 'has-block-and-has-block-params' },
         { handler: 'silence', matchId: 'ember-simple-auth.initializer.setup-session-restoration' },

--- a/lib/osf-components/addon/components/carousel/component.ts
+++ b/lib/osf-components/addon/components/carousel/component.ts
@@ -1,6 +1,6 @@
 import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
-import { action, computed } from '@ember/object';
+import { action } from '@ember/object';
 
 import { layout } from 'ember-osf-web/decorators/component';
 import CarouselItem from 'osf-components/components/carousel/x-item/component';
@@ -14,19 +14,15 @@ export default class Carousel extends Component {
     // Private properties
     carouselItems: CarouselItem[] = [];
 
-    @computed('carouselItems.{length,@each.isActive}')
-    get activeSlide() {
-        return this.carouselItems.findBy('isActive');
-    }
-
     @action
     register(item: CarouselItem) {
         this.carouselItems.pushObject(item);
+        this.carouselItems[0].set('isActive', true);
     }
 
     @action
     changeSlide(direction: string) {
-        const activeSlide = this.carouselItems.findBy('isActive');
+        const activeSlide = this.carouselItems.findBy('active');
         const activeIndex = activeSlide!.index;
         let newIndex = direction === 'previous' ? activeIndex - 1 : activeIndex + 1;
 
@@ -42,7 +38,7 @@ export default class Carousel extends Component {
 
     @action
     navClick(item: CarouselItem) {
-        const activeSlide = this.carouselItems.findBy('isActive');
+        const activeSlide = this.carouselItems.findBy('active');
         const activeIndex = activeSlide!.index;
         const newIndex = item.index;
 

--- a/lib/osf-components/addon/components/carousel/x-item/component.ts
+++ b/lib/osf-components/addon/components/carousel/x-item/component.ts
@@ -14,6 +14,9 @@ export default class CarouselItem extends Component {
     allItems!: CarouselItem[];
     @requiredAction register!: (item: CarouselItem) => void;
 
+    // Optional parameters
+    isActive?: Boolean;
+
     // Private properties
     index = 0;
     slideIndex = 0;
@@ -25,13 +28,19 @@ export default class CarouselItem extends Component {
         this.set('slideIndex', this.allItems.indexOf(this) + 1);
     }
 
-    @computed('allItems.[]')
-    get isActive() {
+    @computed('allItems.[]', 'isActive')
+    get active() {
+        if (this.isActive === true){
+            return true;
+        }
+        if (this.isActive === false){
+            return false;
+        }
         return this === this.allItems[0];
     }
 
-    @computed('isActive')
+    @computed('active')
     get tabIndex() {
-        return this.isActive ? 0 : -1;
+        return this.active ? 0 : -1;
     }
 }

--- a/lib/osf-components/addon/components/validated-input/base-component.ts
+++ b/lib/osf-components/addon/components/validated-input/base-component.ts
@@ -32,6 +32,7 @@ export default abstract class BaseValidatedInput<M extends Model> extends Compon
     disabled = false;
     shouldShowMessages = true;
     model?: M;
+    isRequired?: Boolean;
 
     // Private properties
     @service intl!: Intl;
@@ -43,9 +44,15 @@ export default abstract class BaseValidatedInput<M extends Model> extends Compon
     isValidating?: boolean;
     validation?: ResultCollection;
 
-    @computed('errors', 'validation.options')
-    get isRequired(): boolean {
+    @computed('errors', 'validation.options', 'isRequired')
+    get required(): boolean {
         if (!this.validation) {
+            return false;
+        }
+        if (this.isRequired === true) {
+            return true;
+        }
+        if (this.isRequired === false) {
             return false;
         }
         const { options } = this.validation;
@@ -64,9 +71,9 @@ export default abstract class BaseValidatedInput<M extends Model> extends Compon
         return false;
     }
 
-    @computed('placeholder', 'isRequired')
+    @computed('placeholder', 'required')
     get _placeholder(): string {
-        return this.placeholder || this.intl.t(this.isRequired ? 'general.required' : 'general.optional');
+        return this.placeholder || this.intl.t(this.required ? 'general.required' : 'general.optional');
     }
 
     @dependentKeyCompat

--- a/tests/helpers/require-auth.ts
+++ b/tests/helpers/require-auth.ts
@@ -1,3 +1,4 @@
+import { computed } from '@ember/object';
 import CurrentUser from 'ember-osf-web/services/current-user';
 
 // CurrentUserStub works with acceptance tests that need to ensure that
@@ -14,4 +15,14 @@ export class CurrentUserStub extends CurrentUser.extend({
     async login(nextUrl?: string) {
         this.urlCalled = nextUrl !== undefined ? nextUrl : '';
     },
-}) { }
+}) {
+    testUser?: any;
+
+    @computed('testUser')
+    get user() {
+        if (this.testUser === undefined){
+            return super.user;
+        }
+        return this.testUser;
+    }
+}

--- a/tests/integration/components/contributor-list/component-test.ts
+++ b/tests/integration/components/contributor-list/component-test.ts
@@ -7,11 +7,11 @@ import { setupRenderingTest } from 'ember-qunit';
 import { TestContext } from 'ember-test-helpers';
 import { module, test } from 'qunit';
 
-import CurrentUser from 'ember-osf-web/services/current-user';
 import { click } from 'ember-osf-web/tests/helpers';
+import { CurrentUserStub } from 'ember-osf-web/tests/helpers/require-auth';
 
 interface ThisTestContext extends TestContext {
-    currentUser: CurrentUser;
+    currentUser: CurrentUserStub;
 }
 
 module('Integration | Component | contributor-list', hooks => {
@@ -32,6 +32,7 @@ module('Integration | Component | contributor-list', hooks => {
 
     hooks.beforeEach(function(this: ThisTestContext) {
         this.store = this.owner.lookup('service:store');
+        this.owner.register('service:current-user', CurrentUserStub);
         this.currentUser = this.owner.lookup('service:current-user');
     });
 
@@ -161,7 +162,7 @@ module('Integration | Component | contributor-list', hooks => {
         const node = await this.store.findRecord('node', mirageNode.id);
         this.set('node', node);
 
-        this.currentUser.setProperties({ user, currentUserId: user.id });
+        this.currentUser.setProperties({ testUser: user, currentUserId: user.id });
         await render(hbs`<ContributorList @model={{this.node}}
             @shouldTruncate={{false}} @shouldLinkUsers={{true}} @allowRemoveMe={{true}} />`);
 

--- a/tests/integration/components/contributors/component-test.ts
+++ b/tests/integration/components/contributors/component-test.ts
@@ -5,7 +5,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { timeout } from 'ember-concurrency';
 import { setupIntl, t } from 'ember-intl/test-support';
 import { Permission } from 'ember-osf-web/models/osf-model';
-import CurrentUser from 'ember-osf-web/services/current-user';
+import { CurrentUserStub } from 'ember-osf-web/tests/helpers/require-auth';
 import { selectChoose } from 'ember-power-select/test-support';
 import { clickTrigger } from 'ember-power-select/test-support/helpers';
 import { setupRenderingTest } from 'ember-qunit';
@@ -15,7 +15,7 @@ import { module, skip, test } from 'qunit';
 import { OsfLinkRouterStub } from '../../helpers/osf-link-router-stub';
 
 interface ThisTestContext extends TestContext {
-    currentUser: CurrentUser;
+    currentUser: CurrentUserStub;
 }
 
 module('Integration | Component | contributors', hooks => {
@@ -25,6 +25,7 @@ module('Integration | Component | contributors', hooks => {
 
     hooks.beforeEach(function(this: ThisTestContext) {
         this.store = this.owner.lookup('service:store');
+        this.owner.register('service:current-user', CurrentUserStub);
         this.currentUser = this.owner.lookup('service:current-user');
         this.owner.unregister('service:router');
         this.owner.register('service:router', OsfLinkRouterStub);
@@ -112,7 +113,7 @@ module('Integration | Component | contributors', hooks => {
         const currentUser = server.create('user', { id: 'sprout' });
         const currentUserModel = await this.store.findRecord('user', 'sprout');
         this.owner.lookup('service:current-user').setProperties({
-            user: currentUserModel, currentUserId: currentUserModel.id,
+            testUser: currentUserModel, currentUserId: currentUserModel.id,
         });
 
         const firstContributor = server.create('contributor', {

--- a/tests/integration/components/files-widget/component-test.ts
+++ b/tests/integration/components/files-widget/component-test.ts
@@ -10,10 +10,10 @@ import { module, test } from 'qunit';
 
 import File from 'ember-osf-web/models/file';
 import { Permission } from 'ember-osf-web/models/osf-model';
-import CurrentUser from 'ember-osf-web/services/current-user';
+import { CurrentUserStub } from 'ember-osf-web/tests/helpers/require-auth';
 
 interface ThisTestContext extends TestContext {
-    currentUser: CurrentUser;
+    currentUser: CurrentUserStub;
 }
 
 type Field = 'name' | 'date-modified';
@@ -41,6 +41,7 @@ module('Integration | Component | files-widget', hooks => {
 
     hooks.beforeEach(function(this: ThisTestContext) {
         this.store = this.owner.lookup('service:store');
+        this.owner.register('service:current-user', CurrentUserStub);
         this.currentUser = this.owner.lookup('service:current-user');
     });
 

--- a/tests/integration/components/moderators/component-test.ts
+++ b/tests/integration/components/moderators/component-test.ts
@@ -5,6 +5,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupIntl, TestContext } from 'ember-intl/test-support';
 import { PermissionGroup } from 'ember-osf-web/models/moderator';
 import RegistrationProviderModel from 'ember-osf-web/models/registration-provider';
+import { CurrentUserStub } from 'ember-osf-web/tests/helpers/require-auth';
 import { selectChoose, selectSearch } from 'ember-power-select/test-support';
 import { clickTrigger } from 'ember-power-select/test-support/helpers';
 import { setupRenderingTest } from 'ember-qunit';
@@ -25,6 +26,7 @@ module('Integration | Component | moderators', hooks => {
         this.intl = this.owner.lookup('service:intl');
         this.owner.unregister('service:router');
         this.owner.register('service:router', OsfLinkRouterStub);
+        this.owner.register('service:current-user', CurrentUserStub);
         this.provider = server.create('registration-provider', { id: 'egap', name: 'EGAP' });
         const providerModel = await this.store.findRecord('registration-provider', 'egap');
         this.set('providerModel', providerModel);
@@ -58,7 +60,7 @@ module('Integration | Component | moderators', hooks => {
         const currentUser = server.create('user', { id: 'sprout' });
         const currentUserModel = await this.store.findRecord('user', 'sprout');
         this.owner.lookup('service:current-user').setProperties({
-            user: currentUserModel, currentUserId: currentUserModel.id,
+            testUser: currentUserModel, currentUserId: currentUserModel.id,
         });
         const moderator = server.create('moderator', {
             permissionGroup: PermissionGroup.Moderator,
@@ -104,7 +106,7 @@ module('Integration | Component | moderators', hooks => {
         const currentUser = server.create('user', { id: 'sprout' });
         const currentUserModel = await this.store.findRecord('user', 'sprout');
         this.owner.lookup('service:current-user').setProperties({
-            user: currentUserModel, currentUserId: currentUserModel.id,
+            testUser: currentUserModel, currentUserId: currentUserModel.id,
         });
         const admin = server.create('moderator', {
             permissionGroup: PermissionGroup.Admin,
@@ -150,7 +152,7 @@ module('Integration | Component | moderators', hooks => {
         const currentUser = server.create('user', { id: 'sprout' });
         const currentUserModel = await this.store.findRecord('user', 'sprout');
         this.owner.lookup('service:current-user').setProperties({
-            user: currentUserModel, currentUserId: currentUserModel.id,
+            testUser: currentUserModel, currentUserId: currentUserModel.id,
         });
         server.create('moderator', {
             id: currentUserModel.id,
@@ -192,7 +194,7 @@ module('Integration | Component | moderators', hooks => {
         const currentUser = server.create('user', { id: 'sprout' });
         const currentUserModel = await this.store.findRecord('user', 'sprout');
         this.owner.lookup('service:current-user').setProperties({
-            user: currentUserModel, currentUserId: currentUserModel.id,
+            testUser: currentUserModel, currentUserId: currentUserModel.id,
         });
         server.create('moderator', {
             id: currentUserModel.id,

--- a/tests/integration/components/move-file-modal/component-test.ts
+++ b/tests/integration/components/move-file-modal/component-test.ts
@@ -12,12 +12,13 @@ import { Permission } from 'ember-osf-web/models/osf-model';
 import OsfStorageFile from 'ember-osf-web/packages/files/osf-storage-file';
 import OsfStorageProviderFile from 'ember-osf-web/packages/files/osf-storage-provider-file';
 import { click } from 'ember-osf-web/tests/helpers';
+import { CurrentUserStub } from 'ember-osf-web/tests/helpers/require-auth';
 
 interface MoveTestContext extends TestContext {
     manager: any;
     filesToMove: OsfStorageFile[];
     close: () => void;
-    currentUser: any;
+    currentUser: CurrentUserStub;
 }
 
 module('Integration | Component | move-file-modal', hooks => {
@@ -26,6 +27,7 @@ module('Integration | Component | move-file-modal', hooks => {
 
     hooks.beforeEach(function(this: MoveTestContext) {
         this.store = this.owner.lookup('service:store');
+        this.owner.register('service:current-user', CurrentUserStub);
         this.currentUser = this.owner.lookup('service:current-user');
     });
 

--- a/tests/integration/components/registries/my-registrations-list/component-test.ts
+++ b/tests/integration/components/registries/my-registrations-list/component-test.ts
@@ -2,6 +2,7 @@ import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupIntl, TestContext } from 'ember-intl/test-support';
+import { CurrentUserStub } from 'ember-osf-web/tests/helpers/require-auth';
 import { OsfLinkRouterStub } from 'ember-osf-web/tests/integration/helpers/osf-link-router-stub';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -16,6 +17,7 @@ module('Integration | Component | my-registrations-list', hooks => {
         this.intl = this.owner.lookup('service:intl');
         this.owner.unregister('service:router');
         this.owner.register('service:router', OsfLinkRouterStub);
+        this.owner.register('service:current-user', CurrentUserStub);
     });
 
     test('draft list empty', async function(this: TestContext, assert) {
@@ -38,7 +40,7 @@ module('Integration | Component | my-registrations-list', hooks => {
         const currentUserModel = await this.store.findRecord('user', currentUser.id);
         this.set('user', currentUserModel);
         this.owner.lookup('service:current-user').setProperties({
-            user: currentUserModel, currentUserId: currentUserModel.id,
+            testUser: currentUserModel, currentUserId: currentUserModel.id,
         });
         await render(
             hbs`<Registries::MyRegistrationsList::Registrations @user={{this.user}} />`,
@@ -58,7 +60,7 @@ module('Integration | Component | my-registrations-list', hooks => {
         const currentUser = server.create('user', { id: 'wraith' });
         const currentUserModel = await this.store.findRecord('user', currentUser.id);
         this.owner.lookup('service:current-user').setProperties({
-            user: currentUserModel, currentUserId: currentUserModel.id,
+            testUser: currentUserModel, currentUserId: currentUserModel.id,
         });
         server.createList('draft-registration', 11, { initiator: currentUser });
         await render(
@@ -76,7 +78,7 @@ module('Integration | Component | my-registrations-list', hooks => {
         const currentUserModel = await this.store.findRecord('user', currentUser.id);
         this.set('user', currentUserModel);
         this.owner.lookup('service:current-user').setProperties({
-            user: currentUserModel, currentUserId: currentUserModel.id,
+            testUser: currentUserModel, currentUserId: currentUserModel.id,
         });
         for (let i = 0; i < 11; i++) {
             server.create('registration', {
@@ -100,7 +102,7 @@ module('Integration | Component | my-registrations-list', hooks => {
         const currentUserModel = await this.store.findRecord('user', currentUser.id);
         this.set('user', currentUserModel);
         this.owner.lookup('service:current-user').setProperties({
-            user: currentUserModel, currentUserId: currentUserModel.id,
+            testUser: currentUserModel, currentUserId: currentUserModel.id,
         });
         const parent = server.create('registration', {
             id: 'parnt',

--- a/tests/integration/components/tos-consent-banner/component-test.ts
+++ b/tests/integration/components/tos-consent-banner/component-test.ts
@@ -7,11 +7,11 @@ import { TestContext } from 'ember-test-helpers';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-import CurrentUser from 'ember-osf-web/services/current-user';
 import { click } from 'ember-osf-web/tests/helpers';
+import { CurrentUserStub } from 'ember-osf-web/tests/helpers/require-auth';
 
 interface ThisTestContext extends TestContext {
-    currentUser: CurrentUser;
+    currentUser: CurrentUserStub;
 }
 
 const sessionStub = Service.extend({
@@ -27,6 +27,7 @@ module('Integration | Component | tos-consent-banner', hooks => {
 
     hooks.beforeEach(function(this: ThisTestContext) {
         this.store = this.owner.lookup('service:store');
+        this.owner.register('service:current-user', CurrentUserStub);
         this.currentUser = this.owner.lookup('service:current-user');
         this.owner.unregister('service:session');
         this.owner.register('service:session', sessionStub);

--- a/tests/integration/services/current-user-test.ts
+++ b/tests/integration/services/current-user-test.ts
@@ -3,13 +3,13 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import config from 'ember-get-config';
 import { TestContext } from 'ember-intl/test-support';
 import { startMirage } from 'ember-osf-web/initializers/ember-cli-mirage';
-import CurrentUserService from 'ember-osf-web/services/current-user';
+import { CurrentUserStub } from 'ember-osf-web/tests/helpers/require-auth';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 const { OSF: { apiUrl, apiVersion } } = config;
 
-type ExtendedTestContext = TestContext & { currentUser: CurrentUserService };
+type ExtendedTestContext = TestContext & { currentUser: CurrentUserStub };
 
 module('Integration | Service | current-user', hooks => {
     setupTest(hooks);
@@ -17,6 +17,7 @@ module('Integration | Service | current-user', hooks => {
 
     hooks.beforeEach(function(this: ExtendedTestContext) {
         this.store = this.owner.lookup('service:store');
+        this.owner.register('service:current-user', CurrentUserStub);
         this.currentUser = this.owner.lookup('service:current-user');
     });
 

--- a/tests/unit/packages/files/dataverse-file-test.ts
+++ b/tests/unit/packages/files/dataverse-file-test.ts
@@ -3,11 +3,13 @@ import { t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import DataverseFile from 'ember-osf-web/packages/files/dataverse-file';
+import { CurrentUserStub } from 'ember-osf-web/tests/helpers/require-auth';
 
 module('Unit | Packages | files | dataverse-file', hooks => {
     setupTest(hooks);
     setupMirage(hooks);
     test('proper display names', async function(assert) {
+        this.owner.register('service:current-user', CurrentUserStub);
         const mirageFilePublished = server.create('file');
         mirageFilePublished.extra.datasetVersion = 'latest-published';
         const publishedFile = await this.owner.lookup('service:store').findRecord('file', mirageFilePublished.id);


### PR DESCRIPTION
-   Ticket: [ENG-4021]
-   Feature flag: n/a

## Purpose

Un-silence the deprecation for computed property overrides and fix the problems.

## Summary of Changes

1. Un-silence the deprecation
2. Update validated input to accept isActive as a parameter and computer the active state property properly rather than overriding the computed property
3. Fix the logged-out home page carousel
4. Update the current-user stub to accept a testUser rather than overriding the user computed property
5. Fix usage of current-user in tests to use the new testUser property

## QA Notes

The main thing I would be concerned about is if I broke some indications that fields are required, but I think I fixed that in a pretty safe way.


[ENG-4021]: https://openscience.atlassian.net/browse/ENG-4021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ