### PR TITLE
Fix branded navbar colors for mobile

### DIFF
--- a/lib/app-components/addon/components/branded-navbar/styles.scss
+++ b/lib/app-components/addon/components/branded-navbar/styles.scss
@@ -128,8 +128,8 @@
 
         /* stylelint-disable */
         .desktop {
-            >ul>li a:not(:global(.btn-top-signup)),
-            >:global(.secondary-nav-dropdown) {
+            a:not(:global(.btn-top-signup)),
+            :global(.secondary-nav-dropdown) {
                 color: $color-text-black !important;
             }
         }

--- a/lib/app-components/addon/components/branded-navbar/styles.scss
+++ b/lib/app-components/addon/components/branded-navbar/styles.scss
@@ -113,31 +113,30 @@
 .preprint-branded-navbar.preprint-branded-navbar {
     background-color: var(--primary-color);
     background-image: none;
+    color: $color-text-white;
 
     .secondary-navigation {
         border-color: transparent;
     }
 
-    &.light-text {
-        a:not(:global(.btn-top-signup)),
-        :global(.secondary-nav-dropdown) {
-            color: $color-text-white !important;
-        }
-    }
-
+    // Dark text only applied to provider name, hamburger menu (only shows up in mobile), and navbar links in desktop view
     &.dark-text {
-        a:not(:global(.btn-top-signup)),
-        :global(.secondary-nav-dropdown) {
+        a:global(.navbar-brand),
+        .navbar-toggle {
             color: $color-text-black !important;
         }
+
+        /* stylelint-disable */
+        .desktop {
+            >ul>li a:not(:global(.btn-top-signup)),
+            >:global(.secondary-nav-dropdown) {
+                color: $color-text-black !important;
+            }
+        }
+        /* stylelint-enable */
     }
 }
 
-.white-background-branded-navbar.white-background-branded-navbar.white-background-branded-navbar {
-    background-color: #fff;
-
-    a:not(:global(.btn-top-signup)),
-    :global(.secondary-nav-dropdown) {
-        color: $color-text-black !important;
-    }
+.white-background-branded-navbar {
+    background-color: #fff !important;
 }

--- a/lib/app-components/addon/components/branded-navbar/template.hbs
+++ b/lib/app-components/addon/components/branded-navbar/template.hbs
@@ -2,8 +2,8 @@
     <nav
         local-class='branded-nav
         {{if (eq this.theme.providerType 'preprint') 'preprint-branded-navbar'}}
-        {{if (sufficient-contrast this.brandPrimaryColor '#fff') 'light-text' 'dark-text'}}
-        {{if this.useWhiteBackground 'white-background-branded-navbar'}}'
+        {{if (not (sufficient-contrast this.brandPrimaryColor '#fff')) 'dark-text'}}
+        {{if this.useWhiteBackground 'white-background-branded-navbar dark-text'}}'
         class='navbar navbar-inverse navbar-fixed-top'
         id='navbarScope'
     >
@@ -34,7 +34,7 @@
             {{#if this.shouldShowNavLinks}}
                 <div
                     class='navbar-collapse navbar-right'
-                    local-class='secondary-navigation'
+                    local-class='secondary-navigation {{if this.isMobileOrTablet 'mobile' 'desktop'}}'
                 >
                     <ul class='nav navbar-nav' local-class='links'>
                         {{#if (eq this.theme.providerType 'collection')}}


### PR DESCRIPTION
-   Ticket: [[Notion Card]](https://www.notion.so/cos/iOSSafari-Labels-not-visible-in-hamburger-menu-icon-7d6e3cffa74247cd8746908dae090c06?pvs=4)
-   Feature flag: n/a

## Purpose
- Fix visibility issue of links for mobile branded navbar

## Summary of Changes
- CSS updates to make the branded-navbar slightly less gross
  - Remove `light-text` class, and just make white text the default
  - Simplify `.white-background` by just using `.dark-text` to indicate which text-color to use

## Screenshot(s)
- Before photos in the notion card

- Biohackrxiv (special-cased to use white background and black text on desktop)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/b53dbd21-2ce4-4c95-a848-df7228c12402)
![Screen Shot 2023-11-17 at 11 37 04 AM](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/9d2b45bb-dc4f-41e1-a40e-72ff3f6cec6d)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/9ccef81e-a069-482f-ac2e-e18fc2d82ab5)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/dd0ff221-0761-4b09-8cee-b4dd48a5d754)


- Agrixiv (uses black text on desktop)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/75051787-5d83-4597-b2ee-a0af4ff3d579)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/283049dc-b0ea-45b1-9017-8e14592ce2dc)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/e0e58f85-26a4-4ddf-beb6-efb8a6bc21f1)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/0baf1bf7-d77e-4659-9925-fe66d0002a00)


- Other provider with white text
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/bea9561a-ee15-44b2-aa2f-450fd8e7eec6)

![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/c4c7c520-e440-4611-9b88-2a467e0b3bbd)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
