### PR TITLE
[ENG-4814] creator search

### DIFF
--- a/lib/app-components/addon/components/branded-navbar/styles.scss
+++ b/lib/app-components/addon/components/branded-navbar/styles.scss
@@ -2,7 +2,7 @@
 
 .branded-nav-wrapper {
     .branded-nav {
-        z-index: 999;
+        z-index: 998;
     }
 
     :global(.navbar) {

--- a/lib/osf-components/addon/components/osf-dialog/styles.scss
+++ b/lib/osf-components/addon/components/osf-dialog/styles.scss
@@ -11,7 +11,7 @@
     align-items: center;
     justify-content: center;
 
-    z-index: 1100;
+    z-index: 999;
     background-color: rgba(0, 0, 0, 0.5);
 }
 

--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -240,7 +240,7 @@ export default class SearchPage extends Component<SearchArgs> {
             }
             this.filterQueryObject = filterQueryObject;
             const searchResult = await this.store.queryRecord('index-card-search', {
-                cardSearchText,
+                'cardSearchText[*,creator.name]': cardSearchText,
                 'page[cursor]': page,
                 sort,
                 cardSearchFilter: filterQueryObject,

--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -240,7 +240,7 @@ export default class SearchPage extends Component<SearchArgs> {
             }
             this.filterQueryObject = filterQueryObject;
             const searchResult = await this.store.queryRecord('index-card-search', {
-                'cardSearchText[*,creator.name]': cardSearchText,
+                'cardSearchText[*,creator.name,isContainedBy.creator.name]': cardSearchText,
                 'page[cursor]': page,
                 sort,
                 cardSearchFilter: filterQueryObject,

--- a/lib/osf-components/addon/components/search-page/filter-facet/template.hbs
+++ b/lib/osf-components/addon/components/search-page/filter-facet/template.hbs
@@ -86,9 +86,10 @@
                         @search={{perform this.debouncedValueSearch}}
                         @onChange={{action this.updateSelectedProperty}}
                         @afterOptionsComponent={{component 'search-page/filter-facet/after-options' fetchValues=(perform this.loadMoreValues) hasMoreValues=this.hasMoreValueOptions}}
+                        @selectedItemComponent={{component 'search-page/filter-facet/value-option' isSelected=true}}
                         as |property|
                     >
-                        <span>{{property.indexCard.label}} ({{property.cardSearchResultCount}})</span>
+                        <SearchPage::FilterFacet::ValueOption @option={{property}} />
                     </PowerSelect>
                 </dialog.main>
                 <dialog.footer>

--- a/lib/osf-components/addon/components/search-page/filter-facet/value-option/component.ts
+++ b/lib/osf-components/addon/components/search-page/filter-facet/value-option/component.ts
@@ -1,0 +1,17 @@
+import Component from '@glimmer/component';
+
+import SearchResultModel from 'ember-osf-web/models/search-result';
+
+interface ValueOptionArgs {
+    option: SearchResultModel;
+    isSelected?: Boolean;
+}
+
+export default class ValueOption extends Component<ValueOptionArgs> {
+    get additionalDetail() {
+        const { affiliation: affiliatedEntities = [] } = this.args.option.resourceMetadata;
+        return affiliatedEntities.flatMap(
+            (entity: any) => entity.name?.map((name: any) => name['@value']),
+        ).filter(Boolean).join(', ');
+    }
+}

--- a/lib/osf-components/addon/components/search-page/filter-facet/value-option/styles.scss
+++ b/lib/osf-components/addon/components/search-page/filter-facet/value-option/styles.scss
@@ -1,0 +1,8 @@
+.SelectedValueOption {
+    margin-left: 0.5em;
+}
+
+.AdditionalDetail {
+    margin-left: 0.5em;
+    font-size: 0.8em;
+}

--- a/lib/osf-components/addon/components/search-page/filter-facet/value-option/template.hbs
+++ b/lib/osf-components/addon/components/search-page/filter-facet/value-option/template.hbs
@@ -1,0 +1,6 @@
+<div local-class={{if @isSelected 'SelectedValueOption'}}>
+    <div>{{@option.indexCard.label}} ({{@option.cardSearchResultCount}})</div>
+    {{#if this.additionalDetail}}
+        <div local-class='AdditionalDetail'>{{this.additionalDetail}}</div>
+    {{/if}}
+</div>

--- a/lib/osf-components/app/components/search-page/filter-facet/value-option/component.js
+++ b/lib/osf-components/app/components/search-page/filter-facet/value-option/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/search-page/filter-facet/value-option/component';

--- a/lib/osf-components/app/components/search-page/filter-facet/value-option/template.js
+++ b/lib/osf-components/app/components/search-page/filter-facet/value-option/template.js
@@ -1,0 +1,2 @@
+export { default } from 'osf-components/components/search-page/filter-facet/value-option/template';
+


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-4814]
-   Feature flag: n/a

## Purpose
allow searching by creator



<!-- Describe the purpose of your changes. -->

## Summary of Changes
- add `creator.name` to the properties used for free-text search (depends on https://github.com/CenterForOpenScience/SHARE/pull/812 )
- skip showing creators without a text query
- when searching within a filter facet, display affiliations
- fix a z-index bug so dropdown content is visible atop the dialog box
<!-- Briefly describe or list your changes. -->

## Screenshot(s)
https://github.com/CenterForOpenScience/ember-osf-web/assets/6776190/0bddf490-488e-4d1f-bae0-19e88b2fd264

user with affiliation:
<img width="735" alt="Screenshot 2023-10-19 at 13 19 03" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6776190/eab6ccb6-2b0f-4b45-9a7b-bf9d3626b754">



z-index bug (before fix):

https://github.com/CenterForOpenScience/ember-osf-web/assets/6776190/1588b69e-991d-4907-9321-735800cc6854


<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-4814]: https://openscience.atlassian.net/browse/ENG-4814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ