### PR TITLE
Prevent mutation after consumption; Change arg name to something more…

### DIFF
--- a/app/institutions/discover/controller.ts
+++ b/app/institutions/discover/controller.ts
@@ -3,7 +3,9 @@ import { inject as service } from '@ember/service';
 import CurrentUser from 'ember-osf-web/services/current-user';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { Filter, OnSearchParams, ResourceTypeFilterValue } from 'osf-components/components/search-page/component';
+import {
+    Filter, OnQueryParamChangeParams, ResourceTypeFilterValue,
+} from 'osf-components/components/search-page/component';
 
 export default class InstitutionDiscoverController extends Controller {
     @service currentUser!: CurrentUser;
@@ -35,7 +37,7 @@ export default class InstitutionDiscoverController extends Controller {
     }
 
     @action
-    onSearch(queryOptions: OnSearchParams) {
+    onQueryParamChange(queryOptions: OnQueryParamChangeParams) {
         this.q = queryOptions.cardSearchText;
         this.sort = queryOptions.sort;
         this.resourceType = queryOptions.resourceType as ResourceTypeFilterValue;

--- a/app/institutions/discover/template.hbs
+++ b/app/institutions/discover/template.hbs
@@ -5,7 +5,7 @@
     @query={{this.q}}
     @defaultQueryOptions={{this.defaultQueryOptions}}
     @queryParams={{this.queryParams}}
-    @onSearch={{action this.onSearch}}
+    @onQueryParamChange={{action this.onQueryParamChange}}
     @resourceType={{this.resourceType}}
     @institution={{this.model}}
     @sort={{this.sort}}

--- a/app/preprints/discover/controller.ts
+++ b/app/preprints/discover/controller.ts
@@ -8,7 +8,7 @@ import config from 'ember-osf-web/config/environment';
 
 import Theme from 'ember-osf-web/services/theme';
 import pathJoin from 'ember-osf-web/utils/path-join';
-import { Filter, OnSearchParams } from 'osf-components/components/search-page/component';
+import { Filter, OnQueryParamChangeParams } from 'osf-components/components/search-page/component';
 
 export default class PreprintDiscoverController extends Controller {
     @service store!: Store;
@@ -28,7 +28,7 @@ export default class PreprintDiscoverController extends Controller {
     }
 
     @action
-    onSearch(queryOptions: OnSearchParams) {
+    onQueryParamChange(queryOptions: OnQueryParamChangeParams) {
         this.q = queryOptions.cardSearchText;
         this.sort = queryOptions.sort;
         this.activeFilters = queryOptions.activeFilters;

--- a/app/preprints/discover/template.hbs
+++ b/app/preprints/discover/template.hbs
@@ -8,7 +8,7 @@
         @showResourceTypeFilter={{false}}
         @provider={{this.model}}
         @queryParams={{this.queryParams}}
-        @onSearch={{action this.onSearch}}
+        @onQueryParamChange={{action this.onQueryParamChange}}
         @sort={{this.sort}}
         @activeFilters={{this.activeFilters}}
     />

--- a/app/search/controller.ts
+++ b/app/search/controller.ts
@@ -1,7 +1,9 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { Filter, OnSearchParams, ResourceTypeFilterValue } from 'osf-components/components/search-page/component';
+import {
+    Filter, OnQueryParamChangeParams, ResourceTypeFilterValue,
+} from 'osf-components/components/search-page/component';
 
 export default class SearchController extends Controller {
     @tracked q?: string = '';
@@ -12,7 +14,7 @@ export default class SearchController extends Controller {
     queryParams = ['q', 'sort', 'resourceType', 'activeFilters'];
 
     @action
-    onSearch(queryOptions: OnSearchParams) {
+    onQueryParamChange(queryOptions: OnQueryParamChangeParams) {
         this.q = queryOptions.cardSearchText;
         this.sort = queryOptions.sort;
         this.resourceType = queryOptions.resourceType;

--- a/app/search/template.hbs
+++ b/app/search/template.hbs
@@ -4,7 +4,7 @@
     @route='search'
     @cardSearchText={{this.q}}
     @queryParams={{this.queryParams}}
-    @onSearch={{action this.onSearch}}
+    @onQueryParamChange={{action this.onQueryParamChange}}
     @showResourceTypeFilter={{true}}
     @sort={{this.sort}}
     @resourceType={{this.resourceType}}

--- a/lib/registries/addon/branded/discover/controller.ts
+++ b/lib/registries/addon/branded/discover/controller.ts
@@ -6,7 +6,7 @@ import { inject as service } from '@ember/service';
 import Intl from 'ember-intl/services/intl';
 import Media from 'ember-responsive';
 import { tracked } from '@glimmer/tracking';
-import { Filter, OnSearchParams } from 'osf-components/components/search-page/component';
+import { Filter, OnQueryParamChangeParams } from 'osf-components/components/search-page/component';
 import pathJoin from 'ember-osf-web/utils/path-join';
 import config from 'ember-osf-web/config/environment';
 export default class BrandedDiscover extends Controller.extend() {
@@ -27,9 +27,9 @@ export default class BrandedDiscover extends Controller.extend() {
     }
 
     @action
-    onSearch(onSearchParams: OnSearchParams) {
-        this.cardSearchText = onSearchParams.cardSearchText;
-        this.sort = onSearchParams.sort;
-        this.activeFilters = onSearchParams.activeFilters;
+    onQueryParamChange(onQueryParamChangeParams: OnQueryParamChangeParams) {
+        this.cardSearchText = onQueryParamChangeParams.cardSearchText;
+        this.sort = onQueryParamChangeParams.sort;
+        this.activeFilters = onQueryParamChangeParams.activeFilters;
     }
 }

--- a/lib/registries/addon/branded/discover/template.hbs
+++ b/lib/registries/addon/branded/discover/template.hbs
@@ -11,7 +11,7 @@
         @queryParams={{this.queryParams}}
         @query={{this.q}}
         @sort={{this.sort}}
-        @onSearch={{action this.onSearch}}
+        @onQueryParamChange={{action this.onQueryParamChange}}
         @showResourceTypeFilter={{false}}
         @activeFilters={{this.activeFilters}}
     />


### PR DESCRIPTION
… appropriate

<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: []
-   Feature flag: n/a

## Purpose
- Prevent hitting this deprecation on search page (thank you @adlius for finding this): https://deprecations.emberjs.com/v3.x/#toc_autotracking-mutation-after-consumption

## Summary of Changes
- Move logic to update query params before the search task
- Rename `onSearch` argument to `onQueryParamChange` for more clarity

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
