### PR TITLE
Reroute users to general discover page for preprints/discover and preprints/osf/discover

### DIFF
--- a/app/preprints/discover/route.ts
+++ b/app/preprints/discover/route.ts
@@ -2,6 +2,7 @@ import Store from '@ember-data/store';
 import Route from '@ember/routing/route';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
+import config from 'ember-get-config';
 
 import Theme from 'ember-osf-web/services/theme';
 
@@ -21,6 +22,10 @@ export default class PreprintDiscoverRoute extends Route {
 
     async model(args: any) {
         try {
+            if (!args.provider_id || args.provider_id === config.defaultProvider) {
+                this.router.transitionTo('search', { queryParams: { resourceType: 'Preprint' } });
+                return null;
+            }
             const provider = await this.store.findRecord('preprint-provider', args.provider_id);
             this.theme.providerType = 'preprint';
             this.theme.id = args.provider_id;

--- a/app/router.ts
+++ b/app/router.ts
@@ -26,6 +26,7 @@ Router.map(function() {
         this.route('dashboard', { path: '/:institution_id/dashboard' });
     });
     this.route('preprints', function() {
+        this.route('discover');
         this.route('discover', { path: '/:provider_id/discover' });
     });
     this.route('register');


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Reroute users going to `preprints/discover` and `preprints/osf/discover` to general search page

## Summary of Changes
- Add route to router to handle `preprints/discover`
- Add logic to handle these cases

## Screenshot(s)
- NA

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
