### PR TITLE
 [ENG-4687] Add v2 models, adapters, and serializers

### DIFF
--- a/app/adapters/addon.ts
+++ b/app/adapters/addon.ts
@@ -1,0 +1,10 @@
+import OsfAdapter from './osf-adapter';
+
+export default class AddonAdapter extends OsfAdapter {
+}
+
+declare module 'ember-data/types/registries/adapter' {
+    export default interface AdapterRegistry {
+        addon: AddonAdapter;
+    } // eslint-disable-line semi
+}

--- a/app/adapters/external-account.ts
+++ b/app/adapters/external-account.ts
@@ -1,0 +1,10 @@
+import OsfAdapter from './osf-adapter';
+
+export default class ExternalAccountAdapter extends OsfAdapter {
+}
+
+declare module 'ember-data/types/registries/adapter' {
+    export default interface AdapterRegistry {
+        'external-account': ExternalAccountAdapter;
+    } // eslint-disable-line semi
+}

--- a/app/adapters/node-addon.ts
+++ b/app/adapters/node-addon.ts
@@ -1,0 +1,10 @@
+import OsfAdapter from './osf-adapter';
+
+export default class NodeAddonAdapter extends OsfAdapter {
+}
+
+declare module 'ember-data/types/registries/adapter' {
+    export default interface AdapterRegistry {
+        'node-addon': NodeAddonAdapter;
+    } // eslint-disable-line semi
+}

--- a/app/adapters/user-addon.ts
+++ b/app/adapters/user-addon.ts
@@ -1,0 +1,10 @@
+import OsfAdapter from './osf-adapter';
+
+export default class UserAddonAdapter extends OsfAdapter {
+}
+
+declare module 'ember-data/types/registries/adapter' {
+    export default interface AdapterRegistry {
+        'user-addon': UserAddonAdapter;
+    } // eslint-disable-line semi
+}

--- a/app/models/addon.ts
+++ b/app/models/addon.ts
@@ -1,0 +1,14 @@
+import { attr } from '@ember-data/model';
+
+import OsfModel from './osf-model';
+
+export default class AddonModel extends OsfModel {
+    @attr('string') name!: string;
+    @attr('array') categories!: string[];
+}
+
+declare module 'ember-data/types/registries/model' {
+    export default interface ModelRegistry {
+        addon: AddonModel;
+    } // eslint-disable-line semi
+}

--- a/app/models/external-accounts.ts
+++ b/app/models/external-accounts.ts
@@ -1,0 +1,15 @@
+import { attr } from '@ember-data/model';
+
+import OsfModel from './osf-model';
+
+export default class ExternalAccountsModel extends OsfModel {
+    @attr('string') provider!: string;
+    @attr('string') profileUrl?: string;
+    @attr('string') displayName!: string;
+}
+
+declare module 'ember-data/types/registries/model' {
+    export default interface ModelRegistry {
+        'external-account': ExternalAccountsModel;
+    } // eslint-disable-line semi
+}

--- a/app/models/external-accounts.ts
+++ b/app/models/external-accounts.ts
@@ -4,8 +4,8 @@ import OsfModel from './osf-model';
 
 export default class ExternalAccountsModel extends OsfModel {
     @attr('string') provider!: string;
-    @attr('string') profileUrl?: string;
-    @attr('string') displayName!: string;
+    @attr('fixstring') profileUrl?: string;
+    @attr('fixstring') displayName!: string;
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/models/node-addon.ts
+++ b/app/models/node-addon.ts
@@ -1,0 +1,17 @@
+import { attr } from '@ember-data/model';
+
+import OsfModel from './osf-model';
+
+export default class NodeAddonModel extends OsfModel {
+    @attr('boolean') nodeHasAuth!: boolean;
+    @attr('boolean') configured!: boolean;
+    @attr('string') external_account_id!: string;
+    @attr('string') folder_id?: string;
+    @attr('string') folder_path?: string;
+}
+
+declare module 'ember-data/types/registries/model' {
+    export default interface ModelRegistry {
+        'node-addon': NodeAddonModel;
+    } // eslint-disable-line semi
+}

--- a/app/models/node-addon.ts
+++ b/app/models/node-addon.ts
@@ -5,9 +5,9 @@ import OsfModel from './osf-model';
 export default class NodeAddonModel extends OsfModel {
     @attr('boolean') nodeHasAuth!: boolean;
     @attr('boolean') configured!: boolean;
-    @attr('string') external_account_id!: string;
-    @attr('string') folder_id?: string;
-    @attr('string') folder_path?: string;
+    @attr('string') externalAccountId!: string;
+    @attr('string') folderId?: string;
+    @attr('string') folderPath?: string;
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/models/user-addon.ts
+++ b/app/models/user-addon.ts
@@ -1,0 +1,19 @@
+import { AsyncHasMany, attr, hasMany } from '@ember-data/model';
+
+import ExternalAccountsModel from 'ember-osf-web/models/external-accounts';
+
+import OsfModel from './osf-model';
+
+
+export default class UserAddonModel extends OsfModel {
+    @attr('boolean') userHasAuth!: boolean;
+
+    @hasMany('external-accounts', { inverse: null })
+    externalAccounts!: AsyncHasMany<ExternalAccountsModel> & ExternalAccountsModel[];
+}
+
+declare module 'ember-data/types/registries/model' {
+    export default interface ModelRegistry {
+        'user-addon': UserAddonModel;
+    } // eslint-disable-line semi
+}

--- a/app/serializers/addon.ts
+++ b/app/serializers/addon.ts
@@ -1,0 +1,10 @@
+import OsfSerializer from './osf-serializer';
+
+export default class AddonSerializer extends OsfSerializer {
+}
+
+declare module 'ember-data/types/registries/serializer' {
+    export default interface SerializerRegistry {
+        addon: AddonSerializer;
+    } // eslint-disable-line semi
+}

--- a/app/serializers/external-account.ts
+++ b/app/serializers/external-account.ts
@@ -1,0 +1,10 @@
+import OsfSerializer from './osf-serializer';
+
+export default class ExternalAccountSerializer extends OsfSerializer {
+}
+
+declare module 'ember-data/types/registries/serializer' {
+    export default interface SerializerRegistry {
+        'external-account': ExternalAccountSerializer;
+    } // eslint-disable-line semi
+}

--- a/app/serializers/node-addon.ts
+++ b/app/serializers/node-addon.ts
@@ -1,0 +1,10 @@
+import OsfSerializer from './osf-serializer';
+
+export default class NodeAddonSerializer extends OsfSerializer {
+}
+
+declare module 'ember-data/types/registries/serializer' {
+    export default interface SerializerRegistry {
+        'node-addon': NodeAddonSerializer;
+    } // eslint-disable-line semi
+}

--- a/app/serializers/user-addon.ts
+++ b/app/serializers/user-addon.ts
@@ -1,0 +1,10 @@
+import OsfSerializer from './osf-serializer';
+
+export default class UserAddonSerializer extends OsfSerializer {
+}
+
+declare module 'ember-data/types/registries/serializer' {
+    export default interface SerializerRegistry {
+        'user-addon': UserAddonSerializer;
+    } // eslint-disable-line semi
+}


### PR DESCRIPTION
-   Ticket: [ENG-4687]

## Purpose

Add models, adapters, and serializers for various v2 endpoints we'll need for addons. Note that some of this does not reflect the BE as it exists today, but is a bit aspirational. That being said, it does not include all the changes we ultimately want, just the ones that are necessary to make this function in a sane manner.

## Summary of Changes

1. Add addon, external-account, node-addon, and user-addon models, adapters, and serializers


[ENG-4687]: https://openscience.atlassian.net/browse/ENG-4687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ