### PR TITLE
Navbar for preprints

### DIFF
--- a/app/config/environment.d.ts
+++ b/app/config/environment.d.ts
@@ -70,6 +70,7 @@ declare const config: {
         apiVersion: string;
         apiHeaders: { [k: string]: string };
         learnMoreUrl: string;
+        donateUrl: string;
         renderUrl: string;
         waterbutlerUrl: string;
         helpUrl: string;

--- a/app/router.ts
+++ b/app/router.ts
@@ -27,8 +27,8 @@ Router.map(function() {
     });
 
     this.route('preprints', function() {
-        this.route('index', { path: '/' });
         this.route('index', { path: '/:provider_id' });
+        this.route('index', { path: '/' });
         this.route('discover', { path: '/:provider_id/discover' });
         this.route('detail', { path: '/:provider_id/:guid' });
     });

--- a/config/environment.js
+++ b/config/environment.js
@@ -149,6 +149,7 @@ module.exports = function(environment) {
                 Accept: `application/vnd.api+json; version=${apiVersion}`,
             },
             learnMoreUrl: 'https://cos.io/our-products/osf/',
+            donateUrl: 'https://cos.io/donate',
             renderUrl,
             waterbutlerUrl,
             helpUrl,

--- a/lib/app-components/addon/components/branded-navbar/component.ts
+++ b/lib/app-components/addon/components/branded-navbar/component.ts
@@ -23,7 +23,7 @@ import template from './template';
 
 type ObjectType = 'collection' | 'preprint' | 'registration';
 
-const osfURL = config.OSF.url;
+const { url: osfURL, donateUrl } = config.OSF;
 
 @layout(template, styles)
 @tagName('')
@@ -43,6 +43,7 @@ export default class BrandedNavbar extends Component {
     campaign = `${this.theme.id}-collections`;
 
     myProjectsUrl = serviceLinks.myProjects;
+    donateUrl = donateUrl;
 
     get reviewUrl() {
         return `${osfURL}reviews`;

--- a/lib/app-components/addon/components/branded-navbar/template.hbs
+++ b/lib/app-components/addon/components/branded-navbar/template.hbs
@@ -108,7 +108,7 @@
                         {{/if}}
                         <li>
                             <a
-                                href='https://cos.io/donate'
+                                href={{this.donateUrl}}
                                 onclick={{action 'click' 'link' 'Navbar - Donate' target=this.analytics}}
                             >
                                 {{t 'navbar.donate'}}

--- a/lib/osf-components/addon/components/osf-navbar/component.ts
+++ b/lib/osf-components/addon/components/osf-navbar/component.ts
@@ -2,7 +2,6 @@ import Component from '@ember/component';
 import { action, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Features from 'ember-feature-flags/services/features';
-import config from 'ember-osf-web/config/environment';
 import Media from 'ember-responsive';
 import Session from 'ember-simple-auth/services/session';
 import { tracked } from 'tracked-built-ins';
@@ -12,8 +11,6 @@ import Analytics from 'ember-osf-web/services/analytics';
 
 import styles from './styles';
 import template from './template';
-
-const osfURL = config.OSF.url;
 
 export enum OSFService {
     HOME = 'HOME',
@@ -25,13 +22,12 @@ export enum OSFService {
 
 interface ServiceLink {
     name: string;
-    route?: string;
-    href?: string;
+    route: string;
 }
 
 export const OSF_SERVICES: ServiceLink[] = [
     { name: OSFService.HOME, route: 'home' },
-    { name: OSFService.PREPRINTS, href: `${osfURL}preprints/` },
+    { name: OSFService.PREPRINTS, route: 'preprints'},
     { name: OSFService.REGISTRIES, route: 'registries' },
     { name: OSFService.MEETINGS, route: 'meetings' },
     { name: OSFService.INSTITUTIONS, route: 'institutions' },
@@ -57,9 +53,6 @@ export default class OsfNavbar extends Component {
         const { currentRouteName } = this.router;
         if (activeService === OSFService.HOME && currentRouteName) {
             for (const osfService of OSF_SERVICES) {
-                if (!osfService.route) {
-                    continue;
-                }
                 const routeRegExp = new RegExp(`^${osfService.route}($|\\.)`);
                 if (routeRegExp.test(currentRouteName)) {
                     activeService = osfService.name as OSFService;

--- a/lib/osf-components/addon/components/osf-navbar/preprint-links/component.ts
+++ b/lib/osf-components/addon/components/osf-navbar/preprint-links/component.ts
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import CurrentUserService from 'ember-osf-web/services/current-user';
+import config from 'ember-osf-web/config/environment';
+
+interface Args {
+    onLinkClicked: () => void;
+}
+export default class OsfNavbarPreprintLinks extends Component<Args> {
+    @service currentUser!: CurrentUserService;
+
+    donateURL = `${config.OSF.donateUrl}`;
+    supportURL = `${config.support.faqPageUrl}`;
+}

--- a/lib/osf-components/addon/components/osf-navbar/preprint-links/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/preprint-links/template.hbs
@@ -1,0 +1,57 @@
+<li data-test-nav-my-preprints-link>
+    <OsfLink
+        @href='/myprojects/#preprints/'
+        data-analytics-name='My preprints'
+        {{on 'click' @onLinkClicked}}
+    >
+        {{t 'navbar.my_preprints'}}
+    </OsfLink>
+</li>
+{{#if this.currentUser.user.canViewReviews}}
+    <li data-test-nav-reviews-link>
+        <OsfLink
+            @href='/reviews/'
+            data-analytics-name='My reviews'
+            {{on 'click' @onLinkClicked}}
+        >
+            {{t 'navbar.reviews'}}
+        </OsfLink>
+    </li>
+{{/if}}
+<li data-test-nav-submit-preprint-link>
+    <OsfLink
+        @href='/preprints/submit/'
+        data-analytics-name='Add a preprint'
+        {{on 'click' @onLinkClicked}}
+    >
+        {{t 'navbar.add_a_preprint' preprintWord=(t 'documentType.preprint.singularCapitalized')}}
+    </OsfLink>
+</li>
+<li data-test-nav-search-link>
+    <OsfLink
+        @route='search'
+        @queryParams={{hash resourceType='Preprint'}}
+        data-analytics-name='Search'
+        {{on 'click' @onLinkClicked}}
+    >
+        {{t 'navbar.search'}}
+    </OsfLink>
+</li>
+<li data-test-nav-support-link>
+    <OsfLink
+        @href={{this.supportURL}}
+        data-analytics-name='Support'
+        {{on 'click' @onLinkClicked}}
+    >
+        {{t 'navbar.support'}}
+    </OsfLink>
+</li>
+<li class='navbar-donate-button' data-test-nav-donate-link>
+    <OsfLink
+        @href={{this.donateURL}}
+        data-analytics-name='Donate'
+        {{on 'click' @onLinkClicked}}
+    >
+        {{t 'navbar.donate'}}
+    </OsfLink>
+</li>

--- a/lib/osf-components/addon/components/osf-navbar/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/template.hbs
@@ -81,11 +81,18 @@
                             links=(component 'osf-navbar/x-links'
                                 onLinkClicked=(action 'onLinkClicked')
                             )
+                            preprintLinks=(component 'osf-navbar/preprint-links'
+                                onLinkClicked=(action 'onLinkClicked')
+                            )
                         ) as |ctx|}}
                             {{#if (has-block)}}
                                 {{yield ctx}}
                             {{else}}
-                                {{ctx.links}}
+                                {{#if (eq this._activeService.name 'PREPRINTS')}}
+                                    {{ctx.preprintLinks}}
+                                {{else}}
+                                    {{ctx.links}}
+                                {{/if}}
                             {{/if}}
                         {{/let}}
                     </ul>

--- a/lib/osf-components/addon/components/osf-navbar/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/template.hbs
@@ -18,7 +18,6 @@
                     <OsfLink
                         data-analytics-name={{this._activeService.name}}
                         @route={{this._activeService.route}}
-                        @href={{this._activeService.href}}
                     >
                         <span class='hidden-xs'> {{t 'general.OSF'}} </span>
                         <span class='current-service'><strong>{{this._activeService.name}}</strong></span>
@@ -46,7 +45,6 @@
                                     <OsfLink
                                         data-analytics-name={{service.name}}
                                         @route={{service.route}}
-                                        @href={{service.href}}
                                         local-class='service-links'
                                         @onClick={{action dd.close}}
                                     >

--- a/lib/osf-components/addon/components/osf-navbar/x-links/component.ts
+++ b/lib/osf-components/addon/components/osf-navbar/x-links/component.ts
@@ -8,13 +8,14 @@ import { layout } from 'ember-osf-web/decorators/component';
 
 import template from './template';
 
-const osfURL = config.OSF.url;
+const { url: osfURL, donateUrl } = config.OSF;
 
 @layout(template)
 @tagName('') // Don't wrap this component in a div
 export default class XLinks extends Component {
     @service session!: Session;
 
+    donateURL = donateUrl;
     myProjectsURL = `${osfURL}myprojects/`;
     myRegistrationsURL = `${osfURL}myprojects/#registrations`;
     supportURL = `${config.support.faqPageUrl}`;

--- a/lib/osf-components/addon/components/osf-navbar/x-links/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/x-links/template.hbs
@@ -23,7 +23,7 @@
         onClicked=this.onLinkClicked
     )
     donate=(component 'osf-navbar/x-links/hyper-link'
-        'https://cos.io/donate'
+        this.donateURL
         analyticsLabel='Donate'
         classNames='navbar-donate-button'
         tagName='li'

--- a/lib/osf-components/app/components/osf-navbar/preprint-links/component.js
+++ b/lib/osf-components/app/components/osf-navbar/preprint-links/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/osf-navbar/preprint-links/component';

--- a/lib/osf-components/app/components/osf-navbar/preprint-links/template.js
+++ b/lib/osf-components/app/components/osf-navbar/preprint-links/template.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/osf-navbar/preprint-links/template';

--- a/tests/integration/components/osf-navbar/component-test.ts
+++ b/tests/integration/components/osf-navbar/component-test.ts
@@ -9,6 +9,7 @@ import { module, test } from 'qunit';
 
 const routerStub = Service.extend({
     currentURL: '/',
+    currentRouteName: 'dashboard',
     urlFor() {
         return '/FakeURL';
     },
@@ -37,6 +38,10 @@ module('Integration | Component | osf-navbar', hooks => {
         await render(hbs`<OsfNavbar />`);
         assert.dom('.service-name').includesText('OSF');
         assert.dom('.current-service').hasText('HOME');
+        assert.dom('[data-test-nav-my-projects-link]').exists();
+        assert.dom('[data-test-nav-search-link]').exists();
+        assert.dom('[data-test-nav-support-link]').exists();
+        assert.dom('[data-test-nav-donate-link]').exists();
     });
 
     test('service-dropdown: logged in', async function(assert) {
@@ -70,6 +75,42 @@ module('Integration | Component | osf-navbar', hooks => {
         assert.dom('[data-test-sign-in-button]').exists();
 
         await click('[data-test-service-dropdown]');
+        await percySnapshot(assert);
+    });
+
+    test('osf-navbar: preprints, no moderation', async function(assert) {
+        this.owner.lookup('service:session').set('isAuthenticated', true);
+        this.owner.lookup('service:router').set('currentRouteName', 'preprints.place');
+
+        await render(hbs`<OsfNavbar />`);
+
+        assert.dom('.service-name').includesText('OSF');
+        assert.dom('.current-service').hasText('PREPRINTS');
+        assert.dom('[data-test-nav-my-preprints-link]').exists();
+        assert.dom('[data-test-nav-submit-preprint-link]').exists();
+        assert.dom('[data-test-nav-reviews-link]').doesNotExist();
+
+        assert.dom('[data-test-nav-search-link]').exists();
+        assert.dom('[data-test-nav-donate-link]').hasClass('navbar-donate-button');
+
+        assert.dom('[data-test-nav-my-projects-link]').doesNotExist();
+    });
+
+    test('osf-navbar: preprints with moderation', async function(assert) {
+        this.owner.lookup('service:session').set('isAuthenticated', true);
+        this.owner.lookup('service:router').set('currentRouteName', 'preprints.somewhere');
+        // this.owner.register('service:current-user', currentUserStub);
+        this.owner.lookup('service:current-user').set('user', { canViewReviews: true });
+
+        await render(hbs`<OsfNavbar />`);
+
+        assert.dom('.service-name').includesText('OSF');
+        assert.dom('.current-service').hasText('PREPRINTS');
+        assert.dom('[data-test-nav-my-preprints-link]').exists();
+        assert.dom('[data-test-nav-submit-preprint-link]').exists();
+        assert.dom('[data-test-nav-reviews-link]').exists();
+
+        assert.dom('[data-test-nav-my-projects-link]').doesNotExist();
         await percySnapshot(assert);
     });
 });


### PR DESCRIPTION
-   Ticket: [[NotionCard 1]](https://www.notion.so/cos/Preprints-Navbar-says-Home-instead-of-Preprints-882c31c66709442993b02ed7569bb73c?pvs=4) [[NotionCard 2]](https://www.notion.so/cos/Preprints-Landing-page-needs-My-Preprints-button-19f7a966e17441338ec59327c41cceca?pvs=4)
-   Feature flag: n/a

## Purpose
- Update navbar for non-branded preprints

## Summary of Changes
- Update logic to show the current service user is viewing ("OSFHOME" -> "OSFPREPRINTS")
- Add a new set of buttons to show for non-branded preprints

## Screenshot(s)
- For OSFPreprints Landing page
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/ac0f416a-b844-47c4-baf8-79d3343cae32)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/1a91c814-7565-404d-a717-3f5272dc7196)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
