### PR TITLE
[BUG] Fix search improvements topbar on hover

### DIFF
--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -178,23 +178,40 @@
             list-style: none;
             margin-bottom: 0;
             padding-left: 0;
-
             width: 100%;
         }
 
         li {
             display: inline-flex;
             white-space: nowrap;
-            margin-right: 10px;
+            width: calc(100%/6);
+            justify-content: center;
 
             &.active,
             &:hover {
-                background-color: $color-bg-gray;
+                background-color: $color-bg-white;
             }
         }
 
+        li:nth-of-type(1),
+        li:nth-of-type(2),
+        li:nth-of-type(4) {
+            width: calc(100%/6 + 25px);
+        }
+
+        li:nth-of-type(3) {
+            width: calc(100%/6 + 55px);
+        }
+
+        li:nth-of-type(5),
+        li:nth-of-type(6) {
+            width: calc(100%/6 + 10px);
+        }
+
         a {
-            padding-bottom: 10px;
+            padding: 18px 0 10px;
+            width: 100%;
+            text-align: center;
         }
     }
 

--- a/lib/osf-components/addon/components/search-result-card/styles.scss
+++ b/lib/osf-components/addon/components/search-result-card/styles.scss
@@ -72,6 +72,11 @@
     }
 }
 
+.open-badges-list {
+    margin-bottom: 0;
+    padding-bottom: 0;
+}
+
 .cp-panel {
     padding: 0 10px;
 

--- a/lib/osf-components/addon/components/search-result-card/template.hbs
+++ b/lib/osf-components/addon/components/search-result-card/template.hbs
@@ -77,7 +77,7 @@
             </div>
         {{/if}}
         {{#if (or (eq @result.resourceType 'registration') (eq @result.resourceType 'registration_component'))}}
-            <div>
+            <div local-class='open-badges-list'>
                 <OpenBadgesList
                     @hasData={{@result.hasDataResource}}
                     @hasMaterials={{@result.hasMaterialsResource}}


### PR DESCRIPTION
  -GitHub branch: feature/search-improvements-topbar-hover

## Purpose

The purpose of these changes was to fix the active and hover states of the search top bar and the excessive margin on the open badges list div inside the result card containers.

## Summary of Changes

- Calculations for text width was taken into account for each of the topbar elements
- Styling was applied for topbar when client browser window is resized between full desktop view and tablet screens

## Screenshot(s)

<img width="1680" alt="image" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/82047646/7f67f2f5-88c4-4b3c-bfcc-99aa02a3022c">

Figure 1: Topbar with corrected active and hover states on full desktop mode

<img width="1012" alt="image" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/82047646/564e0456-eb37-4d2e-b751-044dcd945693">

<img width="1013" alt="image" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/82047646/e1ded284-e513-4e8e-893e-2e2fe2dba112">

Figure 2, 3: Topbar with corrected active and hover state at resizing before tablet dimensions

## Side Effects

This will affect the overall UI of the search topbar. Testing should include changes to it and the surrounding layout.

## QA Notes

1. Does the UI look like the mock-ups? Should anything be added/removed: https://preview.uxpin.com/e2821be91003954dec0c29a026bc49989b868e2d#/pages/162679105/simulate/no-panels?mode=i
