### PR TITLE
[ENG-5012] Remove unnecessary URL shenanigans

### DIFF
--- a/app/preprints/-components/preprint-file-render/component.ts
+++ b/app/preprints/-components/preprint-file-render/component.ts
@@ -54,12 +54,6 @@ export default class PreprintFileRender extends Component<InputArgs> {
 
     private serializeVersions(versions: FileVersionModel[]) {
         const downloadUrl = this.primaryFile.links.download as string || '';
-        const primaryFileGuid = this.primaryFile.id;
-
-        const directDownloadUrl = downloadUrl.replace(
-            `download/${primaryFileGuid}`,
-            `${primaryFileGuid}/download`,
-        );
 
         versions.map((version: VersionModel) => {
             const dateFormatted = encodeURIComponent(version.dateCreated.toISOString());
@@ -70,7 +64,7 @@ export default class PreprintFileRender extends Component<InputArgs> {
                   name: version.name,
                   id: version.id,
                   dateCreated: version.dateCreated,
-                  downloadUrl: `${directDownloadUrl}?version=${version.id}&displayName=${displayName}`,
+                  downloadUrl: `${downloadUrl}?version=${version.id}&displayName=${displayName}`,
               } as VersionModel,
             );
             return version;


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-5012]
-   Feature flag: n/a

## Purpose
- Update preprint version URL to prevent going to `Page not found`

## Summary of Changes
- Remove some extra URL manipulation that was ported over from ember-osf-preprints

## Screenshot(s)
- Prevents page not found when clicking a version to download when clicking "Download previous version" button on preprint detail page

![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/727a16a6-d71d-4ace-a84b-3994232d66a0)

## Side Effects
- Not sure on this one. Not positive why this URL manipulation was done in the first place in ember-osf-preprints, but I've tested this out on staging3, and the version downloads I saw there did not work with the `.replace` that was there before (e.g `https://staging3.osf.io/<id>/download/?version=1&displayName=<file_name>` goes to page not found while `https://staging3.osf.io/download/<id>/?version=1&displayName=<file_name>` actually downloads the file.
## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
