### PR TITLE
Show provider hero-banner on search page

### DIFF
--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -19,6 +19,7 @@
     display: flex;
     flex-direction: column;
     padding: 0;
+    z-index: 0;
 
     label > h1 {
         font-weight: 500;
@@ -90,6 +91,7 @@
     display: flex;
     align-items: center;
     padding: 35px;
+    z-index: 0;
 
     label {
         padding: 30px;

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -36,7 +36,7 @@ as |layout|>
                             alt={{concat (t 'search.institutions.institution-logo') @institution.name}}
                         >
                     {{/if}}
-                    <p data-test-institution-description>{{@institution.description}}</p>
+                    <p data-test-institution-description>{{html-safe @institution.description}}</p>
                 </label>
             </div>
         {{else}}


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Show the banner image for branded discover pages
- Allow html entities from institution description

## Summary of Changes
- Add z-index to default banner
- wrap institution description in `{{html-safe}}`

## Screenshot(s)
Before for preprint/registration discover:
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/9e0ca56c-5bb1-46f1-9c1d-449278ebd08a)
After for preprint/registration discover:
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/2e147937-158f-4f45-9af0-9aebfc3deb3d)

Prevents this bug in institutions discover:
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/7ac91653-ca9f-41f8-9032-947107730a8b)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
