### PR TITLE
Use waitFor instead of timeout

### DIFF
--- a/tests/acceptance/settings/tokens-page-test.ts
+++ b/tests/acceptance/settings/tokens-page-test.ts
@@ -76,8 +76,8 @@ module('Acceptance | settings | personal access tokens', hooks => {
         const token = server.create('token', { name: oldName });
 
         await visit('/settings/tokens');
-        await timeout(1500);
         const link = `[data-test-token-link='${token.id}']`;
+        await waitFor(link);
         assert.dom(link).exists({ count: 1 });
         assert.dom(link).containsText(oldName);
 


### PR DESCRIPTION
## Purpose

Fix the token edit test (hopefully for the last time) by waiting for the Dom to change with a waitFor rather than awaiting an arbitrary timeout.

## Summary of Changes

1. Use `waitFor` instead of `timeout`
