### PR TITLE
[ENG-4838] Update search-result card to show preprint word

### DIFF
--- a/lib/osf-components/addon/components/search-page/template.hbs
+++ b/lib/osf-components/addon/components/search-page/template.hbs
@@ -227,7 +227,7 @@ as |layout|>
             <LoadingIndicator @size='large' @dark={{true}} />
         {{else}}
             {{#each this.searchResults as |item|}}
-                <SearchResultCard @result={{item}} />
+                <SearchResultCard @result={{item}} @provider={{@provider}} />
             {{else}}
                 <div local-class='no-results'>
                     <p data-test-search-page-no-results>{{t 'search.no-results'}}</p>

--- a/lib/osf-components/addon/components/search-result-card/component.ts
+++ b/lib/osf-components/addon/components/search-result-card/component.ts
@@ -37,9 +37,10 @@ export default class SearchResultCard extends Component<Args> {
     }
 
     get cardTypeLabel() {
-        const preprintWord = this.args.provider?.preprintWord;
-        return (preprintWord && this.args.result.resourceType === 'preprint') ? preprintWord :
-            this.intl.t(CardLabelTranslationKeys[this.args.result.resourceType]);
+        const provider = this.args.provider;
+        const resourceType = this.args.result.resourceType;
+        return (provider?.preprintWord && resourceType === 'preprint') ? provider.documentType.singularCapitalized :
+            this.intl.t(CardLabelTranslationKeys[resourceType]);
     }
 
     get secondaryMetadataComponent() {

--- a/lib/osf-components/addon/components/search-result-card/component.ts
+++ b/lib/osf-components/addon/components/search-result-card/component.ts
@@ -6,10 +6,11 @@ import { tracked } from '@glimmer/tracking';
 import Intl from 'ember-intl/services/intl';
 
 import SearchResultModel from 'ember-osf-web/models/search-result';
-import UserModel from 'ember-osf-web/models/user';
+import PreprintProviderModel from 'ember-osf-web/models/preprint-provider';
 
 interface Args {
     result: SearchResultModel;
+    provider?: PreprintProviderModel;
 }
 
 export default class SearchResultCard extends Component<Args> {
@@ -17,7 +18,6 @@ export default class SearchResultCard extends Component<Args> {
     @service store!: Store;
 
     @tracked isOpenSecondaryMetadata = false;
-    @tracked osfUser?: UserModel;
 
     @action
     toggleSecondaryMetadata() {
@@ -25,7 +25,9 @@ export default class SearchResultCard extends Component<Args> {
     }
 
     get cardTypeLabel() {
-        return this.intl.t(`osf-components.search-result-card.${this.args.result.resourceType}`);
+        const preprintWord = this.args.provider?.preprintWord;
+        return (preprintWord && this.args.result.resourceType === 'preprint') ? preprintWord :
+            this.intl.t(`osf-components.search-result-card.${this.args.result.resourceType}`);
     }
 
     get secondaryMetadataComponent() {

--- a/lib/osf-components/addon/components/search-result-card/component.ts
+++ b/lib/osf-components/addon/components/search-result-card/component.ts
@@ -8,6 +8,18 @@ import Intl from 'ember-intl/services/intl';
 import SearchResultModel from 'ember-osf-web/models/search-result';
 import PreprintProviderModel from 'ember-osf-web/models/preprint-provider';
 
+
+const CardLabelTranslationKeys = {
+    project: 'osf-components.search-result-card.project',
+    project_component: 'osf-components.search-result-card.project_component',
+    registration: 'osf-components.search-result-card.registration',
+    registration_component: 'osf-components.search-result-card.registration_component',
+    preprint: 'osf-components.search-result-card.preprint',
+    file: 'osf-components.search-result-card.file',
+    user: 'osf-components.search-result-card.user',
+    unknown: 'osf-components.search-result-card.unknown',
+};
+
 interface Args {
     result: SearchResultModel;
     provider?: PreprintProviderModel;
@@ -27,7 +39,7 @@ export default class SearchResultCard extends Component<Args> {
     get cardTypeLabel() {
         const preprintWord = this.args.provider?.preprintWord;
         return (preprintWord && this.args.result.resourceType === 'preprint') ? preprintWord :
-            this.intl.t(`osf-components.search-result-card.${this.args.result.resourceType}`);
+            this.intl.t(CardLabelTranslationKeys[this.args.result.resourceType]);
     }
 
     get secondaryMetadataComponent() {

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1878,7 +1878,7 @@ osf-components:
         date_modified: Date modified
         last_edited: Last edited
         member_since: Member since
-        preprint_provider: Preprint provider
+        preprint_provider: Provider
         registration_provider: Registration provider
         conflict_of_interest: Conflict of Interest response
         no_conflict_of_interest: 'Author asserted no Conflict of Interest'


### PR DESCRIPTION
-   Ticket: [ENG-4838]
-   Feature flag: n/a

## Purpose
- Don't show "PREPRINT" on search result card for branded preprint provider discover page

## Summary of Changes
- Pass provider to search-result card
  - Check result type and provider's `preprintWord`
- Update `Preprint Provider` word to just `Provider`

## Screenshot(s)
- For preprint provider's discover page:
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/356a196f-ad5e-4202-a26d-d1fe28a4554f)

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-4838]: https://openscience.atlassian.net/browse/ENG-4838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ