### PR TITLE
Boa bugs

### DIFF
--- a/lib/osf-components/addon/components/file-actions-menu/component.ts
+++ b/lib/osf-components/addon/components/file-actions-menu/component.ts
@@ -5,6 +5,7 @@ import { inject as service } from '@ember/service';
 import Media from 'ember-responsive';
 import File from 'ember-osf-web/packages/files/file';
 import StorageManager from 'osf-components/components/storage-provider-manager/storage-manager/component';
+import OsfStorageFile from 'ember-osf-web/packages/files/osf-storage-file';
 
 interface Args {
     item: File;
@@ -52,7 +53,17 @@ export default class FileActionsMenu extends Component<Args> {
     }
 
     get showSubmitToBoa() {
-        const { item } = this.args;
-        return this.isBoaEnabled && item.isBoaFile && item.providerIsOsfstorage && item.currentUserCanDelete;
+        const { item, manager } = this.args;
+        if (item.providerIsOsfstorage) {
+            let userCanUploadToHere;
+            if (manager) {
+                userCanUploadToHere = manager.currentFolder.userCanUploadToHere;
+            } else {
+                const parentFolder = new OsfStorageFile(item.currentUser, item.fileModel.get('parentFolder'));
+                userCanUploadToHere = parentFolder.userCanUploadToHere;
+            }
+            return this.isBoaEnabled && item.isBoaFile && userCanUploadToHere;
+        }
+        return false;
     }
 }

--- a/lib/osf-components/addon/components/file-actions-menu/submit-to-boa-modal/component.ts
+++ b/lib/osf-components/addon/components/file-actions-menu/submit-to-boa-modal/component.ts
@@ -18,7 +18,6 @@ interface Args {
 export default class SubmitToBoaModal extends Component<Args> {
     @service toast!: Toastr;
     @service intl!: IntlService;
-    datasets?: string[];
     @tracked selectedDataset?: string;
 
     datasets = [
@@ -63,6 +62,7 @@ export default class SubmitToBoaModal extends Component<Args> {
                     nodeId: fileModel.target.get('id'),
                     name: file.name,
                     materialized: fileModel.materializedPath,
+                    size: fileModel.size,
                     links: {
                         download: file.links.download,
                         upload: file.links.upload,

--- a/lib/osf-components/addon/components/file-actions-menu/submit-to-boa-modal/component.ts
+++ b/lib/osf-components/addon/components/file-actions-menu/submit-to-boa-modal/component.ts
@@ -62,7 +62,7 @@ export default class SubmitToBoaModal extends Component<Args> {
                     nodeId: fileModel.target.get('id'),
                     name: file.name,
                     materialized: fileModel.materializedPath,
-                    size: fileModel.size,
+                    sizeInt: fileModel.size,
                     links: {
                         download: file.links.download,
                         upload: file.links.upload,

--- a/mirage/scenarios/dashboard.ts
+++ b/mirage/scenarios/dashboard.ts
@@ -58,6 +58,7 @@ export function dashboardScenario(server: Server, currentUser: ModelInstance<Use
     server.create('file', {
         id: 'snake',
         name: 'snake.boa',
+        checkout: currentUser.id,
         target: filesNode,
         parentFolder: filesNodeOsfStorage.rootFolder,
     });


### PR DESCRIPTION
-   Ticket: [NotionCard](https://www.notion.so/cos/Cannot-submit-to-Boa-on-a-checked-out-file-on-emberized-pages-5c17502c859b44b69aacb8786c230174?pvs=4)
-   Feature flag: n/a

## Purpose
- Allow users to submit checked out files to boa
- Add file size to boa request

## Summary of Changes
- Use `userCanUploadToHere` of `currentFolder` (file-list view) or `parentFolder` (file-detail view) instead of `currentUserCanDelete` to check whether or not to show "Submit to Boa" option
- Add FileModel.size to boa requests
- Remove redundant `datasets` definition in `submit-to-boa/component.ts`

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
