### PR TITLE
Add more secondary metadata to search-result-card

### DIFF
--- a/app/models/search-result.ts
+++ b/app/models/search-result.ts
@@ -247,7 +247,7 @@ export default class SearchResultModel extends Model {
     }
 
     get registrationTemplate() {
-        return this.resourceMetadata['https://osf.io/vocab/2022/registration_type']?.[0]?.['@value'];
+        return this.resourceMetadata.conformsTo?.[0]?.title?.[0]?.['@value'];
     }
 }
 

--- a/lib/osf-components/addon/components/search-result-card/file-secondary-metadata/template.hbs
+++ b/lib/osf-components/addon/components/search-result-card/file-secondary-metadata/template.hbs
@@ -24,6 +24,19 @@
             </InlineList>
         </dd>
     {{/if}}
+    {{#if @result.doi}}
+        <dt>{{t 'osf-components.search-result-card.doi'}}</dt>
+        <dd>
+            <InlineList
+                @items={{@result.doi}}
+                @total={{@result.doi.count}}
+                @truncate={{5}}
+                as |list|
+            >
+                <a href={{list.item}} target='_blank' rel='noopener noreferrer'>{{list.item}}</a>
+            </InlineList>
+        </dd>
+    {{/if}}
     {{#if @result.nodeLicense}}
         <dt>{{t 'osf-components.search-result-card.license'}}</dt>
         <dd><a href={{@result.nodeLicense.identifier}} target='_blank' rel='noopener noreferrer'>{{@result.nodeLicense.name}}</a></dd>

--- a/lib/osf-components/addon/components/search-result-card/preprint-secondary-metadata/template.hbs
+++ b/lib/osf-components/addon/components/search-result-card/preprint-secondary-metadata/template.hbs
@@ -1,15 +1,21 @@
 <dl>
     {{!-- Description --}}
-    <dt>{{t 'osf-components.search-result-card.description'}}:</dt>
-    <dd>{{@result.description}}</dd>
+    {{#if @result.description}}
+        <dt>{{t 'osf-components.search-result-card.description'}}:</dt>
+        <dd>{{@result.description}}</dd>
+    {{/if}}
 
     {{!-- Preprint Provider --}}
-    <dt>{{t 'osf-components.search-result-card.preprint_provider'}}</dt>
-    <dd>{{@result.provider.name}}</dd>
+    {{#if @result.provider}}
+        <dt>{{t 'osf-components.search-result-card.preprint_provider'}}</dt>
+        <dd>{{@result.provider.name}}</dd>
+    {{/if}}
 
     {{!-- License --}}
-    <dt>{{t 'osf-components.search-result-card.license'}}</dt>
-    <dd><a href={{@result.license.identifier}} target='_blank' rel='noopener noreferrer'>{{@result.license.name}}</a></dd>
+    {{#if @result.license}}
+        <dt>{{t 'osf-components.search-result-card.license'}}</dt>
+        <dd><a href={{@result.license.identifier}} target='_blank' rel='noopener noreferrer'>{{@result.license.name}}</a></dd>
+    {{/if}}
 
     {{!-- DOI --}}
     {{#if @result.doi}}

--- a/lib/osf-components/addon/components/search-result-card/project-secondary-metadata/template.hbs
+++ b/lib/osf-components/addon/components/search-result-card/project-secondary-metadata/template.hbs
@@ -20,6 +20,10 @@
         <dt>{{t 'osf-components.search-result-card.collection'}}</dt>
         <dd><a href={{@result.isPartOfCollection.absoluteUrl}} target='_blank' rel='noopener noreferrer'> {{@result.isPartOfCollection.title}} </a></dd>
     {{/if}}
+    {{#if @result.resourceNature}}
+        <dt>{{t 'osf-components.search-result-card.resource_nature'}}</dt>
+        <dd>{{@result.resourceNature}}</dd>
+    {{/if}}
     {{#if @resource.language}}
         <dt>{{t 'osf-components.search-result-card.language'}}</dt>
         <dd>{{@resource.language}}</dd>

--- a/lib/osf-components/addon/components/search-result-card/registration-secondary-metadata/template.hbs
+++ b/lib/osf-components/addon/components/search-result-card/registration-secondary-metadata/template.hbs
@@ -1,5 +1,13 @@
 <dl>
-    {{#if @result.funder}}
+    {{#if @result.description}}
+        <dt>{{t 'osf-components.search-result-card.description'}}</dt>
+        <dd>{{@result.description}}</dd>
+    {{/if}}
+    {{#if @result.provider}}
+        <dt>{{t 'osf-components.search-result-card.preprint_provider'}}</dt>
+        <dd><a href={{@result.provider.identifier}} target='_blank' rel='noopener noreferrer'>{{@result.provider.name}}</a></dd>
+    {{/if}}
+    {{#if @result.funders}}
         <dt>{{t 'osf-components.search-result-card.funder'}}</dt>
         <dd>
             <InlineList


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: []
-   Feature flag: n/a

## Purpose
- Add missing metadata fields in the expanded view of search-result-cards
- [Notion card](https://www.notion.so/cos/Registration-Search-Result-Card-Missing-Expanded-Card-Data-5283ba6b5be342ac894bfa3cf370e60b)

## Summary of Changes
- should be outlined in commit messages

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
