### PR TITLE
Reroute users to registries landing page instead of discover page for…

### DIFF
--- a/lib/registries/addon/branded/index/route.ts
+++ b/lib/registries/addon/branded/index/route.ts
@@ -1,8 +1,12 @@
 import Route from '@ember/routing/route';
-
+import config from 'ember-get-config';
 export default class BrandedRegistriesIndexRoute extends Route {
     beforeModel() {
         const params: { providerId?: string } = this.paramsFor('branded');
+        if (params.providerId === config.defaultProvider) {
+            return this.replaceWith('index');
+        }
+
         return this.replaceWith('branded.discover', params.providerId);
     }
 }

--- a/tests/engines/registries/acceptance/branded/discover-test.ts
+++ b/tests/engines/registries/acceptance/branded/discover-test.ts
@@ -83,7 +83,7 @@ module('Registries | Acceptance | branded.discover', hooks => {
 
         await visit(`/registries/${osfProvider.id}`);
         assert.equal(currentRouteName(),
-            'search',
-            '/registries/osf redirects to search page');
+            'registries.index',
+            '/registries/osf redirects to registries index page');
     });
 });


### PR DESCRIPTION
… osf

<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: []
-   Feature flag: n/a

## Purpose
- [Notion card](https://www.notion.so/cos/Link-to-OSF-Registries-from-Expanded-Registration-Card-Actually-Routes-to-Old-OSF-Registries-Discove-61b5911663624054a24cb2c50b456796) 
- Avoid taking users from search page, back to search page

## Summary of Changes
- When users go to `registries/osf` route them to the landing page, and not the discover page (made weird behavior when users were on the search page and clicking a registration with "Registration provider: OSF Registries". Clicking on that link would take users back to the search page)


## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
