### PR TITLE
Fixed a link for the "Powered by osf preprints"

### DIFF
--- a/app/preprints/index/template.hbs
+++ b/app/preprints/index/template.hbs
@@ -19,7 +19,7 @@
                     <OsfLink
                         data-test-poweredby-button
                         data-analytics-name='powered-by button'
-                        @href={{concat @host 'preprints'}}
+                        @href={{'/preprints'}}
                     >
                         {{t 'preprints.header.powered_by'}}
                     </OsfLink>


### PR DESCRIPTION
https://www.notion.so/cos/0de7c99478234fd7be57029dd96aa2d3?v=a4e6d7c70c004d27a0955aa2742775a4&p=233e48dfb6354b4a9397c93a709d7431&pm=c

-   Ticket: []
-   Feature flag: n/a

## Purpose

The link was not working

## Summary of Changes

Removed the @host and did a static `/preprints`

## Screenshot(s)

NA

## Side Effects

Should work now

## QA Notes

Verify it is working.
