### PR TITLE
[No ticket] Properly support "q" query-param on institution discover page

### DIFF
--- a/app/institutions/discover/controller.ts
+++ b/app/institutions/discover/controller.ts
@@ -10,7 +10,7 @@ import {
 export default class InstitutionDiscoverController extends Controller {
     @service currentUser!: CurrentUser;
 
-    @tracked cardSearchText?: string = '';
+    @tracked q?: string = '';
     @tracked sort?: string =  '-relevance';
     @tracked resourceType: ResourceTypeFilterValue = ResourceTypeFilterValue.Projects;
     @tracked activeFilters?: Filter[] = [];


### PR DESCRIPTION
-   Ticket: [No ticket]
-   Feature flag: n/a

## Purpose
- Support the `q` query-param for search-text on institution discover page

## Summary of Changes
- Update query-param variable name to match what the controller is expecting

## Screenshot(s)
- Query-param isn't added/used because of this name mismatch
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/04534360-9421-4ed2-896c-cde8ee667da9)


## Side Effects
- None

## QA Notes
- typing something in the search text box of the institution discover page should now update the `q` query-param in the URL
- Loading into a page with the `q` query-param set should now auto-populate the search text box