### PR TITLE
[BUG] Fix top margin on result card title

### DIFF
--- a/lib/osf-components/addon/components/search-result-card/styles.scss
+++ b/lib/osf-components/addon/components/search-result-card/styles.scss
@@ -46,14 +46,8 @@
     text-transform: uppercase;
 }
 
-.date-fields {
-    padding-bottom: 5px;
-
-    span {
-        &:not(:last-child)::after {
-            content: ' | ';
-        }
-    }
+.result-card-title-user {
+    padding-top: 1rem;
 }
 
 .orcid-logo {
@@ -71,6 +65,16 @@
     margin-left: 3px;
     position: relative;
     bottom: 2px;
+}
+
+.date-fields {
+    padding-bottom: 5px;
+
+    span {
+        &:not(:last-child)::after {
+            content: ' | ';
+        }
+    }
 }
 
 .cp-panel {

--- a/lib/osf-components/addon/components/search-result-card/styles.scss
+++ b/lib/osf-components/addon/components/search-result-card/styles.scss
@@ -11,7 +11,6 @@
 
     h4 {
         font-weight: bold;
-        margin-top: 5px;
     }
 
     h4,

--- a/lib/osf-components/addon/components/search-result-card/styles.scss
+++ b/lib/osf-components/addon/components/search-result-card/styles.scss
@@ -11,6 +11,7 @@
 
     h4 {
         font-weight: bold;
+        margin-top: 5px;
     }
 
     h4,

--- a/lib/osf-components/addon/components/search-result-card/styles.scss
+++ b/lib/osf-components/addon/components/search-result-card/styles.scss
@@ -18,7 +18,7 @@
         margin: 0 0 15px 15px;
     }
 
-    div:last-child {
+    > div:last-child {
         margin-bottom: 0;
         padding-bottom: 5px;
     }
@@ -45,9 +45,6 @@
     text-transform: uppercase;
 }
 
-.result-card-title-user {
-    padding-top: 1rem;
-}
 
 .orcid-logo {
     color: $orcid-logo-color;

--- a/lib/osf-components/addon/components/search-result-card/template.hbs
+++ b/lib/osf-components/addon/components/search-result-card/template.hbs
@@ -20,43 +20,23 @@
                 </Button>
             {{/if}}
         </div>
-        {{#if (not-eq @result.resourceType 'user')}}
-            <h4>
-                <a href={{@result.absoluteUrl}} target='_blank' rel='noopener noreferrer'> {{@result.displayTitle}} </a>
-                {{#if @result.isWithdrawn}}
-                    <span local-class='withdrawn-label'>{{t 'osf-components.search-result-card.withdrawn'}}</span>
-                {{/if}}
-                {{#if @result.orcids}}
-                    {{#each @result.orcids as |item|}}
-                        <a href={{item}}
-                            target='_blank'
-                            rel='noopener noreferrer'
-                            aria-label={{t 'osf-components.search-result-card.link_to_orcid_id'}}
-                        >
-                            <FaIcon @prefix='fab' @icon='orcid' local-class='orcid-logo' />
-                        </a>
-                    {{/each}}
-                {{/if}}
-            </h4>
-        {{else}}
-            <h4 local-class='result-card-title-user'>
-                <a href={{@result.absoluteUrl}} target='_blank' rel='noopener noreferrer'> {{@result.displayTitle}} </a>
-                {{#if @result.isWithdrawn}}
-                    <span local-class='withdrawn-label'>{{t 'osf-components.search-result-card.withdrawn'}}</span>
-                {{/if}}
-                {{#if @result.orcids}}
-                    {{#each @result.orcids as |item|}}
-                        <a href={{item}}
-                            target='_blank'
-                            rel='noopener noreferrer'
-                            aria-label={{t 'osf-components.search-result-card.link_to_orcid_id'}}
-                        >
-                            <FaIcon @prefix='fab' @icon='orcid' local-class='orcid-logo' />
-                        </a>
-                    {{/each}}
-                {{/if}}
-            </h4>
-        {{/if}}
+        <h4>
+            <a href={{@result.absoluteUrl}} target='_blank' rel='noopener noreferrer'> {{@result.displayTitle}} </a>
+            {{#if @result.isWithdrawn}}
+                <span local-class='withdrawn-label'>{{t 'osf-components.search-result-card.withdrawn'}}</span>
+            {{/if}}
+            {{#if @result.orcids}}
+                {{#each @result.orcids as |item|}}
+                    <a href={{item}}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                        aria-label={{t 'osf-components.search-result-card.link_to_orcid_id'}}
+                    >
+                        <FaIcon @prefix='fab' @icon='orcid' local-class='orcid-logo' />
+                    </a>
+                {{/each}}
+            {{/if}}
+        </h4>
         {{#if @result.affiliatedEntities}}
             <div local-class='name-fields'>
                 <InlineList

--- a/lib/osf-components/addon/components/search-result-card/template.hbs
+++ b/lib/osf-components/addon/components/search-result-card/template.hbs
@@ -20,24 +20,43 @@
                 </Button>
             {{/if}}
         </div>
-        <h4>
-            <a href={{@result.absoluteUrl}} target='_blank' rel='noopener noreferrer'> {{@result.displayTitle}} </a>
-            {{#if @result.isWithdrawn}}
-                <span local-class='withdrawn-label'>{{t 'osf-components.search-result-card.withdrawn'}}</span>
-            {{/if}}
-            {{#if @result.orcids}}
-                {{#each @result.orcids as |item|}}
-                    <a href={{item}}
-                        target='_blank'
-                        rel='noopener noreferrer'
-                        aria-label={{t 'osf-components.search-result-card.link_to_orcid_id'}}
-                    >
-                        <FaIcon @prefix='fab' @icon='orcid' local-class='orcid-logo' />
-                    </a>
-                {{/each}}
-            {{/if}}
-        </h4>
-        
+        {{#if (not-eq @result.resourceType 'user')}}
+            <h4>
+                <a href={{@result.absoluteUrl}} target='_blank' rel='noopener noreferrer'> {{@result.displayTitle}} </a>
+                {{#if @result.isWithdrawn}}
+                    <span local-class='withdrawn-label'>{{t 'osf-components.search-result-card.withdrawn'}}</span>
+                {{/if}}
+                {{#if @result.orcids}}
+                    {{#each @result.orcids as |item|}}
+                        <a href={{item}}
+                            target='_blank'
+                            rel='noopener noreferrer'
+                            aria-label={{t 'osf-components.search-result-card.link_to_orcid_id'}}
+                        >
+                            <FaIcon @prefix='fab' @icon='orcid' local-class='orcid-logo' />
+                        </a>
+                    {{/each}}
+                {{/if}}
+            </h4>
+        {{else}}
+            <h4 local-class='result-card-title-user'>
+                <a href={{@result.absoluteUrl}} target='_blank' rel='noopener noreferrer'> {{@result.displayTitle}} </a>
+                {{#if @result.isWithdrawn}}
+                    <span local-class='withdrawn-label'>{{t 'osf-components.search-result-card.withdrawn'}}</span>
+                {{/if}}
+                {{#if @result.orcids}}
+                    {{#each @result.orcids as |item|}}
+                        <a href={{item}}
+                            target='_blank'
+                            rel='noopener noreferrer'
+                            aria-label={{t 'osf-components.search-result-card.link_to_orcid_id'}}
+                        >
+                            <FaIcon @prefix='fab' @icon='orcid' local-class='orcid-logo' />
+                        </a>
+                    {{/each}}
+                {{/if}}
+            </h4>
+        {{/if}}
         {{#if @result.affiliatedEntities}}
             <div local-class='name-fields'>
                 <InlineList


### PR DESCRIPTION
-   Notion ticket: https://www.notion.so/cos/Users-Tab-Need-a-little-more-spacing-between-the-USER-object-label-and-the-Name-of-the-User-53f9c3ce1bf944afb0e447389e889ae0?pvs=4
-   GitHub branch: feature/object-label-and-name-spacing

## Purpose

The purpose of these changes is to add a top margin to the result card title element.

## Summary of Changes

A margin of 5px was added to the result card title element h4.

## Screenshot(s)

<img width="1625" alt="image" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/82047646/8bc5e1f2-a98c-4084-85e4-2d35d07f8ba2">

Figure 1: Top margin added to title element for result cards

## Side Effects

This change was made for title-only registrations. QA testing should make sure it does not affect other cards excessively on the styling.

## QA Notes

-Do title-only registrations look proper?
-Are other titles not excessively affected by the change?
