### PR TITLE
Broaden how we find orcid ids

### DIFF
--- a/app/models/search-result.ts
+++ b/app/models/search-result.ts
@@ -245,7 +245,7 @@ export default class SearchResultModel extends Model {
     get orcids() {
         if (this.resourceMetadata.identifier) {
             const orcids = this.resourceMetadata.identifier.filter(
-                (item: any) => item['@value'].includes('http://orcid.org/'),
+                (item: any) => item['@value'].includes('orcid.org/'),
             );
             return orcids.map( (item: any) => item['@value']);
         }

--- a/app/models/search-result.ts
+++ b/app/models/search-result.ts
@@ -245,7 +245,7 @@ export default class SearchResultModel extends Model {
     get orcids() {
         if (this.resourceMetadata.identifier) {
             const orcids = this.resourceMetadata.identifier.filter(
-                (item: any) => item['@value'].includes('orcid.org/'),
+                (item: any) => new URL(item['@value']).host === 'orcid.org',
             );
             return orcids.map( (item: any) => item['@value']);
         }


### PR DESCRIPTION
-   Ticket: [ENG-4760]
-   Feature flag: n/a

## Purpose
- Show ORCID ids on search result cards regardless of protocol

## Summary of Changes
- Look for `orcid.org` in the identifiers array instead of `http://orcid.org`, as some results were using the `https` protocol in the identifier

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-4760]: https://openscience.atlassian.net/browse/ENG-4760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ