### PR TITLE
Search card fixes

### DIFF
--- a/lib/osf-components/addon/components/search-result-card/file-secondary-metadata/styles.scss
+++ b/lib/osf-components/addon/components/search-result-card/file-secondary-metadata/styles.scss
@@ -1,0 +1,3 @@
+.description {
+    white-space: pre-wrap;
+}

--- a/lib/osf-components/addon/components/search-result-card/file-secondary-metadata/template.hbs
+++ b/lib/osf-components/addon/components/search-result-card/file-secondary-metadata/template.hbs
@@ -5,7 +5,7 @@
     {{/if}}
     {{#if @result.description}}
         <dt>{{t 'osf-components.search-result-card.description'}}</dt>
-        <dd>{{@result.description}}</dd>
+        <dd local-class='description'>{{@result.description}}</dd>
     {{/if}}
     {{#if @result.nodeFunders}}
         <dt>{{t 'osf-components.search-result-card.funder'}}</dt>

--- a/lib/osf-components/addon/components/search-result-card/preprint-secondary-metadata/styles.scss
+++ b/lib/osf-components/addon/components/search-result-card/preprint-secondary-metadata/styles.scss
@@ -1,0 +1,3 @@
+.description {
+    white-space: pre-wrap;
+}

--- a/lib/osf-components/addon/components/search-result-card/preprint-secondary-metadata/template.hbs
+++ b/lib/osf-components/addon/components/search-result-card/preprint-secondary-metadata/template.hbs
@@ -2,7 +2,7 @@
     {{!-- Description --}}
     {{#if @result.description}}
         <dt>{{t 'osf-components.search-result-card.description'}}:</dt>
-        <dd>{{@result.description}}</dd>
+        <dd local-class='description'>{{@result.description}}</dd>
     {{/if}}
 
     {{!-- Preprint Provider --}}

--- a/lib/osf-components/addon/components/search-result-card/project-secondary-metadata/styles.scss
+++ b/lib/osf-components/addon/components/search-result-card/project-secondary-metadata/styles.scss
@@ -1,0 +1,3 @@
+.description {
+    white-space: pre-wrap;
+}

--- a/lib/osf-components/addon/components/search-result-card/project-secondary-metadata/template.hbs
+++ b/lib/osf-components/addon/components/search-result-card/project-secondary-metadata/template.hbs
@@ -1,7 +1,7 @@
 <dl>
     {{#if @result.description}}
         <dt>{{t 'osf-components.search-result-card.description'}}</dt>
-        <dd>{{@result.description}}</dd>
+        <dd local-class='description'>{{@result.description}}</dd>
     {{/if}}
     {{#if @result.funders}}
         <dt>{{t 'osf-components.search-result-card.funder'}}</dt>

--- a/lib/osf-components/addon/components/search-result-card/registration-secondary-metadata/styles.scss
+++ b/lib/osf-components/addon/components/search-result-card/registration-secondary-metadata/styles.scss
@@ -1,0 +1,3 @@
+.description {
+    white-space: pre-wrap;
+}

--- a/lib/osf-components/addon/components/search-result-card/registration-secondary-metadata/template.hbs
+++ b/lib/osf-components/addon/components/search-result-card/registration-secondary-metadata/template.hbs
@@ -1,7 +1,7 @@
 <dl>
     {{#if @result.description}}
         <dt>{{t 'osf-components.search-result-card.description'}}</dt>
-        <dd>{{@result.description}}</dd>
+        <dd local-class='description'>{{@result.description}}</dd>
     {{/if}}
     {{#if @result.funders}}
         <dt>{{t 'osf-components.search-result-card.funder'}}</dt>

--- a/lib/osf-components/addon/components/search-result-card/template.hbs
+++ b/lib/osf-components/addon/components/search-result-card/template.hbs
@@ -55,6 +55,11 @@
                 <span>{{t 'osf-components.search-result-card.from'}}: <a href={{@result.isPartOfTitleAndUrl.absoluteUrl}} target='_blank' rel='noopener noreferrer'> {{@result.isPartOfTitleAndUrl.title}} </a></span>
             </div>
         {{/if}}
+        {{#if @result.isContainedBy}}
+            <div>
+                <span>{{t 'osf-components.search-result-card.from'}}: <a href={{@result.isContainedByTitleAndUrl.absoluteUrl}} target='_blank' rel='noopener noreferrer'> {{@result.isContainedByTitleAndUrl.title}} </a></span>
+            </div>
+        {{/if}}
         <div local-class='date-fields'>
             {{#each @result.dateFields as |field|}}
                 {{#if field.date}}
@@ -85,13 +90,6 @@
         <panel.body>
             <hr>
             {{component this.secondaryMetadataComponent result=@result}}
-            {{!-- {{#if (or (eq @result.resourceType 'registration') (eq @result.resourceType 'registration_component'))}}
-                <SearchResultCard::RegistrationSecondaryMetadata @result={{@result}} />
-            {{else if (or (eq @result.resourceType 'project') (eq @result.resourceType 'project_component'))}}
-                <SearchResultCard::ProjectSecondaryMetadata @result={{@result}} />
-            {{else if (eq @result.resourceType 'preprint')}}
-                <SearchResultCard::PreprintSecondaryMetadata @result={{@result}} />
-            {{/if}} --}}
         </panel.body>
     </CpPanel>
 </div>


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Add back the isContainedBy field that tells which node a file belongs to
- Preserve the whitespace for descriptions on the expanded view

## Summary of Changes
- Add back `isContainedBy` field that was removed in an [earlier PR](https://github.com/CenterForOpenScience/ember-osf-web/pull/1940)
- Preserve whitespace for description field (Didn't apply to all `<dd>` as this caused some of the fields to have a lot of unexpected whitespace)

## Screenshot(s)
- Preserved whitespace for description
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/af445ef1-8490-4892-8f99-505c3acbd663)
- Added back the `From:` field for files (highlighted in the screenshot for visibility)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/6cc1f556-3b98-4bc2-92de-b92749116367)


<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
