### PR TITLE
[No ticket] Don't re-throw error in getApiErrorMessage

### DIFF
--- a/app/utils/capture-exception.ts
+++ b/app/utils/capture-exception.ts
@@ -32,10 +32,7 @@ export function getApiError(error: ErrorDocument): ErrorObject|undefined {
 
 export function getApiErrorMessage(error: ErrorDocument): string {
     const apiError = getApiError(error);
-    if(apiError){
-        return (apiError && apiError.detail) ? apiError.detail : '';
-    }
-    throw error;
+    return (apiError && apiError.detail) ? apiError.detail : '';
 }
 
 export function getApiErrors(error: ErrorDocument): Record<string, ErrorObject> {


### PR DESCRIPTION
## Purpose

See if a weird bug gets fixed on staging2 by removing a slightly risky re-throw of error messages.

## Summary of Changes

1. Don't re-throw error message

## Side Effects

Will have anti-side-effects.