### PR TITLE
[ENG-4492] Add data-test selectors to registration components and links page

### DIFF
--- a/lib/registries/addon/overview/children/template.hbs
+++ b/lib/registries/addon/overview/children/template.hbs
@@ -10,6 +10,6 @@
         <NodeCard @node={{child}} />
     {{/list.item}}
     {{#list.empty}}
-        <p>{{t 'registries.overview.components.no_components'}}</p>
+        <p data-test-no-components>{{t 'registries.overview.components.no_components'}}</p>
     {{/list.empty}}
 {{/paginated-list/has-many}}

--- a/lib/registries/addon/overview/links/template.hbs
+++ b/lib/registries/addon/overview/links/template.hbs
@@ -10,7 +10,7 @@
         <NodeCard @node={{child}} />
     {{/list.item}}
     {{#list.empty}}
-        <p>{{t 'registries.overview.links.no_linked_nodes'}}</p>
+        <p data-test-no-linked-nodes>{{t 'registries.overview.links.no_linked_nodes'}}</p>
     {{/list.empty}}
 {{/paginated-list/has-many}}
 
@@ -24,6 +24,6 @@
         <NodeCard @node={{child}} />
     {{/list.item}}
     {{#list.empty}}
-        <p>{{t 'registries.overview.links.no_linked_registrations'}}</p>
+        <p data-test-no-linked-registrations>{{t 'registries.overview.links.no_linked_registrations'}}</p>
     {{/list.empty}}
 {{/paginated-list/has-many}}

--- a/tests/engines/registries/acceptance/overview/components-page-test.ts
+++ b/tests/engines/registries/acceptance/overview/components-page-test.ts
@@ -1,0 +1,40 @@
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { module, test } from 'qunit';
+
+import { Permission } from 'ember-osf-web/models/osf-model';
+import { visit } from 'ember-osf-web/tests/helpers';
+import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
+
+
+module('Registries | Acceptance | overview.components', hooks => {
+    setupEngineApplicationTest(hooks, 'registries');
+    setupMirage(hooks);
+
+    test('With components', async assert => {
+        const parentRegistration = server.create('registration');
+        const childRegistration = server.create('registration', {
+            currentUserPermissions: Object.values(Permission),
+            title: 'Child registration',
+        });
+        const childRegistration2 = server.create('registration', {
+            currentUserPermissions: Object.values(Permission),
+            title: 'Child registration 2',
+        });
+
+        parentRegistration.update({
+            children: [childRegistration, childRegistration2],
+        });
+        await visit(`/${parentRegistration.id}/components`);
+
+        assert.dom('[data-test-node-card]').exists({ count: 2 }, 'Two child registrations are shown');
+        assert.dom('[data-test-no-components]').doesNotExist('No components message is not shown');
+    });
+
+    test('Without components', async assert => {
+        const registration = server.create('registration');
+        await visit(`/${registration.id}/components`);
+
+        assert.dom('[data-test-no-components]').exists('No components message is shown');
+        assert.dom('[data-test-node-card]').doesNotExist('No child registrations are shown');
+    });
+});

--- a/tests/engines/registries/acceptance/overview/links-page-test.ts
+++ b/tests/engines/registries/acceptance/overview/links-page-test.ts
@@ -1,0 +1,40 @@
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { module, test } from 'qunit';
+
+import { visit } from 'ember-osf-web/tests/helpers';
+import { setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
+
+module('Registries | Acceptance | overview.links', hooks => {
+    setupEngineApplicationTest(hooks, 'registries');
+    setupMirage(hooks);
+
+    test('With linked node and no linked registration', async assert => {
+        const registration = server.create('registration');
+        const linkedNode = server.create('node', {
+            title: 'Linked node',
+        });
+
+        registration.update({
+            linkedNodes: [linkedNode],
+        });
+        await visit(`/${registration.id}/links`);
+        assert.dom(`[data-test-node-title="${linkedNode.id}"]`).containsText('Linked node', 'Linked node is shown');
+        assert.dom('[data-test-no-linked-registrations]').exists('No linked registrations message is shown');
+    });
+
+    test('With linked registration and no linked node', async assert => {
+        const registration = server.create('registration');
+        const linkedRegistration = server.create('registration', {
+            title: 'Linked registration',
+        });
+
+        registration.update({
+            linkedRegistrations: [linkedRegistration],
+        });
+        await visit(`/${registration.id}/links`);
+
+        assert.dom(`[data-test-node-title="${linkedRegistration.id}"]`)
+            .containsText('Linked registration', 'Linked registration is shown');
+        assert.dom('[data-test-no-linked-nodes]').exists('No linked nodes message is shown');
+    });
+});

--- a/tests/integration/components/license-text/licence-text-test.ts
+++ b/tests/integration/components/license-text/licence-text-test.ts
@@ -1,6 +1,7 @@
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { timeout } from 'ember-concurrency';
 import { t } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 import { TestContext } from 'ember-test-helpers';
@@ -26,6 +27,7 @@ module('Osf components | Integration | Component | License text', hooks => {
         this.setProperties({ node });
 
         await render(hbs`<LicenseText @node={{this.node}} />`);
+        await timeout(100);
 
         assert.dom(this.element).hasText('I am an emu.');
     });
@@ -48,6 +50,7 @@ module('Osf components | Integration | Component | License text', hooks => {
         this.setProperties({ node });
 
         await render(hbs`<LicenseText @node={{this.node}} />`);
+        await timeout(100);
 
         assert.dom(this.element).hasText('I am an emu. You are Bill and Ted from 1989.');
     });
@@ -71,6 +74,7 @@ module('Osf components | Integration | Component | License text', hooks => {
         this.setProperties({ node });
 
         await render(hbs`<LicenseText @node={{this.node}} />`);
+        await timeout(100);
 
         const placeholder = t('app_components.license_text.anonymized_placeholder');
         assert.dom(this.element).hasText(`I am an emu. You are ${placeholder} from ${placeholder}.`);

--- a/tests/integration/components/registries/new-update-modal/component-test.ts
+++ b/tests/integration/components/registries/new-update-modal/component-test.ts
@@ -1,6 +1,7 @@
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { timeout } from 'ember-concurrency';
 import { setupIntl, TestContext } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -30,6 +31,7 @@ module('Integration | Component | new-update-modal', hooks => {
                 @onClose={{this.noop}}
             />`,
         );
+        await timeout(100);
         assert.dom('[data-test-new-update-dialog-heading]').hasText(
             this.intl.t('registries.newUpdateModal.modalHeader'),
             'Modal header is correct',
@@ -57,6 +59,7 @@ module('Integration | Component | new-update-modal', hooks => {
                 @onClose={{this.noop}}
             />`,
         );
+        await timeout(100);
         assert.dom('[data-test-new-update-dialog-heading]').hasText(
             this.intl.t('registries.newUpdateModal.modalHeaderNoUpdates'),
             'Modal header is correct',


### PR DESCRIPTION
-   Ticket: [ENG-4492]
-   Feature flag: n/a

## Purpose
- Add data-test selectors to registration components and links pages for Selenium test

## Summary of Changes
- Add data-test selectors to the "No components" and "No linked registrations/nodes" messages
- Add acceptance tests for these pages

## Screenshot(s)
- NA
## Side Effects
- None

## QA Notes
- The data-test selector for the "No components" message is `data-test-no-components`
- The data-test selector for the "No linked nodes" message is `data-test-no-linked-nodes `
- The data-test selector for the "No linked registrations" message is `data-test-no-linked-registrations `
- Functionality should not be impacted at all

[ENG-4492]: https://openscience.atlassian.net/browse/ENG-4492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ