### PR TITLE
Fix the missing asset prefix for ember-auto-import

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -23,6 +23,7 @@ module.exports = function(defaults) {
         },
         autoImport: {
             exclude: ['jsonapi-typescript'],
+            publicAssetURL: `${config.assetsPrefix}assets`,
         },
         addons: {
             blacklist: [


### PR DESCRIPTION
## Purpose

Staging2 is broken because we can't find `chunk*.js` and it looks like that's because we need to add our `assetsPrefix` to ember-auto-import to make it work. This fix seems to work locally, but it works locally without the fix, so we'll see what actually happens on staging2.

## Summary of Changes

1. Fix the missing asset prefix
