### PR TITLE
[ENG-4818] Use provider favicon for preprint discover page

### DIFF
--- a/app/preprints/discover/route.ts
+++ b/app/preprints/discover/route.ts
@@ -3,13 +3,17 @@ import Route from '@ember/routing/route';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 import config from 'ember-osf-web/config/environment';
+import PreprintProviderModel from 'ember-osf-web/models/preprint-provider';
 
+import MetaTags, { HeadTagDef } from 'ember-osf-web/services/meta-tags';
 import Theme from 'ember-osf-web/services/theme';
 
 export default class PreprintDiscoverRoute extends Route {
     @service store!: Store;
     @service theme!: Theme;
     @service router!: RouterService;
+    @service metaTags!: MetaTags;
+    headTags?: HeadTagDef[];
 
     buildRouteInfoMetadata() {
         return {
@@ -33,6 +37,20 @@ export default class PreprintDiscoverRoute extends Route {
         } catch (e) {
             this.router.transitionTo('not-found', `preprints/${args.provider_id}/discover`);
             return null;
+        }
+    }
+
+    // TODO: Move this to app/preprints/index/route.ts when landing page PR is merged
+    afterModel(model: PreprintProviderModel) {
+        if (model && model.assets && model.assets.favicon) {
+            const headTags = [{
+                type: 'link',
+                attrs: {
+                    rel: 'icon',
+                    href: model.assets.favicon,
+                },
+            }];
+            this.set('headTags', headTags);
         }
     }
 


### PR DESCRIPTION
-   Ticket: [ENG-4818]
-   Feature flag: n/a

## Purpose
- Use provider's favicon when looking at branded preprint discover page

## Summary of Changes
- Add afterModel hook to preprint-discover route to add favicon (same logic as lib/registries/addon/branded/route.ts)
  - Can move this afterModel hook  to parent route once preprints landing page rewrite

## Screenshot(s)
- favicon associated with a preprint-provider in admin app and used in the browser tab below
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/2c8af403-c3bf-4118-b0b7-f29c60c079f1)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- Please make sure the preprint provider is using a given favicon in the admin app by going to `admin.staging.osf.io/provider_asset_files/<asset_id>/`


[ENG-4818]: https://openscience.atlassian.net/browse/ENG-4818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ