### PR TITLE
[ENG-4485]Search page layout

### DIFF
--- a/app/search/controller.ts
+++ b/app/search/controller.ts
@@ -1,0 +1,46 @@
+import Store from '@ember-data/store';
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { waitFor } from '@ember/test-waiters';
+import { task } from 'ember-concurrency';
+import { taskFor } from 'ember-concurrency-ts';
+import { tracked } from '@glimmer/tracking';
+import Media from 'ember-responsive';
+
+import MetadataPropertySearchModel from 'ember-osf-web/models/metadata-property-search';
+
+export default class SearchController extends Controller {
+    @service store!: Store;
+    @service media!: Media;
+
+    queryParams = ['q', 'page', 'sort'];
+    @tracked q?: string;
+    @tracked page?: number;
+    @tracked sort?: string;
+
+    @tracked propertySearch?: MetadataPropertySearchModel;
+
+    get showSidenavToggle() {
+        return this.media.isMobile || this.media.isTablet;
+    }
+
+    @action
+    onKeyPress(event: KeyboardEvent) {
+        if (event.key === 'Enter') {
+            taskFor(this.doSearch).perform();
+        }
+    }
+
+    @task
+    @waitFor
+    async doSearch() {
+        const { q, page, sort } = this;
+        const searchResult = await this.store.queryRecord('metadata-record-search', {
+            q,
+            page,
+            sort,
+        });
+        this.propertySearch = searchResult.relatedPropertySearch;
+    }
+}

--- a/app/search/styles.scss
+++ b/app/search/styles.scss
@@ -1,0 +1,34 @@
+.search-page {
+    background-color: $color-bg-gray;
+}
+
+.heading-wrapper {
+    text-align: center;
+    color: $color-text-white;
+    background-color: $osf-dark-blue-navbar;
+}
+
+.heading-label {
+    font-size: 1.5em;
+    font-weight: 400;
+    padding: 40px;
+}
+
+.search-input {
+    color: $color-text-black;
+    padding: 9px 5px;
+    font-size: 1.5em;
+    max-width: 700px;
+    min-width: 250px;
+    width: 50vw;
+}
+
+.search-button {
+    position: relative;
+    right: 3px;
+    bottom: 4px;
+}
+
+.sidenav-toggle {
+    float: left;
+}

--- a/app/search/template.hbs
+++ b/app/search/template.hbs
@@ -1,2 +1,51 @@
 {{!-- template-lint-disable no-bare-strings --}}
-New search placeholder
+<OsfLayout 
+    @backgroundClass='search-page'
+as |layout|>
+    <layout.heading local-class='heading-wrapper'>
+        <form role='search'>
+            <label local-class='heading-label'>
+                {{t 'search.search_header'}}
+            </label>
+            <Input
+                local-class='search-input'
+                @type='search'
+                @placeholder={{t 'search.textbox_placeholder'}}
+                @value={{this.q}}
+                {{on 'keydown' this.onKeyPress}}
+            />
+            <Button
+                local-class='search-button'
+                aria-label={{t 'search.search_button_label'}}
+                @type='primary'
+                @layout='large'
+                {{on 'click' (perform this.doSearch)}}
+            >
+                <FaIcon @icon='search' />
+            </Button>
+        </form>
+
+        {{#if this.showSidenavToggle}}
+            <Button
+                aria-label={{t 'search.toggle_sidenav'}}
+                local-class='sidenav-toggle'
+                {{on 'click' layout.toggleSidenav}}
+            >
+                <FaIcon @icon='bars' />
+            </Button>
+        {{/if}}
+    </layout.heading>
+    <layout.left>
+        {{!-- current filters --}}
+        {{!-- filter facets --}}
+        Left
+    </layout.left>
+    <layout.main>
+        Main
+        {{!-- placeholder if no search term (maybe) --}}
+        {{!-- object type filtering tabs --}}
+        {{!-- search cards --}}
+        {{!-- sort dropdown --}}
+        {{!-- paginator --}}
+    </layout.main>
+</OsfLayout>

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -201,6 +201,12 @@ dashboard:
         title: 'Browse the latest research'
         description: 'Check out the latest preprints hosted on OSF covering a variety of research areas.'
         button: 'View preprints'
+
+search:
+    search_header: 'Search OSF'
+    textbox_placeholder: 'Search placeholder'
+    search_button_label: 'Search'
+    toggle_sidenav: 'Toggle search sidebar'
 new_project:
     header: 'Create new project'
     title_placeholder: 'Enter project title'


### PR DESCRIPTION
-   Ticket: [ENG-4485]
-   Feature flag: n/a

## Purpose
- Add basic layout for new search page

## Summary of Changes
- Use OsfLayout to create header, left-panel and main-panel
  - Add searchbox and button to header
  - Add placeholder text to left-panel
  - Add placeholder text to main-panel

## Screenshot(s)
- desktop
<img width="1285" alt="image" src="https://user-images.githubusercontent.com/51409893/233737671-8e28d8c2-96c2-4cfc-8d5b-c52a43fd36d1.png">

- mobile (hamburger menu to show/hide left-panel)
<img width="306" alt="image" src="https://user-images.githubusercontent.com/51409893/233737718-aef94442-4b32-4013-bd10-8cb370f0ee71.png">


## Side Effects
- None


## QA Notes
- Some styling issues may occur for different page sizes, but there's a different ticket for styling this page
- Mockups here: https://preview.uxpin.com/e2821be91003954dec0c29a026bc49989b868e2d#/pages/162334849/specification/sitemap?mode=i