### PR TITLE
Help popover targets for mobile; Search textbox placeholder

### DIFF
--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -97,6 +97,7 @@ export default class SearchPage extends Component<SearchArgs> {
     showTooltip2?: boolean;
     showTooltip3?: boolean;
 
+    sidePanelToggleId = uniqueId(['side-panel-toggle']);
     leftPanelObjectDropdownId = uniqueId(['left-panel-object-dropdown']);
     firstTopbarObjectTypeLinkId = uniqueId(['first-topbar-object-type-link']);
     searchInputWrapperId = uniqueId(['search-input-wrapper']);
@@ -104,20 +105,26 @@ export default class SearchPage extends Component<SearchArgs> {
     firstFilterId = uniqueId(['first-filter']);
 
     get tooltipTarget1Id() {
+        if (this.showSidePanelToggle) {
+            return this.sidePanelToggleId;
+        }
         if (this.args.showResourceTypeFilter) {
-            if (this.showSidePanelToggle) {
-                return this.leftPanelObjectDropdownId;
-            }
             return this.firstTopbarObjectTypeLinkId;
         }
         return this.searchInputWrapperId;
     }
 
     get tooltipTarget2Id() {
+        if (this.showSidePanelToggle) {
+            return this.sidePanelToggleId;
+        }
         return this.leftPanelHeaderId;
     }
 
     get tooltipTarget3Id() {
+        if (this.showSidePanelToggle) {
+            return this.sidePanelToggleId;
+        }
         if (this.relatedProperties) {
             return this.firstFilterId;
         }

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -149,6 +149,11 @@
     white-space: wrap;
     text-align: initial;
 
+    a {
+        font-weight: bold;
+        color: var(--primary-color);
+    }
+
     .enumeration {
         float: left;
     }

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -92,6 +92,7 @@ as |layout|>
                 data-analytics-name='Toggle side panel'
                 aria-label={{t 'search.toggle-sidenav'}}
                 local-class='sidenav-toggle'
+                id={{this.sidePanelToggleId}}
                 {{on 'click' layout.toggleSidenav}}
             >
                 <FaIcon @icon='bars' />

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -274,7 +274,7 @@ as |layout|>
             <h2 local-class='search-help-header' data-test-help-heading-1>
                 {{t 'search.search-help.header-1'}}
             </h2>
-            <p data-test-help-body-1>{{t 'search.search-help.body-1'}}</p>
+            <p data-test-help-body-1>{{t 'search.search-help.body-1' htmlSafe=true}}</p>
             <span local-class='pagination'>
                 <p local-class='enumeration' data-test-help-enumeration-1>{{t 'search.search-help.index-1'}}</p>
                 <span local-class='help-button-wrappers'>

--- a/tests/acceptance/search/search-help-test.ts
+++ b/tests/acceptance/search/search-help-test.ts
@@ -29,7 +29,7 @@ module('Integration | Component | Search help', hooks => {
         assert.dom('[data-test-help-heading-1]').hasText('Improved OSF Search');
         assert.dom('[data-test-help-body-1]').exists();
         assert.dom('[data-test-help-body-1]').hasText(`Enter any term in the search box 
-            and filter by specific object types.`);
+            and filter by specific object types. More information is available on our help guides.`);
         assert.dom('[data-test-help-enumeration-1]').exists();
         assert.dom('[data-test-help-enumeration-1]').hasText('1 of 3');
 

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -219,7 +219,7 @@ search:
         header-1: 'Improved OSF Search'
         header-2: 'OSF Smart Facets'
         header-3: 'Add Metadata'
-        body-1: 'Enter any term in the search box and filter by specific object types.'
+        body-1: 'Enter any term in the search box and filter by specific object types. More information is available on our <a href="https://help.osf.io/article/588-getting-started-with-osf-search" target="_blank" rel="noopener noreferrer">help guides</a>.'
         body-2: 'Narrow the source, discipline, and more. For example, find content supported by a specific funder or view only datasets.'
         body-3: 'Remember to add metadata and resources to your own work on OSF to make it more discoverable!'
         index-1: '1 of 3'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -230,7 +230,7 @@ search:
             next: 'Next'
             done: 'Done'
     search-header: 'Search OSF'
-    textbox-placeholder: 'Search placeholder'
+    textbox-placeholder: 'Enter search term(s) here'
     search-button-label: 'Search'
     search-help-label: 'Help tutorial'
     total-results: '{count} results'


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: []
-   Feature flag: n/a

## Purpose
- Update targets for help popover on mobile
- [notion card](https://www.notion.so/cos/Update-help-text-change-help-guide-target-for-mobile-0f03074ca2a44702983293898b30193f)

## Summary of Changes
- Mobile help popover targets the side-panel toggle button
- Update search input placeholder
- Add link to help guide in help tour
  - Add styling cause the link doesn't show up too well with default styling

## Screenshot(s)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/0e06fa6f-24c5-44fb-98d3-d893cab9ab91)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
