### PR TITLE
[ENG-4551] Ensure tokens always require name and scopes

### DIFF
--- a/app/settings/tokens/-components/create-form/component.ts
+++ b/app/settings/tokens/-components/create-form/component.ts
@@ -34,6 +34,12 @@ export default class CreateFormComponent extends Component {
                 presence: true,
             }),
         ],
+        scopes: [
+            validatePresence({
+                type: 'blank',
+                presence: true,
+            }),
+        ],
     };
     @alias('onSave.isRunning') disabled!: boolean;
 


### PR DESCRIPTION
-   Ticket: [ENG-4551]
-   Feature flag: n/a

## Purpose

Don't allow attempt to create or update a token without scopes and a name

## Summary of Changes

1. Add scopes validator to create token form
2. Add name and scopes validator to edit token form and validate that form

[ENG-4551]: https://openscience.atlassian.net/browse/ENG-4551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ