### PR TITLE
Existing search page links

### DIFF
--- a/app/dashboard/template.hbs
+++ b/app/dashboard/template.hbs
@@ -239,7 +239,7 @@
             <OsfLink
                 data-analytics-name='noteworthy_search'
                 local-class='btn btn-default'
-                @href='/search/?q=*'
+                @route='search'
             >
                 {{t 'dashboard.noteworthy.search_more'}}
             </OsfLink>

--- a/app/home/-components/hero-banner/component.ts
+++ b/app/home/-components/hero-banner/component.ts
@@ -2,12 +2,11 @@ import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import { action } from '@ember/object';
 import { alias } from '@ember/object/computed';
+import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 import { camelize } from '@ember/string';
 import Features from 'ember-feature-flags/services/features';
 import config from 'ember-get-config';
-
-import { serviceLinks } from 'ember-osf-web/const/service-links';
 
 import { layout } from 'ember-osf-web/decorators/component';
 
@@ -20,13 +19,13 @@ const { featureFlagNames: { ABTesting } } = config;
 @tagName('')
 export default class HomeHeroBanner extends Component {
     @service features!: Features;
+    @service router!: RouterService;
 
     @alias(`features.${camelize(ABTesting.homePageHeroTextVersionB)}`)
     shouldShowVersionB!: boolean;
 
     @action
     search(query: string) {
-        const { search } = serviceLinks;
-        window.location.href = `${search}?q=${query}&page=1`;
+        this.router.transitionTo('search', { queryParams: { q: query }});
     }
 }

--- a/app/search/controller.ts
+++ b/app/search/controller.ts
@@ -4,16 +4,16 @@ import { tracked } from '@glimmer/tracking';
 import { OnSearchParams, ResourceTypeFilterValue } from 'osf-components/components/search-page/component';
 
 export default class SearchController extends Controller {
-    @tracked cardSearchText?: string = '';
+    @tracked q?: string = '';
     @tracked sort?: string =  '-relevance';
     @tracked resourceType?: ResourceTypeFilterValue | null = null;
     @tracked page?: string = '';
 
-    queryParams = ['cardSearchText', 'page', 'sort', 'resourceType'];
+    queryParams = ['q', 'page', 'sort', 'resourceType'];
 
     @action
     onSearch(queryOptions: OnSearchParams) {
-        this.cardSearchText = queryOptions.cardSearchText;
+        this.q = queryOptions.cardSearchText;
         this.sort = queryOptions.sort;
         this.resourceType = queryOptions.resourceType;
         this.page = queryOptions.page;

--- a/app/search/template.hbs
+++ b/app/search/template.hbs
@@ -2,7 +2,7 @@
 
 <SearchPage
     @route='search'
-    @cardSearchText={{this.cardSearchText}}
+    @cardSearchText={{this.q}}
     @queryParams={{this.queryParams}}
     @onSearch={{action this.onSearch}}
     @showResourceTypeFilter={{true}}

--- a/lib/osf-components/addon/components/editable-field/tags-manager/component.ts
+++ b/lib/osf-components/addon/components/editable-field/tags-manager/component.ts
@@ -2,17 +2,16 @@ import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import { action, computed } from '@ember/object';
 import { alias, and } from '@ember/object/computed';
+import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 import { waitFor } from '@ember/test-waiters';
 import { task } from 'ember-concurrency';
-import config from 'ember-get-config';
 import Intl from 'ember-intl/services/intl';
 import Toast from 'ember-toastr/services/toast';
 
 import { layout } from 'ember-osf-web/decorators/component';
 import Registration from 'ember-osf-web/models/registration';
 import captureException, { getApiErrorMessage } from 'ember-osf-web/utils/capture-exception';
-import pathJoin from 'ember-osf-web/utils/path-join';
 
 import template from './template';
 
@@ -25,15 +24,10 @@ export interface TagsManager {
     registration: Registration;
 }
 
-const {
-    OSF: {
-        url: baseUrl,
-    },
-} = config;
-
 @tagName('')
 @layout(template)
 export default class TagsManagerComponent extends Component {
+    @service router!: RouterService;
     // required
     registration!: Registration;
 
@@ -95,7 +89,7 @@ export default class TagsManagerComponent extends Component {
 
     @action
     clickTag(tag: string): void {
-        window.location.assign(`${pathJoin(baseUrl, 'search')}?q=(tags:"${encodeURIComponent(tag)}")`);
+        this.router.transitionTo('search', { queryParams: { q: `${encodeURIComponent(tag)}` } });
     }
 
     @action

--- a/lib/osf-components/addon/components/tags-widget/component.ts
+++ b/lib/osf-components/addon/components/tags-widget/component.ts
@@ -2,18 +2,15 @@ import { attribute } from '@ember-decorators/component';
 import Component from '@ember/component';
 import { assert } from '@ember/debug';
 import { action } from '@ember/object';
+import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
-import config from 'ember-get-config';
 
 import { layout } from 'ember-osf-web/decorators/component';
 import OsfModel from 'ember-osf-web/models/osf-model';
 import Analytics from 'ember-osf-web/services/analytics';
-import pathJoin from 'ember-osf-web/utils/path-join';
 
 import styles from './styles';
 import template from './template';
-
-const { OSF: { url: baseUrl } } = config;
 
 interface Taggable extends OsfModel {
     tags: string[];
@@ -21,6 +18,8 @@ interface Taggable extends OsfModel {
 
 @layout(template, styles)
 export default class TagsWidget extends Component.extend({ styles }) {
+    @service router!: RouterService;
+
     // required arguments
     taggable!: Taggable;
 
@@ -64,7 +63,7 @@ export default class TagsWidget extends Component.extend({ styles }) {
 
     @action
     _clickTag(tag: string): void {
-        window.location.assign(`${pathJoin(baseUrl, 'search')}?q=(tags:"${encodeURIComponent(tag)}")`);
+        this.router.transitionTo('search', { queryParams: { q: `${encodeURIComponent(tag)}` } });
     }
 
     _onChange() {

--- a/lib/registries/addon/drafts/draft/-components/tags-manager/component.ts
+++ b/lib/registries/addon/drafts/draft/-components/tags-manager/component.ts
@@ -1,25 +1,22 @@
 import { tagName } from '@ember-decorators/component';
 import Component from '@ember/component';
 import { action, set } from '@ember/object';
+import RouterService from '@ember/routing/router-service';
+import { inject as service } from '@ember/service';
 import { BufferedChangeset } from 'ember-changeset/types';
-import config from 'ember-get-config';
 
 import { layout } from 'ember-osf-web/decorators/component';
 import DraftRegistrationModel from 'ember-osf-web/models/draft-registration';
-import pathJoin from 'ember-osf-web/utils/path-join';
 import { TagsManager } from 'osf-components/components/editable-field/tags-manager/component';
 
 import template from './template';
-
-const {
-    OSF: { url: baseUrl },
-} = config;
 
 export type MetadataTagsManager = Pick<TagsManager, 'addTag' | 'removeTag' | 'clickTag' | 'tags'>;
 
 @tagName('')
 @layout(template)
 export default class MetadataTagsManagerComponent extends Component {
+    @service router!: RouterService;
     // required
     changeset!: BufferedChangeset;
     valuePath!: string;
@@ -58,6 +55,6 @@ export default class MetadataTagsManagerComponent extends Component {
 
     @action
     clickTag(tag: string): void {
-        window.location.assign(`${pathJoin(baseUrl, 'search')}?q=(tags:"${encodeURIComponent(tag)}")`);
+        this.router.transitionTo('search', { queryParams: { q: `${encodeURIComponent(tag)}` } });
     }
 }

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -612,7 +612,7 @@ node_navbar:
     settings: Settings
     comments: Comments
 status:
-    welcome_message: '<h1>Welcome to OSF!</h1><p>Visit our <a href="https://help.osf.io/" target="_blank" rel="noreferrer">Guides</a> to learn about creating a project, or get inspiration from <a href="https://osf.io/explore/activity/#popularPublicProjects">popular public projects</a>.</p>'
+    welcome_message: '<h1>Welcome to OSF!</h1><p>Visit our <a href="https://help.osf.io/" target="_blank" rel="noreferrer">Guides</a> to learn about creating a project, or get inspiration from <a href="https://osf.io/search?resourceType=Project%2CProjectComponent">popular public projects</a>.</p>'
     alternate_email_error: 'The email address has <b>NOT</b> been added to your account. Please log out and revisit the link in your email. Thank you.'
     # remove_addon: 'Because the GitHub add-on for {extra.category} "{extra.title}" was authenticated by {extra.user}, authentication information has been deleted.'
     project_deleted: 'Project has been successfully deleted.'


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: []
-   Feature flag: n/a

## Purpose
- Address links to search page scattered around OSF
- [Notion card on QA bug board](https://www.notion.so/cos/Access-to-Search-Page-from-other-OSF-Ember-Pages-5cc8763d68ec49e4838e45139495ecc7)

## Summary of Changes
- Update "New and noteworthy" link to search
- Update logged out page searchbox enter behavior
- Update link in "Welcome to OSF" banner link
- Update destination when clicking on a tag
- Change query-param to `q` to address any other possible links to search page

## Screenshot(s)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
