### PR TITLE
[ENG-4469] Add object filter and sort dropdown to search

### DIFF
--- a/app/adapters/index-card-search.ts
+++ b/app/adapters/index-card-search.ts
@@ -1,10 +1,9 @@
 import ShareAdapter from './share-adapter';
-
-export default class MetadataRecordAdapter extends ShareAdapter {
+export default class IndexCardSearchAdapter extends ShareAdapter {
 }
 
 declare module 'ember-data/types/registries/adapter' {
     export default interface AdapterRegistry {
-        'metadata-record': MetadataRecordAdapter;
+        'index-card-search': IndexCardSearchAdapter;
     } // eslint-disable-line semi
 }

--- a/app/adapters/index-card.ts
+++ b/app/adapters/index-card.ts
@@ -1,10 +1,10 @@
 import ShareAdapter from './share-adapter';
 
-export default class MetadataValueSearchAdapter extends ShareAdapter {
+export default class IndexCardAdapter extends ShareAdapter {
 }
 
 declare module 'ember-data/types/registries/adapter' {
     export default interface AdapterRegistry {
-        'metadata-value-search': MetadataValueSearchAdapter;
+        'index-card': IndexCardAdapter;
     } // eslint-disable-line semi
 }

--- a/app/adapters/index-property-search.ts
+++ b/app/adapters/index-property-search.ts
@@ -1,9 +1,10 @@
 import ShareAdapter from './share-adapter';
-export default class MetadataRecordSearchAdapter extends ShareAdapter {
+
+export default class IndexPropertySearchAdapter extends ShareAdapter {
 }
 
 declare module 'ember-data/types/registries/adapter' {
     export default interface AdapterRegistry {
-        'metadata-record-search': MetadataRecordSearchAdapter;
+        'index-property-search': IndexPropertySearchAdapter;
     } // eslint-disable-line semi
 }

--- a/app/adapters/index-value-search.ts
+++ b/app/adapters/index-value-search.ts
@@ -1,10 +1,10 @@
 import ShareAdapter from './share-adapter';
 
-export default class MetadataPropertySearchAdapter extends ShareAdapter {
+export default class IndexValueSearchAdapter extends ShareAdapter {
 }
 
 declare module 'ember-data/types/registries/adapter' {
     export default interface AdapterRegistry {
-        'metadata-property-search': MetadataPropertySearchAdapter;
+        'index-value-search': IndexValueSearchAdapter;
     } // eslint-disable-line semi
 }

--- a/app/helpers/get-localized-property.ts
+++ b/app/helpers/get-localized-property.ts
@@ -26,7 +26,6 @@ export default class GetLocalizedPropertyHelper extends Helper {
 
     compute([metadataHash, propertyName]: [Record<string, LanguageText[]>, string]): string {
         const locale = this.intl.locale;
-        // console.log('get-localized-property helper', locale);
         const valueOptions = metadataHash?.[propertyName];
         if (!metadataHash || !valueOptions || valueOptions.length === 0) {
             return this.intl.t('helpers.get-localized-property.not-provided');

--- a/app/helpers/get-localized-property.ts
+++ b/app/helpers/get-localized-property.ts
@@ -1,0 +1,41 @@
+import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
+import IntlService from 'ember-intl/services/intl';
+
+import { LanguageText } from 'ember-osf-web/models/index-card';
+
+/**
+ * This helper is used to get a locale-appropriate string for a property from a metadata hash.
+ * It is used to fetch metadata fields from a index-card's resourceMetadata attribute, but can be used for any
+ * hash that contains an array of LangaugeText objects.
+ * If the property is not found, the first value in the array is returned, or if the property is found,
+ * but there is no locale-appropriate value, the first value in the array is returned.
+ *
+ * @example
+ * ```handlebars
+ * {{get-localized-property indexCard.resourceMetadata 'title'}}
+ * ```
+ *  where `indexCard` is an index-card model instance.
+ * @class get-localized-property
+ * @param {Object} metadataHash The metadata hash to search for the property
+ * @param {String} propertyName The name of the property to search for
+ * @return {String} The locale-appropriate string or the first value in the array or 'Not provided' message
+ */
+export default class GetLocalizedPropertyHelper extends Helper {
+    @service intl!: IntlService;
+
+    compute([metadataHash, propertyName]: [Record<string, LanguageText[]>, string]): string {
+        const locale = this.intl.locale;
+        // console.log('get-localized-property helper', locale);
+        const valueOptions = metadataHash?.[propertyName];
+        if (!metadataHash || !valueOptions || valueOptions.length === 0) {
+            return this.intl.t('helpers.get-localized-property.not-provided');
+        }
+
+        const index = valueOptions.findIndex((valueOption: LanguageText) => valueOption['@language'] === locale);
+        if (index === -1) {
+            return valueOptions[0]['@value'];
+        }
+        return valueOptions[index]['@value'];
+    }
+}

--- a/app/models/index-card-search.ts
+++ b/app/models/index-card-search.ts
@@ -1,6 +1,6 @@
 import Model, { AsyncBelongsTo, AsyncHasMany, attr, belongsTo, hasMany } from '@ember-data/model';
 
-import MetadataPropertySearchModel from './metadata-property-search';
+import IndexPropertySearchModel from './index-property-search';
 import SearchResultModel from './search-result';
 
 export interface SearchFilter {
@@ -9,20 +9,20 @@ export interface SearchFilter {
     filterType?: string;
 }
 
-export default class MetadataRecordSearchModel extends Model {
-    @attr('string') recordSearchText!: string;
-    @attr('array') recordSearchFilters!: SearchFilter[];
+export default class IndexCardSearchModel extends Model {
+    @attr('string') cardSearchText!: string;
+    @attr('array') cardSearchFilters!: SearchFilter[];
     @attr('number') totalResultCount!: number;
 
     @hasMany('search-result', { inverse: null })
     searchResultPage!: AsyncHasMany<SearchResultModel> & SearchResultModel[];
 
-    @belongsTo('metadata-property-search', { inverse: null })
-    relatedPropertySearch!: AsyncBelongsTo<MetadataPropertySearchModel> & MetadataPropertySearchModel;
+    @belongsTo('index-property-search', { inverse: null })
+    relatedPropertySearch!: AsyncBelongsTo<IndexPropertySearchModel> & IndexPropertySearchModel;
 }
 
 declare module 'ember-data/types/registries/model' {
     export default interface ModelRegistry {
-        'metadata-record-search': MetadataRecordSearchModel;
+        'index-card-search': IndexCardSearchModel;
     } // eslint-disable-line semi
 }

--- a/app/models/index-card.ts
+++ b/app/models/index-card.ts
@@ -7,15 +7,15 @@ export interface LanguageText {
     '@value': string;
 }
 
-export default class MetadataRecordModel extends Model {
+export default class IndexCardModel extends Model {
     @service intl!: IntlService;
 
     @attr('array') resourceType!: string[];
     @attr('array') resourceIdentifier!: string[];
     @attr('object') resourceMetadata!: any;
 
-    @hasMany('metadata-record', { inverse: null })
-    relatedRecordSet!: AsyncHasMany<MetadataRecordModel> & MetadataRecordModel[];
+    @hasMany('index-card', { inverse: null })
+    relatedRecordSet!: AsyncHasMany<IndexCardModel> & IndexCardModel[];
 
     get label(): string {
         const { resourceMetadata } = this;
@@ -30,7 +30,7 @@ export default class MetadataRecordModel extends Model {
                 return labels[0]['@value'];
             }
         }
-        return this.intl.t('search.metadata-record.no-label');
+        return this.intl.t('search.index-card.no-label');
     }
 
     get title(): string {
@@ -46,12 +46,12 @@ export default class MetadataRecordModel extends Model {
                 return titles[0]['@value'];
             }
         }
-        return this.intl.t('search.metadata-record.no-title');
+        return this.intl.t('search.index-card.no-title');
     }
 }
 
 declare module 'ember-data/types/registries/model' {
     export default interface ModelRegistry {
-        'metadata-record': MetadataRecordModel;
+        'index-card': IndexCardModel;
     } // eslint-disable-line semi
 }

--- a/app/models/index-card.ts
+++ b/app/models/index-card.ts
@@ -16,38 +16,6 @@ export default class IndexCardModel extends Model {
 
     @hasMany('index-card', { inverse: null })
     relatedRecordSet!: AsyncHasMany<IndexCardModel> & IndexCardModel[];
-
-    get label(): string {
-        const { resourceMetadata } = this;
-        const preferredLanguage = this.intl.locale;
-        const labels = resourceMetadata?.label;
-        if (labels) {
-            const languageAppropriateLabel = labels.filter((label: any) => label['@language'] === preferredLanguage);
-            // give the locale appropriate label if it exists, otherwise give the first label
-            if (languageAppropriateLabel.length > 0) {
-                return labels.filter((label: any) => label['@language'] === preferredLanguage)[0]['@value'];
-            } else if (labels.length > 0) {
-                return labels[0]['@value'];
-            }
-        }
-        return this.intl.t('search.index-card.no-label');
-    }
-
-    get title(): string {
-        const { resourceMetadata } = this;
-        const preferredLanguage = this.intl.locale;
-        const titles = resourceMetadata?.title;
-        if (titles) {
-            const languageAppropriateTitle = titles.filter((title: any) => title['@language'] === preferredLanguage);
-            // give the locale appropriate title if it exists, otherwise give the first title
-            if (languageAppropriateTitle.length > 0) {
-                return titles.filter((title: any) => title['@language'] === preferredLanguage)[0]['@value'];
-            } else if (titles.length > 0) {
-                return titles[0]['@value'];
-            }
-        }
-        return this.intl.t('search.index-card.no-title');
-    }
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/models/index-property-search.ts
+++ b/app/models/index-property-search.ts
@@ -1,13 +1,13 @@
 import Model, { AsyncHasMany, attr, hasMany } from '@ember-data/model';
 
-import { SearchFilter } from './metadata-record-search';
+import { SearchFilter } from './index-card-search';
 import SearchResultModel from './search-result';
 
-export default class MetadataPropertySearchModel extends Model {
+export default class IndexPropertySearchModel extends Model {
     @attr('string') propertySearchText!: string;
     @attr('array') propertySearchFilter!: SearchFilter[];
-    @attr('string') recordSearchText!: string;
-    @attr('array') recordSearchFilter!: SearchFilter[];
+    @attr('string') cardSearchText!: string;
+    @attr('array') cardSearchFilter!: SearchFilter[];
     @attr('number') totalResultCount!: number;
 
     @hasMany('search-result', { inverse: null })
@@ -16,6 +16,6 @@ export default class MetadataPropertySearchModel extends Model {
 
 declare module 'ember-data/types/registries/model' {
     export default interface ModelRegistry {
-        'metadata-property-search': MetadataPropertySearchModel;
+        'index-property-search': IndexPropertySearchModel;
     } // eslint-disable-line semi
 }

--- a/app/models/index-value-search.ts
+++ b/app/models/index-value-search.ts
@@ -1,25 +1,25 @@
 import Model, { AsyncHasMany, AsyncBelongsTo, attr, belongsTo, hasMany } from '@ember-data/model';
 
-import MetadataPropertySearchModel from './metadata-property-search';
-import { SearchFilter } from './metadata-record-search';
+import IndexPropertySearchModel from './index-property-search';
+import { SearchFilter } from './index-card-search';
 import SearchResultModel from './search-result';
 
-export default class MetadataValueSearchModel extends Model {
+export default class IndexValueSearchModel extends Model {
     @attr('string') valueSearchText!: string;
     @attr('array') valueSearchFilter!: SearchFilter[];
-    @attr('string') recordSearchText!: string;
-    @attr('array') recordSearchFilter!: SearchFilter[];
+    @attr('string') cardSearchText!: string;
+    @attr('array') cardSearchFilter!: SearchFilter[];
     @attr('number') totalResultCount!: number;
 
     @hasMany('search-result', { inverse: null })
     searchResultPage!: AsyncHasMany<SearchResultModel> & SearchResultModel[];
 
-    @belongsTo('metadata-property-search', { inverse: null })
-    relatedPropertySearch!: AsyncBelongsTo<MetadataPropertySearchModel> & MetadataPropertySearchModel;
+    @belongsTo('index-property-search', { inverse: null })
+    relatedPropertySearch!: AsyncBelongsTo<IndexPropertySearchModel> & IndexPropertySearchModel;
 }
 
 declare module 'ember-data/types/registries/model' {
     export default interface ModelRegistry {
-        'metadata-value-search': MetadataValueSearchModel;
+        'index-value-search': IndexValueSearchModel;
     } // eslint-disable-line semi
 }

--- a/app/models/search-result.ts
+++ b/app/models/search-result.ts
@@ -1,6 +1,6 @@
 import Model, { AsyncBelongsTo, attr, belongsTo } from '@ember-data/model';
 
-import MetadataRecordModel from './metadata-record';
+import IndexCardModel from './index-card';
 
 export interface IriMatchEvidence {
     '@type': 'IriMatchEvidence';
@@ -18,8 +18,8 @@ export default class SearchResultModel extends Model {
     @attr('array') matchEvidence!: Array<IriMatchEvidence | TextMatchEvidence>;
     @attr('number') recordResultCount!: number;
 
-    @belongsTo('metadata-record', { inverse: null })
-    metadataRecord!: AsyncBelongsTo<MetadataRecordModel> | MetadataRecordModel;
+    @belongsTo('index-card', { inverse: null })
+    indexCard!: AsyncBelongsTo<IndexCardModel> | IndexCardModel;
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/search/-components/filter-facet/component.ts
+++ b/app/search/-components/filter-facet/component.ts
@@ -8,15 +8,15 @@ import { task } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 import IntlService from 'ember-intl/services/intl';
 
-import MetadataRecordModel from 'ember-osf-web/models/metadata-record';
+import IndexCardModel from 'ember-osf-web/models/index-card';
 import SearchResultModel from 'ember-osf-web/models/search-result';
 
 import { Filter } from '../../controller';
 
 interface FilterFacetArgs {
-    recordSearchText: string;
-    recordSearchFilters: Filter[];
-    propertyRecord: MetadataRecordModel;
+    cardSearchText: string;
+    cardSearchFilters: Filter[];
+    propertyCard: IndexCardModel;
     propertySearch: SearchResultModel;
     toggleFilter: (filter: Filter) => void;
 }
@@ -55,11 +55,11 @@ export default class FilterFacet extends Component<FilterFacetArgs> {
     @waitFor
     async applySelectedProperty() {
         if (this.selectedProperty) {
-            const { toggleFilter, propertyRecord } = this.args;
-            const record = await this.selectedProperty.metadataRecord;
+            const { toggleFilter, propertyCard } = this.args;
+            const card = await this.selectedProperty.indexCard;
             const filter = {
-                property: propertyRecord.get('label'),
-                value: record.title,
+                property: propertyCard.get('label'),
+                value: card.title,
             };
             toggleFilter(filter);
             this.selectedProperty = null;
@@ -69,11 +69,11 @@ export default class FilterFacet extends Component<FilterFacetArgs> {
     @task
     @waitFor
     async fetchFacetValues() {
-        const { recordSearchText, recordSearchFilters } = this.args;
+        const { cardSearchText, cardSearchFilters } = this.args;
         const { page, sort } = this;
-        const valueSearch = await this.store.queryRecord('metadata-value-search', {
-            recordSearchText,
-            recordSearchFilters,
+        const valueSearch = await this.store.queryRecord('index-value-search', {
+            cardSearchText,
+            cardSearchFilters,
             page,
             sort,
         });

--- a/app/search/-components/filter-facet/component.ts
+++ b/app/search/-components/filter-facet/component.ts
@@ -1,4 +1,5 @@
 import Store from '@ember-data/store';
+import { getOwner } from '@ember/application';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { waitFor } from '@ember/test-waiters';
@@ -7,6 +8,7 @@ import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 import IntlService from 'ember-intl/services/intl';
+import GetLocalizedPropertyHelper from 'ember-osf-web/helpers/get-localized-property';
 
 import IndexCardModel from 'ember-osf-web/models/index-card';
 import SearchResultModel from 'ember-osf-web/models/search-result';
@@ -33,6 +35,8 @@ export default class FilterFacet extends Component<FilterFacetArgs> {
     @tracked seeMoreModalShown = false;
     @tracked selectedProperty: SearchResultModel | null = null;
 
+    getLocalizedString = new GetLocalizedPropertyHelper(getOwner(this));
+
     get showSeeMoreButton() {
         // TODO: make this actually check if there are more
         return true;
@@ -58,8 +62,8 @@ export default class FilterFacet extends Component<FilterFacetArgs> {
             const { toggleFilter, propertyCard } = this.args;
             const card = await this.selectedProperty.indexCard;
             const filter = {
-                property: propertyCard.get('label'),
-                value: card.title,
+                property: this.getLocalizedString.compute([propertyCard.get('resourceMetadata'), 'label']),
+                value: this.getLocalizedString.compute([card.resourceMetadata, 'title']),
             };
             toggleFilter(filter);
             this.selectedProperty = null;

--- a/app/search/-components/filter-facet/template.hbs
+++ b/app/search/-components/filter-facet/template.hbs
@@ -2,17 +2,17 @@
     data-test-filter-facet
     local-class='facet-wrapper'
 >
-    {{#let (unique-id @propertyRecord.label) as |facetElementId|}}
+    {{#let (unique-id @propertyCard.label) as |facetElementId|}}
         <Button
-            data-analytics-name='filter facet toggle {{@propertyRecord.label}}'
-            data-test-filter-facet-toggle={{@propertyRecord.label}}
+            data-analytics-name='filter facet toggle {{@propertyCard.label}}'
+            data-test-filter-facet-toggle={{@propertyCard.label}}
             @layout='fake-link'
             local-class='facet-expand-button'
             aria-controls={{facetElementId}}
             aria-expanded={{not this.collapsed}}
             {{on 'click' (fn this.toggleFacet this.label)}}
         >
-            <span>{{@propertyRecord.label}}</span>
+            <span>{{@propertyCard.label}}</span>
             <FaIcon @icon={{if this.collapsed 'caret-down' 'caret-up'}} />
         </Button>
         {{#if this.fetchFacetValues.isRunning}}
@@ -26,16 +26,16 @@
             >
                 {{#each this.filterableValues as |value|}}
                     <li
-                        data-test-filter-facet-value={{value.metadataRecord.title}}
+                        data-test-filter-facet-value={{value.indexCard.title}}
                         local-class='facet-value'
                     >
                         <Button
-                            data-analytics-name='toggle filter facet value {{value.metadataRecord.title}}'
+                            data-analytics-name='toggle filter facet value {{value.indexCard.title}}'
                             local-class='facet-link'
                             @layout='fake-link'
-                            {{on 'click' (fn @toggleFilter (hash property=@propertyRecord.label value=value.metadataRecord.title))}}
+                            {{on 'click' (fn @toggleFilter (hash property=@propertyCard.label value=value.indexCard.title))}}
                         >
-                            {{value.metadataRecord.title}}
+                            {{value.indexCard.title}}
                         </Button>
                         <span local-class='facet-count'>
                             {{value.recordResultCount}}
@@ -46,8 +46,8 @@
                 {{#if this.showSeeMoreButton}}
                     <li>
                         <Button
-                            data-analytics-name='see more filterable values {{@propertyRecord.label}}'
-                            data-test-see-more-filterable-values={{@propertyRecord.label}}
+                            data-analytics-name='see more filterable values {{@propertyCard.label}}'
+                            data-test-see-more-filterable-values={{@propertyCard.label}}
                             @layout='fake-link'
                             {{on 'click' (fn (mut this.seeMoreModalShown) true)}}
                         >
@@ -64,7 +64,7 @@
             as |dialog|
         >
             <dialog.heading data-test-see-more-dialog-heading>
-                {{@propertyRecord.label}}
+                {{@propertyCard.label}}
             </dialog.heading>
             <dialog.main local-class='see-more-dialog'>
                 {{t 'search.filter-facet.see-more-modal-text'}}
@@ -78,7 +78,7 @@
                     @onChange={{action this.updateSelectedProperty}}
                     as |property|
                 >
-                    {{property.metadataRecord.title}}
+                    {{property.indexCard.title}}
                 </PowerSelect>
             </dialog.main>
             <dialog.footer>

--- a/app/search/-components/filter-facet/template.hbs
+++ b/app/search/-components/filter-facet/template.hbs
@@ -2,104 +2,108 @@
     data-test-filter-facet
     local-class='facet-wrapper'
 >
-    {{#let (unique-id @propertyCard.label) as |facetElementId|}}
-        <Button
-            data-analytics-name='filter facet toggle {{@propertyCard.label}}'
-            data-test-filter-facet-toggle={{@propertyCard.label}}
-            @layout='fake-link'
-            local-class='facet-expand-button'
-            aria-controls={{facetElementId}}
-            aria-expanded={{not this.collapsed}}
-            {{on 'click' (fn this.toggleFacet this.label)}}
-        >
-            <span>{{@propertyCard.label}}</span>
-            <FaIcon @icon={{if this.collapsed 'caret-down' 'caret-up'}} />
-        </Button>
-        {{#if this.fetchFacetValues.isRunning}}
-            <LoadingIndicator @dark={{true}} />
-        {{else if this.fetchFacetValues.isError}}
-            {{t 'search.filter-facet.facet-load-failed'}}
-        {{else}}
-            <ul
-                local-class='facet-list {{if this.collapsed 'collapsed'}}'
-                id={{facetElementId}}
+    {{#let (get-localized-property @propertyCard.resourceMetadata 'label') as |propertyLabel|}}
+        {{#let (unique-id propertyLabel) as |facetElementId|}}
+            <Button
+                data-analytics-name='filter facet toggle {{propertyLabel}}'
+                data-test-filter-facet-toggle={{propertyLabel}}
+                @layout='fake-link'
+                local-class='facet-expand-button'
+                aria-controls={{facetElementId}}
+                aria-expanded={{not this.collapsed}}
+                {{on 'click' this.toggleFacet}}
             >
-                {{#each this.filterableValues as |value|}}
-                    <li
-                        data-test-filter-facet-value={{value.indexCard.title}}
-                        local-class='facet-value'
+                <span>{{propertyLabel}}</span>
+                <FaIcon @icon={{if this.collapsed 'caret-down' 'caret-up'}} />
+            </Button>
+            {{#if this.fetchFacetValues.isRunning}}
+                <LoadingIndicator @dark={{true}} />
+            {{else if this.fetchFacetValues.isError}}
+                {{t 'search.filter-facet.facet-load-failed'}}
+            {{else}}
+                <ul
+                    local-class='facet-list {{if this.collapsed 'collapsed'}}'
+                    id={{facetElementId}}
+                >
+                    {{#each this.filterableValues as |value|}}
+                        {{#let (get-localized-property value.indexCard.resourceMetadata 'title') as |valueTitle|}}
+                            <li
+                                data-test-filter-facet-value={{valueTitle}}
+                                local-class='facet-value'
+                            >
+                                <Button
+                                    data-analytics-name='toggle filter facet value {{valueTitle}}'
+                                    local-class='facet-link'
+                                    @layout='fake-link'
+                                    {{on 'click' (fn @toggleFilter (hash property=propertyLabel value=valueTitle))}}
+                                >
+                                    {{valueTitle}}
+                                </Button>
+                                <span local-class='facet-count'>
+                                    {{value.recordResultCount}}
+                                </span>
+                            </li>
+                        {{/let}}
+                    {{/each}}
+                
+                    {{#if this.showSeeMoreButton}}
+                        <li>
+                            <Button
+                                data-analytics-name='see more filterable values {{propertyLabel}}'
+                                data-test-see-more-filterable-values={{propertyLabel}}
+                                @layout='fake-link'
+                                {{on 'click' (fn (mut this.seeMoreModalShown) true)}}
+                            >
+                                {{t 'search.filter-facet.see-more'}}
+                            </Button>
+                        </li>
+                    {{/if}}
+                </ul>
+            {{/if}}
+            <OsfDialog
+                data-analytics-scope='filter facet - see more modal'
+                @isOpen={{this.seeMoreModalShown}}
+                @onClose={{fn (mut this.seeMoreModalShown) false}}
+                as |dialog|
+            >
+                <dialog.heading data-test-see-more-dialog-heading>
+                    {{propertyLabel}}
+                </dialog.heading>
+                <dialog.main local-class='see-more-dialog'>
+                    {{t 'search.filter-facet.see-more-modal-text'}}
+                    <PowerSelect
+                        data-test-property-value-select
+                        @options={{this.filterableValues}}
+                        @searchEnabled={{true}}
+                        @selected={{this.selectedProperty}}
+                        @placeholder={{t 'search.filter-facet.see-more-modal-placeholder'}}
+                        @search={{perform this.fetchFacetValues}}
+                        @onChange={{action this.updateSelectedProperty}}
+                        as |property|
                     >
-                        <Button
-                            data-analytics-name='toggle filter facet value {{value.indexCard.title}}'
-                            local-class='facet-link'
-                            @layout='fake-link'
-                            {{on 'click' (fn @toggleFilter (hash property=@propertyCard.label value=value.indexCard.title))}}
-                        >
-                            {{value.indexCard.title}}
-                        </Button>
-                        <span local-class='facet-count'>
-                            {{value.recordResultCount}}
-                        </span>
-                    </li>
-                {{/each}}
-            
-                {{#if this.showSeeMoreButton}}
-                    <li>
-                        <Button
-                            data-analytics-name='see more filterable values {{@propertyCard.label}}'
-                            data-test-see-more-filterable-values={{@propertyCard.label}}
-                            @layout='fake-link'
-                            {{on 'click' (fn (mut this.seeMoreModalShown) true)}}
-                        >
-                            {{t 'search.filter-facet.see-more'}}
-                        </Button>
-                    </li>
-                {{/if}}
-            </ul>
-        {{/if}}
-        <OsfDialog
-            data-analytics-scope='filter facet - see more modal'
-            @isOpen={{this.seeMoreModalShown}}
-            @onClose={{fn (mut this.seeMoreModalShown) false}}
-            as |dialog|
-        >
-            <dialog.heading data-test-see-more-dialog-heading>
-                {{@propertyCard.label}}
-            </dialog.heading>
-            <dialog.main local-class='see-more-dialog'>
-                {{t 'search.filter-facet.see-more-modal-text'}}
-                <PowerSelect
-                    data-test-property-value-select
-                    @options={{this.filterableValues}}
-                    @searchEnabled={{true}}
-                    @selected={{this.selectedProperty}}
-                    @placeholder={{t 'search.filter-facet.see-more-modal-placeholder'}}
-                    @search={{perform this.fetchFacetValues}}
-                    @onChange={{action this.updateSelectedProperty}}
-                    as |property|
-                >
-                    {{property.indexCard.title}}
-                </PowerSelect>
-            </dialog.main>
-            <dialog.footer>
-                <Button
-                    data-analytics-name='cancel filter'
-                    data-test-see-more-dialog-cancel-button
-                    @type='secondary'
-                    {{on 'click' (fn (mut this.seeMoreModalShown) false)}}
-                >
-                    {{t 'general.cancel'}}
-                </Button>
-                <Button
-                    data-analytics-name='apply filter'
-                    data-test-see-more-dialog-apply-button
-                    @type='primary'
-                    disabled={{not this.selectedProperty}}
-                    {{on 'click' (queue (perform this.applySelectedProperty) dialog.close) }}
-                >
-                    {{t 'general.apply'}}
-                </Button>
-            </dialog.footer>
-        </OsfDialog>
+                        {{get-localized-property property.indexCard.resourceMetadata 'title'}}
+                    </PowerSelect>
+                </dialog.main>
+                <dialog.footer>
+                    <Button
+                        data-analytics-name='cancel filter'
+                        data-test-see-more-dialog-cancel-button
+                        @type='secondary'
+                        {{on 'click' (fn (mut this.seeMoreModalShown) false)}}
+                    >
+                        {{t 'general.cancel'}}
+                    </Button>
+                    <Button
+                        data-analytics-name='apply filter'
+                        data-test-see-more-dialog-apply-button
+                        @type='primary'
+                        disabled={{not this.selectedProperty}}
+                        {{on 'click' (queue (perform this.applySelectedProperty) dialog.close) }}
+                    >
+                        {{t 'general.apply'}}
+                    </Button>
+                </dialog.footer>
+            </OsfDialog>
+        {{/let}}
     {{/let}}
 </div>

--- a/app/search/controller.ts
+++ b/app/search/controller.ts
@@ -7,29 +7,86 @@ import { waitFor } from '@ember/test-waiters';
 import { tracked } from '@glimmer/tracking';
 import { task, timeout } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
+import Intl from 'ember-intl/services/intl';
 import Media from 'ember-responsive';
 
 import MetadataPropertySearchModel from 'ember-osf-web/models/metadata-property-search';
+import SearchResultModel from 'ember-osf-web/models/search-result';
 export interface Filter {
     property: string;
+    value: string;
+}
+
+interface ResourceTypeOption {
+    display: string;
+    value: string;
+}
+
+interface SortOption {
+    display: string;
     value: string;
 }
 
 const searchDebounceTime = 100;
 
 export default class SearchController extends Controller {
+    @service intl!: Intl;
     @service store!: Store;
     @service media!: Media;
     @service toast!: Toastr;
 
-    queryParams = ['q', 'page', 'sort'];
+    queryParams = ['q', 'page', 'sort', 'resourceType'];
     @tracked q?: string = '';
     @tracked seachBoxText?: string = '';
 
     @tracked page?: number = 1;
-    @tracked sort?: string = '-relevance';
+
+    // Resource type
+    resourceTypeOptions: ResourceTypeOption[] = [
+        { display: this.intl.t('search.resource-type.all'), value: 'All' },
+        { display: this.intl.t('search.resource-type.projects'), value: 'Projects' },
+        { display: this.intl.t('search.resource-type.registrations'), value: 'Registrations' },
+        { display: this.intl.t('search.resource-type.preprints'), value: 'Preprints' },
+        { display: this.intl.t('search.resource-type.files'), value: 'Files' },
+        { display: this.intl.t('search.resource-type.users'), value: 'Users' },
+    ];
+
+    @tracked resourceType = this.resourceTypeOptions[0].value;
+
+    get selectedResourceTypeOption() {
+        return this.resourceTypeOptions.find(option => option.value === this.resourceType);
+    }
+
+    @action
+    updateResourceType(resourceTypeOption: ResourceTypeOption) {
+        this.resourceType = resourceTypeOption.value;
+        taskFor(this.search).perform();
+    }
+
+    // Sort
+    sortOptions: SortOption[] = [
+        { display: this.intl.t('search.sort.relevance'), value: '-relevance' },
+        { display: this.intl.t('search.sort.created-date-descending'), value: '-date_created' },
+        { display: this.intl.t('search.sort.created-date-ascending'), value: 'date_created' },
+        { display: this.intl.t('search.sort.modified-date-descending'), value: '-date_modified' },
+        { display: this.intl.t('search.sort.modified-date-ascending'), value: 'date_modified' },
+    ];
+
+    @tracked sort: string = this.sortOptions[0].value;
+
+    get selectedSortOption() {
+        return this.sortOptions.find(option => option.value === this.sort);// || this.sortOptions[0];
+    }
+
+    @action
+    updateSort(sortOption: SortOption) {
+        this.sort = sortOption.value;
+        taskFor(this.search).perform();
+    }
+
     @tracked activeFilters = A<Filter>([]);
 
+    @tracked searchResults?: SearchResultModel[];
     @tracked propertySearch?: MetadataPropertySearchModel;
 
     get showSidePanelToggle() {
@@ -76,11 +133,12 @@ export default class SearchController extends Controller {
     @waitFor
     async search() {
         try {
-            const { q, page, sort, activeFilters } = this;
+            const { q, page, sort, activeFilters, resourceType } = this;
             const filterQueryObject = activeFilters.reduce((acc, filter) => {
                 acc[filter.property] = filter.value;
                 return acc;
             }, {} as { [key: string]: string });
+            filterQueryObject['resourceType'] = resourceType;
             const searchResult = await this.store.queryRecord('metadata-record-search', {
                 q,
                 page,
@@ -88,7 +146,8 @@ export default class SearchController extends Controller {
                 filter: filterQueryObject,
             });
 
-            this.propertySearch = searchResult.relatedPropertySearch;
+            this.propertySearch = await searchResult.relatedPropertySearch;
+            this.searchResults =  searchResult.searchResultPage.toArray();
         } catch (e) {
             this.toast.error(e);
         }

--- a/app/search/controller.ts
+++ b/app/search/controller.ts
@@ -10,7 +10,7 @@ import { taskFor } from 'ember-concurrency-ts';
 import Intl from 'ember-intl/services/intl';
 import Media from 'ember-responsive';
 
-import MetadataPropertySearchModel from 'ember-osf-web/models/metadata-property-search';
+import IndexPropertySearchModel from 'ember-osf-web/models/index-property-search';
 import SearchResultModel from 'ember-osf-web/models/search-result';
 export interface Filter {
     property: string;
@@ -87,7 +87,7 @@ export default class SearchController extends Controller {
     @tracked activeFilters = A<Filter>([]);
 
     @tracked searchResults?: SearchResultModel[];
-    @tracked propertySearch?: MetadataPropertySearchModel;
+    @tracked propertySearch?: IndexPropertySearchModel;
 
     get showSidePanelToggle() {
         return this.media.isMobile || this.media.isTablet;
@@ -139,7 +139,7 @@ export default class SearchController extends Controller {
                 return acc;
             }, {} as { [key: string]: string });
             filterQueryObject['resourceType'] = resourceType;
-            const searchResult = await this.store.queryRecord('metadata-record-search', {
+            const searchResult = await this.store.queryRecord('index-card-search', {
                 q,
                 page,
                 sort,

--- a/app/search/styles.scss
+++ b/app/search/styles.scss
@@ -31,6 +31,43 @@
     bottom: 4px;
 }
 
+.topbar {
+    margin-left: 20px;
+    display: flex;
+    border-bottom: 1px solid $color-text-black;
+}
+
+.object-type-nav {
+    ul {
+        padding-left: 0;
+        margin-bottom: 0;
+        list-style: none;
+    }
+
+    li {
+        display: inline-flex;
+        margin-right: 10px;
+    }
+}
+
+.object-type-filter-link {
+    padding: 10px 15px;
+    font-size: 1.3em;
+
+    &:global(.active),
+    &:hover {
+        text-decoration: none;
+        background-color: $color-bg-gray;
+        color: $color-text-black;
+        border-bottom: 2px solid $color-text-black;
+    }
+}
+
+.sort-dropdown {
+    width: 170px;
+    margin-top: 10px;
+}
+
 .sidenav-toggle {
     float: left;
 }
@@ -49,4 +86,3 @@
     display: flex;
     justify-content: space-between;
 }
-

--- a/app/search/template.hbs
+++ b/app/search/template.hbs
@@ -44,12 +44,12 @@ as |layout|>
         {{/if}}
     </layout.heading>
     <layout.left
-        data-analytics-scope='search left panel'
+        data-analytics-scope='Search page left panel'
         local-class='left-panel'
     >
         <h2>{{t 'search.left-panel.header'}}</h2>
         {{#if this.showSidePanelToggle}}
-            <div>
+            <div data-test-left-panel-object-type-dropdown>
                 <label>
                     {{t 'search.resource-type.search-by'}}
                     <PowerSelect @options={{this.resourceTypeOptions}} @selected={{this.selectedResourceTypeOption}}
@@ -58,7 +58,7 @@ as |layout|>
                     </PowerSelect>
                 </label>
             </div>
-            <div>
+            <div data-test-left-panel-sort-dropdown>
                 <label>
                     {{t 'search.sort.sort-by'}}
                     <PowerSelect @options={{this.sortOptions}} @selected={{this.selectedSortOption}}
@@ -106,15 +106,20 @@ as |layout|>
             {{t 'search.left-panel.no-filterable-properties'}}
         {{/each}}
     </layout.left>
-    <layout.main>
+    <layout.main data-analytics-scope='Search page main'>
         {{!-- paginator --}}
         {{#unless this.showSidePanelToggle}}
             <div local-class='topbar'>
-                <nav local-class='object-type-nav'>
+                <nav
+                    data-test-topbar-object-type-nav
+                    local-class='object-type-nav'
+                >
                     <ul>
                         {{#each this.resourceTypeOptions as |resourceType|}}
                             <li>
                                 <LinkTo
+                                    data-analytics-name='Object type filter={{resourceType.value}}'
+                                    data-test-topbar-object-type-link='{{resourceType.value}}'
                                     local-class='object-type-filter-link'
                                     @route='search'
                                     @query={{hash resourceType=resourceType.value}}
@@ -126,7 +131,10 @@ as |layout|>
                         {{/each}}
                     </ul>
                 </nav>
-                <div local-class='sort-dropdown'>
+                <div
+                    data-test-topbar-sort-dropdown
+                    local-class='sort-dropdown'
+                >
                     <PowerSelect
                         @options={{this.sortOptions}}
                         @selected={{this.selectedSortOption}}

--- a/app/search/template.hbs
+++ b/app/search/template.hbs
@@ -1,6 +1,6 @@
 {{!-- template-lint-disable no-bare-strings --}}
 {{page-title (t 'search.page-title')}}
-<OsfLayout 
+<OsfLayout
     @backgroundClass='search-page'
 as |layout|>
     <layout.heading local-class='heading-wrapper'>
@@ -31,7 +31,6 @@ as |layout|>
                 <FaIcon @icon='search' />
             </Button>
         </span>
-
         {{#if this.showSidePanelToggle}}
             <Button
                 data-test-toggle-side-panel
@@ -48,8 +47,27 @@ as |layout|>
         data-analytics-scope='search left panel'
         local-class='left-panel'
     >
-        {{!-- Object type filter dropdown if we are in mobile --}}
         <h2>{{t 'search.left-panel.header'}}</h2>
+        {{#if this.showSidePanelToggle}}
+            <div>
+                <label>
+                    {{t 'search.resource-type.search-by'}}
+                    <PowerSelect @options={{this.resourceTypeOptions}} @selected={{this.selectedResourceTypeOption}}
+                        @onChange={{this.updateResourceType}} as |resourceType|>
+                        {{resourceType.display}}
+                    </PowerSelect>
+                </label>
+            </div>
+            <div>
+                <label>
+                    {{t 'search.sort.sort-by'}}
+                    <PowerSelect @options={{this.sortOptions}} @selected={{this.selectedSortOption}}
+                        @onChange={{this.updateSort}} as |sortOption|>
+                        {{sortOption.display}}
+                    </PowerSelect>
+                </label>
+            </div>
+        {{/if}}
         {{#if this.activeFilters.length}}
             <ul local-class='active-filter-list'>
                 {{#each this.activeFilters as |filter|}}
@@ -58,7 +76,7 @@ as |layout|>
                         local-class='active-filter-item'
                     >
                         <span>
-                            {{filter.property}} |
+                            {{filter.property}}:
                             {{filter.value}}
                         </span>
                         <Button
@@ -89,11 +107,36 @@ as |layout|>
         {{/each}}
     </layout.left>
     <layout.main>
-        Main
-        {{!-- placeholder if no search term (maybe) --}}
-        {{!-- object type filtering tabs if desktop--}}
-        {{!-- search cards --}}
-        {{!-- sort dropdown --}}
         {{!-- paginator --}}
+        {{#unless this.showSidePanelToggle}}
+            <div local-class='topbar'>
+                <nav local-class='object-type-nav'>
+                    <ul>
+                        {{#each this.resourceTypeOptions as |resourceType|}}
+                            <li>
+                                <LinkTo
+                                    local-class='object-type-filter-link'
+                                    @route='search'
+                                    @query={{hash resourceType=resourceType.value}}
+                                    {{on 'click' (fn this.updateResourceType resourceType)}}
+                                >
+                                    {{resourceType.display}}
+                                </LinkTo>
+                            </li>
+                        {{/each}}
+                    </ul>
+                </nav>
+                <div local-class='sort-dropdown'>
+                    <PowerSelect
+                        @options={{this.sortOptions}}
+                        @selected={{this.selectedSortOption}}
+                        @onChange={{this.updateSort}}
+                        as |sortOption|
+                    >
+                        {{sortOption.display}}
+                    </PowerSelect>
+                </div>
+            </div>
+        {{/unless}}
     </layout.main>
 </OsfLayout>

--- a/app/search/template.hbs
+++ b/app/search/template.hbs
@@ -93,11 +93,11 @@ as |layout|>
             </ul>
         {{/if}}
         {{#each this.filterableProperties as |filterableProperty|}}
-            {{#let filterableProperty.metadataRecord as |propertyRecord|}}
+            {{#let filterableProperty.indexCard as |propertyCard|}}
                 <Search::-Components::FilterFacet
-                    @recordSearchText={{this.q}}
-                    @recordSearchFilters={{this.activeFilters}}
-                    @propertyRecord={{propertyRecord}}
+                    @cardSearchText={{this.q}}
+                    @cardSearchFilters={{this.activeFilters}}
+                    @propertyCard={{propertyCard}}
                     @propertySearch={{filterableProperty}}
                     @toggleFilter={{this.toggleFilter}}
                 />

--- a/app/serializers/index-card-search.ts
+++ b/app/serializers/index-card-search.ts
@@ -1,10 +1,10 @@
 import ShareSerializer from './share-serializer';
 
-export default class MetadataPropertySearchSerializer extends ShareSerializer {
+export default class IndexCardSearchSerializer extends ShareSerializer {
 }
 
 declare module 'ember-data/types/registries/serializer' {
     export default interface SerializerRegistry {
-        'metadata-property-search': MetadataPropertySearchSerializer;
+        'index-card-search': IndexCardSearchSerializer;
     } // eslint-disable-line semi
 }

--- a/app/serializers/index-card.ts
+++ b/app/serializers/index-card.ts
@@ -1,10 +1,10 @@
 import ShareSerializer from './share-serializer';
 
-export default class MetadataRecordSerializer extends ShareSerializer {
+export default class IndexCardSerializer extends ShareSerializer {
 }
 
 declare module 'ember-data/types/registries/serializer' {
     export default interface SerializerRegistry {
-        'metadata-record': MetadataRecordSerializer;
+        'index-card': IndexCardSerializer;
     } // eslint-disable-line semi
 }

--- a/app/serializers/index-property-search.ts
+++ b/app/serializers/index-property-search.ts
@@ -1,10 +1,10 @@
 import ShareSerializer from './share-serializer';
 
-export default class MetadataValueSearchSerializer extends ShareSerializer {
+export default class IndexPropertySearchSerializer extends ShareSerializer {
 }
 
 declare module 'ember-data/types/registries/serializer' {
     export default interface SerializerRegistry {
-        'metadata-value-search': MetadataValueSearchSerializer;
+        'index-property-search': IndexPropertySearchSerializer;
     } // eslint-disable-line semi
 }

--- a/app/serializers/index-value-search.ts
+++ b/app/serializers/index-value-search.ts
@@ -1,10 +1,10 @@
 import ShareSerializer from './share-serializer';
 
-export default class MetadataRecordSearchSerializer extends ShareSerializer {
+export default class IndexValueSearchSerializer extends ShareSerializer {
 }
 
 declare module 'ember-data/types/registries/serializer' {
     export default interface SerializerRegistry {
-        'metadata-record-search': MetadataRecordSearchSerializer;
+        'index-value-search': IndexValueSearchSerializer;
     } // eslint-disable-line semi
 }

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -37,7 +37,7 @@ import { createNewSchemaResponse } from './views/schema-response';
 import { createSchemaResponseAction } from './views/schema-response-action';
 import { rootDetail } from './views/root';
 import { shareSearch } from './views/share-search';
-import { recordSearch, valueSearch } from './views/search';
+import { cardSearch, valueSearch } from './views/search';
 import { createToken } from './views/token';
 import { createEmails, updateEmails } from './views/update-email';
 import {
@@ -62,9 +62,9 @@ export default function(this: Server) {
     this.post('/search/creativeworks/_search', shareSearch);
 
     // SHARE-powered search endpoints
-    this.get('/metadata-record-searches', recordSearch);
-    this.get('/metadata-value-searches', valueSearch);
-    // this.get('/metadata-records/:id', metadataRecordDetail);
+    this.get('/index-card-searches', cardSearch);
+    this.get('/index-value-searches', valueSearch);
+    // this.get('/index-cards/:id', Detail);
 
     this.urlPrefix = apiUrl;
     this.namespace = '/v2';

--- a/mirage/views/search.ts
+++ b/mirage/views/search.ts
@@ -1,15 +1,15 @@
 import { Request, Schema } from 'ember-cli-mirage';
 import faker from 'faker';
 
-export function recordSearch(_: Schema, __: Request) {
-    // TODO: replace with a real metadata-record-search and use request to populate attrs
+export function cardSearch(_: Schema, __: Request) {
+    // TODO: replace with a real index-card-search and use request to populate attrs
     return {
         data: {
-            type: 'metadata-record-search',
+            type: 'index-card-search',
             id: 'zzzzzz',
             attributes:{
-                recordSearchText: 'hello',
-                recordSearchFilter: [
+                cardSearchText: 'hello',
+                cardSearchFilter: [
                     {
                         propertyPath: 'resourceType',
                         filterType: 'eq',
@@ -50,7 +50,7 @@ export function recordSearch(_: Schema, __: Request) {
                 },
                 relatedPropertySearch: {
                     data: {
-                        type: 'metadata-property-search',
+                        type: 'index-property-search',
                         id: 'tuv',
                     },
                 },
@@ -73,13 +73,13 @@ export function recordSearch(_: Schema, __: Request) {
                     ],
                 },
                 relationships: {
-                    metadataRecord: {
+                    indexCard: {
                         data: {
-                            type: 'metadata-record',
+                            type: 'index-card',
                             id: 'abc',
                         },
                         links: {
-                            related: 'https://share.osf.io/api/v2/metadata-record/abc',
+                            related: 'https://share.osf.io/api/v2/index-card/abc',
                         },
                     },
                 },
@@ -96,13 +96,13 @@ export function recordSearch(_: Schema, __: Request) {
                     ],
                 },
                 relationships: {
-                    metadataRecord: {
+                    indexCard: {
                         data: {
-                            type: 'metadata-record',
+                            type: 'index-card',
                             id: 'def',
                         },
                         links: {
-                            related: 'https://share.osf.io/api/v2/metadata-record/def',
+                            related: 'https://share.osf.io/api/v2/index-card/def',
                         },
                     },
                 },
@@ -119,19 +119,19 @@ export function recordSearch(_: Schema, __: Request) {
                     ],
                 },
                 relationships: {
-                    metadataRecord: {
+                    indexCard: {
                         data: {
-                            type: 'metadata-record',
-                            id: 'abc',
+                            type: 'index-card',
+                            id: 'ghi',
                         },
                         links: {
-                            related: 'https://share.osf.io/api/v2/metadata-record/abc',
+                            related: 'https://share.osf.io/api/v2/index-card/abc',
                         },
                     },
                 },
             },
             {
-                type: 'metadata-record',
+                type: 'index-card',
                 id: 'abc',
                 attributes: {
                     resourceType: [
@@ -212,25 +212,79 @@ export function recordSearch(_: Schema, __: Request) {
                     },
                 },
                 links: {
-                    self: 'https://share.osf.io/api/v2/metadata-record/abc',
+                    self: 'https://share.osf.io/api/v2/index-card/abc',
                     resource: 'https://osf.example/abcfoo',
                 },
             },
             {
-                type: 'metadata-record',
+                type: 'index-card',
                 id: 'def',
+                attributes: {
+                    resourceType: [
+                        'osf:Registration',
+                        'dcterms:Dataset',
+                    ],
+                    resourceIdentifier: [
+                        'https://osf.example/abcfoo',
+                        'https://doi.org/10.0000/osf.example/abcfoo',
+                    ],
+                    resourceMetadata: {
+                        '@id': 'https://osf.example/abcfoo',
+                        '@type': 'osf:Registration',
+                        title: [
+                            {
+                                '@value': 'Hi!',
+                                '@language': 'en',
+                            },
+                        ],
+                    },
+                },
+                links: {
+                    self: 'https://share.osf.io/api/v2/index-card/ghi',
+                    resource: 'https://osf.example/abcfoo',
+                },
             },
             {
-                type: 'metadata-record',
+                type: 'index-card',
                 id: 'ghi',
+                attributes: {
+                    resourceType: [
+                        'osf:Registration',
+                        'dcterms:Dataset',
+                    ],
+                    resourceIdentifier: [
+                        'https://osf.example/abcfoo',
+                        'https://doi.org/10.0000/osf.example/abcfoo',
+                    ],
+                    resourceMetadata: {
+                        '@id': 'https://osf.example/abcfoo',
+                        '@type': 'osf:Registration',
+                        title: [
+                            {
+                                '@value': 'Ahoj! That\'s hello in Czech!',
+                                '@language': 'en',
+                            },
+                        ],
+                        description: [
+                            {
+                                '@value': 'Some description',
+                                '@language': 'en',
+                            },
+                        ],
+                    },
+                },
+                links: {
+                    self: 'https://share.osf.io/api/v2/index-card/ghi',
+                    resource: 'https://osf.example/abcfoo',
+                },
             },
             // Related properties search object
             {
-                type: 'metadata-property-search',
+                type: 'index-property-search',
                 id: 'tuv',
                 attributes: {
-                    recordSearchText: 'hello',
-                    recordSearchFilter: [
+                    cardSearchText: 'hello',
+                    cardSearchFilter: [
                         {
                             propertyPath: 'resourceType',
                             filterType: 'eq',
@@ -293,13 +347,13 @@ export function recordSearch(_: Schema, __: Request) {
                     recordResultCount: 345,
                 },
                 relationships: {
-                    metadataRecord: {
+                    indexCard: {
                         data: {
-                            type: 'metadata-record',
+                            type: 'index-card',
                             id: 'idForPropertyRecord1',
                         },
                         links: {
-                            related: 'https://share.osf.io/api/v2/metadata-record/idForPropertyRecord1',
+                            related: 'https://share.osf.io/api/v2/index-card/idForPropertyRecord1',
                         },
                     },
                 },
@@ -317,13 +371,13 @@ export function recordSearch(_: Schema, __: Request) {
                     recordResultCount: 123,
                 },
                 relationships: {
-                    metadataRecord: {
+                    indexCard: {
                         data: {
-                            type: 'metadata-record',
+                            type: 'index-card',
                             id: 'idForPropertyRecord2',
                         },
                         links: {
-                            related: 'https://share.osf.io/api/v2/metadata-record/idForPropertyRecord2',
+                            related: 'https://share.osf.io/api/v2/index-card/idForPropertyRecord2',
                         },
                     },
                 },
@@ -341,19 +395,19 @@ export function recordSearch(_: Schema, __: Request) {
                     recordResultCount: 33,
                 },
                 relationships: {
-                    metadataRecord: {
+                    indexCard: {
                         data: {
-                            type: 'metadata-record',
+                            type: 'index-card',
                             id: 'idForPropertyRecord3',
                         },
                         links: {
-                            related: 'https://share.osf.io/api/v2/metadata-record/idForPropertyRecord3',
+                            related: 'https://share.osf.io/api/v2/index-card/idForPropertyRecord3',
                         },
                     },
                 },
             },
             {
-                type: 'metadata-record',
+                type: 'index-card',
                 id: 'idForPropertyRecord1',
                 attributes: {
                     resourceType: [
@@ -380,12 +434,12 @@ export function recordSearch(_: Schema, __: Request) {
                     },
                 },
                 links: {
-                    self: 'https://share.osf.io/api/v2/metadata-record/idForPropertyRecord1',
+                    self: 'https://share.osf.io/api/v2/index-card/idForPropertyRecord1',
                     resource: 'http://purl.org/dc/terms/license',
                 },
             },
             {
-                type: 'metadata-record',
+                type: 'index-card',
                 id: 'idForPropertyRecord2',
                 attributes: {
                     resourceType: [
@@ -412,12 +466,12 @@ export function recordSearch(_: Schema, __: Request) {
                     },
                 },
                 links: {
-                    self: 'https://share.osf.io/api/v2/metadata-record/idForPropertyRecord2',
+                    self: 'https://share.osf.io/api/v2/index-card/idForPropertyRecord2',
                     resource: 'http://purl.org/dc/terms/published',
                 },
             },
             {
-                type: 'metadata-record',
+                type: 'index-card',
                 id: 'idForPropertyRecord3',
                 attributes: {
                     resourceType: [
@@ -444,7 +498,7 @@ export function recordSearch(_: Schema, __: Request) {
                     },
                 },
                 links: {
-                    self: 'https://share.osf.io/api/v2/metadata-record/idForPropertyRecord2',
+                    self: 'https://share.osf.io/api/v2/index-card/idForPropertyRecord2',
                     resource: 'http://purl.org/dc/terms/funder',
                 },
             },
@@ -457,7 +511,7 @@ export function valueSearch(_: Schema, __: Request) {
     const property2Id = faker.random.uuid();
     return {
         data: {
-            type: 'metadata-value-search',
+            type: 'index-value-search',
             id: 'lmnop',
             attributes: {
                 valueSearchText: 'Institute of Health',
@@ -468,8 +522,8 @@ export function valueSearch(_: Schema, __: Request) {
                         filterValues: ['datacite:Funder'],
                     },
                 ],
-                recordSearchText: 'influenza',
-                recordSearchFilter: [
+                cardSearchText: 'influenza',
+                cardSearchFilter: [
                     {
                         propertyPath: 'resourceType',
                         filterType: 'eq',
@@ -490,7 +544,7 @@ export function valueSearch(_: Schema, __: Request) {
                     },
                 },
                 relatedPropertySearch: {
-                    data: {type: 'metadata-property-search', id: '12345'},
+                    data: {type: 'index-property-search', id: '12345'},
                 },
             },
         },
@@ -505,9 +559,9 @@ export function valueSearch(_: Schema, __: Request) {
                     recordResultCount: 2134,
                 },
                 relationships: {
-                    metadataRecord: {
-                        data: {type: 'metadata-record', id: property1Id},
-                        links: {related: 'https://share.osf.example/metadata-record/abc'},
+                    indexCard: {
+                        data: {type: 'index-card', id: property1Id},
+                        links: {related: 'https://share.osf.example/index-card/abc'},
                     },
                 },
             },
@@ -521,14 +575,14 @@ export function valueSearch(_: Schema, __: Request) {
                     recordResultCount: 2,
                 },
                 relationships: {
-                    metadataRecord: {
-                        data: {type: 'metadata-record', id: property2Id},
-                        links: {related: 'https://share.osf.example/metadata-record/def'},
+                    indexCard: {
+                        data: {type: 'index-card', id: property2Id},
+                        links: {related: 'https://share.osf.example/index-card/def'},
                     },
                 },
             },
             {
-                type: 'metadata-record',
+                type: 'index-card',
                 id: property1Id,
                 attributes: {
                     resourceType: 'osf:Funder',
@@ -541,7 +595,7 @@ export function valueSearch(_: Schema, __: Request) {
                 },
             },
             {
-                type: 'metadata-record',
+                type: 'index-card',
                 id: property2Id,
                 attributes: {
                     resourceType: 'osf:Funder',

--- a/tests/acceptance/search/search-filters-test.ts
+++ b/tests/acceptance/search/search-filters-test.ts
@@ -48,7 +48,7 @@ module(moduleName, hooks => {
             .containsText('Search for a filter to apply', 'Placeholder message shown in select');
         assert.dom('[data-test-see-more-dialog-apply-button]').isDisabled('Apply button disabled initially');
         // select a filter value
-        await clickTrigger();
+        await clickTrigger('[data-test-dialog]');
         await untrackedClick('[data-option-index="0"]');
         assert.dom('[data-test-see-more-dialog-apply-button]')
             .isNotDisabled('Apply button enabled after selecting a filter');

--- a/tests/acceptance/search/search-query-params-test.ts
+++ b/tests/acceptance/search/search-query-params-test.ts
@@ -1,0 +1,84 @@
+import { click as untrackedClick, visit } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setBreakpoint } from 'ember-responsive/test-support';
+import { clickTrigger } from 'ember-power-select/test-support/helpers';
+import { module, test } from 'qunit';
+
+import { click, currentURL, setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
+
+const moduleName = 'Acceptance | search | query-params';
+
+module(moduleName, hooks => {
+    setupOSFApplicationTest(hooks);
+    setupMirage(hooks);
+
+    test('default query-parameters', async assert => {
+        // Load search page
+        await visit('/search');
+        // assert object type nav is shown
+        assert.dom('[data-test-topbar-object-type-nav]').exists('Object type nav shown in desktop view');
+        assert.dom('[data-test-left-panel-object-type-dropdown]')
+            .doesNotExist('Left-panel object type dropdown not shown in desktop view');
+        // assert sort dropdown is shown
+        assert.dom('[data-test-topbar-sort-dropdown]').exists('Sort dropdown shown in desktop view');
+        assert.dom('[data-test-left-panel-sort-dropdown]')
+            .doesNotExist('Left-panel sort dropdown not shown in desktop view');
+        // assert default query-param values
+        assert.equal(currentURL(), '/search', 'Default query-params are empty');
+        assert.dom('[data-test-topbar-object-type-link="All"]').hasClass('active', 'All is the default object type');
+        assert.dom('[data-test-topbar-sort-dropdown]').containsText('Relevance', 'Relevance is the default sort');
+        // change object type
+        await click('[data-test-topbar-object-type-link="Projects"]');
+        assert.dom('[data-test-topbar-object-type-link="Projects"]').hasClass('active', 'Projects is selected');
+        assert.dom('[data-test-topbar-object-type-link="All"]').doesNotHaveClass('active', 'All is not selected');
+        assert.equal(currentURL(), '/search?resourceType=Projects', 'Query-params are updated');
+        // change sort
+        await clickTrigger('[data-test-topbar-sort-dropdown]');
+        await untrackedClick('[data-option-index="2"]'); // date-createst, oldest
+        assert.dom('[data-test-topbar-sort-dropdown]').containsText('Date created, oldest',
+            'Date created, oldest first is selected');
+        assert.equal(currentURL(), '/search?resourceType=Projects&sort=date_created', 'Query-params are updated');
+    });
+
+    test('default query-parameters, mobile', async assert => {
+        setBreakpoint('mobile');
+        // Load search page
+        await visit('/search');
+        // assert object type nav is shown
+        await click('[data-test-toggle-side-panel]');
+        assert.dom('[data-test-topbar-object-type-nav]').doesNotExist('Object type nav not shown in mobile view');
+        assert.dom('[data-test-left-panel-object-type-dropdown]')
+            .exists('Left-panel object type dropdown shown in mobile view');
+        // assert sort dropdown is shown
+        assert.dom('[data-test-topbar-sort-dropdown]').doesNotExist('Sort dropdown not shown in mobile view');
+        assert.dom('[data-test-left-panel-sort-dropdown]')
+            .exists('Left-panel sort dropdown shown in mobile view');
+        // assert default query-param values
+        assert.equal(currentURL(), '/search', 'Default query-params are empty');
+        assert.dom('[data-test-left-panel-object-type-dropdown]').containsText('All', 'All is the default object type');
+        assert.dom('[data-test-left-panel-sort-dropdown]').containsText('Relevance', 'Relevance is the default sort');
+        // change object type
+        await clickTrigger('[data-test-left-panel-object-type-dropdown]');
+        await untrackedClick('[data-option-index="2"]'); // Registrations
+        assert.equal(currentURL(), '/search?resourceType=Registrations', 'Object type query-param updated');
+        // change sort
+        await clickTrigger('[data-test-left-panel-sort-dropdown]');
+        await untrackedClick('[data-option-index="4"]'); // date-modified, oldest
+        assert.equal(currentURL(), '/search?resourceType=Registrations&sort=date_modified', 'Query-params are updated');
+    });
+
+    test('query-parameters from url', async assert => {
+        await visit('/search?resourceType=Preprints&sort=-date_modified');
+        assert.dom('[data-test-topbar-object-type-link="Preprints"]')
+            .hasClass('active', 'Desktop: Active object type filter selected from url');
+        assert.dom('[data-test-topbar-sort-dropdown]')
+            .containsText('Date modified, newest', 'Desktop: Active sort selected from url');
+
+        setBreakpoint('mobile');
+        await click('[data-test-toggle-side-panel]');
+        assert.dom('[data-test-left-panel-object-type-dropdown]')
+            .containsText('Preprints', 'Mobile: Active object type filter selected from url');
+        assert.dom('[data-test-left-panel-sort-dropdown]')
+            .containsText('Date modified, newest', 'Mobile: Active sort selected from url');
+    });
+});

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -211,6 +211,21 @@ search:
     search-header: 'Search OSF'
     textbox-placeholder: 'Search placeholder'
     search-button-label: 'Search'
+    resource-type:
+        search-by: 'Search by resource type'
+        all: 'All'
+        projects: 'Projects'
+        registrations: 'Registrations'
+        preprints: 'Preprints'
+        files: 'Files'
+        users: 'Users'
+    sort:
+        sort-by: 'Sort by'
+        relevance: 'Relevance'
+        created-date-descending: 'Date created, newest'
+        created-date-ascending: 'Date created, oldest'
+        modified-date-descending: 'Date modified, newest'
+        modified-date-ascending: 'Date modified, oldest'
     toggle-sidenav: 'Toggle search sidebar'
     left-panel:
         header: Refine

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -205,7 +205,7 @@ dashboard:
 
 search:
     page-title: 'Search'
-    metadata-record:
+    index-card:
         no-label: 'No label found'
         no-title: 'No title found'
     search-header: 'Search OSF'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -237,6 +237,9 @@ search:
         see-more: 'See more'
         see-more-modal-text: 'Please select a filter to apply to your search.'
         see-more-modal-placeholder: 'Search for a filter to apply'
+helpers:
+    get-localized-property:
+        not-provided: 'Not provided'
 new_project:
     header: 'Create new project'
     title_placeholder: 'Enter project title'


### PR DESCRIPTION
-   Ticket: [ENG-4469]
-   Feature flag: n/a

## Purpose
- Add object type filter and sort dropdown to search page

## Summary of Changes
- Add tabs to filter by object type (All, Projects, Registrations, Preprints, Files, Users)
- Add dropdown to sort results by Relevance, Date modified/created ascending and descending
- Change model names to reflect more library-analogy based names
- Change how metadata properties are fetched from SHARE models

## Screenshot(s)
- Desktop
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/0f75eca3-1f8c-46df-8b27-0ed66b0d8d6c)

- Mobile
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/83f81da1-d999-4781-a539-039a2b822ab9)

## Side Effects
- NA

## QA Notes


[ENG-4469]: https://openscience.atlassian.net/browse/ENG-4469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ