### PR TITLE
[ENG-4548] A11y fix for OSF Navbar

### DIFF
--- a/lib/osf-components/addon/components/osf-navbar/styles.scss
+++ b/lib/osf-components/addon/components/osf-navbar/styles.scss
@@ -20,6 +20,7 @@
         /* necessary for the parent flexbox container to shrink smaller than the child element's text */
         min-width: 0;
         margin-left: auto !important;
+        display: flex;
     }
 
     .links > li > a {

--- a/lib/osf-components/addon/components/osf-navbar/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/template.hbs
@@ -89,9 +89,8 @@
                                 {{ctx.links}}
                             {{/if}}
                         {{/let}}
-
-                        <OsfNavbar::AuthDropdown @onLinkClicked={{this.onLinkClicked}} @campaign={{@campaign}} />
                     </ul>
+                    <OsfNavbar::AuthDropdown @onLinkClicked={{this.onLinkClicked}} @campaign={{@campaign}} />
                 </div>
             {{/if}}
         </div>

--- a/tests/acceptance/settings/tokens-page-test.ts
+++ b/tests/acceptance/settings/tokens-page-test.ts
@@ -76,7 +76,7 @@ module('Acceptance | settings | personal access tokens', hooks => {
         const token = server.create('token', { name: oldName });
 
         await visit('/settings/tokens');
-        await timeout(50);
+        await timeout(150);
         const link = `[data-test-token-link='${token.id}']`;
         assert.dom(link).exists({ count: 1 });
         assert.dom(link).containsText(oldName);


### PR DESCRIPTION
-   Ticket: [ENG-4548]
-   Feature flag: n/a

## Purpose

Changing the off navbar's auth dropdown from a bootstrap dropdown to a responsive dropdown caused it to lose the ability to be an li, and instead it became a div. This broke the accessibility, because it was inside the ul where divs are forbidden. This fixes the accessibility problems.

## Summary of Changes

1. Move the auth dropdown outside of the unordered list
2. Fix the styling

## QA Notes

Just need to verify the accessibility and make sure I didn't break anything in the process.


[ENG-4548]: https://openscience.atlassian.net/browse/ENG-4548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ