### PR TITLE
[No ticket] Xenon - Make reason to remove text area wider

### DIFF
--- a/lib/collections/addon/components/collections-submission/styles.scss
+++ b/lib/collections/addon/components/collections-submission/styles.scss
@@ -54,12 +54,12 @@
 
         .remove-button {
             float: left;
-
-            .remove-textarea {
-                margin-top: 12px;
-                max-width: 100%;
-                width: 100%;
-            }
         }
     }
+}
+
+.remove-textarea {
+    margin-top: 12px;
+    max-width: 100%;
+    width: 100%;
 }


### PR DESCRIPTION
## Purpose

Make the collections "Reason to remove from collection" text area wider

## Summary of Changes

1. Make CSS Selector less specific

## Screenshot(s)

<img width="554" alt="Screenshot 2023-05-17 at 10 45 58 AM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/70ad48a5-e74c-42c3-b21b-8117a4270aa4">
