### PR TITLE
[ENG-4598] Enable rest of GTM to be inserted into page

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -22,6 +22,7 @@
     {{content-for "head-footer"}}
   </head>
   <body>
+    {{content-for "gtm"}}
     {{content-for "assets"}}
     <noscript>
       <p>

--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -195,6 +195,7 @@ declare const config: {
     pageTitle: {
         prepend: boolean;
     };
+    gtm: string;
 };
 
 export default config;

--- a/config/environment.js
+++ b/config/environment.js
@@ -303,6 +303,7 @@ module.exports = function(environment) {
         pageTitle: {
             prepend: false,
         },
+        gtm: '<script></script>',
     };
 
     if (environment === 'development') {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -106,6 +106,11 @@ module.exports = function(defaults) {
                 postProcess,
                 /* eslint-enable max-len */
             },
+            gtm: {
+                enabled: IS_PROD,
+                content: config.gtm,
+                postProcess,
+            },
         },
         'ember-cli-babel': {
             includePolyfill: IS_PROD,


### PR DESCRIPTION
-   Ticket: [ENG-4598]
-   Feature flag: n/a

## Purpose

To allow rest of GTM to be configurably added to page body.

## Summary of Changes

1. Add config variable for GTM script so devops can add the script as needed with the proper config per env
2. Add build process to make it available for index.html
3. Add section to index.html
4. Types

## Screenshot(s)

Here's the stub script in where it's supposed to be:

<img width="509" alt="Screenshot 2023-08-08 at 9 00 03 AM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/d1b651d8-4709-4bf4-92cf-e9a6f5f9852b">


[ENG-4598]: https://openscience.atlassian.net/browse/ENG-4598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ