### PR TITLE
Reroute for registry not found

### DIFF
--- a/lib/registries/addon/branded/discover/route.ts
+++ b/lib/registries/addon/branded/discover/route.ts
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 
+import RegistrationProviderModel from 'ember-osf-web/models/registration-provider';
 import { notFoundURL } from 'ember-osf-web/utils/clean-url';
 
 export default class BrandedRegistriesDiscoverRoute extends Route {

--- a/lib/registries/addon/branded/route.ts
+++ b/lib/registries/addon/branded/route.ts
@@ -4,14 +4,20 @@ import { inject as service } from '@ember/service';
 
 import RegistrationProviderModel from 'ember-osf-web/models/registration-provider';
 import MetaTags, { HeadTagDef } from 'ember-osf-web/services/meta-tags';
+import { notFoundURL } from 'ember-osf-web/utils/clean-url';
 
 export default class BrandedRegistriesRoute extends Route {
     @service store!: Store;
     @service metaTags!: MetaTags;
     headTags?: HeadTagDef[];
 
-    model(params: { providerId: string }) {
-        return this.store.findRecord('registration-provider', params.providerId, { include: 'brand' });
+    async model(params: { providerId: string }) {
+        try {
+            return await this.store.findRecord('registration-provider', params.providerId, { include: 'brand' });
+        } catch (e) {
+            this.transitionTo('page-not-found', notFoundURL(window.location.pathname));
+            return null;
+        }
     }
 
     afterModel(model: RegistrationProviderModel) {


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [[Notion Card]](https://www.notion.so/cos/Going-to-an-invalid-registry-s-discover-page-leads-to-a-blank-page-eb4488f6e231499a8ffdbbc659657ac8?pvs=4)
-   Feature flag: n/a

## Purpose
- Show page-not-found if you go to an invalid registry's discover page (e.g. https://osf.io/registries/foo/discover )

## Summary of Changes
- add `try catch` block to branded route
  - `await` the registration-provider

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
