### PR TITLE
See example hot fix

### DIFF
--- a/app/preprints/index/template.hbs
+++ b/app/preprints/index/template.hbs
@@ -41,7 +41,8 @@
                             <OsfLink
                                 data-test-submission-see-submission-example
                                 data-analytics-name='See Submission Example'
-                                @href={{if this.theme.provider.example this.theme.provider.example 'khbvy'}}
+                                @route='resolve-guid'
+                                @models={{array (if this.theme.provider.example this.theme.provider.example 'khbvy')}}
                             >
                                 {{t 'preprints.header.example'}}
                             </OsfLink>

--- a/app/preprints/index/template.hbs
+++ b/app/preprints/index/template.hbs
@@ -41,7 +41,7 @@
                             <OsfLink
                                 data-test-submission-see-submission-example
                                 data-analytics-name='See Submission Example'
-                                @href={{concat '/content/' (if this.theme.provider.example this.theme.provider.example 'khbvy')}}
+                                @href={{if this.theme.provider.example this.theme.provider.example 'khbvy'}}
                             >
                                 {{t 'preprints.header.example'}}
                             </OsfLink>

--- a/mirage/scenarios/preprints.ts
+++ b/mirage/scenarios/preprints.ts
@@ -200,6 +200,21 @@ function buildOSF(
         isPublished: false,
     }, 'acceptedWithdrawalComment');
 
+    const examplePreprint = server.create('preprint', {
+        provider: osf,
+        id: 'khbvy',
+        title: 'The "See Example" hard-coded preprint',
+        currentUserPermissions: [],
+        reviewsState: ReviewsState.ACCEPTED,
+        description: `${faker.lorem.sentence(200)}\n${faker.lorem.sentence(100)}`,
+        doi: '10.30822/artk.v1i1.79',
+        originalPublicationDate: new Date('2016-11-30T16:00:00.000000Z'),
+        preprintDoiCreated: new Date('2016-11-30T16:00:00.000000Z'),
+        hasCoi: true,
+        hasDataLinks: PreprintDataLinksEnum.NOT_APPLICABLE,
+        hasPreregLinks: PreprintPreregLinksEnum.NOT_APPLICABLE,
+    });
+
     const subjects = server.createList('subject', 7);
 
     osf.update({
@@ -212,6 +227,7 @@ function buildOSF(
         brand,
         moderators: [currentUserModerator],
         preprints: [
+            examplePreprint,
             rejectedAdminPreprint,
             approvedAdminPreprint,
             approvedPreprint,


### PR DESCRIPTION
Found during regression on live servers

-   Ticket: []
-   Feature flag: n/a

## Purpose

The "see example" button was attempting to go to a /content/<guid> route that was not ported from OSP.

## Summary of Changes

Removed the "content" prefix

## Screenshot(s)

N/A

## Side Effects

As long as the "example" is set admin, it will go to that preprint example. if the example is not set then it will go to the default OSF example.

## QA Notes

Fill in the admin and click the button.
