### PR TITLE
Fixed the branded footer link for preprints

### DIFF
--- a/app/preprints/-components/branded-footer/styles.scss
+++ b/app/preprints/-components/branded-footer/styles.scss
@@ -2,7 +2,8 @@
 
 .branded-footer-links {
     width: 100%;
-    margin: 10px 0;
+    margin: 10px;
+    text-align: center;
 
     .social > a {
         margin: 0 4px;

--- a/app/preprints/-components/branded-footer/styles.scss
+++ b/app/preprints/-components/branded-footer/styles.scss
@@ -2,10 +2,6 @@
 
 .branded-footer-links {
     width: 100%;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
     margin: 10px 0;
 
     .social > a {

--- a/app/preprints/-components/preprint-author-assertions/component.ts
+++ b/app/preprints/-components/preprint-author-assertions/component.ts
@@ -5,6 +5,7 @@ import PreprintModel from 'ember-osf-web/models/preprint';
 import Features from 'ember-feature-flags';
 import ProviderModel from 'ember-osf-web/models/provider';
 import { tracked } from '@glimmer/tracking';
+import Media from 'ember-responsive';
 
 interface InputArgs {
     preprint: PreprintModel;
@@ -15,6 +16,7 @@ interface InputArgs {
 export default class PreprintAuthorAssertions extends Component<InputArgs> {
     @service features!: Features;
     @service intl!: Intl;
+    @service media!: Media;
 
     @tracked displayCoi = false;
     @tracked displayDataLinks = false;
@@ -59,6 +61,10 @@ export default class PreprintAuthorAssertions extends Component<InputArgs> {
 
     public get hasPreregLinks(): boolean {
         return typeof this.preprint.hasPreregLinks === 'string';
+    }
+
+    get isMobile() {
+        return this.media.isMobile;
     }
 }
 

--- a/app/preprints/-components/preprint-author-assertions/styles.scss
+++ b/app/preprints/-components/preprint-author-assertions/styles.scss
@@ -31,7 +31,6 @@
             margin: 0 10px;
 
             .assertions-container {
-                justify-content: center;
                 display: flex;
                 flex-direction: row;
                 justify-content: center;
@@ -43,6 +42,34 @@
                     padding-bottom: 2px;
                     font-weight: bold;
                     padding: 0 20px;
+                }
+            }
+        }
+    }
+
+    &.mobile {
+        padding: 10px;
+
+        .author-assertions-container {
+            width: calc(100% - 20px);
+
+            .author-assertions {
+                flex-direction: column;
+                align-items: flex-start;
+                margin: 0;
+                width: 100%;
+
+                .assertions-container {
+                    width: 100%;
+                    justify-content: flex-start;
+                    margin-top: 5px;
+                    margin-bottom: 5px;
+
+                    .assertion-header-label {
+                        width: 175px;
+                        padding-left: 10px;
+                        padding-right: 10px;
+                    }
                 }
             }
         }

--- a/app/preprints/-components/preprint-author-assertions/template.hbs
+++ b/app/preprints/-components/preprint-author-assertions/template.hbs
@@ -1,5 +1,5 @@
 {{#if this.shouldShowSloanIcons}}
-    <div local-class='author-assertions-page-container'>
+    <div local-class='author-assertions-page-container {{if this.isMobile 'mobile'}}'>
         <div local-class='author-assertions-container'>
             <div local-class='header-label'>
                 {{~t 'preprints.detail.author-assertions.header_label'~}}
@@ -48,45 +48,43 @@
                         <div local-class='assertion-header-label'>
                             {{~t 'preprints.detail.author-assertions.public_data.title'~}}
                         </div>
-                        <div local-class='assertions-container'>
-                            <Button
-                                data-test-view-data-links
-                                data-analytics-name='View data links'
-                                @type='default'
-                                {{on 'click' (action (mut this.displayDataLinks) (not this.displayDataLinks))}}
-                            >
-                                {{this.availableDataLinksMessage}}
-                                <FaIcon @icon='caret-down' @prefix='fas' aria-hidden='true'/>
-                            </Button>
-                            <OsfDialog
-                                @closeOnOutsideClick={{true}}
-                                @isOpen={{this.displayDataLinks}}
-                                @onClose={{action (mut this.displayDataLinks) false}}
-                                as |dialog|
-                            >
-                                <dialog.heading>
-                                    <h3>{{t 'preprints.detail.author-assertions.public_data.title'}}</h3>
-                                </dialog.heading>
-                                <dialog.main>
-                                    <div>
-                                        {{#if (eq this.preprint.hasDataLinks 'available')}}
-                                            <Preprints::-Components::PreprintAssertionLink
-                                                @links={{this.preprint.dataLinks}}
-                                                @analyticsName={{ t 'preprints.detail.author-assertions.public_data.title'}}
-                                            />
-                                        {{else if (eq this.preprint.hasDataLinks 'no')}}
-                                            {{#if this.preprint.whyNoData}}
-                                                {{this.preprint.whyNoData}}
-                                            {{else}}
-                                                {{~t 'preprints.detail.author-assertions.public_data.no'~}}
-                                            {{/if}}
+                        <Button
+                            data-test-view-data-links
+                            data-analytics-name='View data links'
+                            @type='default'
+                            {{on 'click' (action (mut this.displayDataLinks) (not this.displayDataLinks))}}
+                        >
+                            {{this.availableDataLinksMessage}}
+                            <FaIcon @icon='caret-down' @prefix='fas' aria-hidden='true'/>
+                        </Button>
+                        <OsfDialog
+                            @closeOnOutsideClick={{true}}
+                            @isOpen={{this.displayDataLinks}}
+                            @onClose={{action (mut this.displayDataLinks) false}}
+                            as |dialog|
+                        >
+                            <dialog.heading>
+                                <h3>{{t 'preprints.detail.author-assertions.public_data.title'}}</h3>
+                            </dialog.heading>
+                            <dialog.main>
+                                <div>
+                                    {{#if (eq this.preprint.hasDataLinks 'available')}}
+                                        <Preprints::-Components::PreprintAssertionLink
+                                            @links={{this.preprint.dataLinks}}
+                                            @analyticsName={{ t 'preprints.detail.author-assertions.public_data.title'}}
+                                        />
+                                    {{else if (eq this.preprint.hasDataLinks 'no')}}
+                                        {{#if this.preprint.whyNoData}}
+                                            {{this.preprint.whyNoData}}
                                         {{else}}
-                                            {{~t 'preprints.detail.author-assertions.public_data.not_applicable' documentType=this.documentType~}}
+                                            {{~t 'preprints.detail.author-assertions.public_data.no'~}}
                                         {{/if}}
-                                    </div>
-                                </dialog.main>
-                            </OsfDialog>
-                        </div>
+                                    {{else}}
+                                        {{~t 'preprints.detail.author-assertions.public_data.not_applicable' documentType=this.documentType~}}
+                                    {{/if}}
+                                </div>
+                            </dialog.main>
+                        </OsfDialog>
                     </div>
                 {{/if}}
 
@@ -95,45 +93,43 @@
                         <div local-class='assertion-header-label'>
                             {{~t 'preprints.detail.author-assertions.prereg.title'~}}
                         </div>
-                        <div local-class='assertions-container'>
-                            <Button
-                                data-test-view-prereg
-                                data-analytics-name='View prereg'
-                                @type='default'
-                                {{on 'click' (action (mut this.displayPreregLinks) (not this.displayPreregLinks))}}
-                            >
-                                {{this.availablePreregLinksMessage}}
-                                <FaIcon @icon='caret-down' @prefix='fas' aria-hidden='true'/>
-                            </Button>
-                            <OsfDialog
-                                @closeOnOutsideClick={{true}}
-                                @isOpen={{this.displayPreregLinks}}
-                                @onClose={{action (mut this.displayPreregLinks) false}}
-                                as |dialog|
-                            >
-                                <dialog.heading>
-                                    <h3>{{t 'preprints.detail.author-assertions.prereg.title'}}</h3>
-                                </dialog.heading>
-                                <dialog.main>
-                                    <div>
-                                        {{#if (eq this.preprint.hasPreregLinks 'available')}}
-                                            <Preprints::-Components::PreprintAssertionLink
-                                                @links={{this.preprint.preregLinks}}
-                                                @analyticsName={{ t 'preprints.detail.author-assertions.prereg.title'}}
-                                            />
-                                        {{else if (eq this.preprint.hasPreregLinks 'no')}}
-                                            {{#if this.preprint.whyNoPrereg}}
-                                                {{this.preprint.whyNoPrereg}}
-                                            {{else}}
-                                                {{~t 'preprints.detail.author-assertions.prereg.no'~}}
-                                            {{/if}}
+                        <Button
+                            data-test-view-prereg
+                            data-analytics-name='View prereg'
+                            @type='default'
+                            {{on 'click' (action (mut this.displayPreregLinks) (not this.displayPreregLinks))}}
+                        >
+                            {{this.availablePreregLinksMessage}}
+                            <FaIcon @icon='caret-down' @prefix='fas' aria-hidden='true'/>
+                        </Button>
+                        <OsfDialog
+                            @closeOnOutsideClick={{true}}
+                            @isOpen={{this.displayPreregLinks}}
+                            @onClose={{action (mut this.displayPreregLinks) false}}
+                            as |dialog|
+                        >
+                            <dialog.heading>
+                                <h3>{{t 'preprints.detail.author-assertions.prereg.title'}}</h3>
+                            </dialog.heading>
+                            <dialog.main>
+                                <div>
+                                    {{#if (eq this.preprint.hasPreregLinks 'available')}}
+                                        <Preprints::-Components::PreprintAssertionLink
+                                            @links={{this.preprint.preregLinks}}
+                                            @analyticsName={{ t 'preprints.detail.author-assertions.prereg.title'}}
+                                        />
+                                    {{else if (eq this.preprint.hasPreregLinks 'no')}}
+                                        {{#if this.preprint.whyNoPrereg}}
+                                            {{this.preprint.whyNoPrereg}}
                                         {{else}}
-                                            {{~t 'preprints.detail.author-assertions.prereg.not_applicable' documentType=this.documentType~}}
+                                            {{~t 'preprints.detail.author-assertions.prereg.no'~}}
                                         {{/if}}
-                                    </div>
-                                </dialog.main>
-                            </OsfDialog>
-                        </div>
+                                    {{else}}
+                                        {{~t 'preprints.detail.author-assertions.prereg.not_applicable' documentType=this.documentType~}}
+                                    {{/if}}
+                                </div>
+                            </dialog.main>
+                        </OsfDialog>
                     </div>
                 {{/if}}
             </div>

--- a/app/preprints/-components/preprint-status-banner/component.ts
+++ b/app/preprints/-components/preprint-status-banner/component.ts
@@ -12,6 +12,7 @@ import PreprintProviderModel from 'ember-osf-web/models/preprint-provider';
 import { tracked } from '@glimmer/tracking';
 import { ReviewsState } from 'ember-osf-web/models/provider';
 import ReviewActionModel from 'ember-osf-web/models/review-action';
+import Media from 'ember-responsive';
 
 const UNKNOWN = 'unknown';
 const PENDING = 'pending';
@@ -72,6 +73,7 @@ interface InputArgs {
 export default class PreprintStatusBanner extends Component<InputArgs>{
     @service intl!: Intl;
     @service theme!: Theme;
+    @service media!: Media;
 
     submission = this.args.submission;
     isWithdrawn = this.args.submission.isWithdrawn;
@@ -206,5 +208,9 @@ export default class PreprintStatusBanner extends Component<InputArgs>{
         }
 
         this.latestAction = latestSubmissionAction;
+    }
+
+    get isMobile() {
+        return this.media.isMobile;
     }
 }

--- a/app/preprints/-components/preprint-status-banner/styles.scss
+++ b/app/preprints/-components/preprint-status-banner/styles.scss
@@ -106,6 +106,14 @@ $color-border-light: #ddd;
             }
         }
     }
+
+    &.mobile {
+        height: fit-content;
+
+        .preprint-banner-status {
+            height: fit-content;
+        }
+    }
 }
 
 .status-banner-dialog {

--- a/app/preprints/-components/preprint-status-banner/template.hbs
+++ b/app/preprints/-components/preprint-status-banner/template.hbs
@@ -1,4 +1,4 @@
-<div local-class='preprint-banner-status-container'>
+<div local-class='preprint-banner-status-container  {{if this.isMobile 'mobile'}}'>
     {{#if (or this.submission.provider?.isPending this.loadPreprintState.isRunning) }}
         {{ t 'preprints.detail.status_banner.loading' }}
     {{else}}

--- a/mirage/fixtures/preprint-providers.ts
+++ b/mirage/fixtures/preprint-providers.ts
@@ -26,7 +26,8 @@ const preprintProviders: Array<Partial<PreprintProvider>> = [
         name: 'Thesis Commons',
         preprintWord: 'thesis',
         assets: randomAssets(2),
-        footerLinks: 'fake footer links',
+        // eslint-disable-next-line max-len
+        footerLinks: '<p style="text-align: center;">LawArXiv:&nbsp;<a href="mailto:support+lawarxiv@osf.io">Support&nbsp;</a>|&nbsp;<a href="mailto:contact+lawarxiv@osf.io">Contact&nbsp;</a>|&nbsp;<a href="https://twitter.com/lawarxiv" target="_blank" title="LawArXiv on Twitter"><span class="fa fa-twitter fa-2x" style="vertical-align: middle;">&nbsp;</span></a></p>\n <p>LawrXiv is a trademark of Cornell University, used under license. This license should not be understood to indicate endorsement of content on LawArXiv by Cornell University or arXiv.</p>',
     },
     {
         id: 'preprintrxiv',

--- a/mirage/fixtures/preprint-providers.ts
+++ b/mirage/fixtures/preprint-providers.ts
@@ -34,7 +34,8 @@ const preprintProviders: Array<Partial<PreprintProvider>> = [
         name: 'PreprintrXiv',
         preprintWord: 'preprint',
         assets: randomAssets(3),
-        footerLinks: 'fake footer links',
+        // eslint-disable-next-line max-len
+        footerLinks: 'Removed in mirage scenario',
         reviewsCommentsPrivate: true,
         reviewsWorkflow: PreprintProviderReviewsWorkFlow.PRE_MODERATION,
     },
@@ -43,14 +44,16 @@ const preprintProviders: Array<Partial<PreprintProvider>> = [
         name: 'PaperXiv',
         preprintWord: 'paper',
         assets: randomAssets(4),
-        footerLinks: 'fake footer links',
+        // eslint-disable-next-line max-len
+        footerLinks: '<p style="text-align: right;" data-mce-style="text-align: right;">AgriXiv:&nbsp;<a href="mailto:support+agrixiv@osf.io" data-mce-href="mailto:support+agrixiv@osf.io">Support&nbsp;</a>|&nbsp;<a href="mailto:contact+agrixiv@osf.io" data-mce-href="mailto:contact+agrixiv@osf.io">Contact&nbsp;</a>|&nbsp;<a href="https://twitter.com/AgriXiv" target="_blank" title="AgriXiv on Twitter" rel="noopener" data-mce-href="https://twitter.com/AgriXiv"><span class="fa fa-twitter fa-2x" style="vertical-align: middle;" data-mce-style="vertical-align: middle;">&nbsp;</span></a>&nbsp;<a href="https://www.facebook.com/AgriXiv/" target="_blank" title="AgriXiv on Facebook" rel="noopener" data-mce-href="https://www.facebook.com/AgriXiv/"><span class="fa fa-facebook fa-2x" style="vertical-align: middle;" data-mce-style="vertical-align: middle;">&nbsp;</span></a>&nbsp;<a href="https://www.instagram.com/agrixiv/" target="_blank" title="AgriXiv on Instagram" rel="noopener" data-mce-href="https://www.instagram.com/agrixiv/"><span class="fa fa-2x fa-instagram" style="vertical-align: middle;" data-mce-style="vertical-align: middle;">&nbsp;</span></a><br data-mce-bogus="1"></p><p style="text-align: right;" data-mce-style="text-align: right;">arXiv is a trademark of Cornell University, used under license. This license should not be understood to indicate endorsement of content on AgriXiv by Cornell University or arXiv.</p>',
     },
     {
         id: 'thesisrxiv',
         name: 'ThesisrXiv',
         preprintWord: 'thesis',
         assets: randomAssets(5),
-        footerLinks: 'fake footer links',
+        // eslint-disable-next-line max-len
+        footerLinks: '<p style="text-align: left;" data-mce-style="text-align: left;">AgriXiv:&nbsp;<a href="mailto:support+agrixiv@osf.io" data-mce-href="mailto:support+agrixiv@osf.io">Support&nbsp;</a>|&nbsp;<a href="mailto:contact+agrixiv@osf.io" data-mce-href="mailto:contact+agrixiv@osf.io">Contact&nbsp;</a>|&nbsp;<a href="https://twitter.com/AgriXiv" target="_blank" title="AgriXiv on Twitter" rel="noopener" data-mce-href="https://twitter.com/AgriXiv"><span class="fa fa-twitter fa-2x" style="vertical-align: middle;" data-mce-style="vertical-align: middle;">&nbsp;</span></a>&nbsp;<a href="https://www.facebook.com/AgriXiv/" target="_blank" title="AgriXiv on Facebook" rel="noopener" data-mce-href="https://www.facebook.com/AgriXiv/"><span class="fa fa-facebook fa-2x" style="vertical-align: middle;" data-mce-style="vertical-align: middle;">&nbsp;</span></a>&nbsp;<a href="https://www.instagram.com/agrixiv/" target="_blank" title="AgriXiv on Instagram" rel="noopener" data-mce-href="https://www.instagram.com/agrixiv/"><span class="fa fa-2x fa-instagram" style="vertical-align: middle;" data-mce-style="vertical-align: middle;">&nbsp;</span></a><br data-mce-bogus="1"></p><p style="text-align: left;" data-mce-style="text-align: left;">arXiv is a trademark of Cornell University, used under license. This license should not be understood to indicate endorsement of content on AgriXiv by Cornell University or arXiv.</p>',
     },
     {
         id: 'workrxiv',


### PR DESCRIPTION
https://www.notion.so/cos/0de7c99478234fd7be57029dd96aa2d3?v=a4e6d7c70c004d27a0955aa2742775a4&p=c7b78078a9454234b8fcf168e4448b12&pm=c

-   Ticket: []
-   Feature flag: n/a

## Purpose

The preprint footer links for branded providers was too biased.

## Summary of Changes

removed the css flex and changed it to be text-align: center

## Screenshot(s)

N/A

## Side Effects

N/A

## QA Notes

This bug should be working now.

https://www.notion.so/cos/0de7c99478234fd7be57029dd96aa2d3?v=a4e6d7c70c004d27a0955aa2742775a4&p=c7b78078a9454234b8fcf168e4448b12&pm=c

https://www.notion.so/cos/0de7c99478234fd7be57029dd96aa2d3?v=a4e6d7c70c004d27a0955aa2742775a4&p=6d048fec2c554fb2beae2d838bc63c77&pm=c
