### PR TITLE
[Hotfix][No ticket]Load more schemas at once

### DIFF
--- a/lib/registries/addon/branded/new/controller.ts
+++ b/lib/registries/addon/branded/new/controller.ts
@@ -9,6 +9,7 @@ import { restartableTask, task, timeout } from 'ember-concurrency';
 import DraftRegistrationModel from 'ember-osf-web/models/draft-registration';
 import NodeModel from 'ember-osf-web/models/node';
 import { Permission } from 'ember-osf-web/models/osf-model';
+import RegistrationProviderModel from 'ember-osf-web/models/registration-provider';
 import RegistrationSchemaModel from 'ember-osf-web/models/registration-schema';
 import Analytics from 'ember-osf-web/services/analytics';
 import CurrentUserService from 'ember-osf-web/services/current-user';
@@ -60,7 +61,9 @@ export default class BrandedRegistriesNewSubmissionController extends Controller
     @waitFor
     async findAllSchemas() {
         try {
-            const schemas = await this.model.schemas;
+            const schemas = await (this.model as RegistrationProviderModel).queryHasMany('schemas', {
+                'page[size]': 100,
+            });
             [this.selectedSchema] = schemas.toArray();
             this.schemaOptions = schemas;
         } catch (e) {


### PR DESCRIPTION
-   Ticket: [No ticket]
-   Feature flag: n/a

## Purpose
- Load more than 10 registration schemas on "Add New Registration" page

## Summary of Changes
- Set page[size] when fetching registration schemas on branded registries' add new page (registries/<provider_id>/new)

## Screenshot(s)
- Dropdown should populate with all schemas a provider accepts
<img width="1148" alt="image" src="https://user-images.githubusercontent.com/51409893/231258106-49c70880-e51e-4903-aefe-8f54e2d1b709.png">


## Side Effects
- None
## QA Notes
- This should fix the issue where the Add New Registration page (osf.io/registries/osf/new)only shows the first 10 registration schemas that a provider accepts. This problem does not exist when adding a registration in a project's registration page (`osf.io/<project-guid>/registrations`)