### PR TITLE
Update institution discover default query options

### DIFF
--- a/app/institutions/discover/controller.ts
+++ b/app/institutions/discover/controller.ts
@@ -16,11 +16,9 @@ export default class InstitutionDiscoverController extends Controller {
     queryParams = ['cardSearchText', 'sort', 'resourceType'];
 
     get defaultQueryOptions() {
-        const identifiers = [this.model.rorIri, this.model.iri, this.model.links.self].filter(Boolean).join(',');
+        const identifiers = [this.model.rorIri, this.model.iri, this.model.links.html].filter(Boolean).join(',');
         return {
-            affiliation: identifiers,
-            'creator,affiliation': identifiers,
-            'isContainedby,affiliation': identifiers,
+            'affiliation,creator.affiliation,isContainedby.affiliation': identifiers,
         };
     }
 

--- a/app/institutions/discover/controller.ts
+++ b/app/institutions/discover/controller.ts
@@ -3,8 +3,7 @@ import { inject as service } from '@ember/service';
 import CurrentUser from 'ember-osf-web/services/current-user';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import pathJoin from 'ember-osf-web/utils/path-join';
-import config from 'ember-get-config';
+
 import { OnSearchParams, ResourceTypeFilterValue } from 'osf-components/components/search-page/component';
 
 export default class InstitutionDiscoverController extends Controller {
@@ -17,8 +16,11 @@ export default class InstitutionDiscoverController extends Controller {
     queryParams = ['cardSearchText', 'sort', 'resourceType'];
 
     get defaultQueryOptions() {
+        const identifiers = [this.model.rorIri, this.model.iri, this.model.links.self].filter(Boolean).join(',');
         return {
-            affiliation: pathJoin(config.OSF.url, 'institutions', this.model.id),
+            affiliation: identifiers,
+            'creator,affiliation': identifiers,
+            'isContainedby,affiliation': identifiers,
         };
     }
 

--- a/app/models/institution.ts
+++ b/app/models/institution.ts
@@ -30,6 +30,9 @@ export default class InstitutionModel extends OsfModel {
     @attr('object') assets?: Assets;
     @attr('boolean', { defaultValue: false }) currentUserIsAdmin!: boolean;
     @attr('date') lastUpdated!: Date;
+    @attr('fixstring') rorIri!: string;
+    // identifier_domain in the admin app
+    @attr('fixstring') iri!: string;
 
     // TODO Might want to replace calls to `users` with `institutionUsers.user`?
     @hasMany('user', { inverse: 'institutions' })

--- a/app/models/related-property-path.ts
+++ b/app/models/related-property-path.ts
@@ -27,21 +27,6 @@ export default class RelatedPropertyPathModel extends OsfModel {
 
     getLocalizedString = new GetLocalizedPropertyHelper(getOwner(this));
 
-    get shortFormLabel() {
-        const labelArray = [];
-        // propertyPath is likely an array of length 1,
-        // unless it is nested property(e.g. file's isContainedBy.funder, file's isContainedBy.license)
-        for (const property of this.propertyPath) {
-            const label = this.getLocalizedString.compute(
-                [property as unknown as Record<string, LanguageText[]>, 'shortFormLabel'],
-            );
-            if (label) {
-                labelArray.push(label);
-            }
-        }
-        return labelArray.join(',');
-    }
-
     get displayLabel() {
         // propertyPath is likely an array of length 1,
         // unless it is nested property(e.g. file's isContainedBy.funder, file's isContainedBy.license)

--- a/lib/osf-components/addon/components/search-page/boolean-filters/template.hbs
+++ b/lib/osf-components/addon/components/search-page/boolean-filters/template.hbs
@@ -34,7 +34,7 @@
                             title={{value.displayLabel}}
                             {{on 'click' (fn @toggleFilter (hash
                                 propertyVisibleLabel=this.visibleLabel
-                                propertyShortFormLabel=value.propertyPathKey
+                                propertyPathKey=value.propertyPathKey
                                 label=value.displayLabel
                                 value='is-present'
                                 suggestedFilterOperator='is-present'

--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -38,7 +38,7 @@ interface SortOption {
 
 export interface Filter {
     propertyVisibleLabel: string;
-    propertyShortFormLabel: string; // OSFMAP shorthand label
+    propertyPathKey: string; // OSFMAP shorthand label
     value: string;
     label: string;
     suggestedFilterOperator?: SuggestedFilterOperators;
@@ -205,13 +205,13 @@ export default class SearchPage extends Component<SearchArgs> {
             let filterQueryObject = activeFilters.reduce((acc, filter) => {
                 // boolean filters should look like cardSearchFilter[hasDataResource][is-present]
                 if (filter.suggestedFilterOperator === SuggestedFilterOperators.IsPresent) {
-                    acc[filter.propertyShortFormLabel] = {};
-                    acc[filter.propertyShortFormLabel][filter.value] = true;
+                    acc[filter.propertyPathKey] = {};
+                    acc[filter.propertyPathKey][filter.value] = true;
                     return acc;
                 }
                 // other filters should look like cardSearchFilter[propertyName]=IRI
-                const currentValue = acc[filter.propertyShortFormLabel];
-                acc[filter.propertyShortFormLabel] = currentValue ? currentValue.concat(filter.value) : [filter.value];
+                const currentValue = acc[filter.propertyPathKey];
+                acc[filter.propertyPathKey] = currentValue ? currentValue.concat(filter.value) : [filter.value];
                 return acc;
             }, {} as { [key: string]: any });
             let resourceTypeFilter = this.resourceType as string;
@@ -270,7 +270,7 @@ export default class SearchPage extends Component<SearchArgs> {
     @action
     toggleFilter(filter: Filter) {
         const filterIndex = this.activeFilters.findIndex(
-            f => f.propertyShortFormLabel === filter.propertyShortFormLabel && f.value === filter.value,
+            f => f.propertyPathKey === filter.propertyPathKey && f.value === filter.value,
         );
         if (filterIndex > -1) {
             this.activeFilters.removeAt(filterIndex);

--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -9,6 +9,7 @@ import Intl from 'ember-intl/services/intl';
 import { A } from '@ember/array';
 import Store from '@ember-data/store';
 import { action } from '@ember/object';
+import config from 'ember-get-config';
 import Media from 'ember-responsive';
 
 import { ShareMoreThanTenThousand } from 'ember-osf-web/models/index-card-search';
@@ -66,6 +67,7 @@ interface SearchArgs {
     activeFilters: Filter[];
 }
 
+const osfURL = config.OSF.url;
 const searchDebounceTime = 100;
 
 export default class SearchPage extends Component<SearchArgs> {
@@ -218,6 +220,10 @@ export default class SearchPage extends Component<SearchArgs> {
                 resourceTypeFilter = Object.values(ResourceTypeFilterValue).join(',');
             }
             filterQueryObject['resourceType'] = resourceTypeFilter;
+            // Add the accessService if we are not serving locally
+            if (!osfURL.includes('localhost')) {
+                filterQueryObject['accessService'] = osfURL; // Only fetch items from the current OSF environment
+            }
             filterQueryObject = { ...filterQueryObject, ...this.args.defaultQueryOptions };
             this.filterQueryObject = filterQueryObject;
             const searchResult = await this.store.queryRecord('index-card-search', {

--- a/lib/osf-components/addon/components/search-page/filter-facet/component.ts
+++ b/lib/osf-components/addon/components/search-page/filter-facet/component.ts
@@ -75,7 +75,7 @@ export default class FilterFacet extends Component<FilterFacetArgs> {
             const card = this.selectedProperty.indexCard;
             const filter = {
                 propertyVisibleLabel: property.displayLabel,
-                propertyShortFormLabel: property.shortFormLabel,
+                propertyPathKey: property.propertyPathKey,
                 label: card.get('label'),
                 value: card.get('resourceId'),
             };
@@ -110,7 +110,7 @@ export default class FilterFacet extends Component<FilterFacetArgs> {
         const valueSearch = await this.store.queryRecord('index-value-search', {
             cardSearchText,
             cardSearchFilter,
-            valueSearchPropertyPath: property.shortFormLabel,
+            valueSearchPropertyPath: property.propertyPathKey,
             valueSearchText: filterString || '',
             'page[cursor]': page,
             sort,

--- a/lib/osf-components/addon/components/search-page/filter-facet/template.hbs
+++ b/lib/osf-components/addon/components/search-page/filter-facet/template.hbs
@@ -40,7 +40,7 @@
                                 title={{value.indexCard.label}}
                                 {{on 'click' (fn @toggleFilter (hash
                                     propertyVisibleLabel=@property.displayLabel
-                                    propertyShortFormLabel=@property.shortFormLabel
+                                    propertyPathKey=@property.propertyPathKey
                                     label=value.indexCard.label
                                     value=value.indexCard.resourceId)
                                 )}}

--- a/mirage/factories/institution.ts
+++ b/mirage/factories/institution.ts
@@ -26,6 +26,8 @@ export default Factory.extend<Institution & InstitutionTraits>({
     lastUpdated() {
         return faker.date.recent();
     },
+    iri: faker.internet.url,
+    rorIri: faker.internet.url,
     withMetrics: trait<Institution>({
         afterCreate(institution, server) {
             const userMetrics = server.createList('institution-user', 15);

--- a/mirage/views/search.ts
+++ b/mirage/views/search.ts
@@ -303,6 +303,7 @@ export function cardSearch(_: Schema, __: Request) {
                 type: 'related-property-path',
                 id: 'propertyMatch1',
                 attributes: {
+                    propertyPathKey: 'rights',
                     matchEvidence: [
                         {
                             '@type': ['https://share.osf.io/vocab/2023/trove/IriMatchEvidence'],
@@ -340,6 +341,7 @@ export function cardSearch(_: Schema, __: Request) {
                 type: 'related-property-path',
                 id: 'propertyMatch2',
                 attributes: {
+                    propertyPathKey: 'datePublished',
                     matchEvidence: [
                         {
                             '@type': ['https://share.osf.io/vocab/2023/trove/IriMatchEvidence'],
@@ -377,6 +379,7 @@ export function cardSearch(_: Schema, __: Request) {
                 type: 'related-property-path',
                 id: 'propertyMatch3',
                 attributes: {
+                    propertyPathKey: 'funder',
                     matchEvidence: [
                         {
                             '@type': ['https://share.osf.io/vocab/2023/trove/IriMatchEvidence'],


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Actual fetch stuff in the institution discover page
- Only fetch stuff from the specific environment the search is happening in by using `accessService` query-param
  - This addresses the issue of seeing multiple instances of `OSF Registries` or `Open-ended Registration` registration templates on staging

## Summary of Changes
- Add `rorIri` and `iri` attributes to Institution model (ultimately these comes from the `ror_uri ` and `identifier_domain` respectively in the admin app and is being added in a [BE PR](https://github.com/CenterForOpenScience/osf.io/pull/10452))
- fetch by either ROR, URI, or URL from OSFv2 URL (the URLs that are [relevant to SHARE for understanding institution affiliation](https://github.com/CenterForOpenScience/osf.io/blob/a3e0a0b9ddda5dd75fc8248d58f3bcdeece0323e/osf/metadata/osf_gathering.py#L811-L816))
- Fetch either by `affilation`, `creator,affiliation` (for preprints), `isContainedBy,affiliation` (for files)
- Add `accessService` qp to SHARE requests if we are not serving locally

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
