### PR TITLE
[ENG-2224] "Edit Scopes" creates a new token

### DIFF
--- a/app/settings/tokens/edit/controller.ts
+++ b/app/settings/tokens/edit/controller.ts
@@ -23,9 +23,7 @@ export default class SettingsTokensEditController extends Controller {
     @action
     refresh() {
         this.clearTokenValue();
-
-        // Send action to route
-        this.send('refreshRoute');
+        this.router.transitionTo('settings.tokens');
     }
 
     clearTokenValue() {

--- a/app/settings/tokens/edit/template.hbs
+++ b/app/settings/tokens/edit/template.hbs
@@ -34,7 +34,7 @@
         <Button
             {{on 'click' (action this.refresh)}}
         >
-            {{t 'settings.tokens.createSuccess.editScopes'}}
+            {{t 'settings.tokens.createSuccess.close'}}
         </Button>
     {{else}}
         <h4>{{t 'settings.tokens.editToken'}}</h4>

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -2627,7 +2627,7 @@ settings:
             message: 'Token <strong>{tokenName}</strong> created:'
             instructions: 'This token will never expire. This token should never be shared with others. If it is accidentally revealed publicly, it should be deactivated immediately.'
             warning: 'This is the only time your token will be displayed.'
-            editScopes: 'Edit scopes'
+            close: 'Close'
 verifyEmail:
     merge:
         header: 'Merge account?'


### PR DESCRIPTION
-   Ticket: https://openscience.atlassian.net/browse/ENG-2224
-   GitHub branch: access-token-go-to-list

## Purpose

The purpose of these changes is to have the access token value page close and redirect the user to the token list view upon clicking the 'Close' button.

## Summary of Changes

- The 'Edit scopes' button was updated to 'Close'
- The template file was updated to point to the correct translation string
- The refresh method was updated to transition the user to the token list view

## Screenshot(s)

<img width="1564" alt="Pasted Graphic 28" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/82047646/21675305-20d5-4324-94d4-23448fe8781f">

## Side Effects

There should be no side effects.

## QA Notes

- Does the token value page close properly following clicking the 'Close' button
- Is the user redirected to the token list view?
