### PR TITLE
[ENG-4574] Preprint discover fixes

### DIFF
--- a/app/models/preprint-provider.ts
+++ b/app/models/preprint-provider.ts
@@ -2,6 +2,7 @@ import { attr, hasMany, AsyncHasMany, belongsTo, AsyncBelongsTo } from '@ember-d
 import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
+import config from 'ember-get-config';
 import Intl from 'ember-intl/services/intl';
 import BrandModel from 'ember-osf-web/models/brand';
 
@@ -13,6 +14,7 @@ import ProviderModel, { ReviewPermissions } from './provider';
 export type PreprintWord = 'default' | 'work' | 'paper' | 'preprint' | 'thesis';
 export type PreprintWordGrammar = 'plural' | 'pluralCapitalized' | 'singular' | 'singularCapitalized';
 
+const { defaultProvider } = config;
 export default class PreprintProviderModel extends ProviderModel {
     @service intl!: Intl;
 
@@ -48,6 +50,25 @@ export default class PreprintProviderModel extends ProviderModel {
             singular: this.intl.t(`${documentType}.singular`),
             singularCapitalized: this.intl.t(`${documentType}.singularCapitalized`),
         };
+    }
+
+    @computed('id')
+    get preprintWordInTitle() {
+        return this.id !== 'thesiscommons';
+    }
+
+    // Is either OSF Preprints if provider is the default provider,
+    // name+preprintWord.pluralCapitalized(e.g.AfricArXiv Preprints or MarXiv Papers), or "Thesis Commons"
+    @computed('documentType.pluralCapitalized', 'id', 'name', 'preprintWordInTitle')
+    get providerTitle() {
+        if (this.id !== defaultProvider) {
+            if (this.preprintWordInTitle) {
+                return this.intl.t('preprints.provider-title',
+                    { name: this.name, pluralizedPreprintWord: this.documentType.pluralCapitalized });
+            }
+            return this.name;
+        }
+        return this.intl.t('preprints.osf-title');
     }
 }
 

--- a/app/preprints/controller.ts
+++ b/app/preprints/controller.ts
@@ -1,0 +1,9 @@
+
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+import Theme from 'ember-osf-web/services/theme';
+
+export default class PreprintController extends Controller {
+    @service theme!: Theme;
+}

--- a/app/preprints/discover/template.hbs
+++ b/app/preprints/discover/template.hbs
@@ -1,11 +1,14 @@
-<SearchPage
-    {{with-branding (get-model this.model.brand)}}
-    @route='search'
-    @query={{this.q}}
-    @defaultQueryOptions={{this.defaultQueryOptions}}
-    @showResourceTypeFilter={{false}}
-    @provider={{this.model}}
-    @queryParams={{this.queryParams}}
-    @onSearch={{action this.onSearch}}
-    @sort={{this.sort}}
-/>
+{{page-title (t 'preprints.discover.title')}}
+<div data-analytics-scope='{{concat this.model.providerTitle ' Discover'}}'>
+    <SearchPage
+        {{with-branding (get-model this.model.brand)}}
+        @route='search'
+        @query={{this.q}}
+        @defaultQueryOptions={{this.defaultQueryOptions}}
+        @showResourceTypeFilter={{false}}
+        @provider={{this.model}}
+        @queryParams={{this.queryParams}}
+        @onSearch={{action this.onSearch}}
+        @sort={{this.sort}}
+    />
+</div>

--- a/app/preprints/route.ts
+++ b/app/preprints/route.ts
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+import Theme from 'ember-osf-web/services/theme';
+
+export default class Preprints extends Route {
+    @service theme!: Theme;
+}

--- a/app/preprints/template.hbs
+++ b/app/preprints/template.hbs
@@ -1,3 +1,4 @@
+{{page-title this.theme.provider.providerTitle replace=true}}
 <ThemeStyles />
 <BrandedNavbar
     @translateKey='collections.general.brand'

--- a/lib/app-components/addon/components/branded-navbar/component.ts
+++ b/lib/app-components/addon/components/branded-navbar/component.ts
@@ -11,10 +11,12 @@ import { tracked } from 'tracked-built-ins';
 
 import { serviceLinks } from 'ember-osf-web/const/service-links';
 import { layout, requiredAction } from 'ember-osf-web/decorators/component';
+import PreprintProviderModel from 'ember-osf-web/models/preprint-provider';
 import ProviderModel from 'ember-osf-web/models/provider';
 import Analytics from 'ember-osf-web/services/analytics';
 import CurrentUserService from 'ember-osf-web/services/current-user';
 import Theme from 'ember-osf-web/services/theme';
+
 import styles from './styles';
 import template from './template';
 
@@ -52,11 +54,14 @@ export default class BrandedNavbar extends Component {
     @alias('theme.provider') provider!: ProviderModel;
     @alias('theme.provider.id') providerId!: string;
 
-    @computed('intl.locale', 'theme.provider', 'translateKey')
+    @computed('intl.locale', 'theme.{providerType,provider.providerTitle}', 'translateKey')
     get brandTitle(): string {
-        const { name } = this.theme.provider!;
-
-        return this.intl.t(this.translateKey, { name });
+        if (this.theme.providerType === 'collection') {
+            const { name } = this.theme.provider!;
+            return this.intl.t(this.translateKey, { name });
+        } else { // preprint
+            return (this.theme.provider as PreprintProviderModel).providerTitle;
+        }
     }
 
     @requiredAction loginAction!: () => void;

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -13,7 +13,7 @@ as |layout|>
             >
             </div>
             <p data-test-search-provider-description>
-                {{@provider.description}}
+                {{html-safe @provider.description}}
             </p>
         {{else}}
             <label

--- a/mirage/scenarios/preprints.ts
+++ b/mirage/scenarios/preprints.ts
@@ -19,6 +19,6 @@ export function preprintsScenario(
         brand,
         moderators: [currentUserModerator],
         preprints,
-        description: 'This is the description for Thesis Commons',
+        description: '<p style="color: red">This is the description for Thesis Commons and it has an inline-style!</p>',
     });
 }

--- a/tests/acceptance/preprints/discover-test.ts
+++ b/tests/acceptance/preprints/discover-test.ts
@@ -31,6 +31,8 @@ module('Acceptance | preprints | discover', hooks => {
     test('Desktop', async function(this: PreprintDiscoverTestContext, assert) {
         await visit(`/preprints/${this.provider.id}/discover`);
         assert.equal(currentRouteName(), 'preprints.discover', 'Current route is preprints discover');
+        const pageTitle = document.getElementsByTagName('title')[0].innerText;
+        assert.equal(pageTitle, 'Thesis Commons | Search', 'Page title is correct');
         assert.dom('[data-test-search-provider-logo]').exists('Desktop: Preprint provider logo is shown');
         assert.dom('[data-test-search-provider-description]').exists('Desktop: Preprint provider description is shown');
         assert.dom('[data-test-search-header]').doesNotExist('Desktop: Non-branded search header is not shown');

--- a/tests/unit/models/preprint-provider-test.ts
+++ b/tests/unit/models/preprint-provider-test.ts
@@ -9,4 +9,18 @@ module('Unit | Model | preprint-provider', hooks => {
         const model = run(() => this.owner.lookup('service:store').createRecord('preprint-provider'));
         assert.ok(!!model);
     });
+
+    test('it has the correct provider title', function(assert) {
+        const store = this.owner.lookup('service:store');
+        const thesisCommons = store.createRecord('preprint-provider', { id: 'thesiscommons', name: 'Thesis Commons' });
+        assert.equal(thesisCommons.get('providerTitle'), 'Thesis Commons');
+
+        const osf = store.createRecord('preprint-provider', { id: 'osf', preprintWord: 'preprint' });
+        assert.equal(osf.get('providerTitle'), 'OSF Preprints');
+
+        const workrxiv = store.createRecord('preprint-provider', {
+            id: 'workrxiv', preprintWord: 'paper', name: 'WorkrXiv',
+        });
+        assert.equal(workrxiv.get('providerTitle'), 'WorkrXiv Papers');
+    });
 });

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1077,6 +1077,11 @@ collections:
             accept: accepted
             reject: rejected
             remove: 'removed'
+preprints:
+    osf-title: 'OSF Preprints'
+    provider-title: '{name} {pluralizedPreprintWord}'
+    discover:
+        title: 'Search'
 registries:
     header:
         osf_registrations: 'OSF Registrations'


### PR DESCRIPTION
-   Ticket: [ENG-4574]
-   Feature flag: n/a

## Purpose
- Add appropriate page title to discover page
- Add appropriate analytics scope to discover page
- Make provider description now show html entities

## Summary of Changes
- Use `{{html-safe}}` when showing provider description
- Add `providerTitle` in preprint-provider model
  - Most branded providers should show their name with their preprint word (e.g. AfricaRxiv Preprints, MarXiv Papers), except Thesis Commons
  - If it's OSF, we just show "OSF Preprints"
- Add page-title and analytics scope using the new `providerTitle`

## Screenshot(s)
- Before
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/a221601c-30ac-4aa1-90ad-42d03c55b475)

- After
![Screen Shot 2023-07-13 at 12 29 51 PM](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/0b81b5a0-3259-462e-a924-b21ba386384a)


## Side Effects
- None

## QA Notes
- On production, all preprint providers have their preprint word included in the navbar and page-title (visible in the browser tab), except Thesis Commons

[ENG-4574]: https://openscience.atlassian.net/browse/ENG-4574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ