### PR TITLE
Barium / Remove most non-dirty relationships

### DIFF
--- a/app/serializers/osf-serializer.ts
+++ b/app/serializers/osf-serializer.ts
@@ -147,6 +147,14 @@ export default class OsfSerializer extends JSONAPISerializer {
                     delete serialized.data.attributes![attribute];
                 }
             }
+            if (serialized.data.relationships) {
+                for (const key of Object.keys(serialized.data.relationships)) {
+                    const rel = serialized.data.relationships[key];
+                    if (rel === null) {
+                        delete serialized.data.relationships[key];
+                    }
+                }
+            }
         }
 
         return serialized;


### PR DESCRIPTION
## Purpose

When upgrading to ember 3.28, we lost the ability to distinguish between dirty relationships and clean ones when PATCHing a record, so we would send all the relationships. This was a problem because many of the clean relationships in the serializer had null information, which broke the API, because it doesn't like PATCHed relationships with null information. This fixes that by removing any relationship that is just null info in the serializer. We will still sometimes PATCH relationships we don't need to, but the info should be the same and thus not cause problems for the API. 

## Summary of Changes

1. Scan for null relationships in osf-serializer and remove them from the request payload.

## Screenshot(s)

<img width="583" alt="Screenshot 2023-08-07 at 3 33 23 PM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/1976377d-a43b-48fc-b7d5-0bb03741db84">


## Side Effects

Hypothetically, we might have a relationship at some point that we try to PATCH where the user doesn't have proper permissions for, in which case we might get an inappropriate 403 error. I don't _think_ this will happen, but if it does, we may have to have a more robust solution for this. That being said, this change is only better and not worse than what we currently have in barium.

## QA Notes

This should make adding to a collection work again.
