### PR TITLE
Institutions header

### DIFF
--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -103,6 +103,7 @@ export default class SearchPage extends Component<SearchArgs> {
     leftPanelObjectDropdownId = uniqueId(['left-panel-object-dropdown']);
     firstTopbarObjectTypeLinkId = uniqueId(['first-topbar-object-type-link']);
     searchInputWrapperId = uniqueId(['search-input-wrapper']);
+    searchBoxId = uniqueId(['search-box']);
     leftPanelHeaderId = uniqueId(['left-panel-header']);
     firstFilterId = uniqueId(['first-filter']);
 

--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -27,6 +27,10 @@
         white-space: nowrap;
     }
 
+    .provider-description {
+        width: 100%;
+    }
+
     .search-input-wrapper {
         display: flex;
         flex-direction: row;
@@ -96,6 +100,10 @@
         margin: 0 3rem 0 2rem;
     }
 
+    .provider-description {
+        width: 70vw;
+    }
+
     .heading-label > h1 {
         margin: 0;
         white-space: nowrap;
@@ -135,6 +143,26 @@
         left: 0;
         top: 0;
         z-index: -1;
+    }
+}
+
+.institutions-overlay {
+    background-color: $color-bg-gray-blue-light;
+    background-image: none;
+    border-bottom: solid 1px $alto;
+    color: $color-text-black;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+    min-height: 100%;
+    min-width: 100%;
+    position: relative;
+    z-index: 1;
+
+    img {
+        height: 70px;
+        margin: 0 auto;
     }
 }
 

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -42,7 +42,7 @@ as |layout|>
         {{else}}
             <label
                 data-test-search-header
-                for='search-input'
+                for={{this.searchBoxId}}
                 local-class='heading-label'
             >
                 <h1>{{t 'search.search-header'}}</h1>
@@ -53,6 +53,7 @@ as |layout|>
                 data-test-search-input
                 data-analytics-name='Search input'
                 local-class='search-input'
+                id={{this.searchBoxId}}
                 @type='search'
                 @placeholder={{t 'search.textbox-placeholder'}}
                 @value={{this.cardSearchText}}

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -6,7 +6,7 @@ as |layout|>
         data-test-heading-wrapper
         data-analytics-scope='Search page heading'
         {{with-branding (get-model @provider.brand)}}
-        local-class='{{if this.showSidePanelToggle 'heading-wrapper-mobile' 'heading-wrapper'}} {{if @provider 'hero-overlay'}} {{if @institution 'heading-wrapper-institutions'}} {{if (and this.showSidePanelToggle @institution) 'heading-wrapper-institutions-mobile'}}'
+        local-class='{{if this.showSidePanelToggle 'heading-wrapper-mobile' 'heading-wrapper'}} {{if @provider 'hero-overlay'}} {{if @institution 'institutions-overlay'}}'
     >
         {{#if @provider}}
             <div
@@ -14,31 +14,24 @@ as |layout|>
                 local-class='provider-logo'
             >
             </div>
-            <p data-test-search-provider-description>
+            <p local-class='provider-description' data-test-search-provider-description>
                 {{html-safe @provider.description}}
             </p>
         {{else if @institution}}
-            <div local-class='heading-wrapper-institutions'>
-                <label
-                    for='search-input'
-                    local-class='heading-label-institution'
+            {{#if this.showSidePanelToggle}}
+                <img
+                    data-test-institution-logo
+                    src={{@institution.logoRoundedUrl}}
+                    alt={{concat (t 'search.institutions.institution-logo') @institution.name}}
                 >
-                    {{#if this.showSidePanelToggle}}
-                        <img
-                            data-test-institution-logo
-                            src={{@institution.assets.logo}}
-                            alt={{concat (t 'search.institutions.institution-logo') @institution.name}}
-                        >
-                    {{else}}
-                        <img
-                            data-test-institution-banner
-                            src={{@institution.assets.banner}}
-                            alt={{concat (t 'search.institutions.institution-logo') @institution.name}}
-                        >
-                    {{/if}}
-                    <p data-test-institution-description>{{html-safe @institution.description}}</p>
-                </label>
-            </div>
+            {{else}}
+                <img
+                    data-test-institution-banner
+                    src={{@institution.bannerUrl}}
+                    alt={{concat (t 'search.institutions.institution-logo') @institution.name}}
+                >
+            {{/if}}
+            <p local-class='provider-description' data-test-institution-description>{{html-safe @institution.description}}</p>
         {{else}}
             <label
                 data-test-search-header


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Make institution logo show up
- Update institutions header background color

## Summary of Changes
- Update institution logo image `src`
- Add `institutions-overlay` style to add plain grey background to header

## Screenshot(s)
- Institutions discover page header (Desktop): Before
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/8eb0fda5-afb6-44be-935a-4462e9d81e4b)

- Institutions discover page header (Desktop): After
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/d60fa47f-f51c-41c3-8242-014ac13f5b38)

- Institutions discover page header (Mobile): After
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/4bd287ae-8687-431d-b14e-68bb57fe0b0d)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
