### PR TITLE
Allow multiple values for a filterable property

### DIFF
--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -199,7 +199,8 @@ export default class SearchPage extends Component<SearchArgs> {
                     return acc;
                 }
                 // other filters should look like cardSearchFilter[propertyName]=IRI
-                acc[filter.propertyShortFormLabel] = filter.value;
+                const currentValue = acc[filter.propertyShortFormLabel];
+                acc[filter.propertyShortFormLabel] = currentValue ? currentValue.concat(filter.value) : [filter.value];
                 return acc;
             }, {} as { [key: string]: any });
             let resourceTypeFilter = this.resourceType as string;


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Don't overwrite filter values when selecting multiple filters from a given property
- [Notion card](https://www.notion.so/cos/Selecting-multiple-values-in-a-facet-type-will-only-apply-the-last-value-b3d243c5e27e47119cefb1c7931bb252)

## Summary of Changes
- Use arrays for active filters of a given property (h/t @aaxelb for pointing me to this solution!)

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects
- Filters added from the left-panel will have a redundant `[]` in the request payload, but the API should ignore those
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/0ada783d-c921-4ef5-abc8-09417b635a41)

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
