### PR TITLE
[ENG-4417] Remove BsNav

### DIFF
--- a/app/settings/styles.scss
+++ b/app/settings/styles.scss
@@ -12,11 +12,37 @@
     line-height: 1em;
 }
 
-.ProfileNav {
-    margin-left: 20px;
-    display: none;
-}
+.stacked-nav {
+    ul {
+        list-style: none;
+        padding-left: 0;
+    }
 
-:global(.active) .ProfileNav {
-    display: block;
+    li:has(:global(.active)) {
+        background-color: $color-bg-blue-dark;
+
+        :hover {
+            background-color: $color-bg-blue-dark;
+        }
+    }
+
+    a:global(.active) {
+        color: $color-text-white;
+    }
+
+    li > a {
+        position: relative;
+        display: block;
+        padding: 10px 15px;
+        border-radius: 0;
+        text-decoration: none;
+    }
+
+    li > a:hover {
+        text-decoration: none;
+    }
+
+    li:hover {
+        background-color: $color-bg-gray-lighter;
+    }
 }

--- a/app/settings/template.hbs
+++ b/app/settings/template.hbs
@@ -4,6 +4,7 @@
             <h2 class='page-header'>
                 {{t 'general.settings'}}
                 <Button
+                   data-test-toggle-nav
                    local-class='NavToggle'
                    aria-label={{t 'settings.toggleNav'}}
                    class='hidden-md hidden-lg'
@@ -19,96 +20,64 @@
         <div class='col-md-3'>
             <BsCollapse @collapsed={{this.navCollapsed}} local-class='SideNav'>
                 <div class='panel panel-default'>
-                    <BsNav @type='pills' @stacked={{true}} as |nav|>
-                        <nav.item>
-                            <OsfLink
-                                data-analytics-name='Settings'
-                                @route='settings.profile'
-                            >
-                                {{t 'settings.profile.title'}}
-                            </OsfLink>
-                            <BsNav
-                                data-analytics-scope='Profile Nav'
-                                local-class='ProfileNav'
-                                @stacked={{true}}
-                                @type='pills'
-                                as |profileNav|
-                            >
-                                <profileNav.item>
-                                    <OsfLink
-                                        data-analytics-name='Name'
-                                        @route='settings.profile.name'
-                                    >
-                                        {{t 'settings.profile.name.title'}}
-                                    </OsfLink>
-                                </profileNav.item>
-                                <profileNav.item>
-                                    <OsfLink
-                                        data-analytics-name='Social'
-                                        @route='settings.profile.social'
-                                    >
-                                        {{t 'settings.profile.social.title'}}
-                                    </OsfLink>
-                                </profileNav.item>
-                                <profileNav.item>
-                                    <OsfLink
-                                        data-analytics-name='Education'
-                                        @route='settings.profile.education'
-                                    >
-                                        {{t 'settings.profile.education.title'}}
-                                    </OsfLink>
-                                </profileNav.item>
-                                <profileNav.item>
-                                    <OsfLink
-                                        data-analytics-name='Employment'
-                                        @route='settings.profile.employment'
-                                    >
-                                        {{t 'settings.profile.employment.title'}}
-                                    </OsfLink>
-                                </profileNav.item>
-                            </BsNav>
-                        </nav.item>
-                        <nav.item>
-                            <OsfLink
-                                data-analytics-name='Account'
-                                @route='settings.account'
-                            >
-                                {{t 'settings.account.title'}}
-                            </OsfLink>
-                        </nav.item>
-                        <nav.item>
-                            <OsfLink
-                                data-analytics-name='Configure add-on accounts'
-                                @href='/settings/addons'
-                            >
-                                {{t 'settings.addons.title'}}
-                            </OsfLink>
-                        </nav.item>
-                        <nav.item>
-                            <OsfLink
-                                data-analytics-name='Notifications'
-                                @href='/settings/notifications'
-                            >
-                                {{t 'settings.notifications.title'}}
-                            </OsfLink>
-                        </nav.item>
-                        <nav.item>
-                            <OsfLink
-                                data-analytics-name='Developer apps'
-                                @route='settings.developer-apps'
-                            >
-                                {{t 'settings.developer-apps.title'}}
-                            </OsfLink>
-                        </nav.item>
-                        <nav.item>
-                            <OsfLink
-                                data-analytics-name='Personal access tokens'
-                                @route='settings.tokens'
-                            >
-                                {{t 'settings.tokens.title'}}
-                            </OsfLink>
-                        </nav.item>
-                    </BsNav>
+                    <div local-class='stacked-nav'>
+                        <ul>
+                            <li>
+                                <OsfLink
+                                    data-analytics-name='Settings'
+                                    data-test-settings-link
+                                    @href='/settings'
+                                >
+                                    {{t 'settings.profile.title'}}
+                                </OsfLink>
+                            </li>
+                            <li>
+                                <OsfLink
+                                    data-analytics-name='Account'
+                                    data-test-account-link
+                                    @route='settings.account'
+                                >
+                                    {{t 'settings.account.title'}}
+                                </OsfLink>
+                            </li>
+                            <li>
+                                <OsfLink
+                                    data-analytics-name='Configure add-on accounts'
+                                    data-test-addons-link
+                                    @href='/settings/addons'
+                                >
+                                    {{t 'settings.addons.title'}}
+                                </OsfLink>
+                            </li>
+                            <li>
+                                <OsfLink
+                                    data-analytics-name='Notifications'
+                                    data-test-notifications-link
+                                    @href='/settings/notifications'
+                                >
+                                    {{t 'settings.notifications.title'}}
+                                </OsfLink>
+                            </li>
+                            <li>
+                                <OsfLink
+                                    data-analytics-name='Developer apps'
+                                    data-test-apps-link
+                                    @route='settings.developer-apps'
+                                >
+                                    {{t 'settings.developer-apps.title'}}
+                                </OsfLink>
+                            </li>
+                            <li>
+                                <OsfLink
+                                    data-analytics-name='Personal access tokens'
+                                    data-test-tokens-link
+                                    @route='settings.tokens'
+                                >
+                                    {{t 'settings.tokens.title'}}
+                                </OsfLink>
+                            </li>
+                        </ul>
+                    </div>
                 </div>
             </BsCollapse>
         </div>

--- a/lib/collections/addon/provider/moderation/styles.scss
+++ b/lib/collections/addon/provider/moderation/styles.scss
@@ -20,3 +20,40 @@
 .main {
     padding-top: 40px;
 }
+
+.main-nav {
+    border-bottom: 0;
+    font-size: 18px;
+    list-style: none;
+    padding: 0;
+    overflow: hidden;
+
+    li {
+        float: left;
+    }
+
+    li > a {
+        border: 1px solid transparent;
+        border-radius: 0;
+        margin-right: 2px;
+        line-height: 1.42857;
+        padding: 10px 15px;
+        display: block;
+        position: relative;
+        text-decoration: none;
+    }
+
+    // stylelint-disable selector-no-qualifying-type
+    li.active > a {
+        background-color: $bg-light;
+        border-bottom: 2px solid $color-blue;
+        color: $color-text-gray;
+        cursor: default;
+    }
+
+    li > a:hover,
+    li > a:focus {
+        text-decoration: none;
+        background-color: $bg-light;
+    }
+}

--- a/lib/collections/addon/provider/moderation/template.hbs
+++ b/lib/collections/addon/provider/moderation/template.hbs
@@ -7,9 +7,9 @@
         </div>
     </layout.heading>
     <layout.main local-class='main'>
-        <BsNav local-class='clamped-width-container' @type='tabs' as |nav|>
+        <ul local-class='clamped-width-container main-nav'>
             {{#let 'collections.provider.moderation.all' as |allRoute|}}
-                <nav.item @active={{eq this.target.currentRouteName allRoute}}>
+                <li local-class={{if (eq this.target.currentRouteName allRoute) 'active'}}>
                     <OsfLink
                         data-test-collections-moderation-all-tab
                         @route={{allRoute}}
@@ -17,10 +17,10 @@
                     >
                         {{t 'collections.moderation.all.title'}}
                     </OsfLink>
-                </nav.item>
+                </li>
             {{/let}}
             {{#let 'collections.provider.moderation.moderators' as |moderatorsRoute|}}
-                <nav.item @active={{eq this.target.currentRouteName moderatorsRoute}}>
+                <li local-class={{if (eq this.target.currentRouteName moderatorsRoute) 'active'}}>
                     <OsfLink
                         data-analytics-name='Collection moderation moderators tab'
                         data-test-collections-moderation-moderators-tab
@@ -29,10 +29,10 @@
                     >
                         {{t 'collections.moderation.moderators.title'}}
                     </OsfLink>
-                </nav.item>
+                </li>
             {{/let}}
             {{#let 'collections.provider.moderation.settings' as |settingsRoute|}}
-                <nav.item @active={{eq this.target.currentRouteName settingsRoute}}>
+                <li local-class={{if (eq this.target.currentRouteName settingsRoute) 'active'}}>
                     <OsfLink
                         data-analytics-name='Collection moderation settings tab'
                         data-test-collections-moderation-settings-tab
@@ -41,9 +41,9 @@
                     >
                         {{t 'collections.moderation.settings.title'}}
                     </OsfLink>
-                </nav.item>
+                </li>
             {{/let}}
-        </BsNav>
+        </ul>
         <div local-class='clamped-width-container'>
             {{outlet}}
         </div>

--- a/lib/registries/addon/branded/moderation/styles.scss
+++ b/lib/registries/addon/branded/moderation/styles.scss
@@ -11,9 +11,42 @@
 }
 
 
-.mainNav {
+.main-nav {
     border-bottom: 0;
     font-size: 18px;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+
+    li {
+        float: left;
+    }
+
+    li > a {
+        border: 1px solid transparent;
+        border-radius: 0;
+        margin-right: 2px;
+        line-height: 1.42857;
+        padding: 10px 15px;
+        display: block;
+        position: relative;
+        text-decoration: none;
+    }
+
+    // stylelint-disable selector-no-qualifying-type
+    li.active > a {
+        background-color: $bg-light;
+        border-bottom: 2px solid $color-blue;
+        color: $color-text-gray;
+        cursor: default;
+    }
+
+    li > a:hover,
+    li > a:focus {
+        text-decoration: none;
+        background-color: $bg-light;
+    }
 }
 
 .childNav {

--- a/lib/registries/addon/branded/moderation/template.hbs
+++ b/lib/registries/addon/branded/moderation/template.hbs
@@ -15,48 +15,52 @@
         </layout.heading>
         <layout.main local-class='main'>
             {{!-- TODO: add pending count in Submissions and Withdrawals tab --}}
-            <BsNav local-class='mainNav' @type='tabs' as |nav|>
+            <ul local-class='main-nav'>
                 {{#let 'registries.branded.moderation.submitted' as |submittedRoute|}}
-                    <nav.item @active={{eq this.target.currentRouteName submittedRoute}}>
+                    <li local-class={{if (eq this.target.currentRouteName submittedRoute) 'active'}}>
                         <OsfLink
+                            data-test-submitted-link
                             @route={{submittedRoute}}
                             @models={{array this.model.id}}
                         >
                             {{t 'registries.moderation.submitted.title'}}
                         </OsfLink>
-                    </nav.item>
+                    </li>
                 {{/let}}
                 {{#let 'registries.branded.moderation.pending' as |pendingRoute|}}
-                    <nav.item @active={{eq this.target.currentRouteName pendingRoute}}>
+                    <li local-class={{if (eq this.target.currentRouteName pendingRoute) 'active'}}>
                         <OsfLink
+                            data-test-pending-link
                             @route={{pendingRoute}}
                             @models={{array this.model.id}}
                         >
                             {{t 'registries.moderation.pending.title'}}
                         </OsfLink>
-                    </nav.item>
+                    </li>
                 {{/let}}
                 {{#let 'registries.branded.moderation.moderators' as |moderatorsRoute|}}
-                    <nav.item @active={{eq this.target.currentRouteName moderatorsRoute}}>
+                    <li local-class={{if (eq this.target.currentRouteName moderatorsRoute) 'active'}}>
                         <OsfLink
+                            data-test-moderators-link
                             @route={{moderatorsRoute}}
                             @models={{array this.model.id}}
                         >
                             {{t 'registries.moderation.moderators.title'}}
                         </OsfLink>
-                    </nav.item>
+                    </li>
                 {{/let}}
                 {{#let 'registries.branded.moderation.settings' as |settingsRoute|}}
-                    <nav.item @active={{eq this.target.currentRouteName settingsRoute}}>
+                    <li local-class={{if (eq this.target.currentRouteName settingsRoute) 'active'}}>
                         <OsfLink
+                            data-test-settings-link
                             @route={{settingsRoute}}
                             @models={{array this.model.id}}
                         >
                             {{t 'registries.moderation.settings.title'}}
                         </OsfLink>
-                    </nav.item>
+                    </li>
                 {{/let}}
-            </BsNav>
+            </ul>
             {{outlet}}
         </layout.main>
     </OsfLayout>


### PR DESCRIPTION
-   Ticket: [ENG-4417]
-   Feature flag: n/a

## Purpose

Remove all usages of BsNav from the ember-osf-web codebase.

## Summary of Changes

1. Remove bs-nav from settings page
2. Remove bs-nav from registries moderation
3. Remove bs-nav from collections moderation
4. Add some data-test selectors

## Screenshot(s)

<img width="602" alt="Screenshot 2023-04-13 at 4 28 22 PM" src="https://user-images.githubusercontent.com/6599111/231876065-323f0ce0-1324-40af-99cd-6768661f2113.png">
<img width="945" alt="Screenshot 2023-04-13 at 3 40 47 PM" src="https://user-images.githubusercontent.com/6599111/231876069-36bf203d-dd7b-4d5f-89bc-903603bb1af2.png">
<img width="391" alt="Screenshot 2023-04-13 at 2 42 11 PM" src="https://user-images.githubusercontent.com/6599111/231876071-dbeab994-3435-44cc-b38e-52ebd82481d2.png">


## Side Effects

In the previous version of the settings page, the active element was not highlighting the same way as it does on osf.io legacy pages (it wasn't highlighting at all, in fact). This version does highlight like legacy, but not for Firefox. The test selector I'm using works everywhere but there. So it's better and not worse, but it's not perfect. I think, since we went five years with nobody noticing, it's probably fine.

## QA Notes

Just check the navigation mentioned above to make sure everything is cool.
