### PR TITLE
[ENG-4408] Added the pruned route file

### DIFF
--- a/lib/collections/addon/index/route.ts
+++ b/lib/collections/addon/index/route.ts
@@ -1,0 +1,11 @@
+import Store from '@ember-data/store';
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class Index extends Route {
+    @service store!: Store;
+
+    model() {
+        return this.store.findAll('collection-provider');
+    }
+}


### PR DESCRIPTION
-   Ticket: [ENG-4408]
-   Feature flag: n/a

## Purpose

Fix a "too greedy" pruning of unused files in the name of removing bootstrap.

## Summary of Changes

Readded a route file to allow routing of `http://localhost:4200/collections/studyswap` to `http://localhost:4200/collections/studyswap/discover`

## Screenshot(s)

N/A

## Side Effects

It works

## QA Notes

You should never see the problem with this PR.


[ENG-4408]: https://openscience.atlassian.net/browse/ENG-4408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ