### PR TITLE
[ENG-4598] Try initializing GTM in a way that works runtime

### DIFF
--- a/config/environment.d.ts
+++ b/config/environment.d.ts
@@ -28,6 +28,7 @@ declare const config: {
     rootURL: string;
     assetsPrefix: string;
     sentryDSN: string | null;
+    googleTagManagerId: string | null;
     sentryOptions: {
         release?: string;
         ignoreErrors: string[];
@@ -195,7 +196,6 @@ declare const config: {
     pageTitle: {
         prepend: boolean;
     };
-    gtm: string;
 };
 
 export default config;

--- a/config/environment.js
+++ b/config/environment.js
@@ -77,6 +77,7 @@ module.exports = function(environment) {
         assetsPrefix,
         locationType: 'auto',
         sentryDSN: null,
+        googleTagManagerId: null,
         sentryOptions: {
             release,
             ignoreErrors: [
@@ -303,7 +304,6 @@ module.exports = function(environment) {
         pageTitle: {
             prepend: false,
         },
-        gtm: '<script></script>',
     };
 
     if (environment === 'development') {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -108,7 +108,18 @@ module.exports = function(defaults) {
             },
             gtm: {
                 enabled: IS_PROD,
-                content: config.gtm,
+                content: `<script>
+                    var configJson = document.head.querySelector("meta[name$='/config/environment']").content;
+                    var configObject = JSON.parse(unescape(configJson));
+                    if (configObject.googleTagManagerId) {
+                        window.dataLayer = window.dataLayer || [];
+                        function gtag(){dataLayer.push(arguments);}
+                        gtag('js', new Date());
+
+                        gtag('config', configObject.googleTagManagerId);
+                    }
+                </script>
+            `,
                 postProcess,
             },
         },


### PR DESCRIPTION
-   Ticket: [ENG-4598]
## Purpose

You can't just pull something into the index.html from runtime, it has to happen build time. So we'll try doing this the way raven works instead.

## Summary of Changes

1. Initialize GTM in a way that works runtime.
2. Add environment variable for the gtm id
3. Types

## Screenshot(s)

<img width="783" alt="Screenshot 2023-08-08 at 4 35 06 PM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/ed99fe51-8c7b-42d0-900d-9e8cf36a8e11">

[ENG-4598]: https://openscience.atlassian.net/browse/ENG-4598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ