### PR TITLE
[ENG-5046] Add data-test selectors to the Preprints detail page

### DIFF
--- a/app/preprints/-components/preprint-discipline/template.hbs
+++ b/app/preprints/-components/preprint-discipline/template.hbs
@@ -1,6 +1,8 @@
 <div>
     <h4>{{t 'preprints.detail.disciplines'}}</h4>
-    {{#each this.disciplineReduced as |subject|}}
-        <span local-class='subject-preview'>{{subject.text}}</span>
-    {{/each}}
+    <span data-test-subjects>
+        {{#each this.disciplineReduced as |subject|}}
+            <span local-class='subject-preview'>{{subject.text}}</span>
+        {{/each}}
+    </span>
 </div>

--- a/app/preprints/-components/preprint-status-banner/template.hbs
+++ b/app/preprints/-components/preprint-status-banner/template.hbs
@@ -12,8 +12,8 @@
                 {{else}}
                     <div>
                         <FaIcon @icon='{{this.icon}}' @prefix='far' local-class='status-icon' aria-hidden='true'/>
-                        <strong>{{t this.status }}:</strong>
-                        <span>{{this.bannerContent}}</span>
+                        <strong data-test-status>{{t this.status }}:</strong>
+                        <span data-test-status-explanation>{{this.bannerContent}}</span>
                     </div>
                     {{#if (and this.reviewerComment (not this.submission.provider.reviewsCommentsPrivate))}}
                         <div local-class='reviewer-feedback'>

--- a/app/preprints/-components/preprint-tag/template.hbs
+++ b/app/preprints/-components/preprint-tag/template.hbs
@@ -1,9 +1,11 @@
 <div>
     <h4>{{t 'preprints.detail.tags'}}</h4>
     {{#if @preprint.tags.length}}
-        {{#each @preprint.tags as |tag|}}
-            <span local-class='badge'>{{tag}}</span>
-        {{/each}}
+        <span data-test-tags>
+            {{#each @preprint.tags as |tag|}}
+                <span local-class='badge'>{{tag}}</span>
+            {{/each}}
+        </span>
     {{else}}
         {{t 'preprints.detail.none'}}
     {{/if}}

--- a/app/preprints/detail/template.hbs
+++ b/app/preprints/detail/template.hbs
@@ -5,10 +5,11 @@
     local-class='preprints-details-page-container {{if this.isMobile 'mobile'}}'
     {{with-branding this.model.brand}}
     data-analytics-scope='preprints detail page'
+    data-test-preprint-header
 >
     <div local-class='header-container'>
         <div local-class='preprint-title-container'>
-            <h1>{{this.model.preprint.title}}</h1>
+            <h1 data-test-preprint-title>{{this.model.preprint.title}}</h1>
             {{#unless this.model.preprint.isWithdrawn}}
                 <div class='edit-preprint-button'>
                     {{#if (and this.userIsContrib (not this.isPendingWithdrawal))}}
@@ -122,7 +123,14 @@
                             </OsfLink>
                         </div>
                         <div>
-                            {{t 'preprints.detail.share.views'}}: {{this.model.preprint.apiMeta.metrics.views}} | {{t 'preprints.detail.share.downloads'}}: {{this.model.preprint.apiMeta.metrics.downloads}}
+                            <span data-test-view-count-label>
+                                {{t 'preprints.detail.share.views'}}: 
+                            </span>
+                            <span data-test-view-count> {{this.model.preprint.apiMeta.metrics.views}} </span> | 
+                            <span data-test-download-count-label>
+                                {{t 'preprints.detail.share.downloads'}}: 
+                            </span>
+                            <span data-test-download-count>{{this.model.preprint.apiMeta.metrics.downloads}}</span>
                             <EmberTooltip>
                                 {{t 'preprints.detail.share.metrics_disclaimer'}} {{moment-format this.metricsStartDate 'YYYY-MM-DD'}}
                             </EmberTooltip>


### PR DESCRIPTION
-   Ticket: [ENG-5046]
-   Feature flag: n/a

## Purpose

Add some data test selectors to the Preprints detail page

## Summary of Changes

1. Identity/Header
2. Title
3. Status
4. Status Explanation
5. View Count
6. View Count label
7. Download Count
8. Download Count label
9. Download Button
10. Subjects
11. Tags

Note: The ticket also calls for a Make Decision Button selector, but I'm pretty sure that's just on the reviews app. I will update if I find out differently.

## QA Notes

Make sure your selectors are there.
