### PR TITLE
Update qp name in search-page component invocation

### DIFF
--- a/app/institutions/discover/template.hbs
+++ b/app/institutions/discover/template.hbs
@@ -2,7 +2,7 @@
 
 <SearchPage
     @route='search'
-    @query={{this.q}}
+    @cardSearchText={{this.q}}
     @defaultQueryOptions={{this.defaultQueryOptions}}
     @queryParams={{this.queryParams}}
     @onQueryParamChange={{action this.onQueryParamChange}}


### PR DESCRIPTION
-   Ticket: [No ticket]
-   Feature flag: n/a

## Purpose
- Allow `q` query-param in URL to set the search textbox value

## Summary of Changes
- Update query-param in component invocation that was missed in [previous PR](https://github.com/CenterForOpenScience/ember-osf-web/pull/2085)

## Screenshot(s)
- Institution discover page with the `q` query-param
<img width="1129" alt="image" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/ab3f9c19-873c-4a21-a815-22ae30e39eee">


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- Enter an institution's discover page with the `q` query-param set to something (`https://staging3.osf.io/institutions/uva?q=some text here`), and the search text-box should be pre-populated
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
