### PR TITLE
Show loading indicators and no-results message

### DIFF
--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -185,9 +185,15 @@
     float: left;
 }
 
+.no-results {
+    margin: 10px 20px;
+    font-size: 1.2em;
+}
+
 .left-panel {
     padding-left: 12px;
     width: 300px;
+    min-width: 300px;
 }
 
 .search-count {

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -157,20 +157,24 @@ as |layout|>
                 {{/each}}
             </ul>
         {{/if}}
-        {{#each this.filterableProperties as |filterableProperty index|}}
-            {{#let filterableProperty.indexCard as |propertyCard|}}
-                <SearchPage::FilterFacet
-                    id={{if (eq index 0) this.firstFilterId null}}
-                    @cardSearchText={{@query}}
-                    @cardSearchFilters={{this.activeFilters}}
-                    @propertyCard={{propertyCard}}
-                    @propertySearch={{filterableProperty}}
-                    @toggleFilter={{this.toggleFilter}}
-                />
-            {{/let}}
+        {{#if this.search.isRunning}}
+            <LoadingIndicator @dark={{true}} />
         {{else}}
-            {{t 'search.left-panel.no-filterable-properties'}}
-        {{/each}}
+            {{#each this.filterableProperties as |filterableProperty index|}}
+                {{#let filterableProperty.indexCard as |propertyCard|}}
+                    <SearchPage::FilterFacet
+                        id={{if (eq index 0) this.firstFilterId null}}
+                        @cardSearchText={{@query}}
+                        @cardSearchFilters={{this.activeFilters}}
+                        @propertyCard={{propertyCard}}
+                        @propertySearch={{filterableProperty}}
+                        @toggleFilter={{this.toggleFilter}}
+                    />
+                {{/let}}
+            {{else}}
+                {{t 'search.left-panel.no-filterable-properties'}}
+            {{/each}}
+        {{/if}}
     </layout.left>
     <layout.main data-analytics-scope='Search page main'>
         {{!-- paginator --}}
@@ -221,9 +225,15 @@ as |layout|>
                 </div>
             </div>
         {{/unless}}
-        {{#each this.searchResults as |item|}}
-            <SearchResultCard @result={{item}} />
-        {{/each}}
+        {{#if this.search.isRunning}}
+            <LoadingIndicator @size='large' @dark={{true}} />
+        {{else}}
+            {{#each this.searchResults as |item|}}
+                <SearchResultCard @result={{item}} />
+            {{else}}
+                <p local-class='no-results'>{{t 'search.no-results'}}</p>
+            {{/each}}
+        {{/if}}
     </layout.main>
 </OsfLayout>
 {{#if this.showTooltip1}}

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -234,6 +234,7 @@ search:
     search-button-label: 'Search'
     search-help-label: 'Help tutorial'
     total-results: '{count} results'
+    no-results: 'No results found'
     resource-type:
         search-by: 'Search by resource type'
         all: 'All'


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Show loading indicators and "No results" message

## Summary of Changes
- Conditionally show loading indicators
- Catch when results list is empty and show "No results" message

## Screenshot(s)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/476b704f-5b95-4232-803e-b1ccc21b8fa2)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/fb9ff378-cc85-4131-888f-c55a724c9616)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
