### PR TITLE
[BUG] Fix expanded card elements, result card title, fold line separator

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -156,3 +156,9 @@ $color-black: #000;
 .bg-color-grey {
     background-color: $color-grey;
 }
+
+/*
+* Affiliated Institutions Color Palette
+*/
+
+$orcid-logo-color: #a6ce39;

--- a/lib/osf-components/addon/components/open-badges-list/styles.scss
+++ b/lib/osf-components/addon/components/open-badges-list/styles.scss
@@ -6,4 +6,5 @@
 .horizontal-layout {
     display: flex;
     gap: 10px;
+    padding-bottom: 0;
 }

--- a/lib/osf-components/addon/components/search-result-card/styles.scss
+++ b/lib/osf-components/addon/components/search-result-card/styles.scss
@@ -1,6 +1,7 @@
 .result-card-container {
     background-color: $color-bg-white;
     margin: 35px 35px 0;
+    padding: 10px;
     width: 60vw;
 
     dt,
@@ -13,9 +14,18 @@
     display: flex;
     flex-direction: column;
 
+    h4 {
+        font-weight: bold;
+    }
+
     h4,
     div:not(:first-child) {
         margin: 0 0 15px 15px;
+    }
+
+    div:last-child {
+        margin-bottom: 0;
+        padding-bottom: 5px;
     }
 }
 
@@ -35,12 +45,14 @@
 .type-label {
     background-color: $color-gradient-primary;
     margin: 15px;
-    padding: 0 5px;
+    padding: 0.2rem 0.4rem;
     width: fit-content;
     text-transform: uppercase;
 }
 
 .date-fields {
+    padding-bottom: 5px;
+
     span {
         &:not(:last-child)::after {
             content: ' | ';
@@ -49,7 +61,7 @@
 }
 
 .orcid-logo {
-    color: #a6ce39;
+    color: $orcid-logo-color;
     margin-left: 3px;
 }
 
@@ -63,4 +75,18 @@
     margin-left: 3px;
     position: relative;
     bottom: 2px;
+}
+
+.cp-panel {
+    padding: 0 10px;
+
+    div > dl {
+        border-top: 2px solid $color-border-gray;
+        padding-top: 10px;
+    }
+
+    dl > dt,
+    dl > dd {
+        margin: 15px 0 0 10px;
+    }
 }

--- a/lib/osf-components/addon/components/search-result-card/styles.scss
+++ b/lib/osf-components/addon/components/search-result-card/styles.scss
@@ -3,11 +3,6 @@
     margin: 35px 35px 0;
     padding: 10px;
     width: 60vw;
-
-    dt,
-    dd {
-        margin-left: 15px;
-    }
 }
 
 .primary-metadata-container {
@@ -80,13 +75,13 @@
 .cp-panel {
     padding: 0 10px;
 
-    div > dl {
+    dl {
         border-top: 2px solid $color-border-gray;
         padding-top: 10px;
     }
 
-    dl > dt,
-    dl > dd {
-        margin: 15px 0 0 10px;
+    dt,
+    dd {
+        margin: 15px 0 0 5px;
     }
 }

--- a/lib/osf-components/addon/components/search-result-card/template.hbs
+++ b/lib/osf-components/addon/components/search-result-card/template.hbs
@@ -86,7 +86,7 @@
             </div>
         {{/if}}
     </div>
-    <CpPanel @open={{this.isOpenSecondaryMetadata}} as |panel|>
+    <CpPanel local-class='cp-panel' @open={{this.isOpenSecondaryMetadata}} as |panel|>
         <panel.body>
             <hr>
             {{component this.secondaryMetadataComponent result=@result}}


### PR DESCRIPTION
Tickets (Notion): 
    -https://www.notion.so/cos/Styling-Expanded-Card-Elements-Could-Use-More-Padding-Between-Them-5271761d87b240a7a9af2092a912371b?pvs=4, 
    -https://www.notion.so/cos/What-happened-to-the-Fold-Line-Separator-Between-Top-of-Card-and-Expanded-Card-9e9e10bc80a14d78a4e62f350346ced3?pvs=4
    -https://www.notion.so/cos/Reduce-margin-at-bottom-of-resources-1ae018883f314d25a53ac54bc981da09?pvs=4
    -https://www.notion.so/cos/Result-card-titles-need-to-be-bold-ef738a46d57e44f69e1d3d56b22b5f8e?pvs=4
    
GitHub branch: feature/search-improvements-b-and-i-part-2

## Purpose

The purpose of these changes was to address the styling in the secondary metadata container.

## Summary of Changes

- top border was added to the secondary metadata container
- local class selector was added to the secondary metadata container 
- excessive padding was removed from the open resources badges container
- padding was added to the bottom of the date field element
- data term and definition elements were styled
- bold font weight was given to the result card container title
- side padding was added to the type label element

## Screenshot(s)

<img width="1625" alt="image" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/82047646/ff16a466-28cf-48f1-a9d9-81867ba1c260">

## Side Effects

This will affect the overall UI of the search result cards. Testing should include changes to it and the surrounding layout.

## QA Notes

1. Does the UI look like the mock ups? Should anything be added/removed: https://preview.uxpin.com/e2821be91003954dec0c29a026bc49989b868e2d#/pages/162679105/simulate/no-panels?mode=i
