### PR TITLE
[No ticket] Xenon / Add ember tooltips to analytics engine

### DIFF
--- a/lib/analytics-page/package.json
+++ b/lib/analytics-page/package.json
@@ -26,6 +26,7 @@
     "ember-intl": "*",
     "ember-moment": "*",
     "ember-page-title": "*",
+    "ember-tooltips": "*",
     "ember-wormhole": "*"
   },
   "ember-addon": {


### PR DESCRIPTION
## Purpose

Make the linked nodes list show private projects

## Summary of Changes

1. Add ember-tooltips to the analytics engine.