### PR TITLE
[Hotfix][ENG-4649] Reset page QP on new search text

### DIFF
--- a/app/institutions/discover/controller.ts
+++ b/app/institutions/discover/controller.ts
@@ -14,7 +14,7 @@ export default class InstitutionDiscoverController extends Controller {
     @tracked sort?: string =  '-relevance';
     @tracked resourceType?: ResourceTypeFilterValue | null = null;
 
-    queryParams = ['cardSearchText', 'page', 'sort', 'resourceType'];
+    queryParams = ['cardSearchText', 'sort', 'resourceType'];
 
     get defaultQueryOptions() {
         return {

--- a/app/preprints/discover/controller.ts
+++ b/app/preprints/discover/controller.ts
@@ -17,7 +17,7 @@ export default class PreprintDiscoverController extends Controller {
     @tracked cardSearchText?: string = '';
     @tracked sort?: string =  '-relevance';
 
-    queryParams = ['cardSearchText', 'page', 'sort'];
+    queryParams = ['cardSearchText', 'sort'];
 
     get defaultQueryOptions() {
         return {

--- a/app/search/controller.ts
+++ b/app/search/controller.ts
@@ -7,15 +7,13 @@ export default class SearchController extends Controller {
     @tracked q?: string = '';
     @tracked sort?: string =  '-relevance';
     @tracked resourceType?: ResourceTypeFilterValue | null = null;
-    @tracked page?: string = '';
 
-    queryParams = ['q', 'page', 'sort', 'resourceType'];
+    queryParams = ['q', 'sort', 'resourceType'];
 
     @action
     onSearch(queryOptions: OnSearchParams) {
         this.q = queryOptions.cardSearchText;
         this.sort = queryOptions.sort;
         this.resourceType = queryOptions.resourceType;
-        this.page = queryOptions.page;
     }
 }

--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -252,6 +252,7 @@ export default class SearchPage extends Component<SearchArgs> {
     @waitFor
     async doDebounceSearch() {
         await timeout(searchDebounceTime);
+        this.page = '';
         taskFor(this.search).perform();
     }
 

--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -234,7 +234,7 @@ export default class SearchPage extends Component<SearchArgs> {
             this.totalResultCount = searchResult.totalResultCount === ShareMoreThanTenThousand ? '10,000+' :
                 searchResult.totalResultCount;
             if (this.args.onSearch) {
-                this.args.onSearch({cardSearchText, sort, resourceType, page});
+                this.args.onSearch({cardSearchText, sort, resourceType});
             }
         } catch (e) {
             this.toast.error(e);


### PR DESCRIPTION
-   Ticket: [ENG-4649]
-   Feature flag: n/a

## Purpose
- Reset the page when entering new text into the search box
- Remove the query-param for `page`

## Summary of Changes
- Reset page query param on debounceSearch task
- Remove the query-param for `page` from general search page and branded pages

## Screenshot(s)
- Look ma, no query-params
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/73fd1940-4271-40f4-bf1b-7007cbd1cd92)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- The page query param should ~reset when you are on the second page and enter new text into the search-box. The "Prev" button should go away in this case as well~ be gone entirely

[ENG-4649]: https://openscience.atlassian.net/browse/ENG-4649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ