### PR TITLE
[ENG-5019] Add missing collection discover page translations

### DIFF
--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -990,6 +990,8 @@ collections:
             volume: Volume
             study_design: 'Study Design'
             school_type: 'School Type'
+            data_type: 'Data Type'
+            disease: Disease
     collections_submission:
         title: Submit
         add_header: 'Add to Collection'


### PR DESCRIPTION
-   Ticket: [ENG-5019]
-   Feature flag: n/a

## Purpose
- Address missing translation strings in collection discovery page for new collection metadata types

## Summary of Changes
- Add missing translation strings

## Screenshot(s)
- Prevents this issue on a collections discover page
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/ef2a11fc-40bf-40c1-b643-2e62729dbe82)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
