### PR TITLE
[ENG-4551] Cesium/fourth batch of bug fixes

### DIFF
--- a/app/institutions/dashboard/-components/institutional-users-list/component.ts
+++ b/app/institutions/dashboard/-components/institutional-users-list/component.ts
@@ -23,7 +23,7 @@ export default class InstitutionalUsersList extends Component {
 
     // Private properties
     modelTaskInstance!: TaskInstance<InstitutionsDashboardModel>;
-    department = this.intl.t('institutions.dashboard.select_default');
+    department?: string;
     sort = 'user_name';
 
     reloadUserList?: () => void;
@@ -40,6 +40,11 @@ export default class InstitutionalUsersList extends Component {
         if (this.institution && this.departmentMetrics) {
             const institutionDepartments = this.departmentMetrics.map((x: InstitutionDepartmentsModel) => x.name);
             departments = departments.concat(institutionDepartments);
+        }
+
+        if (!this.department) {
+            // eslint-disable-next-line ember/no-side-effects
+            this.set('department', departments[0]);
         }
 
         return departments;

--- a/app/institutions/dashboard/-components/institutional-users-list/component.ts
+++ b/app/institutions/dashboard/-components/institutional-users-list/component.ts
@@ -23,7 +23,7 @@ export default class InstitutionalUsersList extends Component {
 
     // Private properties
     modelTaskInstance!: TaskInstance<InstitutionsDashboardModel>;
-    department?: string;
+    department = this.intl.t('institutions.dashboard.select_default');
     sort = 'user_name';
 
     reloadUserList?: () => void;
@@ -40,11 +40,6 @@ export default class InstitutionalUsersList extends Component {
         if (this.institution && this.departmentMetrics) {
             const institutionDepartments = this.departmentMetrics.map((x: InstitutionDepartmentsModel) => x.name);
             departments = departments.concat(institutionDepartments);
-        }
-
-        if (!this.department) {
-            // eslint-disable-next-line ember/no-side-effects
-            this.set('department', departments[0]);
         }
 
         return departments;

--- a/app/styles/_components.scss
+++ b/app/styles/_components.scss
@@ -391,7 +391,7 @@
 .nav-tabs>li.active>a,
 .nav-tabs>li.active>a:hover,
 .nav-tabs>li.active>a:focus {
-    background-color: $bg-light;
+    background-color: inherit;
     border: none;
     border-bottom: 2px solid #204762;
 }
@@ -403,7 +403,7 @@
 
 .nav>li>a:hover,
 .nav>li>a:focus {
-    background-color: $bg-light;
+    background-color: inherit;
 }
 
 

--- a/lib/osf-components/addon/components/banners/view-only-link/styles.scss
+++ b/lib/osf-components/addon/components/banners/view-only-link/styles.scss
@@ -1,8 +1,12 @@
-.Alert.Alert {
+.alert.alert {
     margin-bottom: 0;
 }
 
-.Banner {
+.banner-warning.banner-warning {
+    margin-bottom: 10px;
+}
+
+.banner {
     display: flex;
     align-items: center;
     flex-direction: column;

--- a/lib/osf-components/addon/components/banners/view-only-link/template.hbs
+++ b/lib/osf-components/addon/components/banners/view-only-link/template.hbs
@@ -1,11 +1,11 @@
 <Alert
     data-analytics-scope='View-only link banner'
-    local-class='Alert'
+    local-class='alert'
     @visible={{this.shouldDisplay}}
     @type='info'
 >
-    <div local-class='Banner'>
-        <p>
+    <div local-class='banner'>
+        <p local-class='banner-warning'>
             {{t 'banners.view_only.warning'}}
         </p>
 

--- a/lib/osf-components/addon/components/maintenance-banner/template.hbs
+++ b/lib/osf-components/addon/components/maintenance-banner/template.hbs
@@ -4,6 +4,7 @@
         @type={{this.alertType}}
         @onDismiss={{action this.dismiss}}
         @visible={{true}}
+        @dismissible={{true}}
     >
         <strong>{{t 'maintenance.title'}}</strong>
         {{#if this.maintenance.message.length}}

--- a/lib/osf-components/addon/components/sort-button/styles.scss
+++ b/lib/osf-components/addon/components/sort-button/styles.scss
@@ -15,7 +15,7 @@
         background: transparent !important;
         height: 29px;
         padding: 0.4em 0 0 0.2em;
-        color: $color-text-white !important;
+        color: $secondary-blue !important;
     }
 
     :global(.btn) {

--- a/lib/osf-components/addon/components/subscriptions/list-row/styles.scss
+++ b/lib/osf-components/addon/components/subscriptions/list-row/styles.scss
@@ -11,3 +11,7 @@ li:last-of-type {
         border-bottom: 1px solid $color-bg-gray-dark;
     }
 }
+
+.power-select-box {
+    min-width: 75px;
+}

--- a/lib/osf-components/addon/components/subscriptions/list-row/template.hbs
+++ b/lib/osf-components/addon/components/subscriptions/list-row/template.hbs
@@ -8,6 +8,7 @@
                 @selected={{@subscription.frequency}}
                 @options={{this.frequencyOptions}}
                 @onChange={{fn @manager.updateSubscriptionFrequency @subscription}}
+                local-class='power-select-box'
                 as |option|
             >
                 <span data-test-subscription-option={{option}}>

--- a/lib/registries/addon/components/registries-header/styles.scss
+++ b/lib/registries/addon/components/registries-header/styles.scss
@@ -82,9 +82,6 @@
     }
 
     .provider-description {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
         justify-content: center;
         margin-top: 15px;
         margin-bottom: 25px;

--- a/lib/registries/addon/overview/-components/overview-topbar/template.hbs
+++ b/lib/registries/addon/overview/-components/overview-topbar/template.hbs
@@ -107,10 +107,10 @@
                     local-class='Icon'
                     @icon='share-alt'
                 />
-                <EmberTooltip>
-                    <span data-test-sharing-tooltip>{{t 'registries.overview.tooltips.share'}}</span>
-                </EmberTooltip>
             </dd.trigger>
+            <EmberTooltip>
+                <span data-test-sharing-tooltip>{{t 'registries.overview.tooltips.share'}}</span>
+            </EmberTooltip>
         </SharingIcons::Dropdown>
     </div>
 {{/if}}

--- a/package.json
+++ b/package.json
@@ -59,9 +59,7 @@
     "ember-element-helper": "^0.6.1",
     "ember-validators": "^4.1.1"
   },
-  "dependencies": {
-    "ember-tooltips": "^3.6.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@centerforopenscience/eslint-config": "3.0.0",
     "@ember-intl/cp-validations": "^4.0.1",
@@ -213,6 +211,7 @@
     "ember-template-compiler": "^1.9.0-alpha",
     "ember-template-lint": "^3.2.0",
     "ember-toastr": "^3.0.0",
+    "ember-tooltips": "^3.6.0",
     "ember-wormhole": "^0.5.4",
     "eslint": "^7.24.0",
     "eslint-config-airbnb-base": "14.0.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "@embroider/macros": "^1.0.0",
     "ember-cli-clipboard": "0.9.0",
     "ember-element-helper": "^0.6.1",
-    "ember-validators": "^4.1.1"
+    "ember-validators": "^4.1.1",
+    "watch-detector": "^1.0.2"
   },
   "dependencies": {},
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -21428,24 +21428,12 @@ walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
-watch-detector@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/watch-detector/-/watch-detector-0.1.0.tgz#e37b410d149e2a8bf263a4f8b71e2f667633dbf8"
-  integrity sha512-vfzMMfpjQc88xjETwl2HuE6PjEuxCBeyC4bQmqrHrofdfYWi/4mEJklYbNgSzpqM9PxubsiPIrE5SZ1FDyiQ2w==
-  dependencies:
-    heimdalljs-logger "^0.1.9"
-    quick-temp "^0.1.8"
-    rsvp "^4.7.0"
-    semver "^5.4.1"
-    silent-error "^1.1.0"
-
-watch-detector@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/watch-detector/-/watch-detector-1.0.0.tgz#c7b722d8695fee9ab6071e0f38f258e6adb22609"
-  integrity sha512-siywMl3fXK30Tlpu/dUBHhlpxhQmHdguZ8OIb813eU9lrVmmsJa9k0+n1HtJ+7p3SzFCPq2XbmR3GUYpPC3TBA==
+watch-detector@^0.1.0, watch-detector@^1.0.0, watch-detector@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/watch-detector/-/watch-detector-1.0.2.tgz#95deb9189f8c89c0a9f211739cef6d01cffcf452"
+  integrity sha512-MrJK9z7kD5Gl3jHBnnBVHvr1saVGAfmkyyrvuNzV/oe0Gr1nwZTy5VSA0Gw2j2Or0Mu8HcjUa44qlBvC2Ofnpg==
   dependencies:
     heimdalljs-logger "^0.1.10"
-    semver "^6.3.0"
     silent-error "^1.1.1"
     tmp "^0.1.0"
 


### PR DESCRIPTION
-   Ticket: [ENG-4551]
-   Feature flag: n/a

## Purpose

Bug fixes for Cesium. Ignore the last two commits if you go commit-by-commit, they were a mistake and the last one reverts out the second-to-last.

## Summary of Changes

1. No flex on headers provider-description div - This one I found, not QA. It was causing the registries header to separate out anchor tags from the main paragraph and put them in their own little flex space.
2. Choose Bette focus color for sort buttons
3. On collections navbar, don't make background white
4. Ensure power select doesn't get too small
5. Make maintenance banner dismissible
6. Pad the warning text on the VOL banner
7. Make sharing tooltip look good
8. Move ember tooltips to dev dependencies - Not a bug, but a mistake I made earlier that needed fixing
9. Work with newer versions of watchman - unrelated to the cesium upgrade, but I installed watchman on my system and now want the warning message to go away

## Screenshot(s)
<img width="385" alt="Screenshot 2023-06-27 at 3 05 48 PM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/83867ace-972f-4ec1-b345-5e9f4e5f4b8a">
<img width="1181" alt="Screenshot 2023-06-27 at 3 22 39 PM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/13df9575-35a6-430f-9bf4-8ca64b6693fc">
<img width="1147" alt="Screenshot 2023-06-28 at 9 27 55 AM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/90d7ef42-0d90-4034-b9e4-3d780d5b13d3">
<img width="1576" alt="Screenshot 2023-06-28 at 10 19 58 AM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/5b47dea6-aadb-4d8b-a859-7f56e8f46896">
<img width="316" alt="Screenshot 2023-06-28 at 11 12 23 AM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/0d907040-7948-4aa8-abf2-5523fca59914">


[ENG-4551]: https://openscience.atlassian.net/browse/ENG-4551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ