### PR TITLE
Fixed the logic for preprints with a coi of null

### DIFF
--- a/app/preprints/-components/preprint-author-assertions/component.ts
+++ b/app/preprints/-components/preprint-author-assertions/component.ts
@@ -48,6 +48,10 @@ export default class PreprintAuthorAssertions extends Component<InputArgs> {
     }
 
     public get hasCoi(): boolean {
+        return this.preprint.hasCoi !== null;
+    }
+
+    public get isCoiTrue(): boolean {
         return this.preprint.hasCoi;
     }
 

--- a/app/preprints/-components/preprint-author-assertions/template.hbs
+++ b/app/preprints/-components/preprint-author-assertions/template.hbs
@@ -16,7 +16,7 @@
                             @type='default'
                             {{on 'click' (action (mut this.displayCoi) (not this.displayCoi))}}
                         >
-                            {{if this.hasCoi
+                            {{if this.isCoiTrue
                                 (t 'preprints.detail.author-assertions.available.yes')
                                 (t 'preprints.detail.author-assertions.available.no')}}
                             <FaIcon @icon='caret-down' @prefix='fas' aria-hidden='true'/>

--- a/mirage/scenarios/preprints.ts
+++ b/mirage/scenarios/preprints.ts
@@ -127,6 +127,7 @@ function buildOSF(
         currentUserPermissions: [],
         reviewsState: ReviewsState.ACCEPTED,
         public: true,
+        hasCoi: false,
         isPreprintDoi: false,
         isPublished: false,
     }), 'isContributor');


### PR DESCRIPTION

-   Ticket: [https://www.notion.so/cos/0de7c99478234fd7be57029dd96aa2d3?v=a4e6d7c70c004d27a0955aa2742775a4&p=7854e6a6f2a5445a8e57e8f34d54339a&pm=c]
-   Feature flag: n/a

## Purpose

A coi was not displaying if it was set to "false"

## Summary of Changes

Changed the original method to check for null and added a new method for true/false

## Screenshot(s)

N.A

## Side Effects

Should work now

## QA Notes

https://www.notion.so/cos/0de7c99478234fd7be57029dd96aa2d3?v=a4e6d7c70c004d27a0955aa2742775a4&p=7854e6a6f2a5445a8e57e8f34d54339a&pm=c
