### PR TITLE
Preprint metadata

### DIFF
--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -22,8 +22,12 @@ export default function(server: Server) {
     server.loadFixtures('regions');
     server.loadFixtures('preprint-providers');
     server.loadFixtures('licenses');
-    server.loadFixtures('citation-styles');
     // server.loadFixtures('registration-providers');
+
+    // load citations for preprints, registrations, or manyProjectRegistrations
+    if (mirageScenarios.some(s => ['preprints', 'manyProjectRegistrations', 'registrations'].includes(s))) {
+        server.loadFixtures('citation-styles');
+    }
 
     const userTraits = !mirageScenarios.includes('loggedIn') ? []
         : [

--- a/mirage/scenarios/registrations.ts
+++ b/mirage/scenarios/registrations.ts
@@ -14,8 +14,6 @@ export function manyProjectRegistrationsScenario(
     server: Server,
     currentUser: ModelInstance<User>,
 ) {
-    server.loadFixtures('citation-styles');
-
     const registrationNode = server.create(
         'node',
         {
@@ -45,7 +43,6 @@ export function registrationScenario(
     currentUser: ModelInstance<User>,
 ) {
     const { defaultProvider } = config;
-    server.loadFixtures('citation-styles');
 
     server.create('registration-provider', {
         id: defaultProvider,


### PR DESCRIPTION
-   Ticket: [[Notion Card]](https://www.notion.so/cos/Add-preprint-metadata-to-head-tag-57c28a72f7a0451ab55d786ee5e1291e?pvs=4)
-   Feature flag: n/a

## Purpose
- Add metadata info to head for preprint detail page

## Summary of Changes
- Use metatags service to add preprint metadata to head (logic taken primarily from [registration overview page](https://github.com/CenterForOpenScience/ember-osf-web/blob/develop/lib/registries/addon/overview/route.ts#L36))
  - Notably removed `institution` metadata as preprints don't have that

## Screenshot(s)
- Preprint detail page's head tag:
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/2037ceb2-9174-4b2f-b986-ac8511b51942)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
