### PR TITLE
Mobile: Fix squished withdraw label

### DIFF
--- a/lib/osf-components/addon/components/search-result-card/styles.scss
+++ b/lib/osf-components/addon/components/search-result-card/styles.scss
@@ -61,4 +61,6 @@
     font-size: 75%;
     font-weight: bold;
     margin-left: 3px;
+    position: relative;
+    bottom: 2px;
 }

--- a/lib/osf-components/addon/components/search-result-card/styles.scss
+++ b/lib/osf-components/addon/components/search-result-card/styles.scss
@@ -40,11 +40,6 @@
     text-transform: uppercase;
 }
 
-.display-name {
-    display: inline-flex;
-    align-items: center;
-}
-
 .date-fields {
     span {
         &:not(:last-child)::after {

--- a/lib/osf-components/addon/components/search-result-card/template.hbs
+++ b/lib/osf-components/addon/components/search-result-card/template.hbs
@@ -20,7 +20,7 @@
                 </Button>
             {{/if}}
         </div>
-        <h4 local-class='display-name'>
+        <h4>
             <a href={{@result.absoluteUrl}} target='_blank' rel='noopener noreferrer'> {{@result.displayTitle}} </a>
             {{#if @result.isWithdrawn}}
                 <span local-class='withdrawn-label'>{{t 'osf-components.search-result-card.withdrawn'}}</span>


### PR DESCRIPTION
-   Ticket: [Notion card](https://www.notion.so/cos/Mobile-Withdraw-label-for-registration-and-preprints-text-wrap-8e047d77a0e44af9b2e52ecc15dc998f?pvs=4)
-   Feature flag: n/a

## Purpose
Address the following visual bug
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/0823c438-f9ba-4196-85ac-284493eb42ca)


## Summary of Changes

<!-- Briefly describe or list your changes. -->

## Screenshot(s)
- Desktop:
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/378ac127-5502-48d2-a834-d310cf92b5f9)

- mobile:
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/d7feba5c-7f62-4833-8273-72bb1a8e2398)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
