### PR TITLE
[ENG-4502] Replace buttons with Buttons

### DIFF
--- a/lib/analytics-page/addon/application/template.hbs
+++ b/lib/analytics-page/addon/application/template.hbs
@@ -25,14 +25,12 @@
                     {{loading-indicator dark=true}}
                 {{else}}
                     <div local-class='count'>{{this.linkedByCount}}</div>
-                    <button
-                        type='button'
-                        class='btn btn-link'
-                        local-class='button-link'
+                    <Button
+                        @layout='fake-link'
                         {{on 'click' this.showLinksModal}}
                     >
                         {{t 'analytics.viewLinks'}}
-                    </button>
+                    </Button>
                     <OsfDialog
                         @isOpen={{this.linksModalShown}}
                         @onClose={{action this.hideLinksModal}}
@@ -115,13 +113,12 @@
                     >
                         {{#each this.allTimespans as |timespan|}}
                             <li role='menuitem'>
-                                <button
-                                    type='button'
+                                <Button
                                     local-class='date-range-option'
                                     {{on 'click' (fn this.setTimespan timespan)}}
                                 >
                                     {{t (get this.timespanIntlKeys timespan)}}
-                                </button>
+                                </Button>
                             </li>
                         {{/each}}
                     </dd.menu>

--- a/lib/app-components/addon/components/branded-navbar/component.ts
+++ b/lib/app-components/addon/components/branded-navbar/component.ts
@@ -51,8 +51,12 @@ export default class BrandedNavbar extends Component {
         this.toggleProperty('showNavLinks');
     }
 
+    get isMobileOrTablet() {
+        return this.media.isMobile || this.media.isTablet;
+    }
+
     get shouldShowNavLinks() {
-        if (this.media.isMobile || this.media.isTablet) {
+        if (this.isMobileOrTablet) {
             return this.showNavLinks;
         }
         return true;

--- a/lib/app-components/addon/components/branded-navbar/styles.scss
+++ b/lib/app-components/addon/components/branded-navbar/styles.scss
@@ -9,8 +9,22 @@
         box-shadow: 2px 1px 4px rgba(82, 81, 81, 0.7);
     }
 
-    :global(.navbar-toggle) {
-        border-color: transparent;
+    .navbar-toggle {
+        position: relative;
+        float: right;
+        padding: 9px 10px;
+        margin-right: 15px;
+        margin-top: 8px;
+        margin-bottom: 8px;
+        background-color: transparent;
+        background-image: none;
+        border: 1px solid transparent;
+        border-radius: 4px;
+        color: $color-text-white;
+    }
+
+    .navbar-toggle:hover {
+        background-color: $color-bg-black;
     }
 
     :global(.navbar-collapse) {
@@ -54,6 +68,10 @@
     height: 50px;
 }
 
+.dropdown-links {
+    margin-right: 30px;
+}
+
 // The default 340px isn't quite enough for the auth dropdown
 .secondary-navigation {
     max-height: 400px !important;
@@ -68,5 +86,6 @@
 
     .links > li > a {
         line-height: 27px !important;
+        
     }
 }

--- a/lib/app-components/addon/components/branded-navbar/template.hbs
+++ b/lib/app-components/addon/components/branded-navbar/template.hbs
@@ -16,16 +16,15 @@
                 </LinkTo>
 
                 {{! Navigation toggle - XS screen }}
-                <button
-                    type='button'
-                    class='navbar-toggle collapsed'
-                    aria-label={{t 'navbar.toggle_secondary'}}
-                    {{on 'click' this.toggleSecondaryNavigation}}
-                >
-                    <span class='icon-bar'></span>
-                    <span class='icon-bar'></span>
-                    <span class='icon-bar'></span>
-                </button>
+                {{#if this.isMobileOrTablet}}
+                    <Button
+                        aria-label={{t 'navbar.toggle_secondary'}}
+                        local-class='navbar-toggle'
+                        {{on 'click' this.toggleSecondaryNavigation}}
+                    >
+                        <FaIcon @icon='bars' />
+                    </Button>
+                {{/if}}
             </div>
 
             {{! Secondary nav links }}

--- a/lib/app-components/addon/components/project-contributors/list/item/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/list/item/template.hbs
@@ -25,11 +25,14 @@
     </div>
 
     <div class='visible-xs-inline-block col-xs-1'>
-        <button data-test-project-contributors-list-item-x-button type='button' class='text-danger'
-            aria-label={{t 'app_components.project_contributors.list.item.remove_author'}} hidden={{not this.canRemove}}
+        <Button
+            data-test-project-contributors-list-item-x-button
+            @type='destroy'
+            aria-label={{t 'app_components.project_contributors.list.item.remove_author'}}
+            hidden={{not this.canRemove}}
             {{on 'click' (fn @removeContributor @contributor)}}>
             <FaIcon @icon='times' />
-        </button>
+        </Button>
     </div>
 
     {{! Permissions }}
@@ -68,9 +71,14 @@
 
     {{! Remove }}
     <div class='hidden-xs col-sm-2 text-center'>
-        <button data-test-project-contributors-list-item-remove-button type='button' class='btn btn-danger btn-sm'
-            disabled={{not this.canRemove}} {{action @removeContributor @contributor}}>
+        <Button
+            data-test-project-contributors-list-item-remove-button
+            @layout='small'
+            @type='destroy'
+            disabled={{not this.canRemove}}
+            {{on 'click' (action @removeContributor @contributor)}}
+        >
             {{t 'app_components.project_contributors.list.item.remove'}}
-        </button>
+        </Button>
     </div>
 </div>

--- a/lib/app-components/addon/components/project-contributors/search/result/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/search/result/template.hbs
@@ -23,22 +23,23 @@
             class='hint hint--left pull-right'
             aria-label={{t 'components.preprint-form-authors.already_added'}}
         >
-            <button
+            <Button
                 data-test-project-contributors-is-contributor-button
-                type='button'
-                class='btn btn-default btn-small disabled disabled-checkmark'
+                @layout='small'
+                disabled={{true}}
             >
                 <FaIcon @icon='check' @aria-hidden='true' />
-            </button>
+            </Button>
         </span>
     {{else}}
-        <button
+        <Button
             data-test-project-contributors-add-contributor-button
-            type='button'
             class='btn btn-success btn-small pull-right'
-            {{action this.addContributor @user}}
+            @layout='small'
+            @type='create'
+            {{on 'click' (action this.addContributor @user)}}
         >
             {{t 'app_components.project_contributors.search.result.add'}}
-        </button>
+        </Button>
     {{/if}}
 </td>

--- a/lib/app-components/addon/components/project-contributors/search/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/search/template.hbs
@@ -11,15 +11,14 @@
             @placeholder={{t 'app_components.project_contributors.search.placeholder'}}
         />
         <span class='input-group-btn'>
-            <button
+            <Button
                 data-test-project-contributors-search-button
                 aria-label={{t 'app_components.project_contributors.search.perform_search'}}
                 local-class='authors-search-button'
-                class='btn btn-default'
                 type='submit'
             >
                 <i class='glyphicon glyphicon-search'></i>
-            </button>
+            </Button>
         </span>
     </div>
 </form>
@@ -35,14 +34,14 @@
         class='text-center'
     >
         <p>{{t 'app_components.project_contributors.search.unregistered_description'}}</p>
-        <button
+        <Button
             data-test-add-author-by-email-address-button
-            type='button'
-            class='btn btn-primary btn-small'
-            {{action (mut this.showUnregisteredForm) true}}
+            @layout='small'
+            @type='primary'
+            {{on 'click' (action (mut this.showUnregisteredForm) true)}}
         >
             {{t 'app_components.project_contributors.search.unregistered_button'}}
-        </button>
+        </Button>
     </div>
     <h3>
         {{t 'app_components.project_contributors.search.results'}}

--- a/lib/app-components/addon/components/project-contributors/search/unregistered-contributor/template.hbs
+++ b/lib/app-components/addon/components/project-contributors/search/unregistered-contributor/template.hbs
@@ -24,19 +24,16 @@
     {{t 'app_components.project_contributors.search.unregistered_contributor.paragraph'}}
 </p>
 <div class='pull-right text-right'>
-    <button
-        type='button'
-        class='btn btn-default'
-        {{action this.cancel}}
+    <Button
+        {{on 'click' (action this.cancel)}}
     >
         {{t 'app_components.project_contributors.search.unregistered_contributor.cancel'}}
-    </button>
-    <button
-        type='button'
-        class='btn btn-success'
+    </Button>
+    <Button
+        @type='create'
         disabled={{and this.didValidate (v-get this.model 'isInvalid')}}
-        {{action (perform this.add)}}
+        {{on 'click' (action (perform this.add))}}
     >
         {{t 'app_components.project_contributors.search.unregistered_contributor.add'}}
-    </button>
+    </Button>
 </div>

--- a/lib/app-components/addon/components/search-paginator/template.hbs
+++ b/lib/app-components/addon/components/search-paginator/template.hbs
@@ -1,17 +1,16 @@
 <ul local-class='ul'>
     {{#each this.items as |item|}}
         <li local-class='li'>
-            <button
+            <Button
                 data-test-page-number={{item.text}}
                 data-analytics-name='Search paginator button {{item.text}}'
                 aria-label={{item.aria}}
-                type='button'
                 local-class={{if (eq this.current item.text) 'active'}}
                 disabled={{item.disabled}}
-                {{action (or item.action this.setPage) item.text}}
+                {{on 'click' (action (or item.action this.setPage) item.text)}}
             >
                 {{item.text}}
-            </button>
+            </Button>
         </li>
     {{/each}}
 </ul>

--- a/lib/app-components/addon/components/submit-section-buttons/template.hbs
+++ b/lib/app-components/addon/components/submit-section-buttons/template.hbs
@@ -1,9 +1,7 @@
 {{#if this.showDiscard}}
-    <button
+    <Button
         data-test-submit-section-discard
         data-analytics-name='Discard'
-        type='button'
-        class='btn btn-default'
         {{on 'click' this.discard}}
     >
         {{#if @discardButtonLabel}}
@@ -11,13 +9,12 @@
         {{else}}
             {{t (concat 'app_components.submit_section.discard')}}
         {{/if}}
-    </button>
+    </Button>
 {{/if}}
-<button
+<Button
     data-test-submit-section-continue
     data-analytics-name='Continue'
-    type='button'
-    class='btn btn-primary'
+    @type='primary'
     disabled={{this.continueDisabled}}
     {{on 'click' this.continue}}
 >
@@ -26,4 +23,4 @@
     {{else}}
         {{t (concat 'app_components.submit_section.save')}}
     {{/if}}
-</button>
+</Button>

--- a/lib/collections/addon/components/collection-search-result/template.hbs
+++ b/lib/collections/addon/components/collection-search-result/template.hbs
@@ -20,15 +20,14 @@
 
 {{#if @expandable}}
     <div class='text-center'>
-        <button
+        <Button
             data-test-collection-search-expand-button
-            type='button'
-            class='btn btn-link'
+            @layout='fake-link'
             local-class='toggleShowBody'
             aria-label={{t (concat 'collections.collection_search_result.' (if this.showBody 'collapse' 'expand'))}}
             {{action 'toggleShowBody'}}
         >
             <FaIcon @icon={{concat 'caret-' (if this.showBody 'up' 'down')}} />
-        </button>
+        </Button>
     </div>
 {{/if}}

--- a/lib/collections/addon/components/collections-submission/template.hbs
+++ b/lib/collections/addon/components/collections-submission/template.hbs
@@ -198,35 +198,31 @@
                     </DeleteButton>
                 {{/if}}
                 <div class='text-right'>
-                    <button
+                    <Button
                         data-test-collections-submit-cancel-button
-                        type='button'
-                        class='btn btn-default'
                         {{action this.cancel}}
                     >
                         {{t (concat this.intlKeyPrefix 'cancel')}}
-                    </button>
+                    </Button>
                     {{#if this.edit}}
-                        <button
+                        <Button
                             data-test-collections-submit-update-button
                             data-analytics-name='Update'
-                            type='button'
-                            class='btn btn-success'
+                            @type='create'
                             {{action (perform this.save)}}
                         >
                             {{t (concat this.intlKeyPrefix 'update' '_button')}}
-                        </button>
+                        </Button>
                     {{else}}
-                        <button
+                        <Button
                             data-test-collections-submit-submit-button
                             data-analytics-name='Submit'
-                            type='button'
-                            class='btn btn-success'
+                            @type='create'
                             disabled={{not (eq this.activeSection this.sections.submit)}}
                             {{on 'click' this.setShowSubmitModal}}
                         >
                             {{t (concat this.intlKeyPrefix 'add' '_button')}}
-                        </button>
+                        </Button>
                     {{/if}}
                 </div>
             </div>

--- a/lib/collections/addon/components/discover-page/active-filters/filter/template.hbs
+++ b/lib/collections/addon/components/discover-page/active-filters/filter/template.hbs
@@ -6,15 +6,14 @@
     {{@text}}
     {{#unless @hide}}
         <span>
-            <button
+            <Button
                 aria-label={{@ariaLabel}}
                 data-test-active-filter-remove-button
-                type='button'
                 local-class='removeActiveFilter'
                 {{on 'click' this.removeFilterItem}}
             >
                 <FaIcon @icon='times-circle' />
-            </button>
+            </Button>
         </span>
     {{/unless}}
 </span>

--- a/lib/collections/addon/components/discover-page/active-filters/template.hbs
+++ b/lib/collections/addon/components/discover-page/active-filters/template.hbs
@@ -3,15 +3,14 @@
         <h4>{{t 'collections.discover_page.active_filters.heading'}}:</h4>
     </div>
     <div local-class='button-container'>
-        <button
+        <Button
             data-test-clear-filters-button
-            type='button'
-            class='btn btn-default btn-sm'
+            @layout='small'
             {{action @clearFilters}}
         >
             {{t 'collections.discover_page.active_filters.button'}}
             <FaIcon @icon='times' />
-        </button>
+        </Button>
     </div>
 </div>
 

--- a/lib/collections/addon/components/discover-page/template.hbs
+++ b/lib/collections/addon/components/discover-page/template.hbs
@@ -60,26 +60,22 @@
             />
             <div class='input-group-btn'>
                 {{!HELP BUTTON}}
-                <button
+                <Button
                     local-class='lucene-button'
                     data-test-help-button
-                    type='button'
-                    class='btn btn-default'
                     aria-label={{t 'collections.discover_page.luceneHelp'}}
                     {{action this.toggleShowLuceneHelp}}
                 >
                     <FaIcon @icon='question' @class='text-muted' />
-                </button>
+                </Button>
                 {{!SEARCH BUTTON}}
-                <button
+                <Button
                     local-class='search-button'
                     data-test-search-button
-                    type='button'
-                    class='btn btn-default'
                     {{action this.searchAction}}
                 >
                     {{t 'collections.discover_page.search'}}
-                </button>
+                </Button>
             </div>
             {{!Lucene search help modal}}
             <SearchHelpModal @isOpen={{this.showLuceneHelp}} />
@@ -117,15 +113,14 @@
                 >
                     {{#each this.sortOptions as |sortChoice|}}
                         <ddm.item>
-                            <button
+                            <Button
                                 data-test-sort-by-item={{sortChoice.sortBy}}
-                                type='button'
-                                class='btn btn-link'
+                                @layout='fake-link'
                                 local-class='list-option'
                                 {{action this.selectSortOption sortChoice.sortBy}}
                             >
                                 {{sortChoice.display}}
-                            </button>
+                            </Button>
                         </ddm.item>
                     {{/each}}
                 </dd.menu>

--- a/lib/osf-components/addon/components/carousel/template.hbs
+++ b/lib/osf-components/addon/components/carousel/template.hbs
@@ -13,10 +13,9 @@
                 local-class={{if item.isActive 'current' ''}}
                 aria-selected={{if item.isActive 'true' 'false'}}
             >
-                <button
+                <Button
                     data-test-navigation-button
                     data-analytics-name='Go to slide {{item.slideIndex}}'
-                    type='button'
                     data-slide={{item.index}}
                     aria-label={{t 'osf-components.carousel.go_to_slide' slideIndex=item.slideIndex}}
                     {{action this.navClick item}}
@@ -25,7 +24,7 @@
                     {{#if item.isActive}}
                         <span class='visuallyhidden'>{{t 'osf-components.carousel.current_slide'}}</span>
                     {{/if}}
-                </button>
+                </Button>
             </li>
         {{/each}}
     </ol>

--- a/lib/osf-components/addon/components/license-picker/template.hbs
+++ b/lib/osf-components/addon/components/license-picker/template.hbs
@@ -49,14 +49,13 @@
             />
         {{/each}}
     </this.form.custom>
-    <button
-        type='button'
+    <Button
+        @layout='fake-link'
         local-class='button-link'
-        class='btn btn-link'
         {{on 'click' (fn (mut this.showText) (not this.showText))}}
     >
         {{t (concat 'app_components.license_picker.' (if this.showText 'hide' 'show'))}}
-    </button>
+    </Button>
     {{#if this.showText}}
         <LicenseText @node={{this.node}} />
     {{/if}}

--- a/lib/osf-components/addon/components/sharing-icons/popover/template.hbs
+++ b/lib/osf-components/addon/components/sharing-icons/popover/template.hbs
@@ -1,8 +1,7 @@
-<button
+<Button
     aria-label={{t 'registries.discover.search_result.sharing_popover'}}
-    type='button'
+    @layout='fake-link'
     local-class='SharingIconsPopover__anchor'
-    class='btn-link pull-right'
     tabindex='0'
     data-analytics-name='Sharing Icons Popover{{if @provider (concat ' ' @provider.name)}}'
     ...attributes
@@ -22,4 +21,4 @@
             @showText={{@showText}}
         />
     </EmberPopover>
-</button>
+</Button>

--- a/lib/registries/addon/branded/moderation/pending/template.hbs
+++ b/lib/registries/addon/branded/moderation/pending/template.hbs
@@ -8,38 +8,35 @@
 >
     <div local-class='tabSortingWrapper'>
         <div local-class='tabs'>
-            <button
+            <Button
                 data-test-submissions-type='pending'
                 data-test-is-selected={{if (eq this.state 'pending') 'true' 'false'}}
-                type='button'
                 {{on 'click' (fn this.changeTab 'pending')}}
                 local-class='tab {{if (eq this.state 'pending') 'selected'}}'
             >
                 <FaIcon @icon='hourglass' />
                 {{t 'registries.moderation.states.pending'}}
-            </button>
+            </Button>
             {{#if this.model.allowUpdates}}
-                <button
+                <Button
                     data-test-submissions-type='revision-pending'
                     data-test-is-selected={{if (eq this.state 'pending_moderation') 'true' 'false'}}
-                    type='button'
                     {{on 'click' (fn this.changeTab 'pending_moderation')}}
                     local-class='tab {{if (eq this.state 'pending_moderation') 'selected'}}'
                 >
                     <FaIcon @icon='hourglass' />
                     {{t 'registries.moderation.states.revisionPending'}}
-                </button>
+                </Button>
             {{/if}}
-            <button
+            <Button
                 data-test-submissions-type='pending-withdraw'
                 data-test-is-selected={{if (eq this.state 'pending_withdraw') 'true' 'false'}}
-                type='button'
                 {{on 'click' (fn this.changeTab 'pending_withdraw')}}
                 local-class='tab {{if (eq this.state 'pending_withdraw') 'selected'}}'
             >
                 <FaIcon @icon='clock' />
                 {{t 'registries.moderation.states.pendingWithdraw'}}
-            </button>
+            </Button>
         </div>
         <SortButton
             local-class='sortButton'

--- a/lib/registries/addon/branded/moderation/submitted/template.hbs
+++ b/lib/registries/addon/branded/moderation/submitted/template.hbs
@@ -8,46 +8,42 @@
 >
     <div local-class='tabSortingWrapper'>
         <div local-class='tabs'>
-            <button
+            <Button
                 data-test-submissions-type='accepted'
                 data-test-is-selected={{if (eq this.state 'accepted') 'true' 'false'}}
-                type='button'
                 {{on 'click' (fn this.changeTab 'accepted')}}
                 local-class='tab {{if (eq this.state 'accepted') 'selected'}}'
             >
                 <FaIcon @icon='check' />
                 {{t 'registries.moderation.states.accepted'}}
-            </button>
-            <button
+            </Button>
+            <Button
                 data-test-submissions-type='embargo'
                 data-test-is-selected={{if (eq this.state 'embargo') 'true' 'false'}}
-                type='button'
                 {{on 'click' (fn this.changeTab 'embargo')}}
                 local-class='tab {{if (eq this.state 'embargo') 'selected'}}'
             >
                 <FaIcon @icon='lock' />
                 {{t 'registries.moderation.states.embargo'}}
-            </button>
-            <button
+            </Button>
+            <Button
                 data-test-submissions-type='rejected'
                 data-test-is-selected={{if (eq this.state 'rejected') 'true' 'false'}}
-                type='button'
                 {{on 'click' (fn this.changeTab 'rejected')}}
                 local-class='tab {{if (eq this.state 'rejected') 'selected'}}'
             >
                 <FaIcon @icon='times' />
                 {{t 'registries.moderation.states.rejected'}}
-            </button>
-            <button
+            </Button>
+            <Button
                 data-test-submissions-type='withdrawn'
                 data-test-is-selected={{if (eq this.state 'withdrawn') 'true' 'false'}}
-                type='button'
                 {{on 'click' (fn this.changeTab 'withdrawn')}}
                 local-class='tab {{if (eq this.state 'withdrawn') 'selected'}}'
             >
                 <FaIcon @icon='ban' />
                 {{t 'registries.moderation.states.withdrawn'}}
-            </button>
+            </Button>
         </div>
         <SortButton
             local-class='sortButton'

--- a/lib/registries/addon/components/registries-discover-results-header/template.hbs
+++ b/lib/registries/addon/components/registries-discover-results-header/template.hbs
@@ -17,16 +17,14 @@
             <dd.content local-class='DropdownContent'>
                 {{#each @sortOptions as |option index|}}
                     <div>
-                        <button
+                        <Button
                             data-test-sort-option-id='{{index}}'
-                            class='btn'
-                            type='button'
                             local-class='SortDropDown__Option'
                             {{on 'click' (fn @setOrder option)}}
                             {{on 'click' dd.close}}
                         >
                             {{t option.display}}
-                        </button>
+                        </Button>
                     </div>
                 {{/each}}
             </dd.content>


### PR DESCRIPTION
-   Ticket: [ENG-4502]
-   Feature flag: n/a

## Purpose

Get rid of boring HTML buttons and replace them with exciting ember-osf-web Buttons. Except for:
1. In component tests
2. In the Button component itself, naturally
3. In the BsAlert component, because that's going to be completely redone soon anyways, so no sense replacing that out just yet.

## Summary of Changes

1. Replace buttons with Buttons
2. Do a bit more work with the button from the collections branded navbar

## Side Effects

There will be some minor visual differences because we're now using a standardized component with standardized styling.


[ENG-4502]: https://openscience.atlassian.net/browse/ENG-4502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ