### PR TITLE
Stop targeting body in css

### DIFF
--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -1,10 +1,12 @@
 // stylelint-disable max-nesting-depth, selector-max-compound-selectors, selector-no-qualifying-type
 
-body {
-    background-color: $color-bg-gray-blue-light;
+.search-page {
+    background: $color-bg-gray-blue-light;
 }
 
 .search-page-mobile {
+    background: $color-bg-gray-blue-light;
+
     > div:first-of-type {
         margin-left: 0;
     }


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Don't target `body` in css file

## Summary of Changes
- rewrite rule targeting `body` to target the  local-class used in `<OsfLayout>`'s backgroundClass

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
