### PR TITLE
Increase color contrast of link in help tour

### DIFF
--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -286,6 +286,12 @@
         margin: 25px 5px 0;
     }
 
+    .help-description {
+        a {
+            color: $color-link-lighter;
+        }
+    }
+
     .skip-button {
         color: $color-text-white;
         overflow: visible;

--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -282,7 +282,7 @@ as |layout|>
             <h2 local-class='search-help-header' data-test-help-heading-1>
                 {{t 'search.search-help.header-1'}}
             </h2>
-            <p data-test-help-body-1>{{t 'search.search-help.body-1' htmlSafe=true}}</p>
+            <p local-class='help-description' data-test-help-body-1>{{t 'search.search-help.body-1' htmlSafe=true}}</p>
             <span local-class='pagination'>
                 <p local-class='enumeration' data-test-help-enumeration-1>{{t 'search.search-help.index-1'}}</p>
                 <span local-class='help-button-wrapper'>
@@ -326,7 +326,7 @@ as |layout|>
             <h2 local-class='search-help-header' data-test-help-heading-2>
                 {{t 'search.search-help.header-2'}}
             </h2>
-            <p data-test-help-body-2>{{t 'search.search-help.body-2'}}</p>
+            <p local-class='help-description' data-test-help-body-2>{{t 'search.search-help.body-2'}}</p>
             <span local-class='pagination'>
                 <p local-class='enumeration' data-test-help-enumeration-2>{{t 'search.search-help.index-2'}}</p>
                 <span local-class='help-button-wrapper'>
@@ -370,7 +370,7 @@ as |layout|>
             <h2 local-class='search-help-header' data-test-help-heading-3>
                 {{t 'search.search-help.header-3'}}
             </h2>
-            <p data-test-help-body-3>{{t 'search.search-help.body-3' htmlSafe=true}}</p>
+            <p local-class='help-description' data-test-help-body-3>{{t 'search.search-help.body-3' htmlSafe=true}}</p>
             <span local-class='pagination'>
                 <p local-class='enumeration' data-test-help-enumeration-3>{{t 'search.search-help.index-3'}}</p>
                 <span local-class='help-button-wrapper'>


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [NotionCard](https://www.notion.so/cos/Search-Help-Feature-Appears-Empty-on-Branded-Registry-Discover-Pages-Because-the-Color-of-the-Text-i-0db1ca6d1c374d5a8f6c0925d03ae679?pvs=4)
-   Feature flag: n/a

## Purpose
- Increase color contrast of help link in search page help tour
<!-- Describe the purpose of your changes. -->

## Summary of Changes
- Use different color for links in help tour 
  - color contrast is now 4.32 (#15A5EB vs. #263947, which should pass for WCAG AA for large text (14px and bold, or 18pt or larger)
<!-- Briefly describe or list your changes. -->

## Screenshot(s)
Before:
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/ea27975e-aca2-428b-8016-6794adcbcdc5)

After:
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/9d453e2d-e05d-4606-a84d-0dcab163624e)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
