### PR TITLE
[BUG] Fix search topbar active and hover state, pagination buttons, panel header

### DIFF
--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -184,7 +184,8 @@
         li {
             display: inline-flex;
             white-space: nowrap;
-            margin-right: 10px;
+            width: calc(100%/6);
+            justify-content: center;
 
             &.active,
             &:hover {
@@ -193,7 +194,9 @@
         }
 
         a {
-            padding-bottom: 10px;
+            padding: 18px 0 10px;
+            width: 100%;
+            text-align: center;
         }
     }
 
@@ -331,9 +334,8 @@
     .left-panel-header {
         border-bottom: 1px solid $alto;
         font-weight: 300;
-        margin-bottom: 0;
-        margin-top: 2rem;
-        padding: 0 0 1rem;
+        margin: 1rem 0;
+        padding: 0 0 1.5rem;
     }
 }
 

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -375,26 +375,7 @@
 
     button {
         color: $color-bg-blue-dark;
-        height: 44px;
-        width: 44px;
-        margin-bottom: 0;
-        margin-left: 10px;
-        text-align: center;
-
-        p {
-            margin-bottom: 0;
-        }
-    }
-
-    > div {
-        background-color: $color-bg-white;
-        color: $color-bg-blue-dark;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        height: 44px;
-        width: 44px;
-        text-align: center;
+        margin-left: 5px;
     }
 }
 

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -74,6 +74,7 @@
 
     .pagination-buttons {
         padding-right: 0;
+        padding-top: 0;
     }
 }
 
@@ -368,8 +369,33 @@
 .pagination-buttons {
     display: flex;
     padding: 2rem;
+    align-items: center;
     justify-content: flex-end;
     height: fit-content;
+
+    button {
+        color: $color-bg-blue-dark;
+        height: 44px;
+        width: 44px;
+        margin-bottom: 0;
+        margin-left: 10px;
+        text-align: center;
+
+        p {
+            margin-bottom: 0;
+        }
+    }
+
+    > div {
+        background-color: $color-bg-white;
+        color: $color-bg-blue-dark;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 44px;
+        width: 44px;
+        text-align: center;
+    }
 }
 
 // for tablet displays

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -241,38 +241,25 @@ as |layout|>
             {{/each}}
         {{/if}}
         <div local-class='pagination-buttons'>
-            {{#if this.prevPageCursor}}
-                <Button
-                    {{on 'click' (fn this.switchPage this.prevPageCursor)}}
-                >
-                    <p>
-                        {{t 'search.previous-pagination-button'}}
-                    </p>
-                </Button>
-            {{/if}}
             {{#if this.firstPageCursor}}
                 <Button
                     {{on 'click' (fn this.switchPage this.firstPageCursor)}}
                 >
-                    <p>
-                        {{t 'search.first-pagination-button'}}
-                    </p>
+                    {{t 'search.first'}}
                 </Button>
             {{/if}}
-            {{#if this.nextPageCursor}}
-                <div>
-                    <p>
-                        {{t 'search.more-pagination-button'}}
-                    </p>
-                </div>
+            {{#if this.prevPageCursor}}
+                <Button
+                    {{on 'click' (fn this.switchPage this.prevPageCursor)}}
+                >
+                    {{t 'search.prev'}}
+                </Button>
             {{/if}}
             {{#if this.nextPageCursor}}
                 <Button
                     {{on 'click' (fn this.switchPage this.nextPageCursor)}}
                 >
-                    <p>
-                        {{t 'search.next-pagination-button'}}
-                    </p>
+                    {{t 'search.next'}}
                 </Button>
             {{/if}}
         </div>

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -241,25 +241,38 @@ as |layout|>
             {{/each}}
         {{/if}}
         <div local-class='pagination-buttons'>
-            {{#if this.firstPageCursor}}
-                <Button
-                    {{on 'click' (fn this.switchPage this.firstPageCursor)}}
-                >
-                    {{t 'search.first'}}
-                </Button>
-            {{/if}}
             {{#if this.prevPageCursor}}
                 <Button
                     {{on 'click' (fn this.switchPage this.prevPageCursor)}}
                 >
-                    {{t 'search.prev'}}
+                    <p>
+                        {{t 'search.previous-pagination-button'}}
+                    </p>
                 </Button>
+            {{/if}}
+            {{#if this.firstPageCursor}}
+                <Button
+                    {{on 'click' (fn this.switchPage this.firstPageCursor)}}
+                >
+                    <p>
+                        {{t 'search.first-pagination-button'}}
+                    </p>
+                </Button>
+            {{/if}}
+            {{#if this.nextPageCursor}}
+                <div>
+                    <p>
+                        {{t 'search.more-pagination-button'}}
+                    </p>
+                </div>
             {{/if}}
             {{#if this.nextPageCursor}}
                 <Button
                     {{on 'click' (fn this.switchPage this.nextPageCursor)}}
                 >
-                    {{t 'search.next'}}
+                    <p>
+                        {{t 'search.next-pagination-button'}}
+                    </p>
                 </Button>
             {{/if}}
         </div>

--- a/lib/osf-components/addon/components/search-result-card/styles.scss
+++ b/lib/osf-components/addon/components/search-result-card/styles.scss
@@ -18,7 +18,7 @@
         margin: 0 0 15px 15px;
     }
 
-    div:last-child {
+    > div:last-child {
         margin-bottom: 0;
         padding-bottom: 5px;
     }
@@ -45,16 +45,6 @@
     text-transform: uppercase;
 }
 
-.date-fields {
-    padding-bottom: 5px;
-
-    span {
-        &:not(:last-child)::after {
-            content: ' | ';
-        }
-    }
-}
-
 .orcid-logo {
     color: $orcid-logo-color;
     margin-left: 3px;
@@ -70,6 +60,16 @@
     margin-left: 3px;
     position: relative;
     bottom: 2px;
+}
+
+.date-fields {
+    padding-bottom: 5px;
+
+    span {
+        &:not(:last-child)::after {
+            content: ' | ';
+        }
+    }
 }
 
 .cp-panel {

--- a/lib/osf-components/addon/components/search-result-card/template.hbs
+++ b/lib/osf-components/addon/components/search-result-card/template.hbs
@@ -1,4 +1,4 @@
-<div local-class='result-card-container'>
+<div data-test-search-result-card local-class='result-card-container'>
     <div local-class='primary-metadata-container'>
         <div local-class='header'>
             <div local-class='type-label'>
@@ -21,7 +21,7 @@
             {{/if}}
         </div>
         <h4>
-            <a href={{@result.absoluteUrl}} target='_blank' rel='noopener noreferrer'> {{@result.displayTitle}} </a>
+            <a data-test-search-result-card-title href={{@result.absoluteUrl}} target='_blank' rel='noopener noreferrer'> {{@result.displayTitle}} </a>
             {{#if @result.isWithdrawn}}
                 <span local-class='withdrawn-label'>{{t 'osf-components.search-result-card.withdrawn'}}</span>
             {{/if}}

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -246,6 +246,10 @@ search:
     first: First
     prev: Prev
     next: Next
+    previous-pagination-button: '<<'
+    first-pagination-button: '1'
+    more-pagination-button: '...'
+    next-pagination-button: '>>'
     sort:
         sort-by: 'Sort by'
         relevance: 'Relevance'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -246,10 +246,6 @@ search:
     first: First
     prev: Prev
     next: Next
-    previous-pagination-button: '<<'
-    first-pagination-button: '1'
-    more-pagination-button: '...'
-    next-pagination-button: '>>'
     sort:
         sort-by: 'Sort by'
         relevance: 'Relevance'


### PR DESCRIPTION
Tickets (Notion): 
    -https://www.notion.so/cos/Pagination-buttons-added-styling-0ef0c6bfca96423e9b323fd7b9031172?pvs=4
    -https://www.notion.so/cos/Selenium-Request-to-add-data-test-attributes-to-Search-Page-Elements-969958ae9c1e431a98125584bd8c6028?pvs=4
    
GitHub branch: feature/search-improvements-b-and-i-part-3

## Purpose

The purpose of these changes was to fix the active and hover states of the search top bar, the excessive top margin in the left panel header, increase pagination button padding, and to provide QA with data test selectors for the result card container and its individual title link.

## Summary of Changes

- Top margin of the left panel header was reduced to balance it with the corresponding facet filter border
- Width of list elements of the topbar was evenly divided across topbar width
- Padding was added to the pagination buttons to improve visibility
- Data test selectors were added to the result card and the result card title link

## Screenshot(s)

<img width="1623" alt="image" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/82047646/6b2ab638-63cf-4ae1-bde5-74cca3f75fbe">

Figure 1: Topbar with corrected active and hover states

<img width="1624" alt="image" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/82047646/8c90af12-5706-4a43-a025-5bddb289ed7b">

Figure 2: Pagination buttons with proper spacing, shape, and size

## Side Effects

This will affect the overall UI of the search topbar, facet filter left panel, and the pagination button section. Testing should include changes to it and the surrounding layout.

## QA Notes

1. Does the UI look like the mock ups? Should anything be added/removed: https://preview.uxpin.com/e2821be91003954dec0c29a026bc49989b868e2d#/pages/162679105/simulate/no-panels?mode=i
