### PR TITLE
Fix branded page query-params

### DIFF
--- a/app/institutions/discover/controller.ts
+++ b/app/institutions/discover/controller.ts
@@ -18,7 +18,7 @@ export default class InstitutionDiscoverController extends Controller {
 
     get defaultQueryOptions() {
         return {
-            publisher: pathJoin(config.OSF.url, 'institutions', this.model.id),
+            affiliation: pathJoin(config.OSF.url, 'institutions', this.model.id),
         };
     }
 

--- a/lib/registries/addon/branded/discover/controller.ts
+++ b/lib/registries/addon/branded/discover/controller.ts
@@ -23,7 +23,7 @@ export default class BrandedDiscover extends Controller.extend() {
 
     get defaultQueryOptions() {
         return {
-            publisher: pathJoin(config.OSF.url, 'registrations', this.model.id),
+            publisher: pathJoin(config.OSF.url, 'registries', this.model.id),
         };
     }
 


### PR DESCRIPTION

-   Ticket: []
-   Feature flag: n/a

## Purpose
- Fix issue where FE is querying SHARE incorrectly on branded discover pages

## Summary of Changes
- Use `affiliation` query-param for institution discover
- Fix link to provider IRI for registrations

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
