### PR TITLE
[ENG-4535] Search help feature

### DIFF
--- a/lib/osf-components/addon/components/osf-layout/component.ts
+++ b/lib/osf-components/addon/components/osf-layout/component.ts
@@ -48,6 +48,11 @@ export default class OsfLayout extends Component {
     }
 
     @action
+    openSidenavGutter() {
+        this.set('sidenavGutterClosed', false);
+    }
+
+    @action
     toggleMetadata() {
         this.toggleProperty('metadataGutterClosed');
     }

--- a/lib/osf-components/addon/components/osf-layout/template.hbs
+++ b/lib/osf-components/addon/components/osf-layout/template.hbs
@@ -2,6 +2,7 @@
     heading=(element 'div')
     sidenavGutterClosed=this.sidenavGutterClosed
     toggleSidenav=(action this.toggleSidenav)
+    openSidenavGutter=(action this.openSidenavGutter)
     metadataGutterClosed=this.metadataGutterClosed
     toggleMetadata=(action this.toggleMetadata)
 )}}

--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -14,6 +14,7 @@ import Media from 'ember-responsive';
 import IndexPropertySearchModel from 'ember-osf-web/models/index-property-search';
 import SearchResultModel from 'ember-osf-web/models/search-result';
 import ProviderModel from 'ember-osf-web/models/provider';
+import uniqueId from 'ember-osf-web/utils/unique-id';
 
 interface ResourceTypeOption {
     display: string;
@@ -78,25 +79,31 @@ export default class SearchPage extends Component<SearchArgs> {
     showTooltip2?: boolean;
     showTooltip3?: boolean;
 
+    leftPanelObjectDropdownId = uniqueId(['left-panel-object-dropdown']);
+    firstTopbarObjectTypeLinkId = uniqueId(['first-topbar-object-type-link']);
+    searchInputWrapperId = uniqueId(['search-input-wrapper']);
+    leftPanelHeaderId = uniqueId(['left-panel-header']);
+    firstFilterId = uniqueId(['first-filter']);
+
     get tooltipTarget1Id() {
         if (this.args.showResourceTypeFilter) {
             if (this.showSidePanelToggle) {
-                return 'left-panel-object-dropdown';
+                return this.leftPanelObjectDropdownId;
             }
-            return 'first-topbar-object-type-link';
+            return this.firstTopbarObjectTypeLinkId;
         }
-        return 'search-input-wrapper';
+        return this.searchInputWrapperId;
     }
 
     get tooltipTarget2Id() {
-        return 'left-panel-header';
+        return this.leftPanelHeaderId;
     }
 
     get tooltipTarget3Id() {
         if (this.propertySearch) {
-            return 'first-filter';
+            return this.firstFilterId;
         }
-        return 'left-panel-header';
+        return this.leftPanelHeaderId;
     }
 
     get showSidePanelToggle() {

--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -74,6 +74,31 @@ export default class SearchPage extends Component<SearchArgs> {
         taskFor(this.search).perform();
     }
 
+    showTooltip1?: boolean;
+    showTooltip2?: boolean;
+    showTooltip3?: boolean;
+
+    get tooltipTarget1Id() {
+        if (this.args.showResourceTypeFilter) {
+            if (this.showSidePanelToggle) {
+                return 'left-panel-object-dropdown';
+            }
+            return 'first-topbar-object-type-link';
+        }
+        return 'search-input-wrapper';
+    }
+
+    get tooltipTarget2Id() {
+        return 'left-panel-header';
+    }
+
+    get tooltipTarget3Id() {
+        if (this.propertySearch) {
+            return 'first-filter';
+        }
+        return 'left-panel-header';
+    }
+
     get showSidePanelToggle() {
         return this.media.isMobile || this.media.isTablet;
     }

--- a/lib/osf-components/addon/components/search-page/filter-facet/template.hbs
+++ b/lib/osf-components/addon/components/search-page/filter-facet/template.hbs
@@ -1,6 +1,7 @@
 <div
     data-test-filter-facet
     local-class='facet-wrapper'
+    ...attributes
 >
     {{#let (get-localized-property @propertyCard.resourceMetadata 'label') as |propertyLabel|}}
         {{#let (unique-id propertyLabel) as |facetElementId|}}

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -82,6 +82,31 @@
     }
 }
 
+.search-help-tutorial {
+    background-color: $osf-dark-blue-navbar;
+    color: $color-text-white;
+    width: 400px;
+    max-width: 100%;
+    z-index: 100;
+
+    // prevent target element styles from dictating popover text-styles
+    white-space: wrap;
+    text-align: initial;
+
+    .enumeration {
+        float: left;
+    }
+    
+    .help-button-wrappers {
+        float: right;
+    }
+
+    .skip-button {
+        color: $color-text-white;
+    }
+}
+
+
 .object-type-filter-link {
     padding: 10px 15px;
     font-size: 1.3em;

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -24,7 +24,7 @@ as |layout|>
                 <h1>{{t 'search.search-header'}}</h1>
             </label>
         {{/if}}
-        <span id='search-input-wrapper' local-class='search-input-wrapper'>
+        <span id={{this.searchInputWrapperId}} local-class='search-input-wrapper'>
             <Input
                 local-class='search-input'
                 @type='search'
@@ -84,10 +84,10 @@ as |layout|>
                 {{t 'search.total-results' count=this.totalResultCount}}
             </p>
         {{/if}}
-        <h2 id='left-panel-header'>{{t 'search.left-panel.header'}}</h2>
+        <h2 id={{this.leftPanelHeaderId}}>{{t 'search.left-panel.header'}}</h2>
         {{#if this.showSidePanelToggle}}
             {{#if @showResourceTypeFilter}}
-                <div data-test-left-panel-object-type-dropdown id='left-panel-object-dropdown'>
+                <div data-test-left-panel-object-type-dropdown id={{this.leftPanelObjectDropdownId}}>
                     <label>
                         {{t 'search.resource-type.search-by'}}
                         <PowerSelect @options={{this.resourceTypeOptions}} @selected={{this.selectedResourceTypeOption}}
@@ -134,7 +134,7 @@ as |layout|>
         {{#each this.filterableProperties as |filterableProperty index|}}
             {{#let filterableProperty.indexCard as |propertyCard|}}
                 <SearchPage::FilterFacet
-                    id={{if (eq index 0) 'first-filter' null}}
+                    id={{if (eq index 0) this.firstFilterId null}}
                     @cardSearchText={{@query}}
                     @cardSearchFilters={{this.activeFilters}}
                     @propertyCard={{propertyCard}}
@@ -162,7 +162,7 @@ as |layout|>
                                         data-analytics-name='Object type filter={{resourceType.value}}'
                                         data-test-topbar-object-type-link='{{resourceType.value}}'
                                         local-class='object-type-filter-link'
-                                        id={{if (eq index 0) 'first-topbar-object-type-link' null}}
+                                        id={{if (eq index 0) this.firstTopbarObjectTypeLinkId null}}
                                         @query={{hash resourceType=resourceType.value}}
                                         {{on 'click' (fn this.updateResourceType resourceType)}}
                                     >
@@ -199,7 +199,7 @@ as |layout|>
 </OsfLayout>
 {{#if this.showTooltip1}}
     <EmberPopover
-        data-test-search-help-mobile-1
+        data-test-search-help-1
         @targetId={{this.tooltipTarget1Id}}
         @tooltipClass={{local-class 'search-help-tutorial'}}
         @innerClass={{'search-help-tutorial-inner'}}
@@ -242,7 +242,7 @@ as |layout|>
 {{/if}}
 {{#if this.showTooltip2}}
     <EmberPopover
-        data-test-search-help-mobile-2
+        data-test-search-help-2
         @targetId={{this.tooltipTarget2Id}}
         @tooltipClass={{local-class 'search-help-tutorial'}}
         @innerClass={{'search-help-tutorial-inner'}}
@@ -285,7 +285,7 @@ as |layout|>
 {{/if}}
 {{#if this.showTooltip3}}
     <EmberPopover
-        data-test-search-help-mobile-3
+        data-test-search-help-3
         @targetId={{this.tooltipTarget3Id}}
         @tooltipClass={{local-class 'search-help-tutorial'}}
         @innerClass={{'search-help-tutorial-inner'}}

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -24,10 +24,9 @@ as |layout|>
                 <h1>{{t 'search.search-header'}}</h1>
             </label>
         {{/if}}
-        <span local-class='search-input-wrapper'>
+        <span id='search-input-wrapper' local-class='search-input-wrapper'>
             <Input
                 local-class='search-input'
-                id='search-input'
                 @type='search'
                 @placeholder={{t 'search.textbox-placeholder'}}
                 @value={{this.searchText}}
@@ -43,6 +42,22 @@ as |layout|>
                 {{on 'click' (perform this.doDebounceSearch)}}
             >
                 <FaIcon @icon='search' />
+            </Button>
+            <Button
+                data-test-start-help
+                data-analytics-name='search help'
+                local-class='help-button'
+                aria-label={{t 'search.search-help-label'}}
+                @type='primary'
+                @layout='large'
+                {{on 'click' (queue
+                    layout.openSidenavGutter
+                    (fn (mut this.showTooltip3) false)
+                    (fn (mut this.showTooltip2) false)
+                    (fn (mut this.showTooltip1) true)
+                )}}
+            >
+                <FaIcon @icon='question' />
             </Button>
         </span>
         {{#if this.showSidePanelToggle}}
@@ -69,10 +84,10 @@ as |layout|>
                 {{t 'search.total-results' count=this.totalResultCount}}
             </p>
         {{/if}}
-        <h2>{{t 'search.left-panel.header'}}</h2>
+        <h2 id='left-panel-header'>{{t 'search.left-panel.header'}}</h2>
         {{#if this.showSidePanelToggle}}
             {{#if @showResourceTypeFilter}}
-                <div data-test-left-panel-object-type-dropdown>
+                <div data-test-left-panel-object-type-dropdown id='left-panel-object-dropdown'>
                     <label>
                         {{t 'search.resource-type.search-by'}}
                         <PowerSelect @options={{this.resourceTypeOptions}} @selected={{this.selectedResourceTypeOption}}
@@ -116,9 +131,10 @@ as |layout|>
                 {{/each}}
             </ul>
         {{/if}}
-        {{#each this.filterableProperties as |filterableProperty|}}
+        {{#each this.filterableProperties as |filterableProperty index|}}
             {{#let filterableProperty.indexCard as |propertyCard|}}
                 <SearchPage::FilterFacet
+                    id={{if (eq index 0) 'first-filter' null}}
                     @cardSearchText={{@query}}
                     @cardSearchFilters={{this.activeFilters}}
                     @propertyCard={{propertyCard}}
@@ -140,12 +156,13 @@ as |layout|>
                         local-class='object-type-nav'
                     >
                         <ul>
-                            {{#each this.resourceTypeOptions as |resourceType|}}
+                            {{#each this.resourceTypeOptions as |resourceType index|}}
                                 <li>
                                     <LinkTo
                                         data-analytics-name='Object type filter={{resourceType.value}}'
                                         data-test-topbar-object-type-link='{{resourceType.value}}'
                                         local-class='object-type-filter-link'
+                                        id={{if (eq index 0) 'first-topbar-object-type-link' null}}
                                         @query={{hash resourceType=resourceType.value}}
                                         {{on 'click' (fn this.updateResourceType resourceType)}}
                                     >
@@ -180,3 +197,121 @@ as |layout|>
         {{/unless}}
     </layout.main>
 </OsfLayout>
+{{#if this.showTooltip1}}
+    <EmberPopover
+        data-test-search-help-mobile-1
+        @targetId={{this.tooltipTarget1Id}}
+        @tooltipClass={{local-class 'search-help-tutorial'}}
+        @innerClass={{'search-help-tutorial-inner'}}
+        @isShown={{this.showTooltip1}}
+        @event='none'
+        @side='bottom'
+        @spacing={{10}}
+    >
+        <div local-class='help-content'>
+            <h2 local-class='search-help-header' data-test-help-heading-1>
+                {{t 'search.search-help.header-1'}}
+            </h2>
+            <p data-test-help-body-1>{{t 'search.search-help.body-1'}}</p>
+            <span local-class='pagination'>
+                <p local-class='enumeration' data-test-help-enumeration-1>{{t 'search.search-help.index-1'}}</p>
+                <span local-class='help-button-wrappers'>
+                    <Button
+                        data-test-help-skip-1
+                        local-class='skip-button'
+                        @layout='fake-link'
+                        onclick={{fn (mut this.showTooltip1) false}}
+                    >
+                        {{t 'search.search-help.footer.skip'}}
+                    </Button>
+                    <Button
+                        data-test-help-next-1
+                        local-class='next-button'
+                        @type='primary'
+                        onclick={{queue
+                            (fn (mut this.showTooltip1) false)
+                            (fn (mut this.showTooltip2) true)
+                        }}
+                    >
+                        {{t 'search.search-help.footer.next'}}
+                    </Button>
+                </span>
+            </span>
+        </div>
+    </EmberPopover>
+{{/if}}
+{{#if this.showTooltip2}}
+    <EmberPopover
+        data-test-search-help-mobile-2
+        @targetId={{this.tooltipTarget2Id}}
+        @tooltipClass={{local-class 'search-help-tutorial'}}
+        @innerClass={{'search-help-tutorial-inner'}}
+        @isShown={{this.showTooltip2}}
+        @event='none'
+        @side='{{if this.showSidePanelToggle 'bottom' 'right'}}'
+        @spacing={{10}}
+    >
+        <div local-class='help-content'>
+            <h2 local-class='search-help-header' data-test-help-heading-2>
+                {{t 'search.search-help.header-2'}}
+            </h2>
+            <p data-test-help-body-2>{{t 'search.search-help.body-2'}}</p>
+            <span local-class='pagination'>
+                <p local-class='enumeration' data-test-help-enumeration-2>{{t 'search.search-help.index-2'}}</p>
+                <span local-class='help-button-wrappers'>
+                    <Button
+                        data-test-help-skip-2
+                        local-class='skip-button'
+                        @layout='fake-link'
+                        onclick={{fn (mut this.showTooltip2) false}}
+                    >
+                        {{t 'search.search-help.footer.skip'}}
+                    </Button>
+                    <Button
+                        data-test-help-next-2
+                        local-class='next-button'
+                        @type='primary'
+                        onclick={{queue
+                            (fn (mut this.showTooltip2) false)
+                            (fn (mut this.showTooltip3) true)
+                        }}
+                    >
+                        {{t 'search.search-help.footer.next'}}
+                    </Button>
+                </span>
+            </span>
+        </div>
+    </EmberPopover>
+{{/if}}
+{{#if this.showTooltip3}}
+    <EmberPopover
+        data-test-search-help-mobile-3
+        @targetId={{this.tooltipTarget3Id}}
+        @tooltipClass={{local-class 'search-help-tutorial'}}
+        @innerClass={{'search-help-tutorial-inner'}}
+        @isShown={{this.showTooltip3}}
+        @event='none'
+        @side='{{if this.showSidePanelToggle 'bottom' 'right'}}'
+        @spacing={{10}}
+    >
+        <div local-class='help-content'>
+            <h2 local-class='search-help-header' data-test-help-heading-3>
+                {{t 'search.search-help.header-3'}}
+            </h2>
+            <p data-test-help-body-3>{{t 'search.search-help.body-3'}}</p>
+            <span local-class='pagination'>
+                <p local-class='enumeration' data-test-help-enumeration-3>{{t 'search.search-help.index-3'}}</p>
+                <span local-class='help-button-wrappers'>
+                    <Button
+                        data-test-help-done
+                        local-class='next-button'
+                        @type='primary'
+                        onclick={{fn (mut this.showTooltip3) false}}
+                    >
+                        {{t 'search.search-help.footer.done'}}
+                    </Button>
+                </span>
+            </span>
+        </div>
+    </EmberPopover>
+{{/if}}

--- a/tests/acceptance/search/search-help-test.ts
+++ b/tests/acceptance/search/search-help-test.ts
@@ -1,0 +1,80 @@
+import { click, currentURL, visit } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { module, test } from 'qunit';
+import { setupOSFApplicationTest } from 'ember-osf-web/tests/helpers';
+import { EnginesIntlTestContext } from 'ember-engines/test-support';
+
+module('Integration | Component | Search help', hooks => {
+    setupOSFApplicationTest(hooks);
+    setupMirage(hooks);
+
+    test('ember popover renders', async function(this: EnginesIntlTestContext, assert) {
+        await visit('/search');
+        assert.equal(currentURL(), '/search');
+
+        // start help tutorial
+        assert.dom('[data-test-start-help]').exists();
+        await click('[data-test-start-help]');
+
+        // verify first popover displays
+        assert.dom('[data-test-search-help-1]').exists();
+        // verify skip button present
+        assert.dom('[data-test-help-skip-1]').exists();
+        assert.dom('[data-test-help-skip-1]').hasText('Skip');
+        // verify next button works
+        assert.dom('[data-test-help-next-1]').exists();
+        assert.dom('[data-test-help-next-1]').hasText('Next');
+        // verify first popover content
+        assert.dom('[data-test-help-heading-1]').exists();
+        assert.dom('[data-test-help-heading-1]').hasText('Improved OSF Search');
+        assert.dom('[data-test-help-body-1]').exists();
+        assert.dom('[data-test-help-body-1]').hasText(`Enter any term in the search box 
+            and filter by specific object types.`);
+        assert.dom('[data-test-help-enumeration-1]').exists();
+        assert.dom('[data-test-help-enumeration-1]').hasText('1 of 3');
+
+        // verify second popover displays
+        await click('[data-test-help-next-1]');
+        assert.dom('[data-test-search-help-2]').exists();
+        // verify second popover content
+        assert.dom('[data-test-help-heading-2]').exists();
+        assert.dom('[data-test-help-heading-2]').hasText('OSF Smart Facets');
+        assert.dom('[data-test-help-body-2]').exists();
+        assert.dom('[data-test-help-body-2]').hasText(`Narrow the source, discipline, and more. 
+            For example, find content supported by a specific funder or view only datasets.`);
+        assert.dom('[data-test-help-enumeration-2]').exists();
+        assert.dom('[data-test-help-enumeration-2]').hasText('2 of 3');
+
+        // verify third popover displays
+        await click('[data-test-help-next-2]');
+        assert.dom('[data-test-search-help-3]').exists();
+        // verify third popover content
+        assert.dom('[data-test-help-heading-3]').exists();
+        assert.dom('[data-test-help-heading-3]').hasText('Add Metadata');
+        assert.dom('[data-test-help-body-3]').exists();
+        assert.dom('[data-test-help-body-3]').hasText(`Remember to add metadata and resources 
+            to your own work on OSF to make it more discoverable!`);
+        assert.dom('[data-test-help-enumeration-3]').exists();
+        assert.dom('[data-test-help-enumeration-3]').hasText('3 of 3');
+
+        // verify popover closes
+        assert.dom('[data-test-help-done]').exists();
+        assert.dom('[data-test-help-done]').hasText('Done');
+        await click('[data-test-help-done]');
+        assert.dom('[data-test-search-help-1]').isNotVisible();
+    });
+
+    test('help tutorial can be skipped', async assert => {
+        await visit('/search');
+        assert.equal(currentURL(), '/search');
+
+        // verify help tutorial starts
+        assert.dom('[data-test-start-help]').exists();
+        await click('[data-test-start-help]');
+
+        // verify skip button works
+        assert.dom('[data-test-help-skip-1]').exists();
+        await click('[data-test-help-skip-1]');
+        assert.dom('[data-test-search-help-1]').isNotVisible();
+    });
+});

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -208,9 +208,24 @@ search:
     index-card:
         no-label: 'No label found'
         no-title: 'No title found'
+    search-help:
+        header-1: 'Improved OSF Search'
+        header-2: 'OSF Smart Facets'
+        header-3: 'Add Metadata'
+        body-1: 'Enter any term in the search box and filter by specific object types.'
+        body-2: 'Narrow the source, discipline, and more. For example, find content supported by a specific funder or view only datasets.'
+        body-3: 'Remember to add metadata and resources to your own work on OSF to make it more discoverable!'
+        index-1: '1 of 3'
+        index-2: '2 of 3'
+        index-3: '3 of 3'
+        footer:
+            skip: 'Skip'
+            next: 'Next'
+            done: 'Done'
     search-header: 'Search OSF'
     textbox-placeholder: 'Search placeholder'
     search-button-label: 'Search'
+    search-help-label: 'Help tutorial'
     total-results: '{count} results'
     resource-type:
         search-by: 'Search by resource type'


### PR DESCRIPTION
-   Ticket: [ENG-4535]
-   Feature flag: n/a

## Purpose
- Add search help feature
  - Basically a re-implementation of https://github.com/CenterForOpenScience/ember-osf-web/pull/1891 and https://github.com/CenterForOpenScience/ember-osf-web/pull/1877
  - Notable difference is moving the Popovers to the end of the file to avoid merge conflicts

## Summary of Changes
- Added EmberPopovers to the search-page component
- Added getters to search-page component to fetch EmberPopover targets dynamically
- Translations
- Tests

## Screenshot(s)
- General search page, desktop
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/aefc7bbc-332e-4d63-b7f1-5706ea8116e2)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/9930bd33-6113-4b08-84bb-e25352c07672)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/b4c3887a-8d7d-46db-bc3e-9baeb2e4c4c2)

- Preprints mobile
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/ce3a3757-1338-4088-b228-31d36fcdf8ef)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/627e39ef-f818-4c59-ac52-f6089a849416)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/a76eb75d-5cb7-49ab-ad0a-7fffc889a85c)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-4535]: https://openscience.atlassian.net/browse/ENG-4535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ