### PR TITLE
Hide empty properties better

### DIFF
--- a/app/models/related-property-path.ts
+++ b/app/models/related-property-path.ts
@@ -15,7 +15,7 @@ interface PropertyPath {
 
 export default class RelatedPropertyPathModel extends OsfModel {
     @attr('string') propertyPathKey!: string;
-    @attr('string') cardSearchResultCount!: string;
+    @attr('number') cardSearchResultCount!: number;
     @attr('array') osfmapPropertyPath!: string[];
     @attr('array') propertyPath!: PropertyPath[];
 

--- a/lib/osf-components/addon/components/search-page/filter-facet/template.hbs
+++ b/lib/osf-components/addon/components/search-page/filter-facet/template.hbs
@@ -1,4 +1,4 @@
-{{#if (gt @property.cardSearchResultCount 0)}}
+{{#if @property.cardSearchResultCount}}
     <div
         data-analytics-scope='Search page filter facet wrapper'
         data-test-filter-facet

--- a/lib/osf-components/addon/components/search-page/filter-facet/template.hbs
+++ b/lib/osf-components/addon/components/search-page/filter-facet/template.hbs
@@ -1,4 +1,4 @@
-{{#if @property.cardSearchResultCount}}
+{{#if (gt @property.cardSearchResultCount 0)}}
     <div
         data-analytics-scope='Search page filter facet wrapper'
         data-test-filter-facet


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: []
-   Feature flag: n/a

## Purpose
- Fix a bug where properties with no filterable values were showing up in the filter list

## Summary of Changes
- Check for length of property.cardSearchResultCount

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- This should prevent properties from showing up that have no values when you expand them
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
