### PR TITLE
Address bugs in file-detail page

### DIFF
--- a/lib/osf-components/addon/components/file-actions-menu/component.ts
+++ b/lib/osf-components/addon/components/file-actions-menu/component.ts
@@ -5,7 +5,7 @@ import { inject as service } from '@ember/service';
 import Media from 'ember-responsive';
 import File from 'ember-osf-web/packages/files/file';
 import StorageManager from 'osf-components/components/storage-provider-manager/storage-manager/component';
-import OsfStorageFile from 'ember-osf-web/packages/files/osf-storage-file';
+import NodeModel from 'ember-osf-web/models/node';
 
 interface Args {
     item: File;
@@ -54,15 +54,16 @@ export default class FileActionsMenu extends Component<Args> {
 
     get showSubmitToBoa() {
         const { item, manager } = this.args;
-        if (item.providerIsOsfstorage) {
+        if (item.providerIsOsfstorage && item.isBoaFile && this.isBoaEnabled) {
             let userCanUploadToHere;
             if (manager) {
                 userCanUploadToHere = manager.currentFolder.userCanUploadToHere;
             } else {
-                const parentFolder = new OsfStorageFile(item.currentUser, item.fileModel.get('parentFolder'));
-                userCanUploadToHere = parentFolder.userCanUploadToHere;
+                const storage = (item.fileModel.target as unknown as NodeModel).get('storage');
+                const writableTarget = item.currentUserPermission === 'write' && !item.targetIsRegistration;
+                userCanUploadToHere = writableTarget && !storage.get('isOverStorageCap');
             }
-            return this.isBoaEnabled && item.isBoaFile && userCanUploadToHere;
+            return userCanUploadToHere;
         }
         return false;
     }

--- a/lib/osf-components/addon/components/file-actions-menu/template.hbs
+++ b/lib/osf-components/addon/components/file-actions-menu/template.hbs
@@ -128,11 +128,13 @@
     </dropdown.content>
 </ResponsiveDropdown>
 <FileActionsMenu::DeleteModal @file={{@item}} @isOpen={{this.isDeleteModalOpen}} @closeModal={{this.closeDeleteModal}} @onDelete={{@onDelete}} />
-<FileActionsMenu::SubmitToBoaModal
-    @file={{@item}}
-    @isOpen={{this.isSubmitToBoaModalOpen}}
-    @closeModal={{this.closeSubmitToBoaModal}}
-/>
+{{#if this.showSubmitToBoa}}
+    <FileActionsMenu::SubmitToBoaModal
+        @file={{@item}}
+        @isOpen={{this.isSubmitToBoaModalOpen}}
+        @closeModal={{this.closeSubmitToBoaModal}}
+    />
+{{/if}}
 {{#if @manager}}
     <MoveFileModal
         @isOpen={{this.moveModalOpen}}


### PR DESCRIPTION
-   Ticket: [Notion Card 1](https://www.notion.so/cos/Files-Detail-Page-There-s-to-cancel-the-kebob-menu-fa7d22471f164d979adf13f2de686748?pvs=4) [Notion Card 2]
(https://www.notion.so/cos/Submit-to-Boa-not-present-on-file-detail-page-4366c4f5864147c8bd7d6338b9e003d3?pvs=4)
-   Feature flag: n/a

## Purpose
- Show "Submit to Boa" for file detail page properly
- Avoid issue with mobile view where modal wasn't closable due to the error that was caused by this bug

## Summary of Changes
- Avoid using `parentFolder.userCanUploadToHere` as this was causing issues due to some unresolved promises (`target` specifically)
  - `showSubmitToBoa` will now basically do the same check as `userCanUploadToHere` sans `this.isFolder` condition

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
