### PR TITLE
Scroll to top on page change

### DIFF
--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -245,6 +245,7 @@ export default class SearchPage extends Component<SearchArgs> {
     switchPage(pageCursor: string) {
         this.page = pageCursor;
         taskFor(this.search).perform();
+        document.querySelector('[data-test-topbar-wrapper]')?.scrollIntoView({ behavior: 'smooth' });
     }
 
     @task({ restartable: true })

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -182,7 +182,6 @@ as |layout|>
         {{/if}}
     </layout.left>
     <layout.main local-class={{if this.showSidePanelToggle 'search-main-mobile' 'search-main'}} data-analytics-scope='Search page main'>
-        {{!-- paginator --}}
         {{#unless this.showSidePanelToggle}}
             <div data-test-topbar-wrapper local-class='topbar'>
                 {{#if @showResourceTypeFilter}}


### PR DESCRIPTION
-   Ticket: [Notion card](https://www.notion.so/cos/Scroll-to-top-of-page-when-changing-pages-f1c70059d51d4b4693ada9a2934fb021?pvs=4)
-   Feature flag: n/a

## Purpose
- Scroll to top between page changes

## Summary of Changes
- Add scroll to `switchPage` task (scroll target is a little higher than the first card, since the navbar can cover up the first result)

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
