### PR TITLE
Address branded registries style issues

### DIFF
--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -19,7 +19,6 @@
     display: flex;
     flex-direction: column;
     padding: 0;
-    z-index: 0;
 
     label > h1 {
         font-weight: 500;
@@ -28,7 +27,7 @@
         white-space: nowrap;
     }
 
-    span {
+    .search-input-wrapper {
         display: flex;
         flex-direction: row;
         justify-content: flex-start;
@@ -91,7 +90,6 @@
     display: flex;
     align-items: center;
     padding: 35px;
-    z-index: 0;
 
     label {
         padding: 30px;
@@ -121,6 +119,11 @@
     min-height: 100%;
     min-width: 100%;
     position: relative;
+    z-index: 1;
+
+    p {
+        color: $color-text-white;
+    }
 
     &::after {
         background: var(--hero-background-img-url);
@@ -242,6 +245,7 @@
     }
 
     h2 {
+        color: $color-text-white;
         font-weight: 400;
         height: 22px;
         margin-top: 0.5rem;
@@ -249,6 +253,7 @@
     }
 
     p {
+        color: $color-text-white;
         white-space: normal;
         margin: 25px 5px 0;
     }


### PR DESCRIPTION
-   Ticket: [[Notion Card 1]](https://www.notion.so/cos/Darpaasist-registry-header-text-not-displaying-properly-df1fc7d9b7974989a60fce0715147298?pvs=4) [[Notion Card 2]](https://www.notion.so/cos/Help-modal-on-branded-registries-appears-to-have-no-text-as-opposed-to-too-dark-Doug-s-tix-above--5f32ad262ad64682b775bafb3ef7673b?pvs=4) [[Notion Card 3]](https://www.notion.so/cos/Search-Help-Feature-Appears-Empty-on-Branded-Registry-Discover-Pages-Because-the-Color-of-the-Text-i-0db1ca6d1c374d5a8f6c0925d03ae679?pvs=4)
-   Feature flag: n/a

## Purpose
- Fix DAPRA ASIST description text styling
- Fix text-color issue in help popovers
- Fix issue with help popovers showing up under search-result cards

## Summary of Changes
- For DARPA ASIST description: Update selector in `. heading-wrapper-mobile` class to not select extraneous elements
- For help popover showing up below search-cards: increase `z-index` for `.hero-overlay` to show up above search-result cards and other main panel content
- Override `RegistriesStyle` text color for provider description and help modal header and paragraph

## Screenshot(s)
- DARPA ASIST description before/after:
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/2a8ab8b9-19a5-47d4-9a52-f0d2e450e074)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/1c3aab2e-5de6-426a-ba3b-c5df8296fb5b)

- Help popover before/after:
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/9e4ff38b-5458-4fa2-b952-4149177d01ed)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/27263b8c-1c5b-4ad1-b1ef-b83fe99cf5fe)



## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
