### PR TITLE
[ENG-5032] Add proxy-properties to node-addon model

### DIFF
--- a/app/models/node-addon.ts
+++ b/app/models/node-addon.ts
@@ -16,6 +16,18 @@ export default class NodeAddonModel extends OsfModel {
 
     @belongsTo('external-account', { inverse: null })
     externalAccount!: AsyncBelongsTo<ExternalAccountsModel> & ExternalAccountsModel;
+
+    get externalUserId() {
+        return this.externalAccount?.get('user').get('id');
+    }
+
+    get externalUserDisplayName() {
+        return this.externalAccount?.get('displayName');
+    }
+
+    get rootFolder() {
+        return this.folderId || this.folderPath;
+    }
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/tests/unit/models/node-addon-test.ts
+++ b/tests/unit/models/node-addon-test.ts
@@ -1,0 +1,29 @@
+import { run } from '@ember/runloop';
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Model | node-addon', hooks => {
+    setupTest(hooks);
+
+    test('it exists and has proxy properties', function(assert) {
+        const externalAccount = run(() => this.owner.lookup('service:store').createRecord('external-account', {
+            displayName: 'test account',
+            user: this.owner.lookup('service:store').createRecord('user', {id: 'account-user-id'}),
+        }));
+        const model = run(() => this.owner.lookup('service:store').createRecord('node-addon', {
+            node: this.owner.lookup('service:store').createRecord('node'),
+            externalAccount,
+            folderId: 'folder-id',
+        }));
+        assert.ok(!!model, 'model exists');
+        assert.equal(model.get('externalUserId'), 'account-user-id',
+            'externalUserId is a proxy of externalAccount.user.id');
+        assert.equal(model.get('externalUserDisplayName'), 'test account',
+            'externalUserDisplayName is a proxy of externalAccount.displayName');
+        assert.equal(model.get('rootFolder'), 'folder-id', 'rootFolder is a proxy of folderId if it exists');
+        model.set('folderId', undefined);
+        model.set('folderPath', 'folder-path');
+        assert.equal(model.get('rootFolder'), 'folder-path',
+            'rootFolder is a proxy of folderPath if folderId is undefined');
+    });
+});


### PR DESCRIPTION
-   Ticket: [ENG-5032]
-   Feature flag: n/a

## Purpose
- Add properties to v2 `node-addon` model to match what is found on the new addons service's `configured-storage-addon` model properties

## Summary of Changes
- Added the following properties to the node-addon model
  - `externalUserId`
  - `externalUserDisplayName`
  - `rootFolder`
- Add test

## Screenshot(s)
- NA
## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-5032]: https://openscience.atlassian.net/browse/ENG-5032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ