### PR TITLE
Bring back Date Created filter

### DIFF
--- a/app/models/related-property-path.ts
+++ b/app/models/related-property-path.ts
@@ -15,7 +15,8 @@ interface PropertyPath {
 
 export enum SuggestedFilterOperators {
     AnyOf = 'any-of',
-    IsPresent = 'is-present'
+    IsPresent = 'is-present',
+    AtDate = 'at-date'
 }
 
 export default class RelatedPropertyPathModel extends OsfModel {

--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -230,8 +230,9 @@ export default class SearchPage extends Component<SearchArgs> {
             await searchResult.relatedProperties;
             this.booleanFilters = searchResult.relatedProperties
                 .filterBy('suggestedFilterOperator', SuggestedFilterOperators.IsPresent);
-            this.relatedProperties = searchResult.relatedProperties
-                .filterBy('suggestedFilterOperator', SuggestedFilterOperators.AnyOf);
+            this.relatedProperties = searchResult.relatedProperties.filter(
+                property => property.suggestedFilterOperator !== SuggestedFilterOperators.IsPresent, // AnyOf or AtDate
+            );
             this.firstPageCursor = searchResult.firstPageCursor;
             this.nextPageCursor = searchResult.nextPageCursor;
             this.prevPageCursor = searchResult.prevPageCursor;


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [Notion card](https://www.notion.so/cos/Date-created-facet-missing-in-all-searches-cd8a168282d8419e94118dfd76162f3c)
-   Feature flag: n/a

## Purpose
- Bring back date Created filter on search page

## Summary of Changes
- Make the condition for getting non-boolean type filters less restrictive

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
