### PR TITLE
Restore placeholder text on sign-up page

### DIFF
--- a/lib/osf-components/addon/components/sign-up-form/template.hbs
+++ b/lib/osf-components/addon/components/sign-up-form/template.hbs
@@ -9,7 +9,7 @@
         @valuePath='fullName'
         @shouldShowMessages={{this.didValidate}}
         disabled={{this.hasSubmitted}}
-        placeholder={{t 'osf-components.sign-up-form.full_name'}}
+        @placeholder={{t 'osf-components.sign-up-form.full_name'}}
         ariaLabel={{t 'osf-components.sign-up-form.full_name'}}
     />
     <ValidatedInput::Text
@@ -18,7 +18,7 @@
         @valuePath='email1'
         @shouldShowMessages={{this.didValidate}}
         disabled={{this.hasSubmitted}}
-        placeholder={{t 'osf-components.sign-up-form.contact_email'}}
+        @placeholder={{t 'osf-components.sign-up-form.contact_email'}}
         ariaLabel={{t 'osf-components.sign-up-form.contact_email'}}
     />
     <ValidatedInput::Text
@@ -27,7 +27,7 @@
         @valuePath='email2'
         @shouldShowMessages={{this.didValidate}}
         disabled={{this.hasSubmitted}}
-        placeholder={{t 'osf-components.sign-up-form.confirm_email'}}
+        @placeholder={{t 'osf-components.sign-up-form.confirm_email'}}
         ariaLabel={{t 'osf-components.sign-up-form.confirm_email'}}
     />
     <ValidatedInput::Text
@@ -38,7 +38,7 @@
         @shouldShowMessages={{this.didValidate}}
         disabled={{this.hasSubmitted}}
         @onKeyUp={{perform this.strength this.userRegistration.password}}
-        placeholder={{t 'osf-components.sign-up-form.password'}}
+        @placeholder={{t 'osf-components.sign-up-form.password'}}
         ariaLabel={{t 'osf-components.sign-up-form.password'}}
     />
     <div local-class='progress' hidden={{not this.progress}}>


### PR DESCRIPTION
## Purpose

Placeholder text went away on the sign-up page. This restores the placeholders.

## Summary of Changes

1. Send the placeholders to the component properly.

## Screenshot(s)

Before:

<img width="524" alt="Screenshot 2023-09-25 at 1 20 59 PM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/ed9d0406-9e0e-4f29-ba7c-652786822179">

After:

<img width="522" alt="Screenshot 2023-09-25 at 1 18 49 PM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/5b189396-e0e1-4a3d-8b07-942594ca0dd4">
