### PR TITLE
[ENG-4492] Data test selectors for Selenium tests

### DIFF
--- a/lib/registries/addon/overview/children/template.hbs
+++ b/lib/registries/addon/overview/children/template.hbs
@@ -1,5 +1,5 @@
 {{page-title (t 'registries.overview.components.title')}}
-<h3>{{t 'registries.overview.components.title'}}</h3>
+<h3 data-test-components-page-heading>{{t 'registries.overview.components.title'}}</h3>
 
 {{#paginated-list/has-many
     modelTaskInstance=this.model.taskInstance

--- a/lib/registries/addon/overview/links/template.hbs
+++ b/lib/registries/addon/overview/links/template.hbs
@@ -1,6 +1,6 @@
 {{page-title (t 'registries.overview.links.title')}}
 
-<h3>{{t 'registries.overview.links.linked_nodes'}}</h3>
+<h3 data-test-links-page-heading>{{t 'registries.overview.links.linked_nodes'}}</h3>
 {{#paginated-list/has-many
     modelTaskInstance=this.model.taskInstance
     relationshipName='linkedNodes'

--- a/tests/engines/registries/acceptance/overview/components-page-test.ts
+++ b/tests/engines/registries/acceptance/overview/components-page-test.ts
@@ -26,6 +26,7 @@ module('Registries | Acceptance | overview.components', hooks => {
         });
         await visit(`/${parentRegistration.id}/components`);
 
+        assert.dom('[data-test-components-page-heading]').exists('Components page heading is shown');
         assert.dom('[data-test-node-card]').exists({ count: 2 }, 'Two child registrations are shown');
         assert.dom('[data-test-no-components]').doesNotExist('No components message is not shown');
     });

--- a/tests/engines/registries/acceptance/overview/links-page-test.ts
+++ b/tests/engines/registries/acceptance/overview/links-page-test.ts
@@ -18,6 +18,7 @@ module('Registries | Acceptance | overview.links', hooks => {
             linkedNodes: [linkedNode],
         });
         await visit(`/${registration.id}/links`);
+        assert.dom('[data-test-links-page-heading]').exists('Links page heading is shown');
         assert.dom(`[data-test-node-title="${linkedNode.id}"]`).containsText('Linked node', 'Linked node is shown');
         assert.dom('[data-test-no-linked-registrations]').exists('No linked registrations message is shown');
     });


### PR DESCRIPTION
-   Ticket: [ENG-4492]
-   Feature flag: n/a

## Purpose
- Add data-test selectors for selenium tests in a better place

## Summary of Changes
- Add data test selectors to the heading element for components and links page

## Screenshot(s)
- NA
<!-- Attach screenshots if applicable. -->

## Side Effects
- None
<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- The data test selectors for the `<h3>`s are `data-test-components-page-heading` and `data-test-links-page-heading`

[ENG-4492]: https://openscience.atlassian.net/browse/ENG-4492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ