### PR TITLE
Properly show result count; handle 10k+ results

### DIFF
--- a/app/models/index-card-search.ts
+++ b/app/models/index-card-search.ts
@@ -9,10 +9,12 @@ export interface SearchFilter {
     filterType?: string;
 }
 
+export const ShareMoreThanTenThousand = 'https://share.osf.io/vocab/2023/trove/ten-thousands-and-more';
+
 export default class IndexCardSearchModel extends Model {
     @attr('string') cardSearchText!: string;
     @attr('array') cardSearchFilters!: SearchFilter[];
-    @attr('number') totalResultCount!: number;
+    @attr('string') totalResultCount!: number | typeof ShareMoreThanTenThousand;
 
     @hasMany('search-result', { inverse: null })
     searchResultPage!: AsyncHasMany<SearchResultModel> & SearchResultModel[];

--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -11,6 +11,7 @@ import Store from '@ember-data/store';
 import { action } from '@ember/object';
 import Media from 'ember-responsive';
 
+import { ShareMoreThanTenThousand } from 'ember-osf-web/models/index-card-search';
 import SearchResultModel from 'ember-osf-web/models/search-result';
 import ProviderModel from 'ember-osf-web/models/provider';
 import RelatedPropertyPathModel from 'ember-osf-web/models/related-property-path';
@@ -77,7 +78,7 @@ export default class SearchPage extends Component<SearchArgs> {
     @tracked searchResults?: SearchResultModel[];
     @tracked relatedProperties?: RelatedPropertyPathModel[] = [];
     @tracked page?: string = '';
-    @tracked totalResultCount?: number;
+    @tracked totalResultCount?: string | number;
     @tracked firstPageCursor?: string | null;
     @tracked prevPageCursor?: string | null;
     @tracked nextPageCursor?: string | null;
@@ -132,13 +133,11 @@ export default class SearchPage extends Component<SearchArgs> {
     }
 
     get showResultCountMiddle() {
-        const hasResults = this.totalResultCount && this.totalResultCount > 0;
-        return hasResults && !this.args.showResourceTypeFilter && !this.showSidePanelToggle;
+        return this.totalResultCount && !this.args.showResourceTypeFilter && !this.showSidePanelToggle;
     }
 
     get showResultCountLeft() {
-        const hasResults = this.totalResultCount && this.totalResultCount > 0;
-        return hasResults && this.showSidePanelToggle;
+        return this.totalResultCount && this.args.showResourceTypeFilter;
     }
 
     get selectedSortOption() {
@@ -223,7 +222,8 @@ export default class SearchPage extends Component<SearchArgs> {
             this.nextPageCursor = searchResult.nextPageCursor;
             this.prevPageCursor = searchResult.prevPageCursor;
             this.searchResults = searchResult.searchResultPage.toArray();
-            this.totalResultCount = searchResult.totalResultCount;
+            this.totalResultCount = searchResult.totalResultCount === ShareMoreThanTenThousand ? '10,000+' :
+                searchResult.totalResultCount;
             if (this.args.onSearch) {
                 this.args.onSearch({cardSearchText, sort, resourceType, page});
             }


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: []
-   Feature flag: n/a

## Purpose
- Show search result counts properly
- [notion card](https://www.notion.so/cos/No-Visible-Count-of-Total-Search-Results-Either-Before-or-After-Applying-Filters-cc26a6201696481b9e17ed64f9166581)

## Summary of Changes
- Add handling for over 10k search results
- Update logic for showing result count

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
