### PR TITLE
[No ticket] Throw an error when registries overview page errors

### DIFF
--- a/lib/registries/addon/overview/route.ts
+++ b/lib/registries/addon/overview/route.ts
@@ -151,6 +151,6 @@ export default class Overview extends GuidRoute {
     @action
     error(error: Error, _: unknown) {
         this.replaceWith('page-not-found', notFoundURL(this.router.currentURL));
-        throw(error);
+        captureException(error);
     }
 }

--- a/lib/registries/addon/overview/route.ts
+++ b/lib/registries/addon/overview/route.ts
@@ -149,7 +149,8 @@ export default class Overview extends GuidRoute {
     }
 
     @action
-    error() {
+    error(error: Error, _: unknown) {
         this.replaceWith('page-not-found', notFoundURL(this.router.currentURL));
+        throw(error);
     }
 }


### PR DESCRIPTION
## Purpose

Help to be able to debug situations where the registries overview page goes to the not-found page inappropriately.

## Summary of Changes

1. Send the error to sentry after transitioning to page not found.

## Side Effects

Shouldn't be any