### PR TITLE
[ENG-4551] Fixed the registries and collection moderation menus on mobile

### DIFF
--- a/app/institutions/dashboard/-components/institutional-users-list/component.ts
+++ b/app/institutions/dashboard/-components/institutional-users-list/component.ts
@@ -42,12 +42,10 @@ export default class InstitutionalUsersList extends Component {
             departments = departments.concat(institutionDepartments);
         }
 
-        /*
         if (!this.department) {
             // eslint-disable-next-line ember/no-side-effects
             this.set('department', departments[0]);
         }
-        */
 
         return departments;
     }

--- a/app/institutions/dashboard/-components/institutional-users-list/component.ts
+++ b/app/institutions/dashboard/-components/institutional-users-list/component.ts
@@ -42,10 +42,12 @@ export default class InstitutionalUsersList extends Component {
             departments = departments.concat(institutionDepartments);
         }
 
+        /*
         if (!this.department) {
             // eslint-disable-next-line ember/no-side-effects
             this.set('department', departments[0]);
         }
+        */
 
         return departments;
     }

--- a/lib/collections/addon/provider/moderation/styles.scss
+++ b/lib/collections/addon/provider/moderation/styles.scss
@@ -30,6 +30,7 @@
 
     li {
         float: left;
+        height: 50px; 
     }
 
     li > a {

--- a/lib/osf-components/addon/components/draft-registration-card/styles.scss
+++ b/lib/osf-components/addon/components/draft-registration-card/styles.scss
@@ -1,13 +1,12 @@
 // stylelint-disable max-nesting-depth, selector-max-compound-selectors
+
 .draft-registration-card {
     margin-bottom: 10px;
     width: 100%;
-    min-width: 300px;
 
     :global(.ember-content-placeholders-text__line) {
         height: 1em;
     }
-
 
     :global(.btn) {
         margin-left: 5px;
@@ -51,7 +50,7 @@
 
             .review-container {
                 flex: 1;
-                min-width: 200px; 
+                min-width: 180px; 
             }
 
             .delete-container {

--- a/lib/osf-components/addon/components/subscriptions/list-row/styles.scss
+++ b/lib/osf-components/addon/components/subscriptions/list-row/styles.scss
@@ -1,18 +1,13 @@
-.SubscriptionRow {
+.subscription-row {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    width: 75%;
     height: 45px;
     border-top: 1px solid $color-bg-gray-dark;
 }
 
 li:last-of-type {
-    .SubscriptionRow {
+    .subscription-row {
         border-bottom: 1px solid $color-bg-gray-dark;
     }
-}
-
-.RowPowerSelectSection {
-    width: 15%;
 }

--- a/lib/osf-components/addon/components/subscriptions/list-row/template.hbs
+++ b/lib/osf-components/addon/components/subscriptions/list-row/template.hbs
@@ -1,14 +1,9 @@
 <li data-test-subscription-list-row={{@subscription.id}}>
-    <div local-class='SubscriptionRow'>
-        <span
-            data-test-subscription-event-name
-        >
+    <div local-class='subscription-row'>
+        <span data-test-subscription-event-name>
             {{humanize @subscription.eventName}}
         </span>
-        <span
-            data-test-power-select
-            local-class='RowPowerSelectSection'
-        >
+        <span data-test-power-select>
             <PowerSelect
                 @selected={{@subscription.frequency}}
                 @options={{this.frequencyOptions}}

--- a/lib/registries/addon/branded/moderation/styles.scss
+++ b/lib/registries/addon/branded/moderation/styles.scss
@@ -21,6 +21,7 @@
 
     li {
         float: left;
+        height: 50px; 
     }
 
     li > a {


### PR DESCRIPTION
-   Ticket: [ENG-4551]
-   Feature flag: n/a

## Purpose

Ensure that the menu for moderation is correct in mobile

## Summary of Changes

Updated the menus to have a fixed height

## Screenshot(s)
![collections - mobile](https://github.com/CenterForOpenScience/ember-osf-web/assets/113387478/ce12215a-d854-4f46-ae8c-090794c30e1f)
![registries - mobile](https://github.com/CenterForOpenScience/ember-osf-web/assets/113387478/e2d84aef-91d7-4b51-9685-b28213242059)

## Side Effects

Hopefully none

## QA Notes

Automated tests, looks at the screenshot or browse to it.


[ENG-4551]: https://openscience.atlassian.net/browse/ENG-4551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ