### PR TITLE
Increase timeout for Jenkins

### DIFF
--- a/tests/acceptance/settings/tokens-page-test.ts
+++ b/tests/acceptance/settings/tokens-page-test.ts
@@ -76,7 +76,7 @@ module('Acceptance | settings | personal access tokens', hooks => {
         const token = server.create('token', { name: oldName });
 
         await visit('/settings/tokens');
-        await timeout(150);
+        await timeout(750);
         const link = `[data-test-token-link='${token.id}']`;
         assert.dom(link).exists({ count: 1 });
         assert.dom(link).containsText(oldName);

--- a/tests/acceptance/settings/tokens-page-test.ts
+++ b/tests/acceptance/settings/tokens-page-test.ts
@@ -76,7 +76,7 @@ module('Acceptance | settings | personal access tokens', hooks => {
         const token = server.create('token', { name: oldName });
 
         await visit('/settings/tokens');
-        await timeout(750);
+        await timeout(1500);
         const link = `[data-test-token-link='${token.id}']`;
         assert.dom(link).exists({ count: 1 });
         assert.dom(link).containsText(oldName);


### PR DESCRIPTION
## Purpose

Jenkins keeps failing on one test due to not waiting long enough. This increases the timeout so hopefully Jenkins will start deploying our branches.

## Summary of Changes

1. Increase timeout
