### PR TITLE
[ENG-4598] Add GTM to metrics adapters

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -24,6 +24,7 @@ const {
     FB_APP_ID,
     GIT_COMMIT: release,
     GOOGLE_ANALYTICS_ID,
+    GOOGLE_TAG_MANAGER_ID,
     KEEN_CONFIG: keenConfig,
     LINT_ON_BUILD: lintOnBuild = false,
     MIRAGE_ENABLED = false,
@@ -117,6 +118,13 @@ module.exports = function(environment) {
                     isPublic: 'dimension3',
                     isWithdrawn: 'dimension4',
                     version: 'dimension5',
+                },
+            },
+            {
+                name: 'GoogleTagManager',
+                environments: GOOGLE_TAG_MANAGER_ID ? ['all'] : [],
+                config: {
+                    id: GOOGLE_TAG_MANAGER_ID,
                 },
             },
         ],


### PR DESCRIPTION
-   Ticket: [ENG-4598]
-   Feature flag: n/a

## Purpose

Try to get Google Tag Manager working in ember-osf-web

## Summary of Changes

1. Added GoogleTagManager config to ember-metrics

[ENG-4598]: https://openscience.atlassian.net/browse/ENG-4598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ