### PR TITLE
Use vertical layout for registries search result cards

### DIFF
--- a/lib/registries/addon/components/registries-search-result/template.hbs
+++ b/lib/registries/addon/components/registries-search-result/template.hbs
@@ -77,6 +77,7 @@
                 @hasAnalyticCode={{@result.relatedResourceTypes.analytic_code}}
                 @hasPapers={{@result.relatedResourceTypes.papers}}
                 @hasSupplements={{@result.relatedResourceTypes.supplements}}
+                @verticalLayout={{true}}
             />
         </div>
     {{/if}}


### PR DESCRIPTION
-   Ticket: [Notion card](https://www.notion.so/cos/Resource-Badges-on-Branded-Registry-Discover-Pages-Should-be-Vertical-62ec199fda5f43fb84b3d2709408c0bf)
-   Feature flag: n/a

## Purpose
- Use vertical align for registration badges on branded discover pages

## Summary of Changes

## Screenshot(s)
- Fixes this issue on branded discover page
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/8ce053a9-3318-4043-89ee-79600afc6563)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
