### PR TITLE
fix: consistent cardSearchText for value-search

### DIFF
--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -23,6 +23,8 @@ interface ResourceTypeOption {
     value?: ResourceTypeFilterValue | null;
 }
 
+export const CARD_SEARCH_TEXT_PARAM = 'cardSearchText[*,creator.name,isContainedBy.creator.name]';
+
 export enum ResourceTypeFilterValue {
     Registrations = 'Registration,RegistrationComponent',
     Projects = 'Project,ProjectComponent',
@@ -240,7 +242,7 @@ export default class SearchPage extends Component<SearchArgs> {
             }
             this.filterQueryObject = filterQueryObject;
             const searchResult = await this.store.queryRecord('index-card-search', {
-                'cardSearchText[*,creator.name,isContainedBy.creator.name]': cardSearchText,
+                [CARD_SEARCH_TEXT_PARAM]: cardSearchText,
                 'page[cursor]': page,
                 sort,
                 cardSearchFilter: filterQueryObject,

--- a/lib/osf-components/addon/components/search-page/filter-facet/component.ts
+++ b/lib/osf-components/addon/components/search-page/filter-facet/component.ts
@@ -11,7 +11,7 @@ import RelatedPropertyPathModel from 'ember-osf-web/models/related-property-path
 
 import SearchResultModel from 'ember-osf-web/models/search-result';
 
-import { Filter } from '../component';
+import { Filter, CARD_SEARCH_TEXT_PARAM } from '../component';
 
 interface FakeIndexCard {
     resourceId: string;
@@ -123,7 +123,7 @@ export default class FilterFacet extends Component<FilterFacetArgs> {
             return;  // skip fetching
         }
         const valueSearch = await this.store.queryRecord('index-value-search', {
-            cardSearchText,
+            [CARD_SEARCH_TEXT_PARAM]: cardSearchText,
             cardSearchFilter,
             valueSearchPropertyPath: property.propertyPathKey,
             valueSearchText: filterString || '',


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: []
-   Feature flag: n/a

## Purpose
correct creator-facet behavior when already searching by creator name in free-text search
<!-- Describe the purpose of your changes. -->

## Summary of Changes
send same `cardSearchText` param for index-value-search as already used for index-card-search
<!-- Briefly describe or list your changes. -->

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
on the search page:
1. search by a creator name in the main search box (note the creator in search results)
2. click on the "Creator" facet and search by the same creator name
3. should be able to select and filter by the creator in question
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
