### PR TITLE
Darken institution description links

### DIFF
--- a/lib/osf-components/addon/components/search-page/styles.scss
+++ b/lib/osf-components/addon/components/search-page/styles.scss
@@ -164,6 +164,12 @@
         height: 70px;
         margin: 0 auto;
     }
+
+    .provider-description {
+        a {
+            color: $color-link-dark;
+        }
+    }
 }
 
 .search-input-wrapper {


### PR DESCRIPTION
-   Ticket: [Notion Card](https://www.notion.so/cos/Accessibility-Issue-Color-Contrast-on-Institution-Discover-Page-08359c9b31344379be0ad6efad2e711a?pvs=4)
-   Feature flag: n/a

## Purpose
- Address a11y issue

## Summary of Changes
- Increase institution description links to color contrast 4.98:1 (#2D6A9F vs #ECF0F1)

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
