### PR TITLE
Allow provider-specfic default citation styles

### DIFF
--- a/app/models/provider.ts
+++ b/app/models/provider.ts
@@ -1,6 +1,7 @@
 import { attr, hasMany, SyncHasMany, AsyncHasMany } from '@ember-data/model';
 import { computed } from '@ember/object';
 
+import CitationStyleModel from './citation-style';
 import LicenseModel from './license';
 import ModeratorModel from './moderator';
 import OsfModel from './osf-model';
@@ -83,6 +84,9 @@ export default abstract class ProviderModel extends OsfModel {
 
     @hasMany('moderator', { inverse: 'provider' })
     moderators!: AsyncHasMany<ModeratorModel> | ModeratorModel[];
+
+    @hasMany('citation-style', { inverse: null })
+    citationStyles!: AsyncHasMany<CitationStyleModel> & CitationStyleModel[];
 
     @computed('permissions')
     get currentUserCanReview() {

--- a/app/preprints/detail/template.hbs
+++ b/app/preprints/detail/template.hbs
@@ -190,7 +190,10 @@
                     {{/if}}
                     <div>
                         <h4>{{t 'preprints.detail.citations'}}</h4>
-                        <CitationViewer @citable={{this.model.preprint}} />
+                        <CitationViewer
+                            @citable={{this.model.preprint}}
+                            @provider={{this.model.provider}}
+                        />
                     </div>
                 </div>
             {{/unless}}

--- a/lib/osf-components/addon/components/citation-viewer/component.ts
+++ b/lib/osf-components/addon/components/citation-viewer/component.ts
@@ -5,9 +5,11 @@ import { waitFor } from '@ember/test-waiters';
 import { all, restartableTask, task, timeout } from 'ember-concurrency';
 
 import { layout } from 'ember-osf-web/decorators/component';
+import CitationStyleModel from 'ember-osf-web/models/citation-style';
 import CitationStyle from 'ember-osf-web/models/citation-style';
 import Node from 'ember-osf-web/models/node';
 import Preprint from 'ember-osf-web/models/preprint';
+import ProviderModel from 'ember-osf-web/models/provider';
 import CurrentUser from 'ember-osf-web/services/current-user';
 import fixSpecialChars from 'ember-osf-web/utils/fix-special-char';
 import getRelatedHref from 'ember-osf-web/utils/get-related-href';
@@ -18,14 +20,14 @@ import template from './template';
 
 interface DefaultCitation {
     id: string;
-    displayTitle: string;
+    title: string;
     citation?: string;
 }
 
 const defaultCitations: DefaultCitation[] = [
-    { id: 'apa', displayTitle: 'APA' },
-    { id: 'modern-language-association', displayTitle: 'MLA' },
-    { id: 'chicago-author-date', displayTitle: 'Chicago' },
+    { id: 'apa', title: 'APA' },
+    { id: 'modern-language-association', title: 'MLA' },
+    { id: 'chicago-author-date', title: 'Chicago' },
 ];
 
 function citationUrl(citable: Node | Preprint, citationStyleId: string) {
@@ -46,6 +48,8 @@ export default class CitationViewer extends Component {
     // Required parameter
     citable!: Node | Preprint;
 
+    // Optional parameter
+    provider?: ProviderModel;
 
     // Private properties
     @service store!: Store;
@@ -68,13 +72,21 @@ export default class CitationViewer extends Component {
     @task({ on: 'init' })
     @waitFor
     async loadDefaultCitations() {
+        let citations: CitationStyleModel[] | DefaultCitation[] = [];
+        if (this.provider) {
+            citations = (await this.provider.citationStyles).toArray();
+        }
+        if (citations.length === 0) {
+            citations = defaultCitations;
+        }
         const responses: SingleResourceDocument[] = await all(
-            defaultCitations.map(
+            citations.map(
                 c => this.currentUser.authenticatedAJAX({ url: citationUrl(this.citable, c.id) }),
             ),
         );
         return responses.map((r, i) => ({
-            ...defaultCitations[i],
+            ...citations[i],
+            title: citations[i].title,
             citation: typeof r.data.attributes!.citation === 'string'
                 ? fixSpecialChars(r.data.attributes!.citation)
                 : r.data.attributes!.citation,

--- a/lib/osf-components/addon/components/citation-viewer/template.hbs
+++ b/lib/osf-components/addon/components/citation-viewer/template.hbs
@@ -3,8 +3,8 @@
         <LoadingIndicator @dark={{true}} />
     {{else}}
         {{#each this.loadDefaultCitations.last.value as |citation|}}
-            <h5>{{citation.displayTitle}}</h5>
-            <p data-analytics-scope='{{citation.displayTitle}} citation'>
+            <h5>{{citation.title}}</h5>
+            <p data-analytics-scope='{{citation.title}} citation'>
                 <CopyableText
                     data-test-default-citation={{citation.id}}
                     @text={{citation.citation}}

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -310,6 +310,12 @@ export default function(this: Server) {
         relatedModelName: 'preprint',
     });
 
+    osfNestedResource(this, 'preprint-provider', 'citationStyles', {
+        only: ['index'],
+        path: '/providers/preprints/:parentID/citation_styles/',
+        relatedModelName: 'citation-style',
+    });
+
     /**
      * Preprint Details
      */

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -22,6 +22,7 @@ export default function(server: Server) {
     server.loadFixtures('regions');
     server.loadFixtures('preprint-providers');
     server.loadFixtures('licenses');
+    server.loadFixtures('citation-styles');
     // server.loadFixtures('registration-providers');
 
     const userTraits = !mirageScenarios.includes('loggedIn') ? []

--- a/mirage/scenarios/preprints.ts
+++ b/mirage/scenarios/preprints.ts
@@ -236,6 +236,9 @@ function buildrXiv(
     currentUser: ModelInstance<User>,
 ) {
     const preprintrxiv = server.schema.preprintProviders.find('preprintrxiv') as ModelInstance<PreprintProvider>;
+    preprintrxiv.update({
+        citationStyles: [server.schema.citationStyles.find('another-citation')],
+    });
 
     const brand = server.create('brand', {
         primaryColor: '#286090',

--- a/mirage/serializers/preprint-provider.ts
+++ b/mirage/serializers/preprint-provider.ts
@@ -58,6 +58,14 @@ export default class PreprintProviderSerializer extends ApplicationSerializer<Pr
                     },
                 },
             },
+            citationStyles: {
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/providers/preprints/${model.id}/citation_styles/`,
+                        meta: {},
+                    },
+                },
+            },
             // TODO: subscriptions when we move ember-osf-reviews¥
         };
 

--- a/mirage/views/citation.ts
+++ b/mirage/views/citation.ts
@@ -20,6 +20,7 @@ export function getCitation(this: HandlerContext, schema: Schema, request: Reque
             id: citationStyleID,
             type: 'citations',
             attributes: {
+                title: citationStyle.title,
                 citation: `Pretend citation for "${citable.title}" in the style "${citationStyle.title}"`,
             },
         },


### PR DESCRIPTION
-   Ticket: [ENG-4567][[Notion Card]](https://www.notion.so/cos/Preprint-Detail-regression-Provider-s-default-citation-styles-are-not-supported-7c70a556020f4591b42bfd1440e93d1b?pvs=4)
-   Feature flag: n/a

## Purpose
- Allow provider to override default citation styles

## Summary of Changes
- Mirage updates
- Update `<CitationStyles>` component to accept optional `@provider` argument and check if given provider has `citationStyles` defined

## Screenshot(s)
- Provider with default citation styles set
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/da56041a-51cd-455b-84e4-8ff15dfd90c9)

- Provider without default citation styles
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/dec96c30-1639-4967-84bb-4e313df977a7)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- Default citation styles can be set in the admin app for a given preprint-provider
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-4567]: https://openscience.atlassian.net/browse/ENG-4567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ