### PR TITLE
[ENG-4681] Add mirage for v2 api

### DIFF
--- a/app/models/external-accounts.ts
+++ b/app/models/external-accounts.ts
@@ -1,11 +1,18 @@
-import { attr } from '@ember-data/model';
+import { AsyncBelongsTo, attr, belongsTo } from '@ember-data/model';
 
+import AddonModel from 'ember-osf-web/models/addon';
+import UserModel from 'ember-osf-web/models/user';
 import OsfModel from './osf-model';
 
 export default class ExternalAccountsModel extends OsfModel {
-    @attr('string') provider!: string;
     @attr('fixstring') profileUrl?: string;
     @attr('fixstring') displayName!: string;
+
+    @belongsTo('addon', { inverse: null })
+    provider!: AsyncBelongsTo<AddonModel> & AddonModel;
+
+    @belongsTo('user', { inverse: null} )
+    user!: AsyncBelongsTo<UserModel> & UserModel;
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/models/node-addon.ts
+++ b/app/models/node-addon.ts
@@ -1,13 +1,21 @@
-import { attr } from '@ember-data/model';
+import { AsyncBelongsTo, attr, belongsTo } from '@ember-data/model';
+
+import ExternalAccountsModel from 'ember-osf-web/models/external-accounts';
+import NodeModel from 'ember-osf-web/models/node';
 
 import OsfModel from './osf-model';
 
 export default class NodeAddonModel extends OsfModel {
     @attr('boolean') nodeHasAuth!: boolean;
     @attr('boolean') configured!: boolean;
-    @attr('string') externalAccountId!: string;
     @attr('string') folderId?: string;
     @attr('string') folderPath?: string;
+
+    @belongsTo('node', { inverse: 'nodeAddons' })
+    node!: AsyncBelongsTo<NodeModel> & NodeModel;
+
+    @belongsTo('external-account', { inverse: null })
+    externalAccount!: AsyncBelongsTo<ExternalAccountsModel> & ExternalAccountsModel;
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/models/node.ts
+++ b/app/models/node.ts
@@ -10,6 +10,7 @@ import Intl from 'ember-intl/services/intl';
 import getRelatedHref from 'ember-osf-web/utils/get-related-href';
 
 import AbstractNodeModel from 'ember-osf-web/models/abstract-node';
+import NodeAddonModel from 'ember-osf-web/models/node-addon';
 import CitationModel from './citation';
 import CommentModel from './comment';
 import ContributorModel from './contributor';
@@ -176,6 +177,9 @@ export default class NodeModel extends AbstractNodeModel.extend(Validations, Col
 
     @hasMany('subject', { inverse: null, async: false })
     subjects!: SubjectModel[];
+
+    @hasMany('node-addon', { inverse: 'node' })
+    nodeAddons!: AsyncHasMany<NodeAddonModel>;
 
     // These are only computeds because maintaining separate flag values on
     // different classes would be a headache TODO: Improve.

--- a/app/models/user-addon.ts
+++ b/app/models/user-addon.ts
@@ -17,7 +17,7 @@ export default class UserAddonModel extends OsfModel {
     user!: AsyncBelongsTo<UserModel> & UserModel;
 
     @belongsTo('addon', { inverse: null })
-    addon!: AsyncBelongsTo<AddonModel>;
+    addon!: AsyncBelongsTo<AddonModel> & AddonModel;
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/models/user-addon.ts
+++ b/app/models/user-addon.ts
@@ -1,6 +1,8 @@
-import { AsyncHasMany, attr, hasMany } from '@ember-data/model';
+import { AsyncBelongsTo, AsyncHasMany, attr, belongsTo, hasMany } from '@ember-data/model';
 
+import AddonModel from 'ember-osf-web/models/addon';
 import ExternalAccountsModel from 'ember-osf-web/models/external-accounts';
+import UserModel from 'ember-osf-web/models/user';
 
 import OsfModel from './osf-model';
 
@@ -10,6 +12,12 @@ export default class UserAddonModel extends OsfModel {
 
     @hasMany('external-accounts', { inverse: null })
     externalAccounts!: AsyncHasMany<ExternalAccountsModel> & ExternalAccountsModel[];
+
+    @belongsTo('user', { inverse: 'userAddons' })
+    user!: AsyncBelongsTo<UserModel> & UserModel;
+
+    @belongsTo('addon', { inverse: null })
+    addon!: AsyncBelongsTo<AddonModel>;
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/models/user.ts
+++ b/app/models/user.ts
@@ -6,6 +6,7 @@ import { Link } from 'jsonapi-typescript';
 
 import PreprintModel from 'ember-osf-web/models/preprint';
 import SparseNodeModel from 'ember-osf-web/models/sparse-node';
+import UserAddonModel from 'ember-osf-web/models/user-addon';
 import ContributorModel from './contributor';
 import DraftRegistrationModel from './draft-registration';
 import InstitutionModel from './institution';
@@ -126,6 +127,9 @@ export default class UserModel extends OsfModel.extend(Validations) {
 
     @hasMany('sparse-node', { inverse: null })
     sparseNodes!: AsyncHasMany<SparseNodeModel>;
+
+    @hasMany('user-addon', { inverse: 'user' })
+    userAddons!: AsyncHasMany<UserAddonModel>;
 
     // Calculated fields
     @alias('links.html') profileURL!: string;

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -1,6 +1,8 @@
 import { Server } from 'ember-cli-mirage';
 import config from 'ember-osf-web/config/environment';
 
+import { externalAccountDetail, externalAccountList } from 'ember-osf-web/mirage/views/external-account';
+import { nodeAddonDetail, nodeAddonList } from 'ember-osf-web/mirage/views/node-addon';
 import { createReviewAction } from 'ember-osf-web/mirage/views/review-action';
 import { createResource, updateResource } from 'ember-osf-web/mirage/views/resource';
 import { getCitation } from './views/citation';
@@ -72,9 +74,12 @@ export default function(this: Server) {
 
     this.get('/', rootDetail);
 
+    osfResource(this, 'addon', { only: ['index']});
     osfResource(this, 'developer-app', { path: 'applications', except: ['create', 'update'] });
     this.post('/applications', createDeveloperApp);
     this.patch('/applications/:id', updateDeveloperApp);
+
+    osfResource(this, 'external-account', {only: ['index', 'show', 'create']});
 
     osfResource(this, 'file', { only: ['show', 'update'] });
 
@@ -110,6 +115,9 @@ export default function(this: Server) {
         defaultSortKey: 'index',
         onCreate: createBibliographicContributor,
     });
+    this.get('/nodes/:parentID/addons/:id', nodeAddonDetail);
+    this.get('/nodes/:parentID/addons/', nodeAddonList);
+    osfNestedResource(this, 'node', 'nodeAddons', {except: [ 'index', 'show' ]});
 
     this.get('/nodes/:parentID/files', nodeFileProviderList); // Node file providers list
     this.get('/nodes/:parentID/files/:fileProviderId', nodeFilesListForProvider); // Node files list for file provider
@@ -280,6 +288,12 @@ export default function(this: Server) {
     this.post('/users/:id/settings/export', userSettings.requestExport);
     this.post('/users/:parentID/settings/password/', updatePassword);
     this.post('/users/:parentID/claim/', claimUnregisteredUser);
+    osfNestedResource(this, 'user', 'userAddons', {
+        path: '/users/:parentID/addons/',
+        relatedModelName: 'user-addon',
+    });
+    this.get('/users/:userID/addons/:addonID/accounts', externalAccountList);
+    this.get('/users/:userID/addons/:addonID/accounts/:accountID', externalAccountDetail);
 
     osfResource(this, 'external-identity', {
         path: '/users/me/settings/identities',

--- a/mirage/factories/external-account.ts
+++ b/mirage/factories/external-account.ts
@@ -1,0 +1,24 @@
+import { Factory } from 'ember-cli-mirage';
+import faker from 'faker';
+
+import ExternalAccountsModel from 'ember-osf-web/models/external-accounts';
+
+export default Factory.extend<ExternalAccountsModel>({
+    profileUrl: faker.internet.url,
+
+    displayName() {
+        return faker.name.findName();
+    },
+});
+
+declare module 'ember-cli-mirage/types/registries/model' {
+    export default interface MirageModelRegistry {
+        'external-account': ExternalAccountsModel;
+    } // eslint-disable-line semi
+}
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        externalAccounts: ExternalAccountsModel;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/node-addon.ts
+++ b/mirage/factories/node-addon.ts
@@ -1,0 +1,22 @@
+import { Factory } from 'ember-cli-mirage';
+
+import NodeAddonModel from 'ember-osf-web/models/node-addon';
+
+export default Factory.extend<NodeAddonModel>({
+    nodeHasAuth: false,
+    configured: false,
+    folderId: null,
+    folderPath: null,
+});
+
+declare module 'ember-cli-mirage/types/registries/model' {
+    export default interface MirageModelRegistry {
+        'node-addon': NodeAddonModel;
+    } // eslint-disable-line semi
+}
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        nodeAddons: NodeAddonModel;
+    } // eslint-disable-line semi
+}

--- a/mirage/factories/user-addon.ts
+++ b/mirage/factories/user-addon.ts
@@ -1,0 +1,19 @@
+import { Factory } from 'ember-cli-mirage';
+
+import UserAddonModel from 'ember-osf-web/models/user-addon';
+
+export default Factory.extend<UserAddonModel>({
+    userHasAuth: true,
+});
+
+declare module 'ember-cli-mirage/types/registries/model' {
+    export default interface MirageModelRegistry {
+        'user-addon': UserAddonModel;
+    } // eslint-disable-line semi
+}
+
+declare module 'ember-cli-mirage/types/registries/schema' {
+    export default interface MirageSchemaRegistry {
+        userAddons: UserAddonModel;
+    } // eslint-disable-line semi
+}

--- a/mirage/fixtures/addons.ts
+++ b/mirage/fixtures/addons.ts
@@ -1,0 +1,93 @@
+export default [
+    {
+        id: 'box',
+        name: 'Box',
+        categories: [
+            'storage',
+        ],
+    },
+    {
+        id: 'dataverse',
+        name: 'Dataverse',
+        categories: [
+            'storage',
+        ],
+    },
+    {
+        id: 'dropbox',
+        name: 'Dropbox',
+        categories: [
+            'storage',
+        ],
+    },
+    {
+        id: 'figshare',
+        name: 'figshare',
+        categories: [
+            'storage',
+        ],
+    },
+    {
+        id: 'github',
+        name: 'GitHub',
+        categories: [
+            'storage',
+        ],
+    },
+    {
+        id: 'gitlab',
+        name: 'GitLab',
+        categories: [
+            'storage',
+        ],
+    },
+    {
+        id: 'mendeley',
+        name: 'Mendeley',
+        categories: [
+            'citations',
+        ],
+    },
+    {
+        id: 'zotero',
+        name: 'Zotero',
+        categories: [
+            'citations',
+        ],
+    },
+    {
+        id: 'owncloud',
+        name: 'ownCloud',
+        categories: [
+            'storage',
+        ],
+    },
+    {
+        id: 'onedrive',
+        name: 'OneDrive',
+        categories: [
+            'storage',
+        ],
+    },
+    {
+        id: 's3',
+        name: 'Amazon S3',
+        categories: [
+            'storage',
+        ],
+    },
+    {
+        id: 'googledrive',
+        name: 'Google Drive',
+        categories: [
+            'storage',
+        ],
+    },
+    {
+        id: 'bitbucket',
+        name: 'Bitbucket',
+        categories: [
+            'storage',
+        ],
+    },
+];

--- a/mirage/scenarios/dashboard.ts
+++ b/mirage/scenarios/dashboard.ts
@@ -73,6 +73,7 @@ export function dashboardScenario(server: Server, currentUser: ModelInstance<Use
         externalAccounts: [ dropboxAccount, dropboxAccountTwo ],
         userHasAuth: true,
         user: currentUser,
+        addon: dropbox,
     });
     server.create('node-addon', {
         nodeHasAuth: true,

--- a/mirage/scenarios/dashboard.ts
+++ b/mirage/scenarios/dashboard.ts
@@ -1,5 +1,6 @@
 import { ModelInstance, Server } from 'ember-cli-mirage';
 import config from 'ember-osf-web/config/environment';
+import AddonModel from 'ember-osf-web/models/addon';
 
 import { Permission } from 'ember-osf-web/models/osf-model';
 import User from 'ember-osf-web/models/user';
@@ -55,6 +56,30 @@ export function dashboardScenario(server: Server, currentUser: ModelInstance<Use
         users: currentUser,
         permission: Permission.Admin,
         index: 0,
+    });
+
+    // Addons for filesNode
+    const dropbox = server.schema.addons.find('dropbox') as ModelInstance<AddonModel>;
+    const dropboxAccount = server.create('external-account', {
+        displayName: 'Bugs Bunny',
+        provider: dropbox,
+    });
+    const dropboxAccountTwo = server.create('external-account', {
+        displayName: 'Daffy Duck',
+        provider: dropbox,
+    });
+    server.create('user-addon', {
+        id: 'dropbox',
+        externalAccounts: [ dropboxAccount, dropboxAccountTwo ],
+        userHasAuth: true,
+        user: currentUser,
+    });
+    server.create('node-addon', {
+        nodeHasAuth: true,
+        folderId: '/',
+        folderPath: '/',
+        externalAccount: dropboxAccount,
+        node: filesNode,
     });
 
     // NOTE: Some institutions are already created by this point

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -22,6 +22,7 @@ export default function(server: Server) {
     server.loadFixtures('regions');
     server.loadFixtures('preprint-providers');
     server.loadFixtures('licenses');
+    server.loadFixtures('addons');
     // server.loadFixtures('registration-providers');
 
     const userTraits = !mirageScenarios.includes('loggedIn') ? []

--- a/mirage/serializers/addon.ts
+++ b/mirage/serializers/addon.ts
@@ -1,0 +1,6 @@
+import AddonModel from 'ember-osf-web/models/addon';
+
+import ApplicationSerializer from './application';
+
+export default class AddonSerializer extends ApplicationSerializer<AddonModel> {
+}

--- a/mirage/serializers/external-account.ts
+++ b/mirage/serializers/external-account.ts
@@ -1,0 +1,16 @@
+import { ModelInstance } from 'ember-cli-mirage';
+import config from 'ember-osf-web/config/environment';
+
+import ExternalAccountsModel from 'ember-osf-web/models/external-accounts';
+
+import ApplicationSerializer from './application';
+
+const { OSF: { apiUrl } } = config;
+
+export default class ExternalAccountSerializer extends ApplicationSerializer<ExternalAccountsModel> {
+    buildNormalLinks(model: ModelInstance<ExternalAccountsModel>) {
+        return {
+            self: `${apiUrl}/v2/users/me/addons/${model.provider}/accounts/${model.id}`,
+        };
+    }
+}

--- a/mirage/serializers/node-addon.ts
+++ b/mirage/serializers/node-addon.ts
@@ -1,0 +1,29 @@
+import { ModelInstance } from 'ember-cli-mirage';
+import config from 'ember-osf-web/config/environment';
+
+import NodeAddonModel from 'ember-osf-web/models/node-addon';
+
+import ApplicationSerializer from './application';
+
+const { OSF: { apiUrl } } = config;
+
+export default class NodeAddonSerializer extends ApplicationSerializer<NodeAddonModel> {
+    buildRelationships(model: ModelInstance<NodeAddonModel>) {
+        return {
+            node: {
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/nodes/${model.node.id}`,
+                        meta: this.buildRelatedLinkMeta(model, 'node'),
+                    },
+                },
+            },
+        };
+    }
+
+    buildNormalLinks(model: ModelInstance<NodeAddonModel>) {
+        return {
+            self: `${apiUrl}/v2/nodes/${model.node.id}/addons/${model.id}`,
+        };
+    }
+}

--- a/mirage/serializers/node.ts
+++ b/mirage/serializers/node.ts
@@ -133,6 +133,13 @@ export default class NodeSerializer extends ApplicationSerializer<MirageNode> {
                     },
                 },
             },
+            nodeAddons: {
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/nodes/${model.id}/addons/`,
+                    },
+                },
+            },
         };
         if (model.attrs.parentId !== null) {
             const { parentId } = model.attrs;

--- a/mirage/serializers/user-addon.ts
+++ b/mirage/serializers/user-addon.ts
@@ -25,6 +25,13 @@ export default class UserAddonSerializer extends ApplicationSerializer<UserAddon
                     },
                 },
             },
+            addon: {
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/addons/${model.addon.id}`,
+                    },
+                },
+            },
         };
     }
 

--- a/mirage/serializers/user-addon.ts
+++ b/mirage/serializers/user-addon.ts
@@ -1,0 +1,36 @@
+import { ModelInstance } from 'ember-cli-mirage';
+import config from 'ember-osf-web/config/environment';
+
+import UserAddonModel from 'ember-osf-web/models/user-addon';
+
+import ApplicationSerializer from './application';
+
+const { OSF: { apiUrl } } = config;
+
+export default class UserAddonSerializer extends ApplicationSerializer<UserAddonModel> {
+    buildRelationships(model: ModelInstance<UserAddonModel>) {
+        return {
+            user: {
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/users/${model.user.id}`,
+                        meta: this.buildRelatedLinkMeta(model, 'user'),
+                    },
+                },
+            },
+            externalAccounts: {
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/users/${model.user.id}/addons/${model.id}/accounts/`,
+                    },
+                },
+            },
+        };
+    }
+
+    buildNormalLinks(model: ModelInstance<UserAddonModel>) {
+        return {
+            self: `${apiUrl}/v2/users/${model.user.id}/addons/${model.id}`,
+        };
+    }
+}

--- a/mirage/serializers/user.ts
+++ b/mirage/serializers/user.ts
@@ -66,6 +66,13 @@ export default class UserSerializer extends ApplicationSerializer<User> {
                     },
                 },
             },
+            userAddons: {
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/users/${model.id}/addons/`,
+                    },
+                },
+            },
         };
         if (model.defaultRegion) {
             serializedRelationships.defaultRegion = {

--- a/mirage/views/external-account.ts
+++ b/mirage/views/external-account.ts
@@ -1,0 +1,30 @@
+import { HandlerContext, ModelInstance, Request, Schema } from 'ember-cli-mirage';
+
+import ExternalAccountsModel from 'ember-osf-web/models/external-accounts';
+import { process } from './utils';
+
+export function externalAccountDetail(this: HandlerContext, schema: Schema, request: Request) {
+    const { accountID } = request.params;
+    const externalAccount = schema.externalAccounts.find(accountID);
+
+    const serializedExternalAccount = this.serialize(externalAccount);
+    const { data } = process(schema, request, this, [serializedExternalAccount.data]);
+
+    return {
+        data: data[0],
+        meta: serializedExternalAccount.meta,
+    };
+}
+
+export function externalAccountList(this: HandlerContext, schema: Schema, request: Request) {
+    const userAddons = schema.users
+        .find(request.params.userID)['userAddons']
+        .models;
+    const externalAccounts = userAddons.length ? userAddons[0].externalAccounts.models : null;
+    if (externalAccounts) {
+        externalAccounts.map((model: ModelInstance<ExternalAccountsModel>) => this.serialize(model).data);
+        const json = process(schema, request, this, externalAccounts, { defaultSortKey: 'id' });
+        return json;
+    }
+    return {};
+}

--- a/mirage/views/external-account.ts
+++ b/mirage/views/external-account.ts
@@ -22,7 +22,10 @@ export function externalAccountList(this: HandlerContext, schema: Schema, reques
         .models;
     const externalAccounts = userAddons.length ? userAddons[0].externalAccounts.models : null;
     if (externalAccounts) {
-        externalAccounts.map((model: ModelInstance<ExternalAccountsModel>) => this.serialize(model).data);
+        externalAccounts
+            .filter( (item: ModelInstance<ExternalAccountsModel>) => item.provider.id === request.params.addonID )
+            .map((model: ModelInstance<ExternalAccountsModel>) => this.serialize(model).data);
+
         const json = process(schema, request, this, externalAccounts, { defaultSortKey: 'id' });
         return json;
     }

--- a/mirage/views/node-addon.ts
+++ b/mirage/views/node-addon.ts
@@ -1,0 +1,34 @@
+import { HandlerContext, ModelInstance, Request, Schema } from 'ember-cli-mirage';
+
+import NodeAddonModel from 'ember-osf-web/models/node-addon';
+import { filter, process } from './utils';
+
+export function nodeAddonDetail(this: HandlerContext, schema: Schema, request: Request) {
+    const { id } = request.params;
+    const nodeAddon = schema.nodeAddons.find(id);
+
+    nodeAddon.configured = Boolean(nodeAddon.folderPath);
+
+    const serializedNodeAddon = this.serialize(nodeAddon);
+    const { data } = process(schema, request, this, [serializedNodeAddon.data]);
+
+    return {
+        data: data[0],
+        meta: serializedNodeAddon.meta,
+    };
+}
+
+export function nodeAddonList(this: HandlerContext, schema: Schema, request: Request) {
+    const nodeAddons = schema.nodes
+        .find(request.params.parentID)['nodeAddons']
+        .models
+        .filter((m: ModelInstance<NodeAddonModel>) => filter(m, request))
+        .map((model: ModelInstance<NodeAddonModel>) => {
+            model.configured = Boolean(model.folderPath);
+            return model;
+        })
+        .map((model: ModelInstance<NodeAddonModel>) => this.serialize(model).data);
+
+    const json = process(schema, request, this, nodeAddons, { defaultSortKey: 'last_logged' });
+    return json;
+}


### PR DESCRIPTION
-   Ticket: [ENG-4681]
-   Feature flag: n/a

## Purpose

Make the v2 endpoints work with mirage. This includes a lot of normalization of the API but not the extra features such as extended attributes for providers nor getting the folder lists.

## Summary of Changes

1. Add mirage
2. Adjust models

## Screenshot(s)

<img width="684" alt="Screenshot 2023-11-13 at 1 56 05 PM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/fe16c6c1-383a-49fc-8ae4-73ab350d945b">
<img width="1039" alt="Screenshot 2023-11-13 at 1 55 22 PM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/b99fd109-4305-41d0-9c75-64029c9756f2">
<img width="1029" alt="Screenshot 2023-11-13 at 12 35 01 PM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/782010ad-6a80-481d-bc04-61dc19969ff4">
<img width="1048" alt="Screenshot 2023-11-13 at 11 33 02 AM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/2c44b9d0-5b1a-411b-91a4-646ce066b6fb">
<img width="1004" alt="Screenshot 2023-11-13 at 8 26 31 AM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/d82d69de-1bb3-4bf7-83ff-37f90b0b04b0">



[ENG-4681]: https://openscience.atlassian.net/browse/ENG-4681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ