### PR TITLE
Return sort dropdown for registries and preprints discover

### DIFF
--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -408,7 +408,7 @@
         gap: 1rem;
     }
 
-    .topbar {
+    .flex-column-tablet {
         display: flex;
         flex-direction: column;
     }

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -164,6 +164,8 @@
 .topbar {
     border-bottom: 1px solid $color-text-black;
     display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
     margin: 0 auto;
     max-height: 55px;
     margin-top: 1rem;
@@ -198,6 +200,11 @@
         a {
             padding-bottom: 10px;
         }
+    }
+
+    .search-count {
+        // override RegistriesStyle
+        font-size: 1.5em;
     }
 
     .help-button {

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -192,7 +192,7 @@ as |layout|>
     </layout.left>
     <layout.main local-class={{if this.showSidePanelToggle 'search-main-mobile' 'search-main'}} data-analytics-scope='Search page main'>
         {{#unless this.showSidePanelToggle}}
-            <div data-test-topbar-wrapper local-class='topbar'>
+            <div data-test-topbar-wrapper local-class='topbar {{if @showResourceTypeFilter 'flex-column-tablet'}}'>
                 {{#if @showResourceTypeFilter}}
                     <nav
                         data-test-topbar-object-type-nav

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -215,19 +215,6 @@ as |layout|>
                             {{/each}}
                         </ul>
                     </nav>
-                    <div
-                        data-test-topbar-sort-dropdown
-                        local-class='sort-dropdown'
-                    >
-                        <PowerSelect
-                            @options={{this.sortOptions}}
-                            @selected={{this.selectedSortOption}}
-                            @onChange={{action this.updateSort}}
-                            as |sortOption|
-                        >
-                            <p>{{sortOption.display}}</p>
-                        </PowerSelect>
-                    </div>
                 {{else if this.showResultCountMiddle}}
                     <p
                         data-test-middle-search-count
@@ -236,6 +223,19 @@ as |layout|>
                         {{t 'search.total-results' count=this.totalResultCount}}
                     </p>
                 {{/if}}
+                <div
+                    data-test-topbar-sort-dropdown
+                    local-class='sort-dropdown'
+                >
+                    <PowerSelect
+                        @options={{this.sortOptions}}
+                        @selected={{this.selectedSortOption}}
+                        @onChange={{action this.updateSort}}
+                        as |sortOption|
+                    >
+                        <p>{{sortOption.display}}</p>
+                    </PowerSelect>
+                </div>
             </div>
         {{/unless}}
         {{#if this.search.isRunning}}


### PR DESCRIPTION
-   Ticket: [[Notion Card]](https://www.notion.so/cos/Sort-options-missing-on-branded-registries-search-pages-9b2fd17692eb49e6ae00f1a510687167)
-   Feature flag: n/a

## Purpose
- Bring back sort dropdown for preprints and registries discover

## Summary of Changes
- Move sort-dropdown outside of conditional
- Styling

## Screenshot(s)
- General search
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/d5eceb36-12b9-4a48-a83a-53b9dff9e2e6)


- Preprints discover
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/f422237c-e3ae-485e-8561-920630095657)

- Registries discover
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/3929cde2-33c7-4852-87df-027d368c90b1)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
