### PR TITLE
[ENG-4574] Preprint discover rewrite

### DIFF
--- a/app/models/preprint-provider.ts
+++ b/app/models/preprint-provider.ts
@@ -7,7 +7,7 @@ import Intl from 'ember-intl/services/intl';
 import { RelatedLinkMeta } from 'osf-api';
 
 import PreprintModel from './preprint';
-import ProviderModel from './provider';
+import ProviderModel, { ReviewPermissions } from './provider';
 
 export type PreprintWord = 'default' | 'work' | 'paper' | 'preprint' | 'thesis';
 export type PreprintWordGrammar = 'plural' | 'pluralCapitalized' | 'singular' | 'singularCapitalized';
@@ -21,7 +21,7 @@ export default class PreprintProviderModel extends ProviderModel {
     @attr('string') preprintWord!: PreprintWord;
 
     // Reviews settings
-    @attr('array') permissions!: string[];
+    @attr('array') permissions!: ReviewPermissions[];
     @attr('boolean', { allowNull: true }) reviewsCommentsPrivate!: boolean | null;
 
     // Relationships

--- a/app/preprints/discover/controller.ts
+++ b/app/preprints/discover/controller.ts
@@ -1,8 +1,40 @@
 
 import Store from '@ember-data/store';
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import config from 'ember-get-config';
+import Media from 'ember-responsive';
+
+import Theme from 'ember-osf-web/services/theme';
+import pathJoin from 'ember-osf-web/utils/path-join';
 
 export default class PreprintDiscoverController extends Controller {
     @service store!: Store;
+    @service theme!: Theme;
+    @service media!: Media;
+
+    @tracked q?: string = '';
+    @tracked sort?: string =  '-relevance';
+
+    queryParams = ['q', 'page', 'sort'];
+
+    get showSidePanelToggle() {
+        return this.media.isMobile || this.media.isTablet;
+    }
+
+    get defaultQueryOptions() {
+        return {
+            resourceType: 'osf:Preprints',
+            // TODO: get this from the API?
+            publisher: pathJoin(config.OSF.url, 'preprints', this.theme.id),
+        };
+    }
+
+    @action
+    onSearch(queryOptions: Record<string, string>) {
+        this.q = queryOptions.q;
+        this.sort = queryOptions.sort;
+    }
 }

--- a/app/preprints/discover/controller.ts
+++ b/app/preprints/discover/controller.ts
@@ -5,7 +5,6 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import config from 'ember-get-config';
-import Media from 'ember-responsive';
 
 import Theme from 'ember-osf-web/services/theme';
 import pathJoin from 'ember-osf-web/utils/path-join';
@@ -13,16 +12,11 @@ import pathJoin from 'ember-osf-web/utils/path-join';
 export default class PreprintDiscoverController extends Controller {
     @service store!: Store;
     @service theme!: Theme;
-    @service media!: Media;
 
     @tracked q?: string = '';
     @tracked sort?: string =  '-relevance';
 
     queryParams = ['q', 'page', 'sort'];
-
-    get showSidePanelToggle() {
-        return this.media.isMobile || this.media.isTablet;
-    }
 
     get defaultQueryOptions() {
         return {

--- a/app/preprints/discover/route.ts
+++ b/app/preprints/discover/route.ts
@@ -1,5 +1,6 @@
 import Store from '@ember-data/store';
 import Route from '@ember/routing/route';
+import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 
 import Theme from 'ember-osf-web/services/theme';
@@ -7,6 +8,7 @@ import Theme from 'ember-osf-web/services/theme';
 export default class PreprintDiscoverRoute extends Route {
     @service store!: Store;
     @service theme!: Theme;
+    @service router!: RouterService;
 
     buildRouteInfoMetadata() {
         return {
@@ -18,9 +20,18 @@ export default class PreprintDiscoverRoute extends Route {
     }
 
     async model(args: any) {
-        // Error handling?
-        this.theme.providerType = 'preprint';
-        this.theme.id = args.provider_id;
-        return await this.store.findRecord('preprint-provider', args.provider_id);
+        try {
+            const provider = await this.store.findRecord('preprint-provider', args.provider_id);
+            this.theme.providerType = 'preprint';
+            this.theme.id = args.provider_id;
+            return provider;
+        } catch (e) {
+            this.router.transitionTo('not-found', `preprints/${args.provider_id}/discover`);
+            return null;
+        }
+    }
+
+    deactivate() {
+        this.theme.reset();
     }
 }

--- a/app/preprints/discover/route.ts
+++ b/app/preprints/discover/route.ts
@@ -2,10 +2,25 @@ import Store from '@ember-data/store';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
+import Theme from 'ember-osf-web/services/theme';
+
 export default class PreprintDiscoverRoute extends Route {
     @service store!: Store;
+    @service theme!: Theme;
+
+    buildRouteInfoMetadata() {
+        return {
+            osfMetrics: {
+                isSearch: true,
+                providerId: this.theme.id,
+            },
+        };
+    }
 
     async model(args: any) {
+        // Error handling?
+        this.theme.providerType = 'preprint';
+        this.theme.id = args.provider_id;
         return await this.store.findRecord('preprint-provider', args.provider_id);
     }
 }

--- a/app/preprints/discover/template.hbs
+++ b/app/preprints/discover/template.hbs
@@ -1,4 +1,5 @@
 <SearchPage
+    {{with-branding (get-model this.model.brand)}}
     @route='search'
     @query={{this.q}}
     @defaultQueryOptions={{this.defaultQueryOptions}}

--- a/app/preprints/discover/template.hbs
+++ b/app/preprints/discover/template.hbs
@@ -3,9 +3,9 @@
     @route='search'
     @query={{this.q}}
     @defaultQueryOptions={{this.defaultQueryOptions}}
+    @showResourceTypeFilter={{false}}
     @provider={{this.model}}
     @queryParams={{this.queryParams}}
-    @showSidePanelToggle={{this.showSidePanelToggle}}
     @onSearch={{action this.onSearch}}
     @sort={{this.sort}}
 />

--- a/app/preprints/discover/template.hbs
+++ b/app/preprints/discover/template.hbs
@@ -1,1 +1,10 @@
-{{!-- placeholder route for preprint discover --}}
+<SearchPage
+    @route='search'
+    @query={{this.q}}
+    @defaultQueryOptions={{this.defaultQueryOptions}}
+    @provider={{this.model}}
+    @queryParams={{this.queryParams}}
+    @showSidePanelToggle={{this.showSidePanelToggle}}
+    @onSearch={{action this.onSearch}}
+    @sort={{this.sort}}
+/>

--- a/app/preprints/template.hbs
+++ b/app/preprints/template.hbs
@@ -1,0 +1,7 @@
+<ThemeStyles />
+<BrandedNavbar
+    @translateKey='collections.general.brand'
+    @brandRoute='preprints.discover'
+    @addLinkKey='collections.navbar.add'
+/>
+{{outlet}}

--- a/app/search/controller.ts
+++ b/app/search/controller.ts
@@ -1,21 +1,13 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import Media from 'ember-responsive';
 
 export default class SearchController extends Controller {
-    @service media!: Media;
-
     @tracked q?: string = '';
     @tracked sort?: string =  '-relevance';
     @tracked resourceType?: string =  'All';
 
     queryParams = ['q', 'page', 'sort', 'resourceType'];
-
-    get showSidePanelToggle() {
-        return this.media.isMobile || this.media.isTablet;
-    }
 
     @action
     onSearch(queryOptions: Record<string, string>) {

--- a/app/search/controller.ts
+++ b/app/search/controller.ts
@@ -1,16 +1,11 @@
-import Store from '@ember-data/store';
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import Intl from 'ember-intl/services/intl';
 import Media from 'ember-responsive';
 
 export default class SearchController extends Controller {
-    @service intl!: Intl;
-    @service store!: Store;
     @service media!: Media;
-    @service toast!: Toastr;
 
     @tracked q?: string = '';
     @tracked sort?: string =  '-relevance';

--- a/app/search/template.hbs
+++ b/app/search/template.hbs
@@ -4,7 +4,6 @@
     @route='search'
     @query={{this.q}}
     @queryParams={{this.queryParams}}
-    @showSidePanelToggle={{this.showSidePanelToggle}}
     @onSearch={{action this.onSearch}}
     @sort={{this.sort}}
     @resourceType={{this.resourceType}}

--- a/app/search/template.hbs
+++ b/app/search/template.hbs
@@ -5,6 +5,7 @@
     @query={{this.q}}
     @queryParams={{this.queryParams}}
     @onSearch={{action this.onSearch}}
+    @showResourceTypeFilter={{true}}
     @sort={{this.sort}}
     @resourceType={{this.resourceType}}
 />

--- a/lib/app-components/addon/components/branded-navbar/component.ts
+++ b/lib/app-components/addon/components/branded-navbar/component.ts
@@ -3,6 +3,7 @@ import Component from '@ember/component';
 import { action, computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
+import config from 'ember-get-config';
 import Intl from 'ember-intl/services/intl';
 import Media from 'ember-responsive';
 import Session from 'ember-simple-auth/services/session';
@@ -10,12 +11,16 @@ import { tracked } from 'tracked-built-ins';
 
 import { serviceLinks } from 'ember-osf-web/const/service-links';
 import { layout, requiredAction } from 'ember-osf-web/decorators/component';
+import ProviderModel from 'ember-osf-web/models/provider';
 import Analytics from 'ember-osf-web/services/analytics';
+import CurrentUserService from 'ember-osf-web/services/current-user';
 import Theme from 'ember-osf-web/services/theme';
 import styles from './styles';
 import template from './template';
 
 type ObjectType = 'collection' | 'preprint' | 'registration';
+
+const osfURL = config.OSF.url;
 
 @layout(template, styles)
 @tagName('')
@@ -25,6 +30,7 @@ export default class BrandedNavbar extends Component {
     @service media!: Media;
     @service session!: Session;
     @service theme!: Theme;
+    @service currentUser!: CurrentUserService;
 
     brandRoute!: string;
     objectType!: ObjectType;
@@ -35,6 +41,15 @@ export default class BrandedNavbar extends Component {
 
     myProjectsUrl = serviceLinks.myProjects;
 
+    get reviewUrl() {
+        return `${osfURL}reviews`;
+    }
+
+    get submitPreprintUrl() {
+        return this.theme.isProvider ? `${osfURL}preprints/${this.theme.id}/submit/` : `${osfURL}preprints/submit/`;
+    }
+
+    @alias('theme.provider') provider!: ProviderModel;
     @alias('theme.provider.id') providerId!: string;
 
     @computed('intl.locale', 'theme.provider', 'translateKey')

--- a/lib/app-components/addon/components/branded-navbar/template.hbs
+++ b/lib/app-components/addon/components/branded-navbar/template.hbs
@@ -34,47 +34,75 @@
                     local-class='secondary-navigation'
                 >
                     <ul class='nav navbar-nav' local-class='links'>
-                        {{#if @displayModerationButton}}
+                        {{#if (eq this.theme.providerType 'collection')}}
+                            {{#if @displayModerationButton}}
+                                <li>
+                                    <OsfLink
+                                        data-analytics-name='Collection moderation'
+                                        data-test-branded-navbar-moderation
+                                        @route='collections.provider.moderation'
+                                        @models={{array this.providerId}}
+                                    >
+                                        {{t 'app_components.branded_navbar.moderation'}}
+                                    </OsfLink>
+                                </li>
+                            {{/if}}
+                            <li>
+                                <a
+                                    href={{this.myProjectsUrl}}
+                                    onclick={{action 'click' 'link' 'Navbar - navbar.my_projects' target=this.analytics}}
+                                >
+                                    {{t 'app_components.branded_navbar.my_osf_projects'}}
+                                </a>
+                            </li>
+                            <li>
+                                <LinkTo
+                                    @route='provider.submit'
+                                    onclick={{action
+                                        'click'
+                                        'link'
+                                        (concat 'Navbar - ' (t @addLinkKey) ' - ' this.theme.id)
+                                        target=this.analytics
+                                    }}
+                                >
+                                    <span role='button'>{{t @addLinkKey}}</span>
+                                </LinkTo>
+                            </li>
+                            <li>
+                                <LinkTo
+                                    @route='provider.discover'
+                                    onclick={{action 'click' 'link' 'Navbar - Search' target=this.analytics}}
+                                >
+                                    <span role='button'>{{t 'navbar.search'}}</span>
+                                </LinkTo>
+                            </li>
+                        {{else if (eq this.theme.providerType 'preprint')}}
                             <li>
                                 <OsfLink
-                                    data-analytics-name='Collection moderation'
-                                    data-test-branded-navbar-moderation
-                                    @route='collections.provider.moderation'
-                                    @models={{array this.providerId}}
+                                    @href={{concat this.myProjectsUrl '#preprints'}}
                                 >
-                                    {{t 'app_components.branded_navbar.moderation'}}
+                                    <span role='button'>{{t 'navbar.my_preprints'}}</span>
+                                </OsfLink>
+                            </li>
+                            {{#if this.currentUser.user.canViewReviews}}
+                                <li>
+                                    <OsfLink
+                                        {{!-- TODO Preprint emberization: make this an in-app transition --}}
+                                        @href={{this.reviewUrl}}
+                                    >
+                                        <span role='button'>{{t 'navbar.reviews'}}</span>
+                                    </OsfLink>
+                                </li>
+                            {{/if}}
+                            <li>
+                                <OsfLink
+                                    {{!-- TODO Preprint emberization: make this an in-app transition --}}
+                                    @href={{this.submitPreprintUrl}}
+                                >
+                                    <span role='button'>{{t 'navbar.add_a_preprint' preprintWord=this.provider.preprintWord}}</span>
                                 </OsfLink>
                             </li>
                         {{/if}}
-                        <li>
-                            <a
-                                href={{this.myProjectsUrl}}
-                                onclick={{action 'click' 'link' 'Navbar - navbar.my_projects' target=this.analytics}}
-                            >
-                                {{t 'app_components.branded_navbar.my_osf_projects'}}
-                            </a>
-                        </li>
-                        <li>
-                            <LinkTo
-                                @route='provider.submit'
-                                onclick={{action
-                                    'click'
-                                    'link'
-                                    (concat 'Navbar - ' (t @addLinkKey) ' - ' this.theme.id)
-                                    target=this.analytics
-                                }}
-                            >
-                                <span role='button'>{{t @addLinkKey}}</span>
-                            </LinkTo>
-                        </li>
-                        <li>
-                            <LinkTo
-                                @route='provider.discover'
-                                onclick={{action 'click' 'link' 'Navbar - Search' target=this.analytics}}
-                            >
-                                <span role='button'>{{t 'navbar.search'}}</span>
-                            </LinkTo>
-                        </li>
                         <li>
                             <a
                                 href='https://cos.io/donate'

--- a/lib/osf-components/addon/components/osf-layout/template.hbs
+++ b/lib/osf-components/addon/components/osf-layout/template.hbs
@@ -18,6 +18,7 @@
         @leftClosed={{this.sidenavGutterClosed}}
         @rightMode={{this.metadataGutterMode}}
         @rightClosed={{this.metadataGutterClosed}}
+        ...attributes
         as |gutters|
     >
         {{yield (hash

--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -42,7 +42,7 @@ interface SearchArgs {
     sort: string;
     resourceType: string;
     defaultQueryOptions: Record<string, string>;
-    provider: ProviderModel;
+    provider?: ProviderModel;
 }
 
 const searchDebounceTime = 100;

--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -43,6 +43,7 @@ interface SearchArgs {
     resourceType: string;
     defaultQueryOptions: Record<string, string>;
     provider?: ProviderModel;
+    showSidePanelToggle: boolean;
 }
 
 const searchDebounceTime = 100;
@@ -82,6 +83,17 @@ export default class SearchPage extends Component<SearchArgs> {
         const isRegistrationProvider = this.args.provider instanceof RegistrationProviderModel;
         return !(isPreprintProvider || isRegistrationProvider);
     }
+
+    get showResultCountMiddle() {
+        const hasResults = this.totalResultCount && this.totalResultCount > 0;
+        return hasResults && !this.showResourceTypeFilter && !this.args.showSidePanelToggle;
+    }
+
+    get showResultCountLeft() {
+        const hasResults = this.totalResultCount && this.totalResultCount > 0;
+        return hasResults && this.args.showSidePanelToggle;
+    }
+
 
     get selectedSortOption() {
         return this.sortOptions.find(option => option.value === this.sort);// || this.sortOptions[0];

--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -9,11 +9,10 @@ import Intl from 'ember-intl/services/intl';
 import { A } from '@ember/array';
 import Store from '@ember-data/store';
 import { action } from '@ember/object';
+import Media from 'ember-responsive';
 
 import IndexPropertySearchModel from 'ember-osf-web/models/index-property-search';
 import SearchResultModel from 'ember-osf-web/models/search-result';
-import PreprintProviderModel from 'ember-osf-web/models/preprint-provider';
-import RegistrationProviderModel from 'ember-osf-web/models/registration-provider';
 import ProviderModel from 'ember-osf-web/models/provider';
 
 interface ResourceTypeOption {
@@ -43,7 +42,7 @@ interface SearchArgs {
     resourceType: string;
     defaultQueryOptions: Record<string, string>;
     provider?: ProviderModel;
-    showSidePanelToggle: boolean;
+    showResourceTypeFilter: boolean;
 }
 
 const searchDebounceTime = 100;
@@ -52,6 +51,7 @@ export default class SearchPage extends Component<SearchArgs> {
     @service intl!: Intl;
     @service toast!: Toastr;
     @service store!: Store;
+    @service media!: Media;
 
     @tracked searchText?: string;
     @tracked searchResults?: SearchResultModel[];
@@ -67,6 +67,10 @@ export default class SearchPage extends Component<SearchArgs> {
         taskFor(this.search).perform();
     }
 
+    get showSidePanelToggle() {
+        return this.media.isMobile || this.media.isTablet;
+    }
+
     get filterableProperties() {
         if (!this.propertySearch) {
             return [];
@@ -78,22 +82,15 @@ export default class SearchPage extends Component<SearchArgs> {
         return this.resourceTypeOptions.find(option => option.value === this.resourceType);
     }
 
-    get showResourceTypeFilter() {
-        const isPreprintProvider = this.args.provider instanceof PreprintProviderModel;
-        const isRegistrationProvider = this.args.provider instanceof RegistrationProviderModel;
-        return !(isPreprintProvider || isRegistrationProvider);
-    }
-
     get showResultCountMiddle() {
         const hasResults = this.totalResultCount && this.totalResultCount > 0;
-        return hasResults && !this.showResourceTypeFilter && !this.args.showSidePanelToggle;
+        return hasResults && !this.args.showResourceTypeFilter && !this.showSidePanelToggle;
     }
 
     get showResultCountLeft() {
         const hasResults = this.totalResultCount && this.totalResultCount > 0;
-        return hasResults && this.args.showSidePanelToggle;
+        return hasResults && this.showSidePanelToggle;
     }
-
 
     get selectedSortOption() {
         return this.sortOptions.find(option => option.value === this.sort);// || this.sortOptions[0];

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -34,6 +34,7 @@
 .topbar {
     margin-left: 20px;
     display: flex;
+    justify-content: space-between;
     border-bottom: 1px solid $color-text-black;
 }
 
@@ -75,6 +76,13 @@
 .left-panel {
     padding-left: 12px;
     width: 300px;
+}
+
+.search-count {
+    margin-top: 10px;
+    margin-bottom: 10px;
+    font-size: 1.3em;
+    font-weight: bold;
 }
 
 .active-filter-list {

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -8,6 +8,37 @@
     background-color: $osf-dark-blue-navbar;
 }
 
+.provider-logo {
+    background: var(--hero-logo-img-url) top center no-repeat;
+    background-size: contain;
+    height: 70px;
+    width: 100%;
+    margin: 2em 0 1em;
+}
+
+.hero-overlay {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    min-width: 100%;
+    min-height: 100%;
+    position: relative;
+    background-color: transparent; // override .heading-wrapper background-color
+
+    &::after {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: var(--hero-background-img-url);
+        background-size: cover;
+        z-index: -1;
+        content: '';
+    }
+}
+
 .heading-label {
     padding: 40px;
 }

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -45,17 +45,22 @@ as |layout|>
         data-analytics-scope='Search page left panel'
         local-class='left-panel'
     >
+        {{#if this.showResourceTypeFilter}}
+            <p local-class='search-count'>{{t 'search.total-results' count=this.totalResultCount}}</p>
+        {{/if}}
         <h2>{{t 'search.left-panel.header'}}</h2>
         {{#if @showSidePanelToggle}}
-            <div data-test-left-panel-object-type-dropdown>
-                <label>
-                    {{t 'search.resource-type.search-by'}}
-                    <PowerSelect @options={{this.resourceTypeOptions}} @selected={{this.selectedResourceTypeOption}}
-                        @onChange={{this.updateResourceType}} as |resourceType|>
-                        {{resourceType.display}}
-                    </PowerSelect>
-                </label>
-            </div>
+            {{#if this.showResourceTypeFilter}}
+                <div data-test-left-panel-object-type-dropdown>
+                    <label>
+                        {{t 'search.resource-type.search-by'}}
+                        <PowerSelect @options={{this.resourceTypeOptions}} @selected={{this.selectedResourceTypeOption}}
+                            @onChange={{this.updateResourceType}} as |resourceType|>
+                            {{resourceType.display}}
+                        </PowerSelect>
+                    </label>
+                </div>
+            {{/if}}
             <div data-test-left-panel-sort-dropdown>
                 <label>
                     {{t 'search.sort.sort-by'}}
@@ -108,27 +113,30 @@ as |layout|>
         {{!-- paginator --}}
         {{#unless @showSidePanelToggle}}
             <div local-class='topbar'>
-                <nav
-                    data-test-topbar-object-type-nav
-                    local-class='object-type-nav'
-                >
-                    <ul>
-                        {{#each this.resourceTypeOptions as |resourceType|}}
-                            <li>
-                                <LinkTo
-                                    data-analytics-name='Object type filter={{resourceType.value}}'
-                                    data-test-topbar-object-type-link='{{resourceType.value}}'
-                                    local-class='object-type-filter-link'
-                                    @route={{@route}}
-                                    @query={{hash resourceType=resourceType.value}}
-                                    {{on 'click' (fn this.updateResourceType resourceType)}}
-                                >
-                                    {{resourceType.display}}
-                                </LinkTo>
-                            </li>
-                        {{/each}}
-                    </ul>
-                </nav>
+                {{#if this.showResourceTypeFilter}}
+                    <nav
+                        data-test-topbar-object-type-nav
+                        local-class='object-type-nav'
+                    >
+                        <ul>
+                            {{#each this.resourceTypeOptions as |resourceType|}}
+                                <li>
+                                    <LinkTo
+                                        data-analytics-name='Object type filter={{resourceType.value}}'
+                                        data-test-topbar-object-type-link='{{resourceType.value}}'
+                                        local-class='object-type-filter-link'
+                                        @query={{hash resourceType=resourceType.value}}
+                                        {{on 'click' (fn this.updateResourceType resourceType)}}
+                                    >
+                                        {{resourceType.display}}
+                                    </LinkTo>
+                                </li>
+                            {{/each}}
+                        </ul>
+                    </nav>
+                {{else}}
+                    <p local-class='search-count'>{{t 'search.total-results' count=this.totalResultCount}}</p>
+                {{/if}}
                 <div
                     data-test-topbar-sort-dropdown
                     local-class='sort-dropdown'

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -2,13 +2,26 @@
     @backgroundClass='search-page'
     ...attributes
 as |layout|>
-    <layout.heading local-class='heading-wrapper'>
-        <label
-            for='search-input'
-            local-class='heading-label'
-        >
-            <h1>{{t 'search.search-header'}}</h1>
-        </label>
+    <layout.heading
+        {{with-branding (get-model @provider.brand)}}
+        local-class='heading-wrapper {{if @provider 'hero-overlay'}}'
+    >
+        {{#if @provider}}
+            <div
+                local-class='provider-logo'
+            >
+            </div>
+            <p>
+                {{@provider.description}}
+            </p>
+        {{else}}
+            <label
+                for='search-input'
+                local-class='heading-label'
+            >
+                <h1>{{t 'search.search-header'}}</h1>
+            </label>
+        {{/if}}
         <span local-class='search-input-wrapper'>
             <Input
                 local-class='search-input'

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -8,14 +8,16 @@ as |layout|>
     >
         {{#if @provider}}
             <div
+                data-test-search-provider-logo
                 local-class='provider-logo'
             >
             </div>
-            <p>
+            <p data-test-search-provider-description>
                 {{@provider.description}}
             </p>
         {{else}}
             <label
+                data-test-search-header
                 for='search-input'
                 local-class='heading-label'
             >
@@ -59,8 +61,13 @@ as |layout|>
         data-analytics-scope='Search page left panel'
         local-class='left-panel'
     >
-        {{#if this.showResourceTypeFilter}}
-            <p local-class='search-count'>{{t 'search.total-results' count=this.totalResultCount}}</p>
+        {{#if this.showResultCountLeft}}
+            <p
+                data-test-left-search-count
+                local-class='search-count'
+            >
+                {{t 'search.total-results' count=this.totalResultCount}}
+            </p>
         {{/if}}
         <h2>{{t 'search.left-panel.header'}}</h2>
         {{#if @showSidePanelToggle}}
@@ -148,8 +155,13 @@ as |layout|>
                             {{/each}}
                         </ul>
                     </nav>
-                {{else}}
-                    <p local-class='search-count'>{{t 'search.total-results' count=this.totalResultCount}}</p>
+                {{else if this.showResultCountMiddle}}
+                    <p
+                        data-test-middle-search-count
+                        local-class='search-count'
+                    >
+                        {{t 'search.total-results' count=this.totalResultCount}}
+                    </p>
                 {{/if}}
                 <div
                     data-test-topbar-sort-dropdown

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -45,7 +45,7 @@ as |layout|>
                 <FaIcon @icon='search' />
             </Button>
         </span>
-        {{#if @showSidePanelToggle}}
+        {{#if this.showSidePanelToggle}}
             <Button
                 data-test-toggle-side-panel
                 data-analytics-name='toggle side panel'
@@ -70,8 +70,8 @@ as |layout|>
             </p>
         {{/if}}
         <h2>{{t 'search.left-panel.header'}}</h2>
-        {{#if @showSidePanelToggle}}
-            {{#if this.showResourceTypeFilter}}
+        {{#if this.showSidePanelToggle}}
+            {{#if @showResourceTypeFilter}}
                 <div data-test-left-panel-object-type-dropdown>
                     <label>
                         {{t 'search.resource-type.search-by'}}
@@ -132,9 +132,9 @@ as |layout|>
     </layout.left>
     <layout.main data-analytics-scope='Search page main'>
         {{!-- paginator --}}
-        {{#unless @showSidePanelToggle}}
+        {{#unless this.showSidePanelToggle}}
             <div local-class='topbar'>
-                {{#if this.showResourceTypeFilter}}
+                {{#if @showResourceTypeFilter}}
                     <nav
                         data-test-topbar-object-type-nav
                         local-class='object-type-nav'

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -1,5 +1,6 @@
 <OsfLayout
     @backgroundClass='search-page'
+    ...attributes
 as |layout|>
     <layout.heading local-class='heading-wrapper'>
         <label

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -8,6 +8,7 @@ import {
 import { dashboardScenario } from './dashboard';
 import { forksScenario } from './forks';
 import { meetingsScenario } from './meetings';
+import { preprintsScenario } from './preprints';
 import { manyProjectRegistrationsScenario, registrationScenario } from './registrations';
 import { settingsScenario } from './settings';
 
@@ -55,5 +56,8 @@ export default function(server: Server) {
     }
     if (mirageScenarios.includes('manyProjectRegistrations')) {
         manyProjectRegistrationsScenario(server, currentUser);
+    }
+    if (mirageScenarios.includes('preprints')) {
+        preprintsScenario(server, currentUser);
     }
 }

--- a/mirage/scenarios/preprints.ts
+++ b/mirage/scenarios/preprints.ts
@@ -1,0 +1,23 @@
+import { ModelInstance, Server } from 'ember-cli-mirage';
+
+import PreprintProvider from 'ember-osf-web/models/preprint-provider';
+import User from 'ember-osf-web/models/user';
+
+export function preprintsScenario(
+    server: Server,
+    currentUser: ModelInstance<User>,
+) {
+    const thesisCommons = server.schema.preprintProviders.find('thesiscommons') as ModelInstance<PreprintProvider>;
+    const brand = server.create('brand');
+    const currentUserModerator = server.create('moderator',
+        { id: currentUser.id, user: currentUser, provider: thesisCommons }, 'asAdmin');
+
+    const preprints = server.createList('preprint', 3, {
+        provider: thesisCommons,
+    });
+    thesisCommons.update({
+        brand,
+        moderators: [currentUserModerator],
+        preprints,
+    });
+}

--- a/mirage/scenarios/preprints.ts
+++ b/mirage/scenarios/preprints.ts
@@ -19,5 +19,6 @@ export function preprintsScenario(
         brand,
         moderators: [currentUserModerator],
         preprints,
+        description: 'This is the description for Thesis Commons',
     });
 }

--- a/mirage/serializers/preprint-provider.ts
+++ b/mirage/serializers/preprint-provider.ts
@@ -1,0 +1,73 @@
+import { ModelInstance } from 'ember-cli-mirage';
+import config from 'ember-get-config';
+import PreprintProvider from 'ember-osf-web/models/preprint-provider';
+import ApplicationSerializer, { SerializedRelationships } from './application';
+
+const { OSF: { apiUrl } } = config;
+
+export default class PreprintProviderSerializer extends ApplicationSerializer<PreprintProvider> {
+    buildNormalLinks(model: ModelInstance) {
+        return {
+            self: `${apiUrl}/v2/providers/preprints/${model.id}/`,
+        };
+    }
+
+    buildRelationships(model: ModelInstance<PreprintProvider>) {
+        const relationships: SerializedRelationships<PreprintProvider> = {
+            subjects: {
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/providers/preprints/${model.id}/subjects/`,
+                        meta: this.buildRelatedLinkMeta(model, 'subjects'),
+                    },
+                },
+            },
+            highlightedSubjects: {
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/providers/preprints/${model.id}/highlightedSubjects/`,
+                        meta: this.buildRelatedLinkMeta(model, 'highlightedSubjects'),
+                    },
+                },
+            },
+            licensesAcceptable: {
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/providers/preprints/${model.id}/licenses/`,
+                        meta: {},
+                    },
+                },
+            },
+            moderators: {
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/providers/preprints/${model.id}/moderators/`,
+                        meta: this.buildRelatedLinkMeta(model, 'moderators'),
+                    },
+                },
+            },
+            preprints: {
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/providers/preprints/${model.id}/preprints/`,
+                        meta: {},
+                    },
+                },
+            },
+            // TODO: subscriptions when we move ember-osf-reviews¥
+        };
+
+        if (model.brand) {
+            relationships.brand = {
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/brands/${model.brand.id}/`,
+                        meta: {},
+                    },
+                },
+            };
+        }
+
+        return relationships;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -270,6 +270,7 @@
       "lib/analytics-page",
       "lib/assets-prefix-middleware",
       "lib/collections",
+      "lib/app-components",
       "lib/osf-components",
       "lib/registries"
     ]

--- a/tests/acceptance/preprints/discover-test.ts
+++ b/tests/acceptance/preprints/discover-test.ts
@@ -1,0 +1,58 @@
+import { click, currentRouteName } from '@ember/test-helpers';
+import { ModelInstance } from 'ember-cli-mirage';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { TestContext } from 'ember-test-helpers';
+import { percySnapshot } from 'ember-percy';
+import { setBreakpoint } from 'ember-responsive/test-support';
+import { module, test } from 'qunit';
+
+import { setupOSFApplicationTest, visit } from 'ember-osf-web/tests/helpers';
+import PreprintProviderModel from 'ember-osf-web/models/preprint-provider';
+
+interface PreprintDiscoverTestContext extends TestContext {
+    provider: ModelInstance<PreprintProviderModel>;
+}
+
+module('Acceptance | preprints | discover', hooks => {
+    setupOSFApplicationTest(hooks);
+    setupMirage(hooks);
+
+    hooks.beforeEach(async function(this: PreprintDiscoverTestContext) {
+        server.loadFixtures('preprint-providers');
+        const provider = server.schema.preprintProviders.find('thesiscommons') as ModelInstance<PreprintProviderModel>;
+        const brand = server.create('brand');
+        provider.update({
+            brand,
+            description: 'This is the description for Thesis Commons',
+        });
+        this.provider = provider;
+    });
+
+    test('Desktop', async function(this: PreprintDiscoverTestContext, assert) {
+        await visit(`/preprints/${this.provider.id}/discover`);
+        assert.equal(currentRouteName(), 'preprints.discover', 'Current route is preprints discover');
+        assert.dom('[data-test-search-provider-logo]').exists('Desktop: Preprint provider logo is shown');
+        assert.dom('[data-test-search-provider-description]').exists('Desktop: Preprint provider description is shown');
+        assert.dom('[data-test-search-header]').doesNotExist('Desktop: Non-branded search header is not shown');
+        assert.dom('[data-test-topbar-object-type-nav]').doesNotExist('Desktop: Object type nav is not shown');
+        assert.dom('[data-test-middle-search-count]').exists('Desktop: Result count is shown in middle panel');
+        await percySnapshot(assert);
+    });
+
+    test('mobile', async function(this: PreprintDiscoverTestContext, assert) {
+        setBreakpoint('mobile');
+        await visit(`/preprints/${this.provider.id}/discover`);
+        assert.equal(currentRouteName(), 'preprints.discover', 'Current route is preprints discover');
+        assert.dom('[data-test-search-provider-logo]').exists('Mobile: Preprint provider logo is shown');
+        assert.dom('[data-test-search-provider-description]').exists('Mobile: Preprint provider description is shown');
+        assert.dom('[data-test-search-header]').doesNotExist('Mobile: Non-branded search header is not shown');
+        assert.dom('[data-test-topbar-object-type-nav]').doesNotExist('Mobile: Object type nav is not shown');
+        assert.dom('[data-test-middle-search-count]').doesNotExist('Mobile: Result count is not shown in middle panel');
+        assert.dom('[data-test-toggle-side-panel]').exists('Mobile: Toggle side panel button is shown');
+        await click('[data-test-toggle-side-panel]');
+        assert.dom('[data-test-left-search-count]').exists('Mobile: Result count is shown in side panel');
+        assert.dom('[data-test-left-panel-object-type-dropdown]')
+            .doesNotExist('Mobile: Object type dropdown is not shown');
+        await percySnapshot(assert);
+    });
+});

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -293,7 +293,7 @@ move_to_project:
     go_to_project: 'Go to project'
 navbar:
     add: Add
-    # add_a_preprint: 'Add a {preprintWords.preprint}'
+    add_a_preprint: 'Add a {preprintWord}'
     add_registration: 'Add New'
     moderation: 'Moderation'
     browse: Browse
@@ -301,6 +301,7 @@ navbar:
     donate: Donate
     go_home: 'Go home'
     my_projects: 'My Projects'
+    my_preprints: 'My Preprints'
     my_registrations: 'My Registrations'
     reviews: 'My Reviewing'
     search: Search

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -211,6 +211,7 @@ search:
     search-header: 'Search OSF'
     textbox-placeholder: 'Search placeholder'
     search-button-label: 'Search'
+    total-results: '{count} results'
     resource-type:
         search-by: 'Search by resource type'
         all: 'All'


### PR DESCRIPTION
-   Ticket: [ENG-4574]
-   Feature flag: n/a

## Purpose
- Rewrite the preprints discover page to use the new search-page component

## Summary of Changes
- Add `app/preprints/template.hbs` to house general preprints templating (import CSS using `<ThemStyles>` and `<BrandedNavbar>`
- Update `<BrandedNavbar>` to support preprints in ember-osf-web
- Update preprints discover route and controller to support search-page
- Update search-page component 
  - support default query options to send to SHARE
  - Add result count

## To-Do:
- [x] Invalid preprint provider handling
- [x] Reset theme when leaving route
- [x] Branded header
- [x] Screenshots
- [x] Tests


## Screenshot(s)
Preprint branded discover page
Desktop
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/fe4610ba-50d7-41c9-a3b4-dceb0751c7d1)
Mobile
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/8aa74a31-b7ad-474a-aa6b-340a0df19971)


## Side Effects
- Should be none...

## QA Notes
- This touches the `<BrandedNavbar>` component that is used in collections. I checked to make sure these didn't break, but a double-check if the buttons for collections navbars are showing up as expected would be much appreciated ("Moderation", "My OSF Projects", "Add to Collection")

[ENG-4574]: https://openscience.atlassian.net/browse/ENG-4574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ