### PR TITLE
[ENG-4551] Cesium/css fixes

### DIFF
--- a/app/guid-node/registrations/styles.scss
+++ b/app/guid-node/registrations/styles.scss
@@ -133,3 +133,7 @@ h4:global(.new-registration-modal-header) {
     }
 }
 
+.no-registrations-mobile {
+    margin-left: 10px;
+    margin-right: 10px;
+}

--- a/app/guid-node/registrations/template.hbs
+++ b/app/guid-node/registrations/template.hbs
@@ -107,21 +107,23 @@
                         as |nl|
                     >
                         <nl.empty>
-                            <p>
-                                {{t 'node.registrations.no_registrations'}}
-                                {{#if (and this.node.currentUserIsContributor (not this.node.userHasAdminPermission))}}
-                                    {{t 'node.registrations.only_admins_can_initiate'}}
+                            <div local-class={{if this.isMobile 'no-registrations-mobile'}}>
+                                <p>
+                                    {{t 'node.registrations.no_registrations'}}
+                                    {{#if (and this.node.currentUserIsContributor (not this.node.userHasAdminPermission))}}
+                                        {{t 'node.registrations.only_admins_can_initiate'}}
+                                    {{/if}}
+                                </p>
+                                {{#if this.node.userHasAdminPermission}}
+                                    <p>{{t 'node.registrations.start_new'}}</p>
                                 {{/if}}
-                            </p>
-                            {{#if this.node.userHasAdminPermission}}
-                                <p>{{t 'node.registrations.start_new'}}</p>
-                            {{/if}}
-                            <p>
-                                {{t 'node.registrations.learn_more'
-                                    learnMoreLink='https://help.osf.io/'
-                                    htmlSafe=true
-                                }}
-                            </p>
+                                <p>
+                                    {{t 'node.registrations.learn_more'
+                                        learnMoreLink='https://help.osf.io/'
+                                        htmlSafe=true
+                                    }}
+                                </p>
+                            </div>
                         </nl.empty>
                     </NodeList>
                 </div>
@@ -145,16 +147,18 @@
                             </list.item>
 
                             <list.empty>
-                                <p>{{t 'node.registrations.no_drafts'}}</p>
-                                {{#if this.node.userHasAdminPermission}}
-                                    <p>{{t 'node.registrations.start_new'}}</p>
-                                {{/if}}
-                                <p>
-                                    {{t 'node.registrations.learn_more'
-                                        learnMoreLink='https://help.osf.io/'
-                                        htmlSafe=true
-                                    }}
-                                </p>
+                                <div local-class={{if this.isMobile 'no-registrations-mobile'}}>
+                                    <p>{{t 'node.registrations.no_drafts'}}</p>
+                                    {{#if this.node.userHasAdminPermission}}
+                                        <p>{{t 'node.registrations.start_new'}}</p>
+                                    {{/if}}
+                                    <p>
+                                        {{t 'node.registrations.learn_more'
+                                            learnMoreLink='https://help.osf.io/'
+                                            htmlSafe=true
+                                        }}
+                                    </p>
+                                </div>
                             </list.empty>
                         </PaginatedList::HasMany>
                     </div>

--- a/lib/osf-components/addon/components/node-card/styles.scss
+++ b/lib/osf-components/addon/components/node-card/styles.scss
@@ -183,3 +183,7 @@
 .pull-right {
     float: right !important;
 }
+
+.update-button {
+    color: $color-text-blue-dark;
+}

--- a/lib/osf-components/addon/components/node-card/template.hbs
+++ b/lib/osf-components/addon/components/node-card/template.hbs
@@ -247,6 +247,8 @@
                         {{#if this.shouldShowUpdateButton}}
                             <Button
                                 data-test-update-button={{@node.id}}
+                                @type='secondary'
+                                local-class='update-button'
                                 {{on 'click' (fn (mut this.showNewUpdateModal) true)}}
                             >
                                 {{t 'node_card.update_button'}}

--- a/lib/registries/addon/components/registries-recent-list/component.ts
+++ b/lib/registries/addon/components/registries-recent-list/component.ts
@@ -1,0 +1,7 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import Media from 'ember-responsive';
+
+export default class RegistriesRecentList extends Component {
+    @service media!: Media;
+}

--- a/lib/registries/addon/components/registries-recent-list/styles.scss
+++ b/lib/registries/addon/components/registries-recent-list/styles.scss
@@ -31,6 +31,10 @@
         }
     } 
 
+    .mobile {
+        margin-left: 20px;
+    }
+
     .recent-registries-container {
         width: 100%;
         padding-left: 10px;

--- a/lib/registries/addon/components/registries-recent-list/template.hbs
+++ b/lib/registries/addon/components/registries-recent-list/template.hbs
@@ -1,5 +1,5 @@
 <div local-class='recent-list-container' data-analytics-scope='Registries index' >
-    <div local-class='see-more-container'>
+    <div local-class='see-more-container {{if this.media.isMobile 'mobile'}}'>
         <div local-class='title'>
             {{t 'registries.index.recent.title'}}
         </div>


### PR DESCRIPTION
-   Ticket: [ENG-4551]
-   Feature flag: n/a

## Purpose

Fix hopefully the last of the css problems with cesium.

## Summary of Changes

1. Fix text color on node card update button
2. Reduce margin on registries recent list in mobile view to fit the 'See more' link
3. Add margin to the node registration lists for their empty states

## Screenshot(s)
<img width="953" alt="Screenshot 2023-07-11 at 2 29 58 PM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/c8b3c168-cbf9-4de4-a59c-2428a4bced58">
<img width="362" alt="Screenshot 2023-07-11 at 2 42 25 PM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/aa644d03-befc-40c4-a70c-bbbee037f5ab">
<img width="648" alt="Screenshot 2023-07-11 at 2 32 48 PM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/b37c9477-ca61-4596-ba0e-ec5bbf8cb17c">
<img width="743" alt="Screenshot 2023-07-11 at 2 29 35 PM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/3eb023c2-1da7-41f1-9b19-64887e72df71">



[ENG-4551]: https://openscience.atlassian.net/browse/ENG-4551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ