### PR TITLE
Added a min-height to the data-column for the preprint details page

### DIFF
--- a/app/preprints/detail/styles.scss
+++ b/app/preprints/detail/styles.scss
@@ -71,6 +71,7 @@
     .data-container {
         padding: 30px;
         width: 100%;
+        min-height: 1250px;
         display: flex;
         flex-direction: row;
         justify-content: flex-start;


### PR DESCRIPTION

-   Ticket: [Yuhuai reported]
-   Feature flag: n/a

## Purpose

When there were too few elements in the right column on the preprint details page the expand button was below the fold

## Summary of Changes

Added a min-height attribute of 1250px;

## Screenshot(s)
![Screenshot 2023-12-08 at 9 09 27 AM](https://github.com/CenterForOpenScience/ember-osf-web/assets/113387478/ef98bcf3-49a4-4608-b02b-890e4ce0d766)

## Side Effects

None

## QA Notes

The expand button should be fully visible on all preprints.
