### PR TITLE
[ENG-4822] Adjust z-index for general osf navbar

### DIFF
--- a/app/styles/_global.scss
+++ b/app/styles/_global.scss
@@ -337,7 +337,7 @@ fieldset[disabled] .form-control {
     position: fixed;
     right: 0;
     left: 0;
-    z-index: 1030;
+    z-index: 998;
 }
 
 .navbar-inverse .navbar-collapse,


### PR DESCRIPTION
-   Ticket: [ENG-4822]
-   Feature flag: n/a

## Purpose
- Place modal controls over navbar (initially resolved in ENG-4091)

## Summary of Changes
- Adjust z-index of navbar class to be below the DialogBackground z-index

## Screenshot(s)
- Prevents this behavior:
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/48ca8b17-2236-43ec-8521-4107331bdd36)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
