### PR TITLE
[Hotfix] Unwrap text on topbar sort options

### DIFF
--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -283,11 +283,10 @@
 .sort-dropdown {
     background-color: $color-bg-gray-blue-light;
     align-self: flex-end;
-    padding-bottom: 10px;
-    margin-left: 10px;
+    white-space: nowrap;
 
     p {
-        margin: 0 0 0 2px;
+        margin: 0;
     }
 
     div {
@@ -300,6 +299,11 @@
     > div {
         display: flex;
     }
+}
+
+.sort-dropdown-option {
+    margin-bottom: 0;
+    padding: 10px 0;
 }
 
 .sidenav-toggle {
@@ -407,6 +411,7 @@
     .sort-dropdown {
         align-self: flex-end;
         margin: 0.5rem 0;
+        white-space: nowrap;
 
         > div {
             background-color: $color-bg-white;

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -216,7 +216,7 @@ as |layout|>
                             @onChange={{action this.updateSort}}
                             as |sortOption|
                         >
-                            <p>{{sortOption.display}}</p>
+                            <p local-class='sort-dropdown-option'>{{sortOption.display}}</p>
                         </PowerSelect>
                     </div>
                 {{else if this.showResultCountMiddle}}


### PR DESCRIPTION
-   Ticket: TBD
-   Feature flag: n/a

## Purpose

The purpose of these changes was to remove wrapping text in the topbar sort dropdown option selection.

## Summary of Changes

- margin for sort dropdown paragraph elements was removed
- a local class selector for sort dropdown options was added 
- padding was added to sort dropdown options and the bottom margin removed
- `white-space:no-wrap` was added to the sort dropdown local class selector

## Screenshot(s)

<img width="1348" alt="Search OSF" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/82047646/6801a8dc-e18c-4270-a1c7-d16f319b8aca">

Figure 1: Corrected sort dropdown text wrap on desktop view

<img width="246" alt="image" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/82047646/7841c703-7757-4aa2-b036-57b076a63cca">

Figure 2: Corrected dropdown text on mobile/tablet

## Side Effects

There should be no formal side-effects, but this may displace the topbar UI if not properly implemented.

## QA Notes

-Do the elements properly display? Is there any text wrapping taking place on any of the options?
-A negative margin can correct the placement of the right dropdown arrow but this is not recommended practice; is there no excessive overlap currently with the button?
