### PR TITLE
[No ticket] Xenon/Fix active page highlight in Firefox

### DIFF
--- a/app/settings/controller.ts
+++ b/app/settings/controller.ts
@@ -1,4 +1,5 @@
 import Controller from '@ember/controller';
+import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 
 import Analytics from 'ember-osf-web/services/analytics';
@@ -10,6 +11,7 @@ export default class SettingsController extends Controller {
     @service analytics!: Analytics;
     @service currentUser!: CurrentUser;
     @service media!: Media;
+    @service router!: RouterService;
 
     @tracked navCollapsed = true;
 

--- a/app/settings/styles.scss
+++ b/app/settings/styles.scss
@@ -18,14 +18,6 @@
         padding-left: 0;
     }
 
-    li:has(:global(.active)) {
-        background-color: $color-bg-blue-dark;
-
-        :hover {
-            background-color: $color-bg-blue-dark;
-        }
-    }
-
     a:global(.active) {
         color: $color-text-white;
     }
@@ -44,5 +36,13 @@
 
     li:hover {
         background-color: $color-bg-gray-lighter;
+    }
+
+    .active {
+        background-color: $color-bg-blue-dark;
+
+        :hover {
+            background-color: $color-bg-blue-dark;
+        }
     }
 }

--- a/app/settings/template.hbs
+++ b/app/settings/template.hbs
@@ -32,7 +32,7 @@
                                         {{t 'settings.profile.title'}}
                                     </OsfLink>
                                 </li>
-                                <li>
+                                <li local-class={{if (eq this.router.currentRouteName 'settings.account') 'active'}}>
                                     <OsfLink
                                         data-analytics-name='Account'
                                         data-test-account-link
@@ -59,7 +59,7 @@
                                         {{t 'settings.notifications.title'}}
                                     </OsfLink>
                                 </li>
-                                <li>
+                                <li local-class={{if (eq this.router.currentRouteName 'settings.developer-apps.index') 'active'}}>
                                     <OsfLink
                                         data-analytics-name='Developer apps'
                                         data-test-apps-link
@@ -68,7 +68,7 @@
                                         {{t 'settings.developer-apps.title'}}
                                     </OsfLink>
                                 </li>
-                                <li>
+                                <li local-class={{if (eq this.router.currentRouteName 'settings.tokens.index') 'active'}}>
                                     <OsfLink
                                         data-analytics-name='Personal access tokens'
                                         data-test-tokens-link

--- a/lib/analytics-page/addon/application/template.hbs
+++ b/lib/analytics-page/addon/application/template.hbs
@@ -1,6 +1,6 @@
 {{! using unsafeTitle here to avoid double encoding because the title helper does its own }}
 {{page-title (t 'analytics.pageTitle' nodeTitle=this.node.unsafeTitle)}}
-<div class='container' local-class='page-container'>
+<div class='container' local-class='page-container' data-test-analytics-page-heading>
     <div local-class='counts {{if this.isMobile 'mobile'}}'>
         <div local-class='count-box {{if this.isMobile 'mobile'}}'>
             <div local-class='body'>


### PR DESCRIPTION
## Purpose

Not having the active highlight in Firefox for the settings page was a problem that needed fixing. This fixes it.

## Summary of Changes

1. Fix active page highlight on settings page navigation
2. Add page identity test selector for Analytics Page to make QA's life better

## Screenshot(s)

<img width="308" alt="Screenshot 2023-05-11 at 1 26 23 PM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/e70a428c-1936-4dd3-b60b-453af1a7cf62">
