### PR TITLE
[ENG-5055] Fixed an issue that withdrawn preprints get a 404

### DIFF
--- a/app/models/preprint.ts
+++ b/app/models/preprint.ts
@@ -64,7 +64,7 @@ export default class PreprintModel extends OsfModel {
     license!: AsyncBelongsTo<LicenseModel> & LicenseModel;
 
     @belongsTo('file', { inverse: null })
-    primaryFile!: AsyncBelongsTo<FileModel> & FileModel;
+    primaryFile?: AsyncBelongsTo<FileModel> & FileModel;
 
     @belongsTo('preprint-provider', { inverse: 'preprints' })
     provider!: AsyncBelongsTo<PreprintProviderModel> & PreprintProviderModel;

--- a/app/preprints/detail/route.ts
+++ b/app/preprints/detail/route.ts
@@ -58,12 +58,15 @@ export default class PreprintsDetail extends Route {
 
             const provider = await preprint?.get('provider');
 
-            const primaryFile = await preprint?.get('primaryFile');
-
-            primaryFile.versions = await primaryFile?.versions;
-
             this.theme.set('providerType', 'preprint');
             this.theme.set('id', provider.id);
+
+            let primaryFile;
+
+            if (!preprint.isWithdrawn) {
+                primaryFile = await preprint?.get('primaryFile');
+                primaryFile.versions = await primaryFile?.versions;
+            }
 
             const contributors = await preprint?.queryHasMany('contributors');
 

--- a/mirage/scenarios/preprints.ts
+++ b/mirage/scenarios/preprints.ts
@@ -154,7 +154,7 @@ function buildOSF(
         isPublished: false,
         dateWithdrawn: new Date(),
         addLicenseName: false,
-    }), 'isContributor');
+    }), 'isContributor', 'withdrawn' );
 
     const withdrawnLicensePreprint = server.create('preprint', Object({
         provider: osf,
@@ -166,7 +166,7 @@ function buildOSF(
         dateWithdrawn: new Date(),
         withdrawalJustification: 'This is the justification',
         description: `${faker.lorem.sentence(200)}\n${faker.lorem.sentence(100)}`,
-    }), 'isContributor');
+    }), 'isContributor', 'withdrawn');
 
     const pendingWithdrawalPreprint = server.create('preprint', {
         provider: osf,

--- a/mirage/serializers/preprint.ts
+++ b/mirage/serializers/preprint.ts
@@ -44,22 +44,6 @@ export default class PreprintSerializer extends ApplicationSerializer<PreprintMi
                     },
                 },
             },
-            files: {
-                links: {
-                    related: {
-                        href: `${apiUrl}/v2/preprints/${model.id}/files/`,
-                        meta: this.buildRelatedLinkMeta(model, 'files'),
-                    },
-                },
-            },
-            primaryFile: {
-                links: {
-                    related: {
-                        href: `${apiUrl}/v2/files/${model.primaryFile.id}/`,
-                        meta: this.buildRelatedLinkMeta(model, 'files'),
-                    },
-                },
-            },
             license: {
                 links: {
                     related: {
@@ -117,6 +101,26 @@ export default class PreprintSerializer extends ApplicationSerializer<PreprintMi
                 },
             },
         };
+
+        if (model.primaryFile) {
+            relationships['files'] = {
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/preprints/${model.id}/files/`,
+                        meta: this.buildRelatedLinkMeta(model, 'files'),
+                    },
+                },
+            };
+
+            relationships['primaryFile'] = {
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/files/${model.primaryFile.id}/`,
+                        meta: this.buildRelatedLinkMeta(model, 'files'),
+                    },
+                },
+            };
+        }
 
         if (model.license !== null) {
             const { id } = model.license;


### PR DESCRIPTION
-   Ticket: [ENG-5055]
-   Feature flag: n/a

## Purpose

The withdrawn preprints are serving up a 404 error

## Summary of Changes

I didn't know that a widthdrawn preprint didn't have a document. So when the route was fetching data is was attempting to update an attribute on an undefined object throwing an error and being redirected to the 404 page.

I added a conditional statement.

## Screenshot(s)

NA

## Side Effects

None

## QA Notes

All withdrawn preprints should now be visible.


[ENG-5055]: https://openscience.atlassian.net/browse/ENG-5055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ