### PR TITLE
[Hotfix] Add back favicon for preprint discover page

### DIFF
--- a/app/preprints/discover/route.ts
+++ b/app/preprints/discover/route.ts
@@ -4,6 +4,7 @@ import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 import config from 'ember-osf-web/config/environment';
 
+import PreprintProviderModel from 'ember-osf-web/models/preprint-provider';
 import MetaTags, { HeadTagDef } from 'ember-osf-web/services/meta-tags';
 import Theme from 'ember-osf-web/services/theme';
 
@@ -36,6 +37,19 @@ export default class PreprintDiscoverRoute extends Route {
         } catch (e) {
             this.router.transitionTo('not-found', `preprints/${args.provider_id}/discover`);
             return null;
+        }
+    }
+
+    afterModel(model: PreprintProviderModel) {
+        if (model && model.assets && model.assets.favicon) {
+            const headTags = [{
+                type: 'link',
+                attrs: {
+                    rel: 'icon',
+                    href: model.assets.favicon,
+                },
+            }];
+            this.set('headTags', headTags);
         }
     }
 }


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Bring back favicon for branded preprint discover page

## Summary of Changes
- Add back `afterModel` hook to preprint discover page that sets favicon

## Screenshot(s)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
