### PR TITLE
Fix for routing in the FE to handle /preprints/<preprint_guid>

### DIFF
--- a/app/preprints/index/route.ts
+++ b/app/preprints/index/route.ts
@@ -15,26 +15,26 @@ export default class Preprints extends Route {
     @service router!: RouterService;
 
     async model(params: { provider_id : string }) {
+        const provider_id = params.provider_id ? params.provider_id : 'osf';
+        let provider;
         try {
-            const provider_id = params.provider_id ? params.provider_id : 'osf';
-            let provider;
-
-            try {
-                provider = await this.store.findRecord('preprint-provider', provider_id, {
-                    include: 'brand',
-                });
-            } catch (error) {
-                if (params.provider_id) {
-                    this.router.transitionTo('resolve-guid', params.provider_id);
-                    return null;
-                } else {
-                    throw error;
-                }
+            provider = await this.store.findRecord('preprint-provider', provider_id, {
+                include: 'brand',
+            });
+        } catch (error) {
+            if (params.provider_id) {
+                this.router.transitionTo('resolve-guid', params.provider_id);
+                return null;
+            } else {
+                this.router.transitionTo('not-found', 'preprints');
+                return null;
             }
+        }
 
-            this.theme.set('providerType', 'preprint');
-            this.theme.set('id', provider_id);
+        this.theme.set('providerType', 'preprint');
+        this.theme.set('id', provider_id);
 
+        try {
             const taxonomies = await this.theme.provider?.queryHasMany('highlightedSubjects', {
                 page: {
                     size: 20,
@@ -54,7 +54,6 @@ export default class Preprints extends Route {
                 brandedProviders,
                 brand: provider.brand.content,
             };
-
         } catch (error) {
             captureException(error);
             this.router.transitionTo('not-found', 'preprints');


### PR DESCRIPTION
-   Ticket: [https://www.notion.so/cos/0de7c99478234fd7be57029dd96aa2d3?v=a4e6d7c70c004d27a0955aa2742775a4&p=b40cc3e5b898476b8d8434de71d9b8fc&pm=c]
-   Feature flag: n/a

## Purpose

Allow /preprints/<preprint_guid> to be routed correctly and a provider

## Summary of Changes

Added an conditional if statement to the error handling on the index page if the provider_id fails.

## Screenshot(s)

N/A

## Side Effects

N/A

## QA Notes

https://www.notion.so/cos/0de7c99478234fd7be57029dd96aa2d3?v=a4e6d7c70c004d27a0955aa2742775a4&p=b40cc3e5b898476b8d8434de71d9b8fc&pm=c