### PR TITLE
[ENG-4486]  Styling new search page + facet filters and cards

### DIFF
--- a/lib/osf-components/addon/components/osf-dialog/heading/styles.scss
+++ b/lib/osf-components/addon/components/osf-dialog/heading/styles.scss
@@ -3,18 +3,12 @@
     justify-content: space-between;
     max-height: 15vh;
     overflow-y: auto;
-
     border-bottom: 1px solid #ddd;
-
-    button {
-        margin: 5px;
-    }
 }
 
 .Heading {
     padding: 1rem 0.75rem 1rem 1.25rem;
     margin: 0;
-
     color: $color-text-gray-blue;
     font-size: 24px;
     font-weight: 600;
@@ -22,4 +16,5 @@
 
 .CloseButton.CloseButton {
     align-self: flex-start;
+    margin: 10px;
 }

--- a/lib/osf-components/addon/components/osf-dialog/heading/styles.scss
+++ b/lib/osf-components/addon/components/osf-dialog/heading/styles.scss
@@ -5,6 +5,10 @@
     overflow-y: auto;
 
     border-bottom: 1px solid #ddd;
+
+    button {
+        margin: 5px;
+    }
 }
 
 .Heading {

--- a/lib/osf-components/addon/components/search-page/filter-facet/styles.scss
+++ b/lib/osf-components/addon/components/search-page/filter-facet/styles.scss
@@ -1,6 +1,9 @@
 .facet-wrapper {
-    border-top: 1px solid $color-border-gray;
     padding: 0.5rem 0;
+}
+
+.facet-wrapper:not(:first-of-type) {
+    border-top: 1px solid $color-border-gray;
 }
 
 .facet-expand-button {
@@ -15,11 +18,11 @@
 }
 
 .facet-list {
-    padding: 0;
-    margin: 0;
     list-style: none;
     max-height: 300px;
     overflow-y: auto;
+    margin: 0;
+    padding: 0.2rem;
 
     &.collapsed {
         display: none;
@@ -27,9 +30,9 @@
 }
 
 .facet-value {
-    margin: 10px 0;
     display: flex;
     justify-content: space-between;
+    margin: 10px 0;
 
     .facet-link {
         margin: 0 5px;

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -1,6 +1,13 @@
 // stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type
+
 body {
     background-color: $color-bg-gray-blue-light;
+}
+
+.search-page-mobile {
+    > div:first-of-type {
+        margin-left: 0;
+    }
 }
 
 .heading-wrapper-mobile {
@@ -15,6 +22,7 @@ body {
         font-weight: 500;
         margin: 0.2rem;
         padding: 0.75rem 0 0.5rem 0.5rem;
+        white-space: nowrap;
     }
 
     span {
@@ -33,10 +41,6 @@ body {
             right: 0.1rem;
         }
     }
-
-    .sidenav-toggle {
-        width: 100%;
-    }
 }
 
 .left-panel-mobile {
@@ -53,7 +57,7 @@ body {
         margin-bottom: 1rem;
 
         label > div {
-            width: 193px;
+            width: 195px;
         }
     }
 }
@@ -81,7 +85,6 @@ body {
     color: $color-text-white;
     display: flex;
     align-items: center;
-    justify-content: flex-start;
     padding: 35px;
 
     label {
@@ -91,6 +94,7 @@ body {
 
     .heading-label > h1 {
         margin: 0;
+        white-space: nowrap;
     }
 }
 
@@ -140,7 +144,7 @@ body {
     }
 
     .search-button-wrapper {
-        button:not(.search-button, .help-button-mobile) {
+        .help-button {
             border-radius: 5px;
         }
 
@@ -370,12 +374,13 @@ body {
 }
 
 // for sizing between mobile and desktop
-@media screen and (min-width: 899px) and (max-width: 1250px) {
+@media screen and (min-width: 899px) and (max-width: 1275px) {
     .search-page > div:first-of-type {
         margin: 0 auto;
     }
 
     .heading-wrapper > label {
+        white-space: nowrap;
         padding-left: 0;
         margin: 0;
     }

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -1,4 +1,8 @@
 // stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type
+body {
+    background-color: $color-bg-gray-blue-light;
+}
+
 .heading-wrapper-mobile {
     background-image: url('images/default-brand/bg-dark.jpg');
     background-color: $osf-dark-blue-navbar;
@@ -35,14 +39,39 @@
     }
 }
 
-.search-main {
-    display: flex;
-    flex-direction: column;
-    padding-bottom: 35px;
+.left-panel-mobile {
+    padding: 1rem;
+    width: 75vw;
+
+    .object-type-dropdown {
+        label > div {
+            width: 195px;
+        }
+    }
+
+    .object-sort-dropdown {
+        margin-bottom: 1rem;
+
+        label > div {
+            width: 193px;
+        }
+    }
 }
 
-.search-page {
-    background-color: $color-bg-gray-blue-light;
+.search-main-mobile {
+    > div {
+        width: 90vw;
+        margin: 25px auto;
+    }
+
+    .pagination-buttons {
+        padding-right: 0;
+    }
+}
+
+.search-page > div:first-of-type {
+    max-width: 90vw;
+    margin-left: 5rem;
 }
 
 .heading-wrapper {
@@ -51,8 +80,17 @@
     color: $color-text-white;
     display: flex;
     align-items: center;
-    justify-content: center;
-    padding: 40px;
+    justify-content: flex-start;
+    padding: 35px;
+
+    label {
+        padding: 30px;
+        margin: 0 3rem 0 2rem;
+    }
+
+    .heading-label > h1 {
+        margin: 0;
+    }
 }
 
 .provider-logo {
@@ -86,35 +124,41 @@
     }
 }
 
-.heading-label > h1 {
-    padding: 2rem;
-}
-
 .search-input-wrapper {
     display: inline-flex;
+    justify-content: flex-start;
+    align-items: center;
     white-space: nowrap;
+    width: 70vw;
 
-    button {
-        border-radius: 0 2px 2px 0;
+    .search-input {
+        color: $color-text-black;
+        font-size: 1.5em;
+        min-width: 250px;
+        width: 90%;
+        max-width: 70vw;
+        padding: 9px;
     }
-}
 
-.search-input {
-    color: $color-text-black;
-    font-size: 1.5em;
-    min-width: 250px;
-    max-width: 700px;
-    padding: 10px;
-    width: 50vw;
+    .search-button-wrapper {
+        button {
+            border-radius: 5px;
+        }
+
+        .search-button {
+            border-radius: 0 5px 5px 0;
+            margin-right: 30px;
+        }
+    }
 }
 
 .topbar {
     border-bottom: 1px solid $color-text-black;
     display: flex;
-    justify-content: space-around;
-    margin-left: 20px;
+    margin: 0 auto;
+    width: 80%;
 
-    nav {
+    .object-type-nav {
         display: flex;
         width: 100%;
 
@@ -125,39 +169,34 @@
             list-style: none;
             margin-bottom: 0;
             padding-left: 0;
+
+            width: 100%;
         }
 
         li {
             display: inline-flex;
             white-space: nowrap;
+            margin-right: 10px;
 
             &.active,
             &:hover {
                 background-color: $color-bg-gray;
             }
         }
+
+        a {
+            padding-bottom: 10px;
+        }
+    }
+
+    .help-button {
+        margin-left: 1.2rem;
     }
 }
 
-.help-button {
-    margin-left: 1.2rem;
-}
-
-.object-type-nav {
-    ul {
-        list-style: none;
-        margin-bottom: 0;
-        padding-left: 0;
-    }
-
-    li {
-        display: inline-flex;
-        margin-right: 10px;
-    }
-
-    a {
-        padding-bottom: 10px;
-    }
+.search-main {
+    display: grid;
+    justify-content: center;
 }
 
 .search-help-tutorial {
@@ -200,20 +239,20 @@
         color: $color-text-white;
         overflow: visible;
     }
-}
 
-.pagination {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-}
+    .pagination {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+    }
 
-.help-button-wrapper {
-    display: flex;
-    justify-content: flex-end;
+    .help-button-wrapper {
+        display: flex;
+        justify-content: flex-end;
 
-    button:first-of-type {
-        margin-right: 20px;
+        button:first-of-type {
+            margin-right: 20px;
+        }
     }
 }
 
@@ -234,7 +273,7 @@
     background-color: $color-bg-gray-blue-light;
     display: flex;
     flex-direction: column-reverse;
-    margin-bottom: 10px;
+    padding-bottom: 10px;
     margin-left: 10px;
 
     p {
@@ -262,18 +301,6 @@
     margin: 10px 20px;
 }
 
-.left-panel-mobile {
-    padding: 1rem;
-    width: 75vw;
-
-    div:nth-of-type(2) {
-        margin-bottom: 1rem;
-    }
-
-    div[role='button'] {
-        width: 195px;
-    }
-}
 
 .ember-power-select-options {
     max-height: 20em;
@@ -284,7 +311,7 @@
     margin-bottom: 0;
     min-width: 300px;
     padding: 0 12px;
-    width: 300px;
+    width: 340px;
 
     > h2 {
         border-bottom: 1px solid $alto;
@@ -319,4 +346,10 @@
     display: flex;
     padding: 2rem;
     justify-content: flex-end;
+}
+
+@media (min-wdith: 650px) {
+    .left-panel-mobile {
+        width: 60vw;
+    }
 }

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -273,7 +273,7 @@ body {
 .sort-dropdown {
     background-color: $color-bg-gray-blue-light;
     display: flex;
-    flex-direction: column-reverse;
+    align-items: flex-end;
     padding-bottom: 10px;
     margin-left: 10px;
 

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -361,13 +361,44 @@ body {
     display: flex;
     padding: 2rem;
     justify-content: flex-end;
-
-
     height: fit-content;
 }
 
-@media (min-wdith: 650px) {
+// for tablet displays
+@media screen and (min-width: 650px) {
     .left-panel-mobile {
         width: 60vw;
+    }
+}
+
+// for sizing between mobile and desktop
+@media screen and (min-width: 899px) and (max-width: 1250px) {
+    .search-page > div:first-of-type {
+        margin: 0 auto;
+    }
+
+    .heading-wrapper > label {
+        padding-left: 0;
+        margin: 0;
+    }
+
+    .search-main {
+        gap: 1rem;
+    }
+
+    .object-type-nav {
+        display: flex;
+        flex-direction: column;
+        height: fit-content;
+    }
+
+    .sort-dropdown {
+        align-self: flex-end;
+        margin: 0.5rem 0;
+
+        > div {
+            background-color: #fff;
+            margin-top: 0.4rem;
+        }
     }
 }

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -142,7 +142,7 @@ body {
     }
 
     .search-button-wrapper {
-        button:not(.help-button-mobile) {
+        button:not(.search-button, .help-button-mobile) {
             border-radius: 5px;
         }
 
@@ -397,7 +397,7 @@ body {
         margin: 0.5rem 0;
 
         > div {
-            background-color: #fff;
+            background-color: $color-bg-white;
             margin-top: 0.4rem;
         }
     }

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -349,4 +349,6 @@
 
 .pagination-buttons {
     display: flex;
+    padding: 2rem;
+    justify-content: flex-end;
 }

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -126,9 +126,7 @@ body {
 }
 
 .search-input-wrapper {
-    display: inline-flex;
-    justify-content: flex-start;
-    align-items: center;
+    display: flex;
     white-space: nowrap;
     width: 70vw;
 
@@ -386,10 +384,9 @@ body {
         gap: 1rem;
     }
 
-    .object-type-nav {
+    .topbar {
         display: flex;
         flex-direction: column;
-        height: fit-content;
     }
 
     .sort-dropdown {

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -21,7 +21,7 @@
         padding: 0 0 0.5rem 0.5rem;
         width: 100%;
 
-        button:nth-of-type(2) {
+        .help-button {
             transform: scale(0.5);
             border-radius: 50%;
             margin-left: 0;

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -71,7 +71,7 @@ body {
 }
 
 .search-page > div:first-of-type {
-    max-width: 90vw;
+    max-width: 95vw;
     margin-left: 5rem;
 }
 
@@ -157,7 +157,9 @@ body {
     border-bottom: 1px solid $color-text-black;
     display: flex;
     margin: 0 auto;
-    width: 80%;
+    max-height: 55px;
+    margin-top: 1rem;
+    width: 60vw;
 
     .object-type-nav {
         display: flex;
@@ -298,10 +300,16 @@ body {
 }
 
 .no-results {
-    font-size: 1.2em;
-    margin: 10px 20px;
-}
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
+    p {
+        font-size: 1.2em;
+        margin: 10px 20px;
+        text-align: center;
+    }
+}
 
 .ember-power-select-options {
     max-height: 20em;
@@ -345,10 +353,17 @@ body {
     }
 }
 
+.no-properties {
+    padding: 1rem 0;
+}
+
 .pagination-buttons {
     display: flex;
     padding: 2rem;
     justify-content: flex-end;
+
+
+    height: fit-content;
 }
 
 @media (min-wdith: 650px) {

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -298,7 +298,7 @@
 .search-count {
     font-size: 1.3em;
     font-weight: bold;
-    margin-top: 5px 0;
+    margin: 5px 0;
 }
 
 .active-filter-list {

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -30,7 +30,7 @@
         }
     }
 
-    > button {
+    .sidenav-toggle {
         width: 100%;
     }
 }

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -1,78 +1,55 @@
-.search-page {
-    background-color: $color-bg-gray;
-}
-
-.heading-wrapper {
-    text-align: center;
-    color: $color-text-white;
+// stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type
+.heading-wrapper-mobile {
+    background-image: url('images/default-brand/bg-dark.jpg');
     background-color: $osf-dark-blue-navbar;
-}
-
-.provider-logo {
-    background: var(--hero-logo-img-url) top center no-repeat;
-    background-size: contain;
-    height: 70px;
-    width: 100%;
-    margin: 2em 0 1em;
-}
-
-.hero-overlay {
+    color: $color-text-white;
     display: flex;
     flex-direction: column;
-    width: 100%;
-    height: 100%;
-    min-width: 100%;
-    min-height: 100%;
-    position: relative;
-    background-color: transparent; // override .heading-wrapper background-color
-
-    &::after {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: var(--hero-background-img-url);
-        background-size: cover;
-        z-index: -1;
-        content: '';
-    }
-}
-
-.heading-wrapper-institutions {
-    background-color: $color-shadow-gray-dark;
-    color: $color-text-gray-cool;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding-bottom: 0.5rem;
+    align-items: end;
+    padding: 0;
 
     label {
-        max-width: 835px;
-        min-width: 250px;
-        width: 50vw;
-        padding-bottom: 0;
+        margin-left: 0.5rem;
+        padding: 0;
+        text-align: left;
+        width: 100%;
 
-        img {
-            max-height: 65px;
+        > h1 {
+            font-weight: 500;
+            margin: 0.2rem;
+            padding: 0.75rem 0 0.5rem 0.5rem;
         }
+    }
 
-        p {
-            font-weight: 400;
-            text-align: center;
-            padding: 1rem 0;
-            margin: 0;
+    span {
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-start;
+        margin-left: 0.5rem;
+        padding: 0 0 0.5rem 0.5rem;
+        width: 100%;
+
+        button:nth-of-type(2) {
+            transform: scale(0.5);
+            border-radius: 50%;
+            margin-left: 0;
+            position: absolute;
+            right: 0.1rem;
         }
+    }
+
+    > button {
+        width: 100%;
     }
 }
 
 .heading-wrapper-institutions-mobile {
-    padding-bottom: 0.5rem;
+    align-items: center;
+    background: $color-bg-gray-blue-light;
 
     label {
-        padding-bottom: 0.5rem;
         margin-bottom: 0;
-        width: 95%;
+        padding-bottom: 0.5rem;
 
         img {
             margin: 0.5rem auto;
@@ -84,57 +61,134 @@
         }
     }
 
-    span {
-        padding: 0 1rem 1rem;
-    }
-
     > button {
-        width: 100%;
         margin-top: 0.5rem;
+        width: 100%;
     }
 }
 
-.heading-label {
+.search-main {
+    display: flex;
+    flex-direction: column;
+    padding-bottom: 35px;
+}
+
+.search-page {
+    background-color: $color-bg-gray-blue-light;
+}
+
+.heading-wrapper {
+    background-image: url('images/default-brand/bg-dark.jpg');
+    background-color: $osf-dark-blue-navbar;
+    color: $color-text-white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     padding: 40px;
 }
 
+.provider-logo {
+    background: var(--hero-logo-img-url) top center no-repeat;
+    background-size: contain;
+    height: 70px;
+    margin: 2em 0 1em;
+    width: 100%;
+}
+
+.hero-overlay {
+    background-color: transparent;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+    min-height: 100%;
+    min-width: 100%;
+    position: relative;
+
+    &::after {
+        background: var(--hero-background-img-url);
+        background-size: cover;
+        content: '';
+        height: 100%;
+        width: 100%;
+        position: absolute;
+        left: 0;
+        top: 0;
+        z-index: -1;
+    }
+}
+
+.heading-label > h1 {
+    padding: 2rem;
+}
+
 .search-input-wrapper {
+    display: inline-flex;
     white-space: nowrap;
+
+    button {
+        border-radius: 0 2px 2px 0;
+    }
 }
 
 .search-input {
     color: $color-text-black;
-    padding: 9px 5px;
     font-size: 1.5em;
-    max-width: 700px;
     min-width: 250px;
+    max-width: 700px;
+    padding: 10px;
     width: 50vw;
 }
 
-.help-button,
-.search-button {
-    position: relative;
-    right: 3px;
-    bottom: 3px;
+.topbar {
+    border-bottom: 1px solid $color-text-black;
+    display: flex;
+    justify-content: space-around;
+    margin-left: 20px;
+
+    nav {
+        display: flex;
+        width: 100%;
+
+        ul {
+            display: flex;
+            align-items: center;
+            justify-content: space-evenly;
+            list-style: none;
+            margin-bottom: 0;
+            padding-left: 0;
+        }
+
+        li {
+            display: inline-flex;
+            white-space: nowrap;
+
+            &.active,
+            &:hover {
+                background-color: $color-bg-gray;
+            }
+        }
+    }
 }
 
-.topbar {
-    margin-left: 20px;
-    display: flex;
-    justify-content: space-between;
-    border-bottom: 1px solid $color-text-black;
+.help-button {
+    margin-left: 1.2rem;
 }
 
 .object-type-nav {
     ul {
-        padding-left: 0;
-        margin-bottom: 0;
         list-style: none;
+        margin-bottom: 0;
+        padding-left: 0;
     }
 
     li {
         display: inline-flex;
         margin-right: 10px;
+    }
+
+    a {
+        padding-bottom: 10px;
     }
 }
 
@@ -144,8 +198,7 @@
     width: 400px;
     max-width: 100%;
     z-index: 100;
-
-    // prevent target element styles from dictating popover text-styles
+    // prevent overriding popover styling
     white-space: wrap;
     text-align: initial;
 
@@ -169,21 +222,40 @@
 
 
 .object-type-filter-link {
-    padding: 10px 15px;
     font-size: 1.3em;
+    padding: 18px 15px;
 
     &:global(.active),
     &:hover {
-        text-decoration: none;
-        background-color: $color-bg-gray;
+        background-color: $color-bg-white;
+        border-bottom: 1px solid $color-text-black;
         color: $color-text-black;
-        border-bottom: 2px solid $color-text-black;
+        text-decoration: none;
     }
 }
 
 .sort-dropdown {
-    width: 170px;
-    margin-top: 10px;
+    background-color: $color-bg-gray-blue-light;
+
+    p {
+        margin: 0 0 0 2px;
+    }
+
+    div {
+        background-color: $color-bg-gray-blue-light;
+        border: 0 solid transparent;
+        color: $color-bg-blue-dark;
+        width: 170px;
+    }
+
+    > div {
+        display: flex;
+    }
+}
+
+.ember-power-select-status-icon {
+    right: 10px;
+    top: 12px;
 }
 
 .sidenav-toggle {
@@ -191,21 +263,46 @@
 }
 
 .no-results {
-    margin: 10px 20px;
     font-size: 1.2em;
+    margin: 10px 20px;
+}
+
+.left-panel-mobile {
+    padding: 1rem;
+    width: 75vw;
+
+    div:nth-of-type(2) {
+        margin-bottom: 1rem;
+    }
+
+    div[role='button'] {
+        width: 195px;
+    }
+}
+
+.ember-power-select-options {
+    max-height: 20em;
 }
 
 .left-panel {
-    padding-left: 12px;
-    width: 300px;
+    background-color: $color-bg-gray-blue-light;
+    margin-bottom: 0;
     min-width: 300px;
+    padding: 0 12px;
+    width: 300px;
+
+    h2 {
+        border-bottom: 1px solid #ddd;
+        font-weight: 300;
+        margin-bottom: 0;
+        padding-bottom: 0.5rem;
+    }
 }
 
 .search-count {
-    margin-top: 10px;
-    margin-bottom: 10px;
     font-size: 1.3em;
     font-weight: bold;
+    margin-top: 5px 0;
 }
 
 .active-filter-list {
@@ -216,6 +313,38 @@
 .active-filter-item {
     display: flex;
     justify-content: space-between;
+    margin: 0.5rem 0.2rem;
+}
+
+.heading-wrapper-institutions {
+    // default for institution colors
+    background: $color-bg-gray-blue-light;
+    color: $color-text-black;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding-bottom: 0;
+    padding-top: 1rem;
+
+    label {
+        width: 50vw;
+        min-width: 250px;
+        max-width: 835px;
+        padding-bottom: 0;
+
+        img {
+            display: block;
+            margin: 0 auto;
+            max-height: 65px;
+        }
+
+        p {
+            font-weight: 400;
+            margin: 0;
+            padding: 1rem 0;
+            text-align: center;
+        }
+    }
 }
 
 .pagination-buttons {

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -5,27 +5,19 @@
     color: $color-text-white;
     display: flex;
     flex-direction: column;
-    align-items: end;
     padding: 0;
 
-    label {
-        margin-left: 0.5rem;
-        padding: 0;
-        text-align: left;
-        width: 100%;
-
-        > h1 {
-            font-weight: 500;
-            margin: 0.2rem;
-            padding: 0.75rem 0 0.5rem 0.5rem;
-        }
+    label > h1 {
+        font-weight: 500;
+        margin: 0.2rem;
+        padding: 0.75rem 0 0.5rem 0.5rem;
     }
 
     span {
         display: flex;
         flex-direction: row;
         justify-content: flex-start;
-        margin-left: 0.5rem;
+        margin-left: 0;
         padding: 0 0 0.5rem 0.5rem;
         width: 100%;
 
@@ -39,30 +31,6 @@
     }
 
     > button {
-        width: 100%;
-    }
-}
-
-.heading-wrapper-institutions-mobile {
-    align-items: center;
-    background: $color-bg-gray-blue-light;
-
-    label {
-        margin-bottom: 0;
-        padding-bottom: 0.5rem;
-
-        img {
-            margin: 0.5rem auto;
-            max-height: inherit;
-        }
-
-        p {
-            margin: 0 auto;
-        }
-    }
-
-    > button {
-        margin-top: 0.5rem;
         width: 100%;
     }
 }
@@ -211,15 +179,43 @@
         float: left;
     }
     
-    .help-button-wrappers {
-        float: right;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    margin-left: -0.2rem;
+
+    h2 {
+        font-weight: 400;
+        height: 22px;
+        margin-top: 0.5rem;
+        margin-left: 0.2rem;
+    }
+
+    p {
+        white-space: normal;
+        margin: 25px 5px 20px;
     }
 
     .skip-button {
         color: $color-text-white;
+        overflow: visible;
     }
 }
 
+.pagination {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+}
+
+.help-button-wrapper {
+    display: flex;
+    justify-content: flex-end;
+
+    button:first-of-type {
+        margin-right: 20px;
+    }
+}
 
 .object-type-filter-link {
     font-size: 1.3em;
@@ -291,8 +287,8 @@
     padding: 0 12px;
     width: 300px;
 
-    h2 {
-        border-bottom: 1px solid #ddd;
+    > h2 {
+        border-bottom: 1px solid $alto;
         font-weight: 300;
         margin-bottom: 0;
         padding-bottom: 0.5rem;
@@ -314,36 +310,9 @@
     display: flex;
     justify-content: space-between;
     margin: 0.5rem 0.2rem;
-}
 
-.heading-wrapper-institutions {
-    // default for institution colors
-    background: $color-bg-gray-blue-light;
-    color: $color-text-black;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding-bottom: 0;
-    padding-top: 1rem;
-
-    label {
-        width: 50vw;
-        min-width: 250px;
-        max-width: 835px;
-        padding-bottom: 0;
-
-        img {
-            display: block;
-            margin: 0 auto;
-            max-height: 65px;
-        }
-
-        p {
-            font-weight: 400;
-            margin: 0;
-            padding: 1rem 0;
-            text-align: center;
-        }
+    button {
+        margin-right: -5px;
     }
 }
 

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -25,7 +25,7 @@ body {
         padding: 0 0 0.5rem 0.5rem;
         width: 100%;
 
-        .help-button {
+        .help-button-mobile {
             transform: scale(0.5);
             border-radius: 50%;
             margin-left: 0;
@@ -60,8 +60,9 @@ body {
 
 .search-main-mobile {
     > div {
-        width: 90vw;
         margin: 25px auto;
+        padding: 20px;
+        width: 90vw;
     }
 
     .pagination-buttons {
@@ -141,7 +142,7 @@ body {
     }
 
     .search-button-wrapper {
-        button {
+        button:not(.help-button-mobile) {
             border-radius: 5px;
         }
 

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -311,21 +311,23 @@ body {
     background-color: $color-bg-gray-blue-light;
     margin-bottom: 0;
     min-width: 300px;
-    padding: 0 12px;
+    padding: 2rem 12px;
     width: 340px;
 
-    > h2 {
+    .left-panel-header {
         border-bottom: 1px solid $alto;
         font-weight: 300;
         margin-bottom: 0;
-        padding-bottom: 0.5rem;
+        margin-top: 2rem;
+        padding: 0 0 1rem;
     }
 }
 
 .search-count {
-    font-size: 1.3em;
-    font-weight: bold;
+    font-size: 1.5em;
+    font-weight: 600;
     margin: 5px 0;
+    padding: 0 0.2rem 0.2rem;
 }
 
 .active-filter-list {

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -232,6 +232,10 @@
 
 .sort-dropdown {
     background-color: $color-bg-gray-blue-light;
+    display: flex;
+    flex-direction: column-reverse;
+    margin-bottom: 10px;
+    margin-left: 10px;
 
     p {
         margin: 0 0 0 2px;
@@ -246,11 +250,6 @@
 
     > div {
         display: flex;
-    }
-
-    .ember-power-select-status-icon {
-        right: 10px;
-        top: 12px;
     }
 }
 

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -247,11 +247,11 @@
     > div {
         display: flex;
     }
-}
 
-.ember-power-select-status-icon {
-    right: 10px;
-    top: 12px;
+    .ember-power-select-status-icon {
+        right: 10px;
+        top: 12px;
+    }
 }
 
 .sidenav-toggle {

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -277,7 +277,7 @@ as |layout|>
             <p data-test-help-body-1>{{t 'search.search-help.body-1' htmlSafe=true}}</p>
             <span local-class='pagination'>
                 <p local-class='enumeration' data-test-help-enumeration-1>{{t 'search.search-help.index-1'}}</p>
-                <span local-class='help-button-wrappers'>
+                <span local-class='help-button-wrapper'>
                     <Button
                         data-test-help-skip-1
                         data-analytics-name='Skip help'
@@ -321,7 +321,7 @@ as |layout|>
             <p data-test-help-body-2>{{t 'search.search-help.body-2'}}</p>
             <span local-class='pagination'>
                 <p local-class='enumeration' data-test-help-enumeration-2>{{t 'search.search-help.index-2'}}</p>
-                <span local-class='help-button-wrappers'>
+                <span local-class='help-button-wrapper'>
                     <Button
                         data-test-help-skip-2
                         data-analytics-name='Skip help'

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -1,12 +1,12 @@
 <OsfLayout
-    @backgroundClass='search-page'
+    @backgroundClass={{local-class 'search-page'}}
     ...attributes
 as |layout|>
     <layout.heading
         data-test-heading-wrapper
         data-analytics-scope='Search page heading'
         {{with-branding (get-model @provider.brand)}}
-        local-class='heading-wrapper {{if @provider 'hero-overlay'}} {{if (and (not this.showSidePanelToggle) @institution) 'heading-wrapper-institutions' 'heading-wrapper-institutions-mobile'}}'
+        local-class='{{if this.showSidePanelToggle 'heading-wrapper-mobile' 'heading-wrapper'}} {{if @provider 'hero-overlay'}} {{if @institution 'heading-wrapper-institutions'}} {{if (and this.showSidePanelToggle @institution) 'heading-wrapper-institutions-mobile'}}'
     >
         {{#if @provider}}
             <div
@@ -18,10 +18,10 @@ as |layout|>
                 {{html-safe @provider.description}}
             </p>
         {{else if @institution}}
-            <div>
+            <div local-class='heading-wrapper-institutions'>
                 <label
                     for='search-input'
-                    local-class='heading-label'
+                    local-class='heading-label-institution'
                 >
                     {{#if this.showSidePanelToggle}}
                         <img
@@ -101,7 +101,7 @@ as |layout|>
     </layout.heading>
     <layout.left
         data-analytics-scope='Search page left panel'
-        local-class='left-panel'
+        local-class='{{if this.showSidePanelToggle 'left-panel-mobile' 'left-panel'}}'
     >
         {{#if this.showResultCountLeft}}
             <p
@@ -116,7 +116,7 @@ as |layout|>
             {{#if @showResourceTypeFilter}}
                 <div data-test-left-panel-object-type-dropdown id={{this.leftPanelObjectDropdownId}}>
                     <label>
-                        {{t 'search.resource-type.search-by'}}
+                        <p>{{t 'search.resource-type.search-by'}}</p>
                         <PowerSelect @options={{this.resourceTypeOptions}} @selected={{this.selectedResourceTypeOption}}
                             @onChange={{this.updateResourceType}} as |resourceType|>
                             {{resourceType.display}}
@@ -126,7 +126,7 @@ as |layout|>
             {{/if}}
             <div data-test-left-panel-sort-dropdown>
                 <label>
-                    {{t 'search.sort.sort-by'}}
+                    <p>{{t 'search.sort.sort-by'}}</p>
                     <PowerSelect @options={{this.sortOptions}} @selected={{this.selectedSortOption}}
                         @onChange={{this.updateSort}} as |sortOption|>
                         {{sortOption.display}}
@@ -177,7 +177,7 @@ as |layout|>
             {{/each}}
         {{/if}}
     </layout.left>
-    <layout.main data-analytics-scope='Search page main'>
+    <layout.main local-class='search-main' data-analytics-scope='Search page main'>
         {{!-- paginator --}}
         {{#unless this.showSidePanelToggle}}
             <div data-test-topbar-wrapper local-class='topbar'>
@@ -201,6 +201,19 @@ as |layout|>
                                     </LinkTo>
                                 </li>
                             {{/each}}
+                            <div
+                                data-test-topbar-sort-dropdown
+                                local-class='sort-dropdown'
+                            >
+                                <PowerSelect
+                                    @options={{this.sortOptions}}
+                                    @selected={{this.selectedSortOption}}
+                                    @onChange={{action this.updateSort}}
+                                    as |sortOption|
+                                >
+                                    <p>{{sortOption.display}}</p>
+                                </PowerSelect>
+                            </div>
                         </ul>
                     </nav>
                 {{else if this.showResultCountMiddle}}
@@ -211,19 +224,6 @@ as |layout|>
                         {{t 'search.total-results' count=this.totalResultCount}}
                     </p>
                 {{/if}}
-                <div
-                    data-test-topbar-sort-dropdown
-                    local-class='sort-dropdown'
-                >
-                    <PowerSelect
-                        @options={{this.sortOptions}}
-                        @selected={{this.selectedSortOption}}
-                        @onChange={{action this.updateSort}}
-                        as |sortOption|
-                    >
-                        {{sortOption.display}}
-                    </PowerSelect>
-                </div>
             </div>
         {{/unless}}
         {{#if this.search.isRunning}}

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -73,7 +73,7 @@ as |layout|>
                 <Button
                     data-test-start-help
                     data-analytics-name='Search help button'
-                    local-class='help-button'
+                    local-class='{{if this.showSidePanelToggle 'help-button-mobile' 'help-button'}}'
                     aria-label={{t 'search.search-help-label'}}
                     @type='primary'
                     @layout='large'

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -113,7 +113,7 @@ as |layout|>
                 {{t 'search.total-results' count=this.totalResultCount}}
             </p>
         {{/if}}
-        <h2 id={{this.leftPanelHeaderId}}>{{t 'search.left-panel.header'}}</h2>
+        <h2 local-class='left-panel-header' id={{this.leftPanelHeaderId}}>{{t 'search.left-panel.header'}}</h2>
         {{#if this.showSidePanelToggle}}
             {{#if @showResourceTypeFilter}}
                 <div data-test-left-panel-object-type-dropdown local-class='object-type-dropdown' id={{this.leftPanelObjectDropdownId}}>

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -206,20 +206,20 @@ as |layout|>
                                 </li>
                             {{/each}}
                         </ul>
-                        <div
-                            data-test-topbar-sort-dropdown
-                            local-class='sort-dropdown'
-                        >
-                            <PowerSelect
-                                @options={{this.sortOptions}}
-                                @selected={{this.selectedSortOption}}
-                                @onChange={{action this.updateSort}}
-                                as |sortOption|
-                            >
-                                <p>{{sortOption.display}}</p>
-                            </PowerSelect>
-                        </div>
                     </nav>
+                    <div
+                        data-test-topbar-sort-dropdown
+                        local-class='sort-dropdown'
+                    >
+                        <PowerSelect
+                            @options={{this.sortOptions}}
+                            @selected={{this.selectedSortOption}}
+                            @onChange={{action this.updateSort}}
+                            as |sortOption|
+                        >
+                            <p>{{sortOption.display}}</p>
+                        </PowerSelect>
+                    </div>
                 {{else if this.showResultCountMiddle}}
                     <p
                         data-test-middle-search-count

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -201,20 +201,20 @@ as |layout|>
                                     </LinkTo>
                                 </li>
                             {{/each}}
-                            <div
-                                data-test-topbar-sort-dropdown
-                                local-class='sort-dropdown'
-                            >
-                                <PowerSelect
-                                    @options={{this.sortOptions}}
-                                    @selected={{this.selectedSortOption}}
-                                    @onChange={{action this.updateSort}}
-                                    as |sortOption|
-                                >
-                                    <p>{{sortOption.display}}</p>
-                                </PowerSelect>
-                            </div>
                         </ul>
+                        <div
+                            data-test-topbar-sort-dropdown
+                            local-class='sort-dropdown'
+                        >
+                            <PowerSelect
+                                @options={{this.sortOptions}}
+                                @selected={{this.selectedSortOption}}
+                                @onChange={{action this.updateSort}}
+                                as |sortOption|
+                            >
+                                <p>{{sortOption.display}}</p>
+                            </PowerSelect>
+                        </div>
                     </nav>
                 {{else if this.showResultCountMiddle}}
                     <p

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -1,5 +1,5 @@
 <OsfLayout
-    @backgroundClass={{local-class 'search-page'}}
+    @backgroundClass='{{if this.showSidePanelToggle (local-class 'search-page-mobile') (local-class 'search-page')}}'
     ...attributes
 as |layout|>
     <layout.heading
@@ -58,33 +58,35 @@ as |layout|>
                 @value={{this.cardSearchText}}
                 @enter={{perform this.doDebounceSearch}}
             />
-            <Button
-                data-test-search-submit
-                data-analytics-name='Search button'
-                local-class='search-button'
-                aria-label={{t 'search.search-button-label'}}
-                @type='primary'
-                @layout='large'
-                {{on 'click' (perform this.doDebounceSearch)}}
-            >
-                <FaIcon @icon='search' />
-            </Button>
-            <Button
-                data-test-start-help
-                data-analytics-name='Search help button'
-                local-class='help-button'
-                aria-label={{t 'search.search-help-label'}}
-                @type='primary'
-                @layout='large'
-                {{on 'click' (queue
-                    layout.openSidenavGutter
-                    (fn (mut this.showTooltip3) false)
-                    (fn (mut this.showTooltip2) false)
-                    (fn (mut this.showTooltip1) true)
-                )}}
-            >
-                <FaIcon @icon='question' />
-            </Button>
+            <div local-class='search-button-wrapper'>
+                <Button
+                    data-test-search-submit
+                    data-analytics-name='Search button'
+                    local-class='search-button'
+                    aria-label={{t 'search.search-button-label'}}
+                    @type='primary'
+                    @layout='large'
+                    {{on 'click' (perform this.doDebounceSearch)}}
+                >
+                    <FaIcon @icon='search' />
+                </Button>
+                <Button
+                    data-test-start-help
+                    data-analytics-name='Search help button'
+                    local-class='help-button'
+                    aria-label={{t 'search.search-help-label'}}
+                    @type='primary'
+                    @layout='large'
+                    {{on 'click' (queue
+                        layout.openSidenavGutter
+                        (fn (mut this.showTooltip3) false)
+                        (fn (mut this.showTooltip2) false)
+                        (fn (mut this.showTooltip1) true)
+                    )}}
+                >
+                    <FaIcon @icon='question' />
+                </Button>
+            </div>
         </span>
         {{#if this.showSidePanelToggle}}
             <Button
@@ -114,7 +116,7 @@ as |layout|>
         <h2 id={{this.leftPanelHeaderId}}>{{t 'search.left-panel.header'}}</h2>
         {{#if this.showSidePanelToggle}}
             {{#if @showResourceTypeFilter}}
-                <div data-test-left-panel-object-type-dropdown id={{this.leftPanelObjectDropdownId}}>
+                <div data-test-left-panel-object-type-dropdown local-class='object-type-dropdown' id={{this.leftPanelObjectDropdownId}}>
                     <label>
                         <p>{{t 'search.resource-type.search-by'}}</p>
                         <PowerSelect @options={{this.resourceTypeOptions}} @selected={{this.selectedResourceTypeOption}}
@@ -124,7 +126,7 @@ as |layout|>
                     </label>
                 </div>
             {{/if}}
-            <div data-test-left-panel-sort-dropdown>
+            <div local-class='object-sort-dropdown' data-test-left-panel-sort-dropdown>
                 <label>
                     <p>{{t 'search.sort.sort-by'}}</p>
                     <PowerSelect @options={{this.sortOptions}} @selected={{this.selectedSortOption}}
@@ -177,7 +179,7 @@ as |layout|>
             {{/each}}
         {{/if}}
     </layout.left>
-    <layout.main local-class='search-main' data-analytics-scope='Search page main'>
+    <layout.main local-class={{if this.showSidePanelToggle 'search-main-mobile' 'search-main'}} data-analytics-scope='Search page main'>
         {{!-- paginator --}}
         {{#unless this.showSidePanelToggle}}
             <div data-test-topbar-wrapper local-class='topbar'>

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -175,7 +175,9 @@ as |layout|>
                     @toggleFilter={{this.toggleFilter}}
                 />
             {{else}}
-                {{t 'search.left-panel.no-filterable-properties'}}
+                <p local-class='no-properties'>
+                    {{t 'search.left-panel.no-filterable-properties'}}
+                </p>
             {{/each}}
         {{/if}}
     </layout.left>
@@ -234,7 +236,9 @@ as |layout|>
             {{#each this.searchResults as |item|}}
                 <SearchResultCard @result={{item}} />
             {{else}}
-                <p local-class='no-results'>{{t 'search.no-results'}}</p>
+                <div local-class='no-results'>
+                    <p>{{t 'search.no-results'}}</p>
+                </div>
             {{/each}}
         {{/if}}
         <div local-class='pagination-buttons'>

--- a/lib/osf-components/addon/components/search-result-card/styles.scss
+++ b/lib/osf-components/addon/components/search-result-card/styles.scss
@@ -1,25 +1,44 @@
 .result-card-container {
-    margin: 10px;
-
-    dt:not(:first-child) {
-        margin-top: 10px;
-    }
+    background-color: $color-bg-white;
+    margin: 35px 35px 0;
 }
 
 .primary-metadata-container {
     display: flex;
     flex-direction: column;
+
+    h4,
+    div:not(:first-child) {
+        margin: 0 0 15px 15px;
+    }
 }
 
 .header {
     display: flex;
     justify-content: space-between;
+
+    button {
+        border: 1px solid transparent;
+        color: $color-text-blue-dark;
+        height: 30px;
+        margin: 5px;
+        padding: 0 10px;
+    }
 }
 
 .type-label {
-    width: fit-content;
-    padding: 5px;
     background-color: $color-gradient-primary;
+    margin: 15px;
+    padding: 0 5px;
+    width: fit-content;
+}
+
+.name-fields {
+    text-transform: capitalize;
+}
+
+.parent-reference {
+    text-transform: capitalize;
 }
 
 .date-fields {

--- a/lib/osf-components/addon/components/search-result-card/styles.scss
+++ b/lib/osf-components/addon/components/search-result-card/styles.scss
@@ -40,10 +40,6 @@
     text-transform: uppercase;
 }
 
-.name-fields {
-    text-transform: capitalize;
-}
-
 .date-fields {
     span {
         &:not(:last-child)::after {

--- a/lib/osf-components/addon/components/search-result-card/styles.scss
+++ b/lib/osf-components/addon/components/search-result-card/styles.scss
@@ -31,6 +31,7 @@
     margin: 15px;
     padding: 0 5px;
     width: fit-content;
+    text-transform: uppercase;
 }
 
 .name-fields {

--- a/lib/osf-components/addon/components/search-result-card/styles.scss
+++ b/lib/osf-components/addon/components/search-result-card/styles.scss
@@ -1,6 +1,12 @@
 .result-card-container {
     background-color: $color-bg-white;
     margin: 35px 35px 0;
+    width: 60vw;
+
+    dt,
+    dd {
+        margin-left: 15px;
+    }
 }
 
 .primary-metadata-container {

--- a/lib/osf-components/addon/components/search-result-card/styles.scss
+++ b/lib/osf-components/addon/components/search-result-card/styles.scss
@@ -38,10 +38,6 @@
     text-transform: capitalize;
 }
 
-.parent-reference {
-    text-transform: capitalize;
-}
-
 .date-fields {
     span {
         &:not(:last-child)::after {

--- a/lib/osf-components/addon/components/search-result-card/template.hbs
+++ b/lib/osf-components/addon/components/search-result-card/template.hbs
@@ -48,19 +48,14 @@
             </div>
         {{/if}}
         {{#if @result.isPartOf}}
-            <div>
-                <span>{{t 'osf-components.search-result-card.from'}}: <a href={{@result.isPartOfTitleAndUrl.absoluteUrl}} target='_blank' rel='noopener noreferrer'> {{@result.isPartOfTitleAndUrl.title}} </a></span>
-            </div>
-        {{/if}}
-        {{#if @result.isContainedBy}}
-            <div>
-                <span>{{t 'osf-components.search-result-card.from'}}: <a href={{@result.isContainedByTitleAndUrl.absoluteUrl}} target='_blank' rel='noopener noreferrer'> {{@result.isContainedByTitleAndUrl.title}} </a></span>
+            <div local-class='parent-reference'>
+                <span>{{t 'osf-components.search-result-card.from'}}: <a href={{@result.isPartOf.absoluteUrl}} target='_blank' rel='noopener noreferrer'>{{@result.isPartOf.title}}</a></span>
             </div>
         {{/if}}
         <div local-class='date-fields'>
             {{#each @result.dateFields as |field|}}
                 {{#if field.date}}
-                    <span>{{field.label}}: {{field.date}}</span>   
+                    <span>{{field.label}}: {{field.date}}</span>
                 {{/if}}
             {{/each}}
         </div>

--- a/lib/osf-components/addon/components/search-result-card/template.hbs
+++ b/lib/osf-components/addon/components/search-result-card/template.hbs
@@ -49,7 +49,7 @@
         {{/if}}
         {{#if @result.isPartOf}}
             <div>
-                <span>{{t 'osf-components.search-result-card.from'}}: <a href={{@result.isPartOf.absoluteUrl}} target='_blank' rel='noopener noreferrer'>{{@result.isPartOf.title}}</a></span>
+                <span>{{t 'osf-components.search-result-card.from'}}: <a href={{@result.isPartOfTitleAndUrl.absoluteUrl}} target='_blank' rel='noopener noreferrer'> {{@result.isPartOfTitleAndUrl.title}} </a></span>
             </div>
         {{/if}}
         <div local-class='date-fields'>

--- a/lib/osf-components/addon/components/search-result-card/template.hbs
+++ b/lib/osf-components/addon/components/search-result-card/template.hbs
@@ -48,7 +48,7 @@
             </div>
         {{/if}}
         {{#if @result.isPartOf}}
-            <div local-class='parent-reference'>
+            <div>
                 <span>{{t 'osf-components.search-result-card.from'}}: <a href={{@result.isPartOf.absoluteUrl}} target='_blank' rel='noopener noreferrer'>{{@result.isPartOf.title}}</a></span>
             </div>
         {{/if}}

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1890,6 +1890,7 @@ osf-components:
         project_component: Project component
         registration_component: Registration component
         link_to_orcid_id: Link to orcid id
+        unknown: Unknown
     resources-list:
         add_instructions: 'Link a DOI from a repository to your registration by clicking the green “+” button.'
         add_instructions_adhere: 'Contributors affirmed to adhere to the criteria for each badge.'


### PR DESCRIPTION
-   Ticket: https://openscience.atlassian.net/browse/ENG-4486
-   Git branch: feature/styling-search-cards

## Purpose

The purpose of these changes is to make the search page easy to scan and aesthetically pleasing as well as functional in both desktop and mobile views.


## Summary of Changes

Styling was added to the main search route to include the heading wrapper, topbar, facet filters, and cards on desktop and mobile. Changes also included institutions' assets styling on desktop and mobile. Individual changes include:
- Background image with default background OSF blue was added to the heading wrapper 
- Flex was added to the header and cards for formatting and responsiveness 
- Cards were formatted, adding semantic tag elements and local class selectors where appropriate
- Padding and margin were augmented to match mock-up formatting for the top bar and relevance dropdown
- Border radius was updated to improve the search button's appearance positioned next to the search input
- Project type tags were given an uppercase text-transform
- The left nav filter facet spacing was improved


## Screenshot(s)

<img width="1680" alt="Search OSF" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/82047646/ca7d7e9b-4eb6-447c-9492-2f8559d90c1c">

Figure 1: OSF Search Styling on Desktop

<img width="373" alt="image" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/82047646/e35a7a1d-28f7-486e-a4da-8ec5de2a9272">

Figure 2: OSF Search Styling on Mobile

<img width="371" alt="image" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/82047646/88d90a86-1d54-4029-8b1c-f0d93405ecb8">

Figure 3: OSF Search Styling on Mobile with filter facets and pagination

<img width="1408" alt="Search OSF" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/82047646/2a690204-f5e4-4b39-8a7f-431d47379331">

Figure 4: Desktop view with no results or filters

<img width="1085" alt="Search OSF Search placeholder" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/82047646/2d8bf151-cf83-453d-ba20-b2eacd43eded">

Figure 5: Layout styling for browser client re-sizings between mobile and full-screen desktop views


## Side Effects

Styling should be tested thoroughly to make sure all elements are both functional and properly rendered.


## QA Notes

-Do all elements on the page fit appropriately?
-Is any button, link, or input field obscured? Does more padding or margin need to be added to improve the overall user experience?
