### PR TITLE
Add back accessService to SHARE request

### DIFF
--- a/app/adapters/share-adapter.ts
+++ b/app/adapters/share-adapter.ts
@@ -1,7 +1,17 @@
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
-import config from 'ember-get-config';
+import config from 'ember-osf-web/config/environment';
+
+const osfUrl = config.OSF.url;
 
 export default class ShareAdapter extends JSONAPIAdapter {
     host = config.OSF.shareBaseUrl.replace(/\/$/, ''); // Remove trailing slash to avoid // in URLs
     namespace = 'api/v3';
+
+    queryRecord(store: any, type: any, query: any) {
+        // check if we aren't serving locally, otherwise add accessService query param to card/value searches
+        if (['index-card-search', 'index-value-search'].includes(type.modelName) && !osfUrl.includes('localhost')) {
+            query.cardSearchFilter['accessService'] = osfUrl;
+        }
+        return super.queryRecord(store, type, query);
+    }
 }

--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -11,6 +11,7 @@ import Store from '@ember-data/store';
 import { action } from '@ember/object';
 import Media from 'ember-responsive';
 
+import config from 'ember-osf-web/config/environment';
 import { ShareMoreThanTenThousand } from 'ember-osf-web/models/index-card-search';
 import SearchResultModel from 'ember-osf-web/models/search-result';
 import ProviderModel from 'ember-osf-web/models/provider';
@@ -66,6 +67,7 @@ interface SearchArgs {
     activeFilters: Filter[];
 }
 
+const osfURL = config.OSF.url;
 const searchDebounceTime = 100;
 
 export default class SearchPage extends Component<SearchArgs> {
@@ -219,6 +221,10 @@ export default class SearchPage extends Component<SearchArgs> {
                 resourceTypeFilter = Object.values(ResourceTypeFilterValue).join(',');
             }
             filterQueryObject['resourceType'] = resourceTypeFilter;
+            // Add the accessService if we are not serving locally
+            if (!osfURL.includes('localhost')) {
+                filterQueryObject['accessService'] = osfURL; // Only fetch items from the current OSF environment
+            }
             filterQueryObject = { ...filterQueryObject, ...this.args.defaultQueryOptions };
             this.filterQueryObject = filterQueryObject;
             const searchResult = await this.store.queryRecord('index-card-search', {

--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -11,7 +11,6 @@ import Store from '@ember-data/store';
 import { action } from '@ember/object';
 import Media from 'ember-responsive';
 
-import config from 'ember-osf-web/config/environment';
 import { ShareMoreThanTenThousand } from 'ember-osf-web/models/index-card-search';
 import SearchResultModel from 'ember-osf-web/models/search-result';
 import ProviderModel from 'ember-osf-web/models/provider';
@@ -67,7 +66,6 @@ interface SearchArgs {
     activeFilters: Filter[];
 }
 
-const osfURL = config.OSF.url;
 const searchDebounceTime = 100;
 
 export default class SearchPage extends Component<SearchArgs> {
@@ -221,10 +219,6 @@ export default class SearchPage extends Component<SearchArgs> {
                 resourceTypeFilter = Object.values(ResourceTypeFilterValue).join(',');
             }
             filterQueryObject['resourceType'] = resourceTypeFilter;
-            // Add the accessService if we are not serving locally
-            if (!osfURL.includes('localhost')) {
-                filterQueryObject['accessService'] = osfURL; // Only fetch items from the current OSF environment
-            }
             filterQueryObject = { ...filterQueryObject, ...this.args.defaultQueryOptions };
             this.filterQueryObject = filterQueryObject;
             const searchResult = await this.store.queryRecord('index-card-search', {


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: []
-   Feature flag: n/a

## Purpose
- Add `accessService` query-param to SHARE requests to filter out items from other staging environments

## Summary of Changes
- Basically undoing this PR: https://github.com/CenterForOpenScience/ember-osf-web/pull/1997

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
