### PR TITLE
Updates to fix the text on the branded search page

### DIFF
--- a/lib/osf-components/addon/components/search-help-modal/component.ts
+++ b/lib/osf-components/addon/components/search-help-modal/component.ts
@@ -21,21 +21,6 @@ interface InputArgs {
 export default class SearchHelpModal extends Component<InputArgs> {
     @service router!: RouterService;
 
-    examples: Array<{ q: string, text: string }> = [
-        {
-            q: 'repro*',
-            text: 'repro*',
-        },
-        {
-            q: 'brian+AND+title%3Amany',
-            text: 'brian AND title:many',
-        },
-        {
-            q: 'tags%3A%28psychology%29',
-            text: 'tags:(psychology)',
-        },
-    ];
-
     get currentPath(): string {
         return getOwner(this).lookup('controller:application').currentPath;
     }

--- a/lib/osf-components/addon/components/search-help-modal/template.hbs
+++ b/lib/osf-components/addon/components/search-help-modal/template.hbs
@@ -10,23 +10,11 @@
             </h3>
         </dialog.heading>
         <dialog.main data-test-search-help-modal-body>
-            <h4>
-                {{t 'app_components.search_help_modal.queries'}}
-            </h4>
             <p>
-                {{t 'app_components.search_help_modal.searchSyntax' htmlSafe=true}}
-                {{t 'app_components.search_help_modal.helpDescription'}}
+                {{t 'app_components.search_help_modal.description' htmlSafe=true}}
             </p>
-            <ul>
-                {{#each this.examples as |example|}}
-                    <li>
-                        <a href={{concat this.currentPath '?q=' example.q}}>
-                            {{example.text}}
-                        </a>
-                    </li>
-                {{/each}}
-            </ul>
         </dialog.main>
+
         <dialog.footer data-test-search-help-modal-footer>
             <Button
                 data-test-search-help-modal-close-button

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -943,9 +943,7 @@ app_components:
     search_help_modal:
         close: Close
         title: 'Search help'
-        queries: Queries
-        searchSyntax: 'Search uses the <a href="http://extensions.xwiki.org/xwiki/bin/view/Extension/Search+Application+Query+Syntax">Lucene search syntax</a>.'
-        helpDescription: 'This gives you many options, but can be very simple as well. Examples of valid searches include:'
+        description: 'OSF Search provides a powerful discovery tool to help you find data, papers, analysis plans, and more content across the research lifecycle. OSF Preprints has some specialized filters, which you can learn more about on our <a href="https://help.osf.io/article/181-search-and-discover-preprints" target="_blank">help guides</a>.'
     search_paginator:
         prev: «
         prev_aria: 'Go to previous page'


### PR DESCRIPTION

-   Ticket: [https://www.notion.so/cos/0de7c99478234fd7be57029dd96aa2d3?v=a4e6d7c70c004d27a0955aa2742775a4&p=5495aac4b73743c1a31e6ebd8db6e7ca&pm=c]
-   Feature flag: n/a

## Purpose

Update the search help text to reflect the current search mechanism

## Summary of Changes

Updated the translation strings and removed anything unnecessary

## Screenshot(s)

![Screenshot 2023-11-27 at 2 56 02 PM](https://github.com/CenterForOpenScience/ember-osf-web/assets/113387478/e58a08e3-a218-41d2-9930-3d8ef7eb56bd)


## Side Effects

None

## QA Notes

Please test

https://www.notion.so/cos/0de7c99478234fd7be57029dd96aa2d3?v=a4e6d7c70c004d27a0955aa2742775a4&p=5495aac4b73743c1a31e6ebd8db6e7ca&pm=c
