### PR TITLE
Remove ember-parachute; Remove page QP

### DIFF
--- a/app/register/controller.ts
+++ b/app/register/controller.ts
@@ -3,10 +3,10 @@ import Controller from '@ember/controller';
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { waitFor } from '@ember/test-waiters';
+import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 import config from 'ember-get-config';
-import QueryParams from 'ember-parachute';
 
 import PreprintProvider from 'ember-osf-web/models/preprint-provider';
 import Analytics from 'ember-osf-web/services/analytics';
@@ -14,21 +14,7 @@ import param from 'ember-osf-web/utils/param';
 
 const { OSF: { casUrl, url: baseUrl } } = config;
 
-interface RegisterQueryParams {
-    next: string;
-    campaign: string;
-}
-
-export const registerQueryParams = new QueryParams<RegisterQueryParams>({
-    next: {
-        defaultValue: '',
-    },
-    campaign: {
-        defaultValue: '',
-    },
-});
-
-export default class Register extends Controller.extend(registerQueryParams.Mixin) {
+export default class Register extends Controller.extend() {
     @service analytics!: Analytics;
     @service store!: Store;
 
@@ -40,7 +26,11 @@ export default class Register extends Controller.extend(registerQueryParams.Mixi
     isOsfPreprints = false;
     isOsfRegistries = false;
 
-    @computed('next')
+    @tracked next?: string = '';
+    @tracked campaign?: string = '';
+
+    queryParams = ['next', 'campaign'];
+
     get orcidUrl() {
         return `${casUrl}/login?${param({
             redirectOrcid: 'true',
@@ -48,7 +38,6 @@ export default class Register extends Controller.extend(registerQueryParams.Mixi
         })}`;
     }
 
-    @computed('next')
     get institutionUrl() {
         return `${casUrl}/login?${param({
             campaign: 'institution',
@@ -77,7 +66,7 @@ export default class Register extends Controller.extend(registerQueryParams.Mixi
         }
     }
 
-    setup({ queryParams }: { queryParams: RegisterQueryParams }) {
+    setup({ queryParams }: { queryParams: { next?: string, campaign?: string } }) {
         if (queryParams.campaign) {
             this.set('signUpCampaign', queryParams.campaign);
             const matches = queryParams.campaign.match(/^(.*)-(.*)$/);

--- a/app/register/controller.ts
+++ b/app/register/controller.ts
@@ -66,10 +66,10 @@ export default class Register extends Controller.extend() {
         }
     }
 
-    setup({ queryParams }: { queryParams: { next?: string, campaign?: string } }) {
-        if (queryParams.campaign) {
-            this.set('signUpCampaign', queryParams.campaign);
-            const matches = queryParams.campaign.match(/^(.*)-(.*)$/);
+    setup() {
+        if (this.campaign) {
+            this.set('signUpCampaign', this.campaign);
+            const matches = this.campaign.match(/^(.*)-(.*)$/);
             if (matches) {
                 const [, provider, type] = matches;
                 if (provider === 'osf') {

--- a/app/register/route.ts
+++ b/app/register/route.ts
@@ -3,6 +3,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import Session from 'ember-simple-auth/services/session';
 
+import RegisterController from './controller';
 
 export default class Register extends Route {
     @service session!: Session;
@@ -17,5 +18,10 @@ export default class Register extends Route {
 
     model() {
         return this.store.createRecord('user-registration');
+    }
+
+    setupController(controller: RegisterController, model: any, transition: Transition) {
+        super.setupController(controller, model, transition);
+        controller.setup();
     }
 }

--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -46,7 +46,6 @@ export interface Filter {
 
 export interface OnSearchParams {
     cardSearchText?: string;
-    page?: string;
     sort?: string;
     resourceType?: ResourceTypeFilterValue | null;
 }

--- a/lib/registries/addon/branded/discover/controller.ts
+++ b/lib/registries/addon/branded/discover/controller.ts
@@ -17,9 +17,8 @@ export default class BrandedDiscover extends Controller.extend() {
 
     @tracked cardSearchText? = '';
     @tracked sort? = '-relevance';
-    @tracked page? = '';
 
-    queryParams = ['cardSearchText', 'page', 'sort'];
+    queryParams = ['cardSearchText', 'sort'];
 
     get defaultQueryOptions() {
         return {
@@ -30,7 +29,6 @@ export default class BrandedDiscover extends Controller.extend() {
     @action
     onSearch(onSearchParams: OnSearchParams) {
         this.cardSearchText = onSearchParams.cardSearchText;
-        this.page = onSearchParams.page;
         this.sort = onSearchParams.sort;
     }
 }

--- a/package.json
+++ b/package.json
@@ -194,7 +194,6 @@
     "ember-moment": "^7.7.0",
     "ember-onbeforeunload": "^2.0.0",
     "ember-page-title": "^6.2.1",
-    "ember-parachute": "^1.0.2",
     "ember-percy": "^1.5.0",
     "ember-power-select": "^4.1.7",
     "ember-promise-helpers": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10587,13 +10587,6 @@ ember-page-title@^6.2.1:
   dependencies:
     ember-cli-babel "^7.22.1"
 
-ember-parachute@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/ember-parachute/-/ember-parachute-1.0.2.tgz#f147f6b29df100d467acc1ddf13761aef92e95de"
-  integrity sha512-wpTn179au/BE2+p4z9mQRh2Cy/a5J038oPpY2Buja3gDO/Qh64ny3klr4dxMRQ5GePniglkWK/LW3qitcs902A==
-  dependencies:
-    ember-cli-babel "^7.1.2"
-
 ember-percy@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/ember-percy/-/ember-percy-1.6.0.tgz#b0b7f27a4f60ac8992648337fc6d64404109d325"


### PR DESCRIPTION
-   Ticket: [No ticket]
-   Feature flag: n/a

## Purpose
- Remove ember-parachute
- Remove page query param from branded discover page

## Summary of Changes
- update package.json and yarn
- update branded discover controller and `OnSearchParams` type to exclude `page`

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
