### PR TITLE
[ENG-4419] No BsDropdown

### DIFF
--- a/lib/analytics-page/addon/application/styles.scss
+++ b/lib/analytics-page/addon/application/styles.scss
@@ -73,7 +73,11 @@
     box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
     padding: 5px;
     margin: 2px 0 0;
-    list-style: none;
+
+    ul {
+        list-style: none;
+        padding-inline-start: 0;
+    }
 }
 
 .date-range-option {

--- a/lib/analytics-page/addon/application/styles.scss
+++ b/lib/analytics-page/addon/application/styles.scss
@@ -63,20 +63,28 @@
                 margin-left: 5px;
             }
         }
+    }
+}
 
-        .date-range-menu {
-            background-color: $color-bg-gray-light;
-        }
+.date-range-menu {
+    background-color: $color-bg-white;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    border-radius: 4px;
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+    padding: 5px;
+    margin: 2px 0 0;
+    list-style: none;
+}
 
-        .date-range-option {
-            color: $color-link-black;
+.date-range-option {
+    color: $color-link-black;
+    background-color: transparent;
+    border: hidden;
 
-            &:hover,
-            &:focus {
-                cursor: pointer;
-                background-image: none;
-                background-color: $color-bg-gray-dark;
-            }
-        }
+    &:hover,
+    &:focus {
+        cursor: pointer;
+        background-image: none;
+        background-color: $color-bg-gray-dark;
     }
 }

--- a/lib/analytics-page/addon/application/template.hbs
+++ b/lib/analytics-page/addon/application/template.hbs
@@ -98,16 +98,19 @@
         <div local-class='pick-date-range'>
             <label>
                 {{t 'analytics.showForDateRange'}}
-                <BsDropdown as |dd|>
-                    <dd.button
+                <ResponsiveDropdown
+                    @buttonStyling={{true}}
+                    as |dd|
+                >
+                    <dd.trigger
                         aria-haspopup='true'
                         aria-expanded='false'
                         local-class='date-range-button'
                     >
                         {{t (get this.timespanIntlKeys this.timespan)}}
                         <FaIcon @icon='caret-down' />
-                    </dd.button>
-                    <dd.menu
+                    </dd.trigger>
+                    <dd.content
                         local-class='date-range-menu'
                         @align='right'
                     >
@@ -115,14 +118,14 @@
                             <li role='menuitem'>
                                 <Button
                                     local-class='date-range-option'
-                                    {{on 'click' (fn this.setTimespan timespan)}}
+                                    {{on 'click' (queue dd.close (fn this.setTimespan timespan))}}
                                 >
                                     {{t (get this.timespanIntlKeys timespan)}}
                                 </Button>
                             </li>
                         {{/each}}
-                    </dd.menu>
-                </BsDropdown>
+                    </dd.content>
+                </ResponsiveDropdown>
             </label>
         </div>
     {{/if}}

--- a/lib/analytics-page/addon/application/template.hbs
+++ b/lib/analytics-page/addon/application/template.hbs
@@ -114,16 +114,18 @@
                         local-class='date-range-menu'
                         @align='right'
                     >
-                        {{#each this.allTimespans as |timespan|}}
-                            <li role='menuitem'>
-                                <Button
-                                    local-class='date-range-option'
-                                    {{on 'click' (queue dd.close (fn this.setTimespan timespan))}}
-                                >
-                                    {{t (get this.timespanIntlKeys timespan)}}
-                                </Button>
-                            </li>
-                        {{/each}}
+                        <ul role='menu' tabindex='-1'>
+                            {{#each this.allTimespans as |timespan|}}
+                                <li role='menuitem'>
+                                    <Button
+                                        local-class='date-range-option'
+                                        {{on 'click' (queue dd.close (fn this.setTimespan timespan))}}
+                                    >
+                                        {{t (get this.timespanIntlKeys timespan)}}
+                                    </Button>
+                                </li>
+                            {{/each}}
+                        </ul>
                     </dd.content>
                 </ResponsiveDropdown>
             </label>

--- a/lib/collections/addon/components/discover-page/styles.scss
+++ b/lib/collections/addon/components/discover-page/styles.scss
@@ -75,25 +75,6 @@
         width: 100%;
         margin-top: 10px;
         margin-bottom: 10px;
-
-        .sort-by-option-list {
-            background-color: #efefef;
-            left: auto;
-
-            li:hover {
-                background-color: #d9d9d9;
-            }
-
-            .list-option {
-                cursor: pointer;
-                color: #000;
-                text-decoration: none;
-
-                &:focus {
-                    outline: none;
-                }
-            }
-        }
     }
 }
 
@@ -231,4 +212,24 @@
         }
     }
 
+}
+
+.sort-by-option-list {
+    background-color: #efefef;
+    left: auto;
+    list-style: none;
+
+    li:hover {
+        background-color: #d9d9d9;
+    }
+
+    .list-option {
+        cursor: pointer;
+        color: #000;
+        text-decoration: none;
+
+        &:focus {
+            outline: none;
+        }
+    }
 }

--- a/lib/collections/addon/components/discover-page/styles.scss
+++ b/lib/collections/addon/components/discover-page/styles.scss
@@ -217,7 +217,11 @@
 .sort-by-option-list {
     background-color: #efefef;
     left: auto;
-    list-style: none;
+
+    ul {
+        list-style: none;
+        padding-inline-start: 0;
+    }
 
     li:hover {
         background-color: #d9d9d9;

--- a/lib/collections/addon/components/discover-page/template.hbs
+++ b/lib/collections/addon/components/discover-page/template.hbs
@@ -110,18 +110,20 @@
                     local-class='sort-by-option-list'
                     @align='right'
                 >
-                    {{#each this.sortOptions as |sortChoice|}}
-                        <li role='menuitem'>
-                            <Button
-                                data-test-sort-by-item={{sortChoice.sortBy}}
-                                @layout='fake-link'
-                                local-class='list-option'
-                                {{on 'click' (queue dd.close (action this.selectSortOption sortChoice.sortBy))}}
-                            >
-                                {{sortChoice.display}}
-                            </Button>
-                        </li>
-                    {{/each}}
+                    <ul role='menu' tabindex='-1'>
+                        {{#each this.sortOptions as |sortChoice|}}
+                            <li role='menuitem'>
+                                <Button
+                                    data-test-sort-by-item={{sortChoice.sortBy}}
+                                    @layout='fake-link'
+                                    local-class='list-option'
+                                    {{on 'click' (queue dd.close (action this.selectSortOption sortChoice.sortBy))}}
+                                >
+                                    {{sortChoice.display}}
+                                </Button>
+                            </li>
+                        {{/each}}
+                    </ul>
                 </dd.content>
             </ResponsiveDropdown>
         </div>

--- a/lib/collections/addon/components/discover-page/template.hbs
+++ b/lib/collections/addon/components/discover-page/template.hbs
@@ -94,8 +94,8 @@
         {{/if}}
         {{!RELEVANCE}}
         <div local-class='relevance-container'>
-            <BsDropdown class='dropdown pull-right' as |dd|>
-                <dd.button
+            <ResponsiveDropdown class='dropdown pull-right' as |dd|>
+                <dd.trigger
                     data-test-sort-by-button
                     class='btn btn-default results-top'
                 >
@@ -105,26 +105,25 @@
                         class='caret'
                         >
                     </span>
-                </dd.button>
-                <dd.menu
+                </dd.trigger>
+                <dd.content
                     local-class='sort-by-option-list'
                     @align='right'
-                    as |ddm|
                 >
                     {{#each this.sortOptions as |sortChoice|}}
-                        <ddm.item>
+                        <li role='menuitem'>
                             <Button
                                 data-test-sort-by-item={{sortChoice.sortBy}}
                                 @layout='fake-link'
                                 local-class='list-option'
-                                {{action this.selectSortOption sortChoice.sortBy}}
+                                {{on 'click' (queue dd.close (action this.selectSortOption sortChoice.sortBy))}}
                             >
                                 {{sortChoice.display}}
                             </Button>
-                        </ddm.item>
+                        </li>
                     {{/each}}
-                </dd.menu>
-            </BsDropdown>
+                </dd.content>
+            </ResponsiveDropdown>
         </div>
     </div>
 </div>

--- a/lib/osf-components/addon/components/node-card/styles.scss
+++ b/lib/osf-components/addon/components/node-card/styles.scss
@@ -118,7 +118,11 @@
 .dropdown-list.dropdown-list {
     background-color: $color-bg-gray-light;
     min-width: 180px;
-    list-style: none;
+
+    ul {
+        list-style: none;
+        padding-inline-start: 0;
+    }
 
     li {
         margin: 10px 0;

--- a/lib/osf-components/addon/components/node-card/styles.scss
+++ b/lib/osf-components/addon/components/node-card/styles.scss
@@ -30,35 +30,7 @@
                 background-color: darken($brand-info, 15%);
             }
 
-            .dropdown {
-                padding-left: 5px;
-
-                .dropdown-button {
-                    padding: 4px 12px;
-                    line-height: 0;
-                }
-
-                .dropdown-list {
-                    background-color: $color-bg-gray-light;
-                    min-width: 180px;
-
-                    .dropdown-link {
-                        color: $color-link-black;
-                        border-color: transparent;
-                        background-color: $color-bg-gray-light;
-                        min-width: 180px;
-                        text-align: left;
-                        padding: 3px 20px;
-                    }
-
-                    .dropdown-link:hover,
-                    .dropdown-link:focus {
-                        cursor: pointer;
-                        background-image: none;
-                        background-color: $color-bg-gray-dark;
-                    }
-                }
-            }
+            
         }
 
         .body {
@@ -131,5 +103,40 @@
     &.mobile {
         width: 10%;
         padding-left: 0;
+    }
+}
+
+.dropdown {
+    padding-left: 5px;
+
+    .dropdown-button {
+        padding: 4px 12px;
+        line-height: 0;
+    }
+}
+
+.dropdown-list.dropdown-list {
+    background-color: $color-bg-gray-light;
+    min-width: 180px;
+    list-style: none;
+
+    li {
+        margin: 10px 0;
+    }
+
+    .dropdown-link {
+        color: $color-link-black;
+        border-color: transparent;
+        background-color: $color-bg-gray-light;
+        min-width: 180px;
+        text-align: left;
+        padding: 3px 20px;
+    }
+
+    .dropdown-link:hover,
+    .dropdown-link:focus {
+        cursor: pointer;
+        background-image: none;
+        background-color: $color-bg-gray-dark;
     }
 }

--- a/lib/osf-components/addon/components/node-card/template.hbs
+++ b/lib/osf-components/addon/components/node-card/template.hbs
@@ -75,12 +75,12 @@
                             class='pull-right generic-dropdown'
                             local-class='dropdown'
                         >
-                            <BsDropdown as |dd|>
-                                <dd.button local-class='dropdown-button'>
+                            <ResponsiveDropdown @buttonStyling={{true}} as |dd|>
+                                <dd.trigger local-class='dropdown-button'>
                                     <span aria-label={{t 'node_card.options'}} class='glyphicon glyphicon-option-horizontal'></span>
-                                </dd.button>
-                                <dd.menu @align='right' local-class='dropdown-list' as |menu|>
-                                    <menu.item role='menuitem'>
+                                </dd.trigger>
+                                <dd.content @align='right' local-class='dropdown-list'>
+                                    <li role='menuitem'>
                                         <OsfLink
                                             data-analytics-name='Manage Contributors'
                                             local-class='dropdown-link'
@@ -88,8 +88,8 @@
                                         >
                                             {{t 'node_card.fork.manage_contributors'}}
                                         </OsfLink>
-                                    </menu.item>
-                                    <menu.item role='menuitem'>
+                                    </li>
+                                    <li role='menuitem'>
                                         <OsfLink
                                             data-analytics-name='Settings'
                                             local-class='dropdown-link'
@@ -97,18 +97,19 @@
                                         >
                                             {{t 'general.settings'}}
                                         </OsfLink>
-                                    </menu.item>
-                                    <menu.item role='menuitem'>
+                                    </li>
+                                    <li role='menuitem'>
                                         <Button
                                             data-analytics-scope='Delete'
                                             local-class='dropdown-link'
+                                            @layout='fake-link'
                                             {{on 'click' (action @delete @node)}}
                                         >
                                             {{t 'general.delete'}}
                                         </Button>
-                                    </menu.item>
-                                </dd.menu>
-                            </BsDropdown>
+                                    </li>
+                                </dd.content>
+                            </ResponsiveDropdown>
                         </div>
                     {{/if}}
                 {{/if}}

--- a/lib/osf-components/addon/components/node-card/template.hbs
+++ b/lib/osf-components/addon/components/node-card/template.hbs
@@ -80,34 +80,36 @@
                                     <span aria-label={{t 'node_card.options'}} class='glyphicon glyphicon-option-horizontal'></span>
                                 </dd.trigger>
                                 <dd.content @align='right' local-class='dropdown-list'>
-                                    <li role='menuitem'>
-                                        <OsfLink
-                                            data-analytics-name='Manage Contributors'
-                                            local-class='dropdown-link'
-                                            @href='/{{@node.id}}/contributors/'
-                                        >
-                                            {{t 'node_card.fork.manage_contributors'}}
-                                        </OsfLink>
-                                    </li>
-                                    <li role='menuitem'>
-                                        <OsfLink
-                                            data-analytics-name='Settings'
-                                            local-class='dropdown-link'
-                                            @href='/{{@node.id}}/settings/'
-                                        >
-                                            {{t 'general.settings'}}
-                                        </OsfLink>
-                                    </li>
-                                    <li role='menuitem'>
-                                        <Button
-                                            data-analytics-scope='Delete'
-                                            local-class='dropdown-link'
-                                            @layout='fake-link'
-                                            {{on 'click' (action @delete @node)}}
-                                        >
-                                            {{t 'general.delete'}}
-                                        </Button>
-                                    </li>
+                                    <ul role='menu' tabindex='-1'>
+                                        <li role='menuitem'>
+                                            <OsfLink
+                                                data-analytics-name='Manage Contributors'
+                                                local-class='dropdown-link'
+                                                @href='/{{@node.id}}/contributors/'
+                                            >
+                                                {{t 'node_card.fork.manage_contributors'}}
+                                            </OsfLink>
+                                        </li>
+                                        <li role='menuitem'>
+                                            <OsfLink
+                                                data-analytics-name='Settings'
+                                                local-class='dropdown-link'
+                                                @href='/{{@node.id}}/settings/'
+                                            >
+                                                {{t 'general.settings'}}
+                                            </OsfLink>
+                                        </li>
+                                        <li role='menuitem'>
+                                            <Button
+                                                data-analytics-scope='Delete'
+                                                local-class='dropdown-link'
+                                                @layout='fake-link'
+                                                {{on 'click' (action @delete @node)}}
+                                            >
+                                                {{t 'general.delete'}}
+                                            </Button>
+                                        </li>
+                                    </ul>
                                 </dd.content>
                             </ResponsiveDropdown>
                         </div>

--- a/lib/osf-components/addon/components/osf-navbar/auth-dropdown/styles.scss
+++ b/lib/osf-components/addon/components/osf-navbar/auth-dropdown/styles.scss
@@ -3,8 +3,27 @@
 }
 
 // osf-style interop
-.AuthDropdown {
-    right: 0 !important;
+.AuthDropdown.AuthDropdown {
+    z-index: 2000;
+    background-color: #2e6a74;
+    list-style: none;
+
+    a {
+        color: $color-text-white;
+        display: block;
+        padding: 3px 20px;
+        line-height: 1.8;
+        font-size: 16px;
+        white-space: nowrap;
+    }
+
+    a:hover {
+        background-color: #5a8288;
+    }
+}
+
+.auth-trigger.auth-trigger.auth-trigger.auth-trigger {
+    padding: 11px 15px;
 }
 
 :global(.dropdown.secondary-nav-dropdown .btn-link.dropdown-toggle) {

--- a/lib/osf-components/addon/components/osf-navbar/auth-dropdown/styles.scss
+++ b/lib/osf-components/addon/components/osf-navbar/auth-dropdown/styles.scss
@@ -6,7 +6,11 @@
 .AuthDropdown.AuthDropdown {
     z-index: 2000;
     background-color: #2e6a74;
-    list-style: none;
+
+    ul {
+        list-style: none;
+        padding-inline-start: 0;
+    }
 
     a {
         color: $color-text-white;

--- a/lib/osf-components/addon/components/osf-navbar/auth-dropdown/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/auth-dropdown/template.hbs
@@ -19,54 +19,56 @@
             local-class='AuthDropdown'
             @align='right'
         >
-            {{#if @headline}}
-                <span role='none' local-class='Headline'>
-                    {{@headline}}
-                </span>
-            {{/if}}
-            <li role='menuitem'>
-                <OsfLink
-                    data-test-ad-my-profile
-                    data-analytics-name='MyProfile'
-                    @href={{this.profileURL}}
-                >
-                    <FaIcon @icon='user' class='fa-lg p-r-xs' />
-                    {{t 'auth_dropdown.my_profile'}}
-                </OsfLink>
-            </li>
-            <li role='menuitem'>
-                <OsfLink
-                    data-test-ad-support
-                    data-analytics-name='Support'
-                    @href={{this.supportURL}}
-                >
-                    <FaIcon @icon='life-ring' class='fa-lg p-r-xs' />
-                    {{t 'auth_dropdown.osf_support'}}
-                </OsfLink>
-            </li>
-            <li role='menuitem'>
-                <OsfLink
-                    data-test-ad-settings
-                    data-analytics-name='Settings'
-                    @href={{this.settingsURL}}
-                >
-                    <FaIcon @icon='cog' class='fa-lg p-r-xs' />
-                    {{t 'general.settings'}}
-                </OsfLink>
-            </li>
-            <li role='menuitem'>
-                <Button
-                    data-test-ad-logout
-                    data-analytics-name='Logout'
-                    class='logoutLink'
-                    local-class='logout-link'
-                    @layout='fake-link'
-                    {{on 'click' (action this.currentUser.logout)}}
-                >
-                    <FaIcon @icon='sign-out-alt' class='fa-lg p-r-xs' />
-                    {{t 'auth_dropdown.log_out'}}
-                </Button>
-            </li>
+            <ul role='menu' tabindex='-1'>
+                {{#if @headline}}
+                    <span role='none' local-class='Headline'>
+                        {{@headline}}
+                    </span>
+                {{/if}}
+                <li role='menuitem'>
+                    <OsfLink
+                        data-test-ad-my-profile
+                        data-analytics-name='MyProfile'
+                        @href={{this.profileURL}}
+                    >
+                        <FaIcon @icon='user' class='fa-lg p-r-xs' />
+                        {{t 'auth_dropdown.my_profile'}}
+                    </OsfLink>
+                </li>
+                <li role='menuitem'>
+                    <OsfLink
+                        data-test-ad-support
+                        data-analytics-name='Support'
+                        @href={{this.supportURL}}
+                    >
+                        <FaIcon @icon='life-ring' class='fa-lg p-r-xs' />
+                        {{t 'auth_dropdown.osf_support'}}
+                    </OsfLink>
+                </li>
+                <li role='menuitem'>
+                    <OsfLink
+                        data-test-ad-settings
+                        data-analytics-name='Settings'
+                        @href={{this.settingsURL}}
+                    >
+                        <FaIcon @icon='cog' class='fa-lg p-r-xs' />
+                        {{t 'general.settings'}}
+                    </OsfLink>
+                </li>
+                <li role='menuitem'>
+                    <Button
+                        data-test-ad-logout
+                        data-analytics-name='Logout'
+                        class='logoutLink'
+                        local-class='logout-link'
+                        @layout='fake-link'
+                        {{on 'click' (action this.currentUser.logout)}}
+                    >
+                        <FaIcon @icon='sign-out-alt' class='fa-lg p-r-xs' />
+                        {{t 'auth_dropdown.log_out'}}
+                    </Button>
+                </li>
+            </ul>
         </dd.content>
     </ResponsiveDropdown>
 {{else}}

--- a/lib/osf-components/addon/components/osf-navbar/auth-dropdown/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/auth-dropdown/template.hbs
@@ -1,29 +1,28 @@
 {{#if this.session.isAuthenticated}}
-    <BsDropdown
+    <ResponsiveDropdown
         data-test-auth-dropdown
         local-class='DropdownContainer'
         class='secondary-nav-dropdown'
         @htmlTag='li'
         as |dd|
     >
-        <dd.toggle data-test-auth-dropdown-toggle class='btn-link'>
+        <dd.trigger data-test-auth-dropdown-toggle class='btn-link' local-class='auth-trigger'>
             <div class='osf-profile-image'>
                 <img src='{{this.user.profileImage}}&s=25' alt='{{t 'auth_dropdown.user_gravatar'}}'>
             </div>
             <div class='nav-profile-name'>{{this.user.fullName}}</div>
             <span class='caret'></span>
-        </dd.toggle>
+        </dd.trigger>
 
-        <dd.menu
+        <dd.content
             class='auth-dropdown'
             local-class='AuthDropdown'
             @align='right'
-            as |ddm|
         >
             {{#if @headline}}
-                <ddm.item role='none' local-class='Headline'>
+                <span role='none' local-class='Headline'>
                     {{@headline}}
-                </ddm.item>
+                </span>
             {{/if}}
             <li role='menuitem'>
                 <OsfLink
@@ -68,8 +67,8 @@
                     {{t 'auth_dropdown.log_out'}}
                 </Button>
             </li>
-        </dd.menu>
-    </BsDropdown>
+        </dd.content>
+    </ResponsiveDropdown>
 {{else}}
     <li class='sign-in'>
         <div class='button-container'>

--- a/lib/osf-components/addon/components/osf-navbar/styles.scss
+++ b/lib/osf-components/addon/components/osf-navbar/styles.scss
@@ -26,3 +26,47 @@
         line-height: 27px !important;
     }
 }
+
+.service-dropdown.service-dropdown {
+    top: 17px;
+    width: 200px;
+    background-color: $osf-teal-navbar;
+    position: absolute;
+    z-index: 1001;
+    float: left;
+    min-width: 160px;
+    padding: 5px 0;
+    font-size: 14px;
+    text-align: left;
+    border: 1px solid $color-shadow-gray-light;
+    border-radius: 4px;
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+    list-style: none;
+}
+
+.service-dropdown ::after {
+    position: absolute;
+    display: inline-block;
+    border-right: 9px solid transparent;
+    border-bottom: 9px solid $osf-teal-navbar;
+    border-left: 9px solid transparent;
+    content: '';
+    top: -8px;
+    left: 126px;
+}
+
+.service-links {
+    color: $color-text-white;
+    font-size: 18px;
+    display: block;
+    padding: 3px 20px;
+    line-height: 1.8;
+    white-space: nowrap;
+}
+
+.service-links:hover {
+    color: $color-text-white;
+    background-image: none;
+    background-color: $osf-highlight-navbar;
+    text-decoration: none;
+}

--- a/lib/osf-components/addon/components/osf-navbar/styles.scss
+++ b/lib/osf-components/addon/components/osf-navbar/styles.scss
@@ -41,7 +41,11 @@
     border: 1px solid $color-shadow-gray-light;
     border-radius: 4px;
     box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
-    list-style: none;
+
+    ul {
+        list-style: none;
+        padding-inline-start: 0;
+    }
 }
 
 .service-dropdown ::after {

--- a/lib/osf-components/addon/components/osf-navbar/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/template.hbs
@@ -26,33 +26,34 @@
                 </div>
 
                 {{! App list dropdown }}
-                <BsDropdown
+                <ResponsiveDropdown
                     data-analytics-scope='Primary dropdown'
                     class='primary-nav'
-                    @onShow={{action this.onClickPrimaryDropdown}}
+                    @onOpen={{action this.onClickPrimaryDropdown}}
                     as |dd|
                 >
-                    <dd.toggle
+                    <dd.trigger
                         data-test-service-dropdown
                         aria-label={{t 'navbar.other_views'}}
                         class={{concat 'btn-link ' (local-class 'PrimaryNav__toggle')}}
                     >
                         <FaIcon @icon='caret-down' @size='2x' />
-                    </dd.toggle>
-                    <dd.menu class='service-dropdown' as |ddm|>
+                    </dd.trigger>
+                    <dd.content local-class='service-dropdown'>
                         {{#each this.services as |service|}}
-                            <ddm.item role='menuitem'>
+                            <li role='menuitem'>
                                 <OsfLink
                                     data-analytics-name={{service.name}}
                                     @route={{service.route}}
                                     @href={{service.href}}
+                                    local-class='service-links'
                                 >
                                     {{t 'general.OSF'}}<b>{{service.name}}</b>
                                 </OsfLink>
-                            </ddm.item>
+                            </li>
                         {{/each}}
-                    </dd.menu>
-                </BsDropdown>
+                    </dd.content>
+                </ResponsiveDropdown>
 
                 {{! Navigation toggle - XS screen }}
                 <Button

--- a/lib/osf-components/addon/components/osf-navbar/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/template.hbs
@@ -40,18 +40,20 @@
                         <FaIcon @icon='caret-down' @size='2x' />
                     </dd.trigger>
                     <dd.content local-class='service-dropdown'>
-                        {{#each this.services as |service|}}
-                            <li role='menuitem'>
-                                <OsfLink
-                                    data-analytics-name={{service.name}}
-                                    @route={{service.route}}
-                                    @href={{service.href}}
-                                    local-class='service-links'
-                                >
-                                    {{t 'general.OSF'}}<b>{{service.name}}</b>
-                                </OsfLink>
-                            </li>
-                        {{/each}}
+                        <ul role='menu' tabindex='-1'>
+                            {{#each this.services as |service|}}
+                                <li role='menuitem'>
+                                    <OsfLink
+                                        data-analytics-name={{service.name}}
+                                        @route={{service.route}}
+                                        @href={{service.href}}
+                                        local-class='service-links'
+                                    >
+                                        {{t 'general.OSF'}}<b>{{service.name}}</b>
+                                    </OsfLink>
+                                </li>
+                            {{/each}}
+                        </ul>
                     </dd.content>
                 </ResponsiveDropdown>
 

--- a/lib/registries/addon/components/registries-navbar/styles.scss
+++ b/lib/registries/addon/components/registries-navbar/styles.scss
@@ -99,6 +99,25 @@
 
 .ServiceDropdownMenu {
     font-size: 20px;
+
+    ul {
+        list-style: none;
+        padding-inline-start: 0;
+    }
+
+    li>a {
+        display: block;
+        padding: 3px 20px;
+        line-height: 1.8;
+        white-space: nowrap;
+        clear: both;
+        font-weight: 400;
+        color: #fff;
+    }
+
+    li>a:hover {
+        text-decoration: none;
+    }
 }
 
 .ServiceDropdownEntry {
@@ -139,6 +158,11 @@
     right: 0;
     left: auto;
 
+    ul {
+        list-style: none;
+        padding-inline-start: 0;
+    }
+
     // Logout and sign in buttons
     & > li > :global(.btn.btn-link) {
         color: $white;
@@ -151,6 +175,21 @@
             text-decoration: none;
             outline: 0;
         }
+    }
+
+    li>a {
+        display: block;
+        padding: 3px 20px;
+        line-height: 1.8;
+        white-space: nowrap;
+        clear: both;
+        font-weight: 400;
+        color: #fff;
+    }
+
+    li>a:hover,
+    li>button:hover {
+        text-decoration: none;
     }
 
     :global(.fa.fa-user-plus) {

--- a/lib/registries/addon/components/registries-navbar/template.hbs
+++ b/lib/registries/addon/components/registries-navbar/template.hbs
@@ -20,12 +20,12 @@
                 {{/if}}
             </OsfLink>
             {{! Left Side (Band, Service Dropdown) }}
-            <BsDropdown
+            <ResponsiveDropdown
                 data-test-service-list
                 data-analytics-scope='Services dropdown'
                 as |dropdown|
             >
-                <dropdown.toggle
+                <dropdown.trigger
                     data-test-service
                     data-analytics-name='Toggle'
                     local-class='Service Dropdown'
@@ -33,26 +33,27 @@
                     <span local-class='HideOnMobile HideOnTablet'>{{t 'general.OSF'}}</span>
                     <strong local-class='HideOnMobile HideOnTablet'>{{t 'general.services.registries'}}</strong>
                     <nav.icon @icon={{if dropdown.isOpen 'caret-up' 'caret-down'}} />
-                </dropdown.toggle>
+                </dropdown.trigger>
 
-                <dropdown.menu
+                <dropdown.content
                     local-class='ServiceDropdownMenu DropdownMenu'
-                    as |menu|
                 >
-                    {{#each this.services as |service|}}
-                        <menu.item role='menuitem'>
-                            <OsfLink
-                                data-analytics-name={{service.name}}
-                                {{! each service has one of `route` and `href` }}
-                                @route={{service.route}}
-                                @href={{service.href}}
-                            >
-                                <strong local-class='ServiceDropdownEntry'>{{service.name}}</strong>
-                            </OsfLink>
-                        </menu.item>
-                    {{/each}}
-                </dropdown.menu>
-            </BsDropdown>
+                    <ul role='menu' tabindex='-1'>
+                        {{#each this.services as |service|}}
+                            <li role='menuitem'>
+                                <OsfLink
+                                    data-analytics-name={{service.name}}
+                                    {{! each service has one of `route` and `href` }}
+                                    @route={{service.route}}
+                                    @href={{service.href}}
+                                >
+                                    <strong local-class='ServiceDropdownEntry'>{{service.name}}</strong>
+                                </OsfLink>
+                            </li>
+                        {{/each}}
+                    </ul>
+                </dropdown.content>
+            </ResponsiveDropdown>
         </nav.section>
 
         {{! Right Side (Search, Buttons, Gravatar, Dropdown) }}
@@ -159,13 +160,13 @@
                 </nav.buttons.secondary>
             {{/unless}}
 
-            <BsDropdown
+            <ResponsiveDropdown
                 data-test-auth-dropdown
                 data-analytics-scope='User dropdown'
                 local-class='AuthDropdown'
                 as |dropdown|
             >
-                <dropdown.toggle
+                <dropdown.trigger
                     data-analytics-name='Toggle'
                     local-class='Dropdown'
                     aria-label={{t 'auth_dropdown.toggle_auth_dropdown'}}
@@ -186,106 +187,107 @@
                             <nav.icon @icon={{if dropdown.isOpen 'times' 'bars'}} />
                         </Button>
                     {{/if}}
-                </dropdown.toggle>
+                </dropdown.trigger>
 
-                <dropdown.menu
+                <dropdown.content
                     @align='right'
                     local-class='AuthDropdownMenu DropdownMenu'
-                    as |menu|
                 >
-                    {{#if this.session.isAuthenticated}}
-                        <menu.item role='menuitem'>
+                    <ul role='menu' tabindex='-1'>
+                        {{#if this.session.isAuthenticated}}
+                            <li role='menuitem'>
+                                <OsfLink
+                                    data-test-ad-my-profile
+                                    data-analytics-name='My Profile'
+                                    @href={{this.profileURL}}
+                                >
+                                    <FaIcon @icon='user' @fixedWidth={{true}} />
+                                    {{t 'auth_dropdown.my_profile'}}
+                                </OsfLink>
+                            </li>
+                            <li role='menuitem'>
+                                <OsfLink
+                                    data-test-ad-support
+                                    data-analytics-name='Support'
+                                    @href={{this.helpRoute}}
+                                >
+                                    <FaIcon @icon='life-ring' @prefix='far' @fixedWidth={{true}} />
+                                    {{t 'auth_dropdown.osf_support'}}
+                                </OsfLink>
+                            </li>
+                            <li role='menuitem'>
+                                <OsfLink
+                                    data-test-ad-settings
+                                    data-analytics-name='Settings'
+                                    @href={{this.settingsURL}}
+                                >
+                                    <FaIcon @icon='cog' @fixedWidth={{true}} />
+                                    {{t 'general.settings'}}
+                                </OsfLink>
+                            </li>
+                        {{else}}
+                            <li role='menuitem' local-class='OnlyOnMobile'>
+                                <OsfLink
+                                    data-test-join-mobile
+                                    data-analytics-name='Sign up {{@campaign}}'
+                                    @route='register'
+                                    @queryParams={{this.signUpQueryParams}}
+                                >
+                                    <FaIcon @icon='user-plus' @fixedWidth={{true}} />
+                                    {{t 'navbar.join'}}
+                                </OsfLink>
+                            </li>
+                            <li role='menuitem' local-class='OnlyOnMobile'>
+                                <Button
+                                    data-test-login-mobile
+                                    data-analytics-name='Sign in'
+                                    @layout='fake-link'
+                                    {{on 'click' (action 'login')}}
+                                >
+                                    <FaIcon @icon='sign-in-alt' @fixedWidth={{true}} />
+                                    {{t 'navbar.login'}}
+                                </Button>
+                            </li>
+                        {{/if}}
+
+                        <li role='menuitem' local-class='OnlyOnMobile'>
                             <OsfLink
-                                data-test-ad-my-profile
-                                data-analytics-name='My Profile'
-                                @href={{this.profileURL}}
+                                data-test-donate-mobile
+                                data-analytics-name='Donate'
+                                @href={{this.donateRoute}}
                             >
-                                <FaIcon @icon='user' @fixedWidth={{true}} />
-                                {{t 'auth_dropdown.my_profile'}}
+                                <FaIcon @icon='dollar-sign' @fixedWidth={{true}} />
+                                {{t 'navbar.donate'}}
                             </OsfLink>
-                        </menu.item>
-                        <menu.item role='menuitem'>
+                        </li>
+                        <li role='menuitem' local-class='OnlyOnMobile'>
                             <OsfLink
-                                data-test-ad-support
-                                data-analytics-name='Support'
+                                data-test-help-mobile
+                                data-analytics-name='Help'
                                 @href={{this.helpRoute}}
                             >
-                                <FaIcon @icon='life-ring' @prefix='far' @fixedWidth={{true}} />
-                                {{t 'auth_dropdown.osf_support'}}
+                                <FaIcon @icon='info-circle' @fixedWidth={{true}} />
+                                {{t 'general.help'}}
                             </OsfLink>
-                        </menu.item>
-                        <menu.item role='menuitem'>
-                            <OsfLink
-                                data-test-ad-settings
-                                data-analytics-name='Settings'
-                                @href={{this.settingsURL}}
-                            >
-                                <FaIcon @icon='cog' @fixedWidth={{true}} />
-                                {{t 'general.settings'}}
-                            </OsfLink>
-                        </menu.item>
-                    {{else}}
-                        <menu.item role='menuitem' local-class='OnlyOnMobile'>
-                            <OsfLink
-                                data-test-join-mobile
-                                data-analytics-name='Sign up {{@campaign}}'
-                                @route='register'
-                                @queryParams={{this.signUpQueryParams}}
-                            >
-                                <FaIcon @icon='user-plus' @fixedWidth={{true}} />
-                                {{t 'navbar.join'}}
-                            </OsfLink>
-                        </menu.item>
-                        <menu.item role='menuitem' local-class='OnlyOnMobile'>
-                            <Button
-                                data-test-login-mobile
-                                data-analytics-name='Sign in'
-                                @layout='fake-link'
-                                {{on 'click' (action 'login')}}
-                            >
-                                <FaIcon @icon='sign-in-alt' @fixedWidth={{true}} />
-                                {{t 'navbar.login'}}
-                            </Button>
-                        </menu.item>
-                    {{/if}}
+                        </li>
 
-                    <menu.item role='menuitem' local-class='OnlyOnMobile'>
-                        <OsfLink
-                            data-test-donate-mobile
-                            data-analytics-name='Donate'
-                            @href={{this.donateRoute}}
-                        >
-                            <FaIcon @icon='dollar-sign' @fixedWidth={{true}} />
-                            {{t 'navbar.donate'}}
-                        </OsfLink>
-                    </menu.item>
-                    <menu.item role='menuitem' local-class='OnlyOnMobile'>
-                        <OsfLink
-                            data-test-help-mobile
-                            data-analytics-name='Help'
-                            @href={{this.helpRoute}}
-                        >
-                            <FaIcon @icon='info-circle' @fixedWidth={{true}} />
-                            {{t 'general.help'}}
-                        </OsfLink>
-                    </menu.item>
-
-                    {{#if this.session.isAuthenticated}}
-                        <menu.item role='menuitem'>
-                            <Button
-                                data-test-ad-logout
-                                data-analytics-name='Logout'
-                                @layout='fake-link'
-                                local-class='logout-link'
-                                {{on 'click' (action this.currentUser.logout)}}
-                            >
-                                <FaIcon @icon='sign-out-alt' @fixedWidth={{true}} />
-                                {{t 'auth_dropdown.log_out'}}
-                            </Button>
-                        </menu.item>
-                    {{/if}}
-                </dropdown.menu>
-            </BsDropdown>
+                        {{#if this.session.isAuthenticated}}
+                            <li role='menuitem'>
+                                <Button
+                                    data-test-ad-logout
+                                    data-analytics-name='Logout'
+                                    @layout='fake-link'
+                                    local-class='logout-link'
+                                    {{on 'click' (action this.currentUser.logout)}}
+                                >
+                                    <FaIcon @icon='sign-out-alt' @fixedWidth={{true}} />
+                                    {{t 'auth_dropdown.log_out'}}
+                                </Button>
+                            </li>
+                        {{/if}}
+                    </ul>
+                </dropdown.content>
+            </ResponsiveDropdown>
         </nav.section>
     </nav.container>
 </Navbar>


### PR DESCRIPTION
-   Ticket: [ENG-4419]
-   Feature flag: n/a

## Purpose

Remove usage of BsDropdown from the ember-osf-web codebase.

## Summary of Changes

Remove BsDropdown from:

1. Analytics page
2. Node card
3. Collections Discover page
4. OSF Navbar and OSF Navbar Auth Dropdown
5. Registries Navbar

## Screenshot(s)

Analytics page:
<img width="243" alt="Screenshot 2023-05-02 at 9 38 15 AM" src="https://user-images.githubusercontent.com/6599111/236227024-e856e9c7-0893-4d3b-a51a-0bf43e72bc1d.png">

Node Card:
<img width="793" alt="Screenshot 2023-05-02 at 10 15 51 AM" src="https://user-images.githubusercontent.com/6599111/236227268-5261c5fd-2816-41a6-941c-8a1aa5379c5d.png">

Collections Discovery page:
<img width="701" alt="Screenshot 2023-05-02 at 10 48 06 AM" src="https://user-images.githubusercontent.com/6599111/236227442-41a6f16e-5f64-4957-869b-28b785be3625.png">

OSF Navbar:
<img width="258" alt="Screenshot 2023-05-02 at 2 32 35 PM" src="https://user-images.githubusercontent.com/6599111/236227599-464a9fe4-1e73-464e-b692-f854f7dbede2.png">

<img width="242" alt="Screenshot 2023-05-02 at 3 09 57 PM" src="https://user-images.githubusercontent.com/6599111/236227705-64936fd1-db5c-44c7-8811-7e598872a1fd.png">

Registries Navbar:
<img width="331" alt="Screenshot 2023-05-04 at 8 55 23 AM" src="https://user-images.githubusercontent.com/6599111/236227845-07f5284d-eb8d-42fe-90e1-e942d3db765c.png">
<img width="254" alt="Screenshot 2023-05-04 at 9 00 49 AM" src="https://user-images.githubusercontent.com/6599111/236227864-b9ead882-dd8e-4b0d-9909-1a43e55691ec.png">



## Side Effects

The look may be a bit different in places

## QA Notes

Just make sure the menus still work and don't look weird. For navbars, be sure to check the logged-out state as well.


[ENG-4419]: https://openscience.atlassian.net/browse/ENG-4419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ