### PR TITLE
[BUG] Fix sort dropdown, help tutorial

### DIFF
--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -39,6 +39,7 @@ body {
             margin-left: 0;
             position: absolute;
             right: 0.1rem;
+            margin-right: -5px;
         }
     }
 }
@@ -225,6 +226,7 @@ body {
 
     .enumeration {
         float: left;
+        white-space: nowrap;
     }
 
     h2 {
@@ -236,7 +238,7 @@ body {
 
     p {
         white-space: normal;
-        margin: 25px 5px 20px;
+        margin: 25px 5px 0;
     }
 
     .skip-button {
@@ -248,13 +250,15 @@ body {
         display: flex;
         justify-content: space-between;
         align-items: baseline;
+        margin-bottom: 0.5rem;
     }
 
     .help-button-wrapper {
         display: flex;
         justify-content: flex-end;
+        padding: 0;
 
-        button:first-of-type {
+        .skip-button {
             margin-right: 20px;
         }
     }
@@ -275,8 +279,7 @@ body {
 
 .sort-dropdown {
     background-color: $color-bg-gray-blue-light;
-    display: flex;
-    align-items: flex-end;
+    align-self: flex-end;
     padding-bottom: 10px;
     margin-left: 10px;
 

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -371,7 +371,7 @@ as |layout|>
             <p data-test-help-body-3>{{t 'search.search-help.body-3'}}</p>
             <span local-class='pagination'>
                 <p local-class='enumeration' data-test-help-enumeration-3>{{t 'search.search-help.index-3'}}</p>
-                <span local-class='help-button-wrappers'>
+                <span local-class='help-button-wrapper'>
                     <Button
                         data-test-help-done
                         data-analytics-name='Complete help'


### PR DESCRIPTION
-   Ticket (Notion): https://www.notion.so/cos/Sort-dropdown-will-not-toggle-open-6f234edd07fc4de7a8f588f237a7e91f?pvs=4
-   Branch name: feature/search-improvements-b-and-i-part-1

## Purpose

The purpose of these changes was to resolve the bug fixes for sort dropdown and the help guide. Further bug fixes will be resolved in any subsequent PRs. 

## Summary of Changes

-Flexbox was removed from the sort dropdown
-Padding and margin was added/removed to the help tutorial buttons and description
-Local class selector name was updated to match other help guides
-Selector name was updated to reflect the skip button local class name

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
