### PR TITLE
[ENG-4415] Replace tooltips and popovers

### DIFF
--- a/app/guid-node/registrations/template.hbs
+++ b/app/guid-node/registrations/template.hbs
@@ -131,9 +131,9 @@
                                                     {{schema.name}}
                                                     <span>
                                                         <FaIcon @icon='info-circle' />
-                                                        <BsTooltip>
+                                                        <EmberTooltip>
                                                             {{schema.schema.description}}
-                                                        </BsTooltip>
+                                                        </EmberTooltip>
                                                     </span>
                                                 </div>
                                             </RadioButton>

--- a/app/guid-node/template.hbs
+++ b/app/guid-node/template.hbs
@@ -71,13 +71,12 @@
                                         @icon='globe'
                                     >
                                     </FaIcon>
-                                    <BsTooltip
-                                        @placement='right'
-                                        @triggerEvents='hover'
+                                    <EmberTooltip
+                                        @side='right'
                                     >
                                         {{t 'osf-components.file-browser.storage_location'}}
                                         {{this.model.taskInstance.value.region.name}}
-                                    </BsTooltip>
+                                    </EmberTooltip>
                                 </span>
                             {{/if}}
                         </div>

--- a/lib/app-components/addon/components/project-contributors/list/component.ts
+++ b/lib/app-components/addon/components/project-contributors/list/component.ts
@@ -37,6 +37,14 @@ export default class List extends Component {
     hasMore = false;
     page = 1;
 
+    popperOptions = {
+        modifiers: {
+            preventOverflow: {
+                escapeWithReference: false,
+            },
+        },
+    };
+
     /**
      * If the current user is an admin
      */

--- a/lib/app-components/addon/components/project-contributors/list/component.ts
+++ b/lib/app-components/addon/components/project-contributors/list/component.ts
@@ -37,14 +37,6 @@ export default class List extends Component {
     hasMore = false;
     page = 1;
 
-    popperOptions = {
-        modifiers: {
-            preventOverflow: {
-                escapeWithReference: false,
-            },
-        },
-    };
-
     /**
      * If the current user is an admin
      */

--- a/lib/app-components/addon/components/project-contributors/list/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/list/template.hbs
@@ -4,27 +4,23 @@
     </div>
     <div class='col-sm-3'>
         <strong>{{t 'app_components.project_contributors.list.permissions'}}</strong>
-        <FaIcon @icon='question-circle'>
-            <BsPopover
-                @placement='bottom'
-                @triggerEvents='hover'
-                @title={{t 'app_components.project_contributors.list.permissions_popover_title'}}
-            >
+        <span>
+            <FaIcon @icon='question-circle' />
+            <EmberPopover @side='bottom' @popperContainer='body'>
+                <h3>{{t 'app_components.project_contributors.list.permissions_popover_title'}}</h3>
                 {{t 'app_components.project_contributors.list.permissions_popover' htmlSafe=true}}
-            </BsPopover>
-        </FaIcon>
+            </EmberPopover>
+        </span>
     </div>
     <div class='col-sm-2 bib-padding'>
         <strong>{{t 'app_components.project_contributors.list.citation'}}</strong>
-        <FaIcon @icon='question-circle'>
-            <BsPopover
-                @placement='bottom'
-                @triggerEvents='hover'
-                @title={{t 'app_components.project_contributors.list.citation_popover_title'}}
-            >
+        <span>
+            <FaIcon @icon='question-circle' />
+            <EmberPopover @side='bottom' @popperContainer='body'>
+                <h3>{{t 'app_components.project_contributors.list.citation_popover_title'}}</h3>
                 {{t 'app_components.project_contributors.list.citation_popover'}}
-            </BsPopover>
-        </FaIcon>
+            </EmberPopover>
+        </span>
     </div>
 </div>
 <SortableGroup

--- a/lib/app-components/addon/components/project-contributors/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/template.hbs
@@ -12,15 +12,17 @@
     <h2 local-class='inline'>
         {{t 'app_components.project_contributors.title'}}
     </h2>
-    <FaIcon @icon='question-circle'>
-        <BsPopover
-            @placement='bottom'
-            @triggerEvents='hover'
-            @title={{t 'app_components.project_contributors.contributors_popover_title'}}
+    <span>
+        <FaIcon @icon='question-circle' />
+        <EmberPopover
+            @side='bottom'
+            @event='hover'
+            @popperContainer='body'
         >
+            <h3>{{t 'app_components.project_contributors.contributors_popover_title'}}</h3>
             {{t 'app_components.project_contributors.contributors_popover'}}
-        </BsPopover>
-    </FaIcon>
+        </EmberPopover>
+    </span>
     <p>
         {{t 'app_components.project_contributors.instructions'}}
     </p>

--- a/lib/app-components/addon/components/submit-section/template.hbs
+++ b/lib/app-components/addon/components/submit-section/template.hbs
@@ -1,9 +1,10 @@
 {{#if this.showTooltip}}
-    <BsTooltip
-        @title={{this.tooltip}}
+    <EmberTooltip
         @autoPlacement={{true}}
-        @viewportSelector={{this.elementId}}
-    />
+        @targetId={{this.elementId}}
+    >
+        {{this.tooltip}}
+    </EmberTooltip>
 {{/if}}
 {{#@panels.panel
     open=this.isOpen

--- a/lib/collections/package.json
+++ b/lib/collections/package.json
@@ -33,6 +33,7 @@
     "ember-cli-string-helpers": "*",
     "ember-tag-input": "*",
     "ember-toastr": "*",
+    "ember-tooltips": "*",
     "ember-wormhole": "*",
     "liquid-fire": "*"
   },

--- a/lib/osf-components/addon/components/contributor-list/unregistered-contributor/template.hbs
+++ b/lib/osf-components/addon/components/contributor-list/unregistered-contributor/template.hbs
@@ -12,15 +12,16 @@
     {{on 'click' this.showDialog}}
     {{on 'keypress' this.onKeyPress}}
 >
-    <BsPopover
+    {{!-- template-lint-disable no-heading-inside-button --}}
+    <EmberPopover
         data-test-claim-user-tooltip-message
         local-class='spanPopover'
-        @placement='top'
-        @triggerEvents='hover focus'
-        @title={{t 'contributor_list.unregistered_contributor.popover_title'}}
+        @side='top'
     >
+        <h3>{{t 'contributor_list.unregistered_contributor.popover_title'}}</h3>
         {{t 'contributor_list.unregistered_contributor.tooltip_message'}}
-    </BsPopover>
+    </EmberPopover>
+    {{!-- template-lint-enable no-heading-inside-button --}}
     {{~@contributor.unregisteredContributor~}}
 </span>
 

--- a/lib/osf-components/addon/components/copyable-text/template.hbs
+++ b/lib/osf-components/addon/components/copyable-text/template.hbs
@@ -9,12 +9,12 @@
         aria-label={{t 'osf-components.copyable-text.copyToClipboard'}}
     >
         <FaIcon @icon='copy' />
-        <BsTooltip
-            @triggerEvents=''
-            @visible={{this.showTooltip}}
+        <EmberTooltip
+            @event='none'
+            @isShown={{this.showTooltip}}
         >
             {{t 'osf-components.copyable-text.copied'}}
-        </BsTooltip>
+        </EmberTooltip>
     </CopyButton>
 </span>
 <input

--- a/lib/osf-components/addon/components/file-browser/file-item/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/file-item/template.hbs
@@ -24,12 +24,11 @@
             {{#if @item.isCheckedOut}}
                 <span data-test-file-list-checkout local-class='CheckoutSpan'>
                     <FaIcon local-class='CheckoutIcon' @icon='lock' />
-                    <BsTooltip
-                        @placement='right'
-                        @triggerEvents='hover'
+                    <EmberTooltip
+                        @side='right'
                     >
                         {{t 'osf-components.file-browser.checked_out_file'}}
-                    </BsTooltip>
+                    </EmberTooltip>
                 </span>
             {{/if}}
             <OsfLink

--- a/lib/osf-components/addon/components/file-version/template.hbs
+++ b/lib/osf-components/addon/components/file-version/template.hbs
@@ -38,13 +38,12 @@
                 </CopyButton>
                 <div>
                     <FaIcon local-class='HelpIcon' @icon='question-circle' />
-                    <BsTooltip
+                    <EmberTooltip
                         data-test-md5-tooltip
-                        @placement='left'
-                        @triggerEvents='hover focus'
+                        @side='left'
                     >
                         {{t 'osf-components.file-version.md5_description'}}
-                    </BsTooltip>
+                    </EmberTooltip>
                 </div>
             </div>
         {{/if}}
@@ -64,13 +63,12 @@
                 </CopyButton>
                 <div>
                     <FaIcon local-class='HelpIcon' @icon='question-circle' />
-                    <BsTooltip
+                    <EmberTooltip
                         data-test-sha2-tooltip
-                        @placement='left'
-                        @triggerEvents='hover focus'
+                        @side='left'
                     >
                         {{t 'osf-components.file-version.sha2_description'}}
-                    </BsTooltip>
+                    </EmberTooltip>
                 </div>
             </div>
         {{/if}}

--- a/lib/osf-components/addon/components/new-feature-popover/component.ts
+++ b/lib/osf-components/addon/components/new-feature-popover/component.ts
@@ -13,9 +13,13 @@ interface Args {
 export default class NewFeaturePopover extends Component<Args> {
     @service cookies!: Cookies;
     @tracked notAgain = false;
+    @tracked shouldShow = true;
 
-    get shouldShow() {
-        return !this.cookies.exists(this.args.featureCookie);
+    constructor(owner: unknown, args: Args) {
+        super(owner, args);
+        if (this.cookies.exists(this.args.featureCookie)){
+            this.shouldShow = false;
+        }
     }
 
     @action

--- a/lib/osf-components/addon/components/new-feature-popover/styles.scss
+++ b/lib/osf-components/addon/components/new-feature-popover/styles.scss
@@ -1,12 +1,23 @@
-.NewFeatureModal {
+:global(.new-feature-modal) {
     background-color: $color-bg-blue-darker !important;
     color: $color-text-white;
     border-radius: 0 !important;
 
-    :global(.arrow::after) {
+    :global(.ember-popover-inner) {
+        background-color: $color-bg-blue-darker;
+        color: $color-text-white;
+    }
+
+    h3 {
+        color: $color-text-white;
+    }
+
+    :global(.ember-popover-arrow) {
         border-right-color: $color-bg-blue-darker !important;
     }
 }
+
+
 
 .FlexFooter {
     display: flex;
@@ -14,4 +25,5 @@
     align-items: center;
     flex-direction: row;
     gap: 10px;
+    margin-top: 20px;
 }

--- a/lib/osf-components/addon/components/new-feature-popover/template.hbs
+++ b/lib/osf-components/addon/components/new-feature-popover/template.hbs
@@ -1,9 +1,9 @@
-<BsPopover
-    @triggerElement={{@triggerElement}}
-    @triggerEvents={{''}}
-    @visible={{this.shouldShow}}
-    @onHide={{this.onAccept}}
-    local-class='NewFeatureModal'
+<EmberPopover
+    @targetId={{@triggerElement}}
+    @isShown={{this.shouldShow}}
+    @event='none'
+    @side={{@side}}
+    @tooltipClass='new-feature-modal'
     as |popover|
 >
     <h3 data-test-popover-header>
@@ -17,7 +17,6 @@
     <footer
         data-test-popover-footer
         local-class='FlexFooter'
-        {{on-click-outside popover.close}}
     >
         {{yield to='footer'}}
         <label data-test-not-again-checkbox>
@@ -27,9 +26,9 @@
         <Button
             data-test-got-it-button
             @type='primary'
-            {{on 'click' popover.close}}
+            {{on 'click' (queue this.onAccept (action 'hide' target=popover))}}
         >
             {{t 'osf-components.new-feature-popover.acknowledge'}}
         </Button>
     </footer>
-</BsPopover>
+</EmberPopover>

--- a/lib/osf-components/addon/components/node-card/template.hbs
+++ b/lib/osf-components/addon/components/node-card/template.hbs
@@ -14,7 +14,9 @@
                     {{#unless @node.public}}
                         <span>
                             <FaIcon @icon='lock' />
-                            <BsTooltip>{{t (concat 'node_card.' @node.nodeType '.private_tooltip')}}</BsTooltip>
+                            <EmberTooltip>
+                                {{t (concat 'node_card.' @node.nodeType '.private_tooltip')}}
+                            </EmberTooltip>
                         </span> |
                     {{/unless}}
                     {{#if @node.pendingRegistrationApproval}}

--- a/lib/osf-components/addon/components/noteworthy-and-popular-project/template.hbs
+++ b/lib/osf-components/addon/components/noteworthy-and-popular-project/template.hbs
@@ -11,7 +11,6 @@
             </i>
         </span>
         <p data-test-nnwp-project-description class='prevent-overflow'>
-            <BsTooltip @title={{this.compactDescription}} />
             {{this.project.description}}
         </p>
     </div>

--- a/lib/osf-components/addon/components/open-badges-list/open-badge-card/template.hbs
+++ b/lib/osf-components/addon/components/open-badges-list/open-badge-card/template.hbs
@@ -24,12 +24,13 @@
                 }}
             >
             {{#if @isMobile}}
-                <BsTooltip
-                    @placement='left'
-                    @triggerEvents='hover'
+                <EmberTooltip
+                    @side='left'
                 >
-                    {{t (concat 'osf-components.open-badges-list.open-' @resourceType)}}
-                </BsTooltip>
+                    <span data-test-badge-tooltip='{{@resourceType}}'>
+                        {{t (concat 'osf-components.open-badges-list.open-' @resourceType)}}
+                    </span>
+                </EmberTooltip>
             {{/if}}
         </span>
         {{#unless @isMobile}}

--- a/lib/osf-components/addon/components/registries/schema-block-renderer/helper-text-icon/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/helper-text-icon/template.hbs
@@ -8,11 +8,10 @@
             @ariaHidden={{false}}
             ...attributes
         />
-        <BsPopover
-            @triggerEvents={{array 'hover' 'focus'}}
-            @triggerElement={{concat '#' id}}
+        <EmberPopover
+            @triggerElement={{id}}
         >
             {{this.helpText}}
-        </BsPopover>
+        </EmberPopover>
     {{/let}}
 {{/if}}

--- a/lib/osf-components/addon/components/sharing-icons/popover/template.hbs
+++ b/lib/osf-components/addon/components/sharing-icons/popover/template.hbs
@@ -8,11 +8,10 @@
     ...attributes
 >
     <FaIcon @icon='share-alt' />
-    <BsPopover
+    <EmberPopover
         local-class='Popover'
-        @placement='left'
-        @viewportSelector='#{{@parentId}}'
-        @autoPlacement={{true}}
+        @side='left'
+        @popperContainer='#{{@parentId}}'
         @renderInPlace={{true}}
     >
         <SharingIcons
@@ -23,5 +22,5 @@
             @parentId={{@parentId}}
             @showText={{@showText}}
         />
-    </BsPopover>
+    </EmberPopover>
 </button>

--- a/lib/registries/addon/components/comment-card/template.hbs
+++ b/lib/registries/addon/components/comment-card/template.hbs
@@ -38,9 +38,13 @@
                 <div>
                     {{#if this.comment.modified}}
                         <span local-class='dateModified'>
-                            {{#bs-tooltip local-class='Tooltip' placement='left' viewportSelector=(concat '#' this.elementId)}}
+                            <EmberTooltip
+                                local-class='Tooltip'
+                                @side='left'
+                                @targetId={{this.elementId}}
+                            >
                                 {{t 'registries.overview.comments.modified'}}{{this.dateModified}}
-                            {{/bs-tooltip}}
+                            </EmberTooltip>
                             <sup><FaIcon @icon='asterisk' /></sup>
                         </span>
                     {{/if}}

--- a/lib/registries/addon/overview/-components/overview-topbar/template.hbs
+++ b/lib/registries/addon/overview/-components/overview-topbar/template.hbs
@@ -31,12 +31,9 @@
                     local-class='Icon'
                     @icon='code-branch'
                 />
-                <BsTooltip
-                    @placement='top'
-                    @triggerEvents='hover'
-                >
-                    {{t 'registries.overview.tooltips.fork'}}
-                </BsTooltip>
+                <EmberTooltip>
+                    <span data-test-fork-tooltip>{{t 'registries.overview.tooltips.fork'}}</span>
+                </EmberTooltip>
             </dd.trigger>
             <dd.content>
                 <div data-test-forks-dropdown-options local-class='ForksMenu'>
@@ -81,16 +78,15 @@
                 @icon='bookmark'
                 @prefix={{if this.isBookmarked 'fas' 'far'}}
             />
-            <BsTooltip
-                @placement='top'
-                @triggerEvents='hover'
-            >
-                {{#if this.isBookmarked}}
-                    {{t 'registries.overview.tooltips.remove_bookmark'}}
-                {{else}}
-                    {{t 'registries.overview.tooltips.bookmark'}}
-                {{/if}}
-            </BsTooltip>
+            <EmberTooltip>
+                <span data-test-bookmark-tooltip>
+                    {{#if this.isBookmarked}}
+                        {{t 'registries.overview.tooltips.remove_bookmark'}}
+                    {{else}}
+                        {{t 'registries.overview.tooltips.bookmark'}}
+                    {{/if}}
+                </span>
+            </EmberTooltip>
         </Button>
 
         <SharingIcons::Dropdown
@@ -111,12 +107,9 @@
                     local-class='Icon'
                     @icon='share-alt'
                 />
-                <BsTooltip
-                    @placement='top'
-                    @triggerEvents='hover'
-                >
-                    {{t 'registries.overview.tooltips.share'}}
-                </BsTooltip>
+                <EmberTooltip>
+                    <span data-test-sharing-tooltip>{{t 'registries.overview.tooltips.share'}}</span>
+                </EmberTooltip>
             </dd.trigger>
         </SharingIcons::Dropdown>
     </div>

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -73,8 +73,9 @@
                         />
                         {{#if this.showNewFeaturePopover}}
                             <NewFeaturePopover
-                                @triggerElement={{concat '#' id}}
+                                @triggerElement={{id}}
                                 @featureCookie={{this.newFeaturePopoverCookie}}
+                                @side='right'
                             >
                                 <:header>
                                     {{t 'general.newFeaturePopoverHeading'}}
@@ -106,13 +107,12 @@
                                                 @icon='globe'
                                             >
                                             </FaIcon>
-                                            <BsTooltip
-                                                @placement='right'
-                                                @triggerEvents='hover'
+                                            <EmberTooltip
+                                                @side='right'
                                             >
                                                 {{t 'osf-components.file-browser.storage_location'}}
                                                 {{this.registration.region.name}}
-                                            </BsTooltip>
+                                            </EmberTooltip>
                                         </span>
                                     {{/if}}
                                 </div>

--- a/lib/registries/package.json
+++ b/lib/registries/package.json
@@ -45,6 +45,7 @@
     "ember-responsive": "*",
     "ember-sortable": "*",
     "ember-toastr": "*",
+    "ember-tooltips": "*",
     "ember-truth-helpers": "*",
     "immutable": "*"
   },

--- a/mirage/scenarios/dashboard.ts
+++ b/mirage/scenarios/dashboard.ts
@@ -48,12 +48,12 @@ export function dashboardScenario(server: Server, currentUser: ModelInstance<Use
     const filesNode = server.create('node', {
         id: 'file5',
         title: 'With some files',
-        currentUserPermissions: [Permission.Read, Permission.Write],
+        currentUserPermissions: [Permission.Read, Permission.Write, Permission.Admin],
     }, 'withFiles', 'withStorage', 'withContributors', 'withAffiliatedInstitutions', 'withDoi');
     server.create('contributor', {
         node: filesNode,
         users: currentUser,
-        permission: Permission.Write,
+        permission: Permission.Admin,
         index: 0,
     });
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,9 @@
     "ember-element-helper": "^0.6.1",
     "ember-validators": "^4.1.1"
   },
-  "dependencies": {},
+  "dependencies": {
+    "ember-tooltips": "^3.6.0"
+  },
   "devDependencies": {
     "@centerforopenscience/eslint-config": "3.0.0",
     "@ember-intl/cp-validations": "^4.0.1",

--- a/tests/engines/registries/acceptance/overview/topbar-test.ts
+++ b/tests/engines/registries/acceptance/overview/topbar-test.ts
@@ -4,6 +4,7 @@ import { ModelInstance } from 'ember-cli-mirage';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { t } from 'ember-intl/test-support';
 import { percySnapshot } from 'ember-percy';
+import { assertTooltipRendered, assertTooltipVisible } from 'ember-tooltips/test-support';
 import moment from 'moment';
 import { module, test } from 'qunit';
 
@@ -156,9 +157,10 @@ module('Registries | Acceptance | overview.topbar', hooks => {
 
         // Bookmark registration
         await triggerEvent('[data-test-bookmarks-button]', 'mouseenter');
-        assert.dom('.ember-bootstrap-tooltip .tooltip-inner').hasText(
-            t('registries.overview.tooltips.bookmark').toString(),
-        );
+        assertTooltipRendered(assert);
+        assertTooltipVisible(assert);
+        assert.dom('[data-test-bookmark-tooltip]')
+            .containsText(t('registries.overview.tooltips.bookmark').toString());
 
         await click('[data-test-bookmarks-button]');
         assert.dom('[data-test-bookmarks-button] svg').hasClass('fa-bookmark');
@@ -168,9 +170,10 @@ module('Registries | Acceptance | overview.topbar', hooks => {
 
         // Remove from bookmarks
         await triggerEvent('[data-test-bookmarks-button]', 'mouseenter');
-        assert.dom('.ember-bootstrap-tooltip .tooltip-inner').hasText(
-            t('registries.overview.tooltips.remove_bookmark').toString(),
-        );
+        assertTooltipRendered(assert);
+        assertTooltipVisible(assert);
+        assert.dom('[data-test-bookmark-tooltip]')
+            .containsText(t('registries.overview.tooltips.remove_bookmark').toString());
 
         await click('[data-test-bookmarks-button]');
         assert.dom('[data-test-bookmarks-button] svg').hasClass('fa-bookmark');
@@ -189,7 +192,9 @@ module('Registries | Acceptance | overview.topbar', hooks => {
         assert.dom('[data-test-social-sharing-button]').isVisible();
 
         await triggerEvent('[data-test-social-sharing-button]', 'mouseenter');
-        assert.dom('.ember-bootstrap-tooltip .tooltip-inner').hasText(
+        assertTooltipRendered(assert);
+        assertTooltipVisible(assert);
+        assert.dom('[data-test-sharing-tooltip]').hasText(
             t('registries.overview.tooltips.share').toString(),
         );
 
@@ -212,7 +217,9 @@ module('Registries | Acceptance | overview.topbar', hooks => {
         assert.dom('[data-test-forks-dropdown-button]').isVisible();
 
         await triggerEvent('[data-test-forks-dropdown-button]', 'mouseenter');
-        assert.dom('.ember-bootstrap-tooltip .tooltip-inner').hasText(
+        assertTooltipRendered(assert);
+        assertTooltipVisible(assert);
+        assert.dom('[data-test-fork-tooltip]').hasText(
             t('registries.overview.tooltips.fork').toString(),
         );
 

--- a/tests/integration/components/new-feature-popover/component-test.ts
+++ b/tests/integration/components/new-feature-popover/component-test.ts
@@ -50,9 +50,10 @@ module('Integration | Component | new-feature-popover', hooks => {
                 <div id='divIdForTesting' >
                 </div>
                 <NewFeaturePopover
-                    @triggerElement={{concat '#' 'divIdForTesting'}}
+                    @triggerElement='divIdForTesting'
                     @featureCookie={{this.featureCookie}}
-                >
+                    @side='right'
+                    >
                     <:header>
                         {{this.headingText}}
                     </:header>
@@ -88,9 +89,10 @@ module('Integration | Component | new-feature-popover', hooks => {
                 <div id='divIdForTesting' >
                 </div>
                 <NewFeaturePopover
-                    @triggerElement={{concat '#' 'divIdForTesting'}}
+                    @triggerElement='divIdForTesting'
                     @featureCookie={{this.featureCookie}}
-                >
+                    @side='right'
+                    >
                     <:header>
                         {{this.headingText}}
                     </:header>
@@ -127,8 +129,9 @@ module('Integration | Component | new-feature-popover', hooks => {
             <div id='divIdForTesting' >
             </div>
             <NewFeaturePopover
-                @triggerElement={{concat '#' 'divIdForTesting'}}
+                @triggerElement='divIdForTesting'
                 @featureCookie={{this.featureCookie}}
+                @side='right'
             >
                 <:header>
                     {{this.headingText}}

--- a/tests/integration/components/open-badges-list/component-test.ts
+++ b/tests/integration/components/open-badges-list/component-test.ts
@@ -5,6 +5,11 @@ import { TestContext } from 'ember-test-helpers';
 import { setupIntl, t } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 import { setBreakpoint } from 'ember-responsive/test-support';
+import {
+    assertTooltipNotRendered,
+    assertTooltipRendered,
+    assertTooltipVisible,
+} from 'ember-tooltips/test-support';
 import { module, test } from 'qunit';
 import { OsfLinkRouterStub } from '../../helpers/osf-link-router-stub';
 
@@ -72,13 +77,15 @@ module('Integration | Component | open-badges-list', hooks => {
             'Materials badge has correct image',
         );
         await triggerEvent('[data-test-badge-icon="data"]', 'mouseenter');
-        assert.dom('.ember-bootstrap-tooltip .tooltip-inner').hasText(
+        assertTooltipRendered(assert);
+        assertTooltipVisible(assert);
+        assert.dom('[data-test-badge-tooltip="data"]').hasText(
             t('osf-components.open-badges-list.open-data'),
             'Correct tooltip in mobile view for data',
         );
         await triggerEvent('[data-test-badge-icon="data"]', 'mouseleave');
         await triggerEvent('[data-test-badge-icon="materials"]', 'mouseenter');
-        assert.dom('.ember-bootstrap-tooltip .tooltip-inner').hasText(
+        assert.dom('[data-test-badge-tooltip="materials"]').hasText(
             t('osf-components.open-badges-list.open-materials'),
             'Correct tooltip in mobile view for materials',
         );
@@ -122,9 +129,7 @@ module('Integration | Component | open-badges-list | open-badge-card', hooks => 
             'Has a link to the registration resources page',
         );
         await triggerEvent('[data-test-badge-icon="data"]', 'mouseenter');
-        assert.dom('.ember-bootstrap-tooltip .tooltip-inner').doesNotExist(
-            'No tooltip in desktop view for data',
-        );
+        assertTooltipNotRendered(assert);
     });
 
     test('it renders materials in the false state mobile view', async function(assert) {
@@ -149,7 +154,9 @@ module('Integration | Component | open-badges-list | open-badge-card', hooks => 
             'Has a link to the registration resources page',
         );
         await triggerEvent('[data-test-badge-icon="materials"]', 'mouseenter');
-        assert.dom('.ember-bootstrap-tooltip .tooltip-inner').hasText(
+        assertTooltipRendered(assert);
+        assertTooltipVisible(assert);
+        assert.dom('[data-test-badge-tooltip]').hasText(
             t('osf-components.open-badges-list.open-materials'),
             'Correct tooltip in mobile view for materials',
         );
@@ -173,7 +180,9 @@ module('Integration | Component | open-badges-list | open-badge-card', hooks => 
             'Has a link to the registration resources page',
         );
         await triggerEvent('[data-test-badge-icon="materials"]', 'mouseenter');
-        assert.dom('.ember-bootstrap-tooltip .tooltip-inner').hasText(
+        assertTooltipRendered(assert);
+        assertTooltipVisible(assert);
+        assert.dom('[data-test-badge-tooltip]').hasText(
             t('osf-components.open-badges-list.open-materials'),
             'Correct tooltip in mobile view for materials',
         );

--- a/types/ember-tooltips/test-support/index.d.ts
+++ b/types/ember-tooltips/test-support/index.d.ts
@@ -1,0 +1,6 @@
+declare module 'ember-tooltips/test-support' {
+    export function assertTooltipRendered(assert: Assert): void;
+    export function assertTooltipNotRendered(assert: Assert): void;
+    export function assertTooltipVisible(assert: Assert): void;
+    export function assertTooltipNotVisible(assert: Assert): void;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2705,7 +2705,7 @@
     walk-sync "^1.1.3"
     wrap-legacy-hbs-plugin-if-needed "^1.0.1"
 
-"@embroider/macros@0.33.0", "@embroider/macros@0.47.2", "@embroider/macros@1.8.3", "@embroider/macros@^0.36.0", "@embroider/macros@^0.41.0", "@embroider/macros@^0.47.2", "@embroider/macros@^0.50.0 || ^1.0.0", "@embroider/macros@^1.0.0", "@embroider/macros@^1.10.0", "@embroider/macros@^1.3.0":
+"@embroider/macros@0.33.0", "@embroider/macros@0.47.2", "@embroider/macros@1.8.3", "@embroider/macros@^0.36.0", "@embroider/macros@^0.41.0", "@embroider/macros@^0.47.2", "@embroider/macros@^0.50.0 || ^1.0.0", "@embroider/macros@^1.0.0", "@embroider/macros@^1.10.0", "@embroider/macros@^1.3.0", "@embroider/macros@^1.8.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-1.8.3.tgz#2f0961ab8871f6ad819630208031d705b357757e"
   integrity sha512-gnIOfTL/pUkoD6oI7JyWOqXlVIUgZM+CnbH10/YNtZr2K0hij9eZQMdgjOZZVgN0rKOFw9dIREqc1ygrJHRYQA==
@@ -11029,6 +11029,22 @@ ember-toastr@^3.0.0:
     ember-cli-babel "^7.22.1"
     ember-cli-htmlbars "^5.3.1"
 
+ember-tooltips@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/ember-tooltips/-/ember-tooltips-3.6.0.tgz#15223e6fa50dec2fcf8dac16be9b12b46f395436"
+  integrity sha512-DsqF6vvL3DKWSUHJKuMJ8KSxbE/T+eZAE2xtzAuHRqjl1AYIOkugGBVynGYYP8+2/10NMwk05LYbT1dirAcEBQ==
+  dependencies:
+    "@embroider/macros" "^1.8.0"
+    broccoli-file-creator "^2.1.1"
+    broccoli-merge-trees "^4.2.0"
+    ember-auto-import "^1.11.3"
+    ember-cli-babel "^7.26.6"
+    ember-cli-htmlbars "^5.7.1"
+    ember-in-element-polyfill "^1.0.1"
+    popper.js "^1.12.5"
+    resolve "^1.10.1"
+    tooltip.js "^1.1.5"
+
 ember-tracked-storage-polyfill@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-tracked-storage-polyfill/-/ember-tracked-storage-polyfill-1.0.0.tgz#84d307a1e4badc5f84dca681db2cfea9bdee8a77"
@@ -17719,7 +17735,7 @@ please-upgrade-node@^3.0.2, please-upgrade-node@^3.1.1:
   dependencies:
     semver-compare "^1.0.0"
 
-popper.js@^1.14.1:
+popper.js@^1.0.2, popper.js@^1.12.5, popper.js@^1.14.1:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
   integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
@@ -20810,6 +20826,13 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
+tooltip.js@^1.1.5:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/tooltip.js/-/tooltip.js-1.3.3.tgz#2ad0d77bb6776a76e117eac0afcd3c7d3a237121"
+  integrity sha512-XWWuy/dBdF/F/YpRE955yqBZ4VdLfiTAUdOqoU+wJm6phJlMpEzl/iYHZ+qJswbeT9VG822bNfsETF9wzmoy5A==
+  dependencies:
+    popper.js "^1.0.2"
 
 toposort@^1.0.6:
   version "1.0.7"


### PR DESCRIPTION
-   Ticket: [ENG-4415]
-   Feature flag: n/a

## Purpose

Get rid of ember-bootstrap's tooltips and popovers, and replace them with [ember-tooltips](https://emberobserver.com/addons/ember-tooltips).

## Summary of Changes

1. Install ember-tooltips
2. Replace tooltips
3. Replace popovers
4. Fix tests
5. Add types for test helpers
6. Adjust perms on file5 project so we can register the project on project registration page

## Screenshot(s)

<img width="272" alt="Screenshot 2023-04-12 at 10 57 26 AM" src="https://user-images.githubusercontent.com/6599111/231504584-6dda7945-041c-4361-b986-55c73a3ae5d2.png">


## Side Effects

Popovers may have a new look

## QA Notes

- [ ] Date Modified on Registration Comments has a tooltip
- [ ] Region name shows up on node files page hover over globe
- [ ] Checked out file tooltip works
- [ ] Double-check new feature popover

[ENG-4415]: https://openscience.atlassian.net/browse/ENG-4415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ