### PR TITLE
Fix broken meetings searches

### DIFF
--- a/app/meetings/detail/-components/meeting-submissions-list/template.hbs
+++ b/app/meetings/detail/-components/meeting-submissions-list/template.hbs
@@ -4,7 +4,7 @@
         placeholder={{t 'meetings.index.meetings-list.search'}}
         aria-label={{t 'meetings.index.meetings-list.search'}}
         @type='text'
-        {{on 'keyup' (perform this.searchSubmissions)}}
+        {{on 'keyup' (perform this.searchSubmissions value='target.value')}}
     />
 </div>
 

--- a/app/meetings/index/-components/meetings-list/template.hbs
+++ b/app/meetings/index/-components/meetings-list/template.hbs
@@ -9,7 +9,7 @@
             aria-label={{t 'meetings.index.meetings-list.search'}}
             placeholder={{t 'meetings.index.meetings-list.search'}}
             @type='text'
-            {{on 'keyup' (perform this.searchMeetings)}}
+            {{on 'keyup' (perform this.searchMeetings value='target.value')}}
         />
     </div>
 </div>


### PR DESCRIPTION
## Purpose

A recent deprecation fix caused [meetings searches to break](https://www.notion.so/cos/Meetings-filtering-is-broken-26e361c983224e1a817be0a29404270f?pvs=4). This should fix that.

## Summary of Changes

1. Add `target` string to `on` actions
