### PR TITLE
Fix link to my-preprints

### DIFF
--- a/lib/osf-components/addon/components/osf-navbar/preprint-links/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/preprint-links/template.hbs
@@ -1,6 +1,6 @@
 <li data-test-nav-my-preprints-link>
     <OsfLink
-        @href='/myprojects/#preprints/'
+        @href='/myprojects/#preprints'
         data-analytics-name='My preprints'
         {{on 'click' @onLinkClicked}}
     >


### PR DESCRIPTION
-   Ticket: [[Notion Card]](https://www.notion.so/cos/When-clicked-on-My-Preprints-navigates-to-All-my-Projects-and-components-instead-of-All-my-Preprint-a8819526916d4b25a8d6728fad9cff34?pvs=4)
-   Feature flag: n/a

## Purpose
- Fix link to "My Preprints" on navbar

## Summary of Changes
- remove trailing `/` from link

## Screenshot(s)
NA

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- Fixes link for non-branded navbar on OSF Preprints landing page