### PR TITLE
[No ticket] Fix selenium test for clipboard button

### DIFF
--- a/lib/osf-components/addon/components/copy-button/template.hbs
+++ b/lib/osf-components/addon/components/copy-button/template.hbs
@@ -1,4 +1,5 @@
 <button
+    data-clipboard-text={{@clipboardText}}
     type='button'
     disabled={{@disabled}}
     {{on 'click' (perform this.copy)}}


### PR DESCRIPTION
## Purpose

Try to fix a selenium test that was broken when we re-wrote the clipboard button.

## Summary of Changes

1. Add data selector

## Screenshot(s)

Here's the problem I'm trying to fix:
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/d7263541-c88d-4b51-93e4-bb4bbf4afc10)


## Side Effects

Shouldn't be.

## QA Notes

Selenium tests should pass.
