### PR TITLE
[No ticket] Remove clean relationships from PATCH request

### DIFF
--- a/app/serializers/osf-serializer.ts
+++ b/app/serializers/osf-serializer.ts
@@ -6,6 +6,14 @@ import DS from 'ember-data';
 import ModelRegistry from 'ember-data/types/registries/model';
 import { AttributesObject } from 'jsonapi-typescript';
 
+// This import will change with 4.12 of ember-data. It will instead be
+// import { peekGraph } from '@ember-data/graph/-private';
+import { peekGraph } from '@ember-data/record-data/-private';
+// You should also be able to
+// import { recordIdentifierFor } from '@ember-data/store';
+// and use that to const relationship = peekGraph(store).get(recordIdentifierFor(record), key)
+// instead of what I did in the hack below.
+
 import {
     PaginatedMeta,
     Resource,
@@ -132,6 +140,17 @@ export default class OsfSerializer extends JSONAPISerializer {
         return underscore(key);
     }
 
+    getGraphRelationships(snapshot: DS.Snapshot) {
+        const graph = peekGraph(this.store);
+        const identifiers = graph.identifiers;
+        for (const [key, value] of identifiers) {
+            if(key.id === snapshot.id && key.type === snapshot.type.modelName) {
+                return value;
+            }
+        }
+        return undefined;
+    }
+
     serialize(snapshot: DS.Snapshot, options: { includeId?: boolean, osf?: OsfSerializerOptions } = {}) {
         const serialized = super.serialize(snapshot, options) as SingleResourceDocument;
         serialized.data.type = underscore(serialized.data.type);
@@ -147,10 +166,30 @@ export default class OsfSerializer extends JSONAPISerializer {
                     delete serialized.data.attributes![attribute];
                 }
             }
+
+            // The following is a bit of a hack as it relies on currently private information.
+            // When https://github.com/emberjs/data/pull/8131 is merged, we should have public access
+            // to this data from a new import location.
             if (serialized.data.relationships) {
+                const relationships = this.getGraphRelationships(snapshot);
                 for (const key of Object.keys(serialized.data.relationships)) {
-                    const rel = serialized.data.relationships[key];
-                    if (rel === null) {
+                    const rel = relationships[camelize(key)];
+                    let isClean = true;
+                    if (rel.definition.kind === 'belongsTo') {
+                        isClean = rel.localState === rel.remoteState;
+                    } else if (rel.definition.kind === 'hasMany') {
+                        if (rel.canonicalState.length !== rel.currentState.length) {
+                            isClean = false;
+                        } else {
+                            for (const stateKey in rel.canonicalState) {
+                                if(rel.canonicalState[stateKey] !== rel.currentState[stateKey]) {
+                                    isClean = false;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if (isClean) {
                         delete serialized.data.relationships[key];
                     }
                 }

--- a/types/@ember-data/record-data/-private.d.ts
+++ b/types/@ember-data/record-data/-private.d.ts
@@ -1,0 +1,3 @@
+declare module '@ember-data/record-data/-private' {
+    export function peekGraph(store: Store);
+}

--- a/types/@ember-data/store.d.ts
+++ b/types/@ember-data/store.d.ts
@@ -1,0 +1,3 @@
+declare module '@ember-data/store' {
+    export function recordIdentifierFor(record: Record);
+}


### PR DESCRIPTION
## Purpose

Properly remove clean relationships from a PATCH request.

## Summary of Changes

1. Get the graph
2. Scan the graph for changes in each relationship in the serializer
3. Remove the relationship from the serializer if there are no changes
4. Types

## Side Effects

If I did this wrong, it would break lots of stuff, but that would break tests, so I don't think I did.

## QA Notes

Should get caught by unit tests and selenium combo.
