### PR TITLE
[ENG-4022] Deprecation/try-invoke part 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "ember-code-snippet": "^2.4.0",
     "ember-collapsible-panel": "^6.0.1",
     "ember-component-attributes": "^0.1.1",
-    "ember-composable-helpers": "^4.4.1",
+    "ember-composable-helpers": "^5.0.0",
     "ember-concurrency": "^2.0.3",
     "ember-concurrency-async": "^1.0.0",
     "ember-concurrency-ts": "^0.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11394,10 +11394,10 @@ ember-component-attributes@^0.1.1:
   dependencies:
     ember-cli-babel "^6.7.0"
 
-ember-composable-helpers@^4.4.1:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/ember-composable-helpers/-/ember-composable-helpers-4.5.0.tgz#94febbdf4348e64f45f7a6f993f326e32540a61e"
-  integrity sha512-XjpDLyVPsLCy6kd5dIxZonOECCO6AA5sY5Hr6tYUbJg3s5ghFAiFWaNcYraYC+fL2yPJQAswwpfwGlQORUJZkw==
+ember-composable-helpers@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ember-composable-helpers/-/ember-composable-helpers-5.0.0.tgz#055bab3a3e234ab2917499b1465e968c253ca885"
+  integrity sha512-gyUrjiSju4QwNrsCLbBpP0FL6VDFZaELNW7Kbcp60xXhjvNjncYgzm4zzYXhT+i1lLA6WEgRZ3lOGgyBORYD0w==
   dependencies:
     "@babel/core" "^7.0.0"
     broccoli-funnel "2.0.1"


### PR DESCRIPTION
-   Ticket: [ENG-4022]
-   Feature flag: n/a

## Purpose

There are two major parts to fixing the try-invoke deprecation. The first is updating ember-composable-helpers, and the second is removing ember parachute. This handles the first. The second will be part of Search Phase 2 once the branded registries discovery page, which is the page that uses ember-parachute, is removed.

## Summary of Changes

1. Update ember-composable-helpers

## Side Effects

This should be fairly straightforward.



[ENG-4022]: https://openscience.atlassian.net/browse/ENG-4022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ