### PR TITLE
[ENG-5049] Update links to license help guide

### DIFF
--- a/lib/osf-components/addon/components/license-picker/component.ts
+++ b/lib/osf-components/addon/components/license-picker/component.ts
@@ -33,7 +33,7 @@ export default class LicensePicker extends Component {
 
     showText = false;
     licensesAcceptable!: QueryHasManyResult<License>;
-    helpLink = 'https://help.osf.io/';
+    licenseHelpLink = 'https://help.osf.io/article/148-licensing';
 
     @alias('theme.provider') provider!: Provider;
     @alias('form.changeset.license') selected!: License;

--- a/lib/osf-components/addon/components/license-picker/template.hbs
+++ b/lib/osf-components/addon/components/license-picker/template.hbs
@@ -23,7 +23,7 @@
     <a
         target='_blank'
         rel='noopener noreferrer'
-        href={{this.helpLink}}
+        href={{this.licenseHelpLink}}
     >
         {{t 'app_components.license_picker.faq'}}
     </a>

--- a/lib/registries/addon/components/registries-license-picker/component.ts
+++ b/lib/registries/addon/components/registries-license-picker/component.ts
@@ -35,6 +35,5 @@ export default class RegistriesLicensePicker extends Component {
 
     shouldShowButtons = false;
     showText = false;
-    helpLink = 'https://help.osf.io/hc/en-us/articles/360019739014-Licensing';
     registration!: BufferedChangeset | Registration;
 }

--- a/lib/registries/addon/components/registries-license-picker/template.hbs
+++ b/lib/registries/addon/components/registries-license-picker/template.hbs
@@ -27,15 +27,6 @@
             <LoadingIndicator @dark={{true}} />
         {{/if}}
 
-        <div local-class='small help-link'>
-            <OsfLink
-                @target='_blank'
-                @rel='noopener noreferrer'
-                @href={{this.helpLink}}>
-                {{t 'app_components.license_picker.faq'}}
-            </OsfLink>
-        </div>
-
         {{#if (and @manager.selectedLicense @manager.selectedLicense.requiredFields)}}
             <form.custom
                 local-class='AdditionalFields'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1540,7 +1540,7 @@ registries:
             save: 'Save'
             clear_all: 'Clear all'
         add_license: 'Add license'
-        license_help_text: 'A license tells others how they can use your work in the future and only applies to the information and files submitted with the registration. For more information, see this <a href="https://help.osf.io/hc/en-us/articles/360019739014-Licensing" target="_blank" rel="noopener noreferrer">article on licenses</a>.'
+        license_help_text: 'A license tells others how they can use your work in the future and only applies to the information and files submitted with the registration. For more information, see this <a href="https://help.osf.io/article/148-licensing" target="_blank" rel="noopener noreferrer">help guide</a>.'
         affiliated_institutions: 'Affiliated institutions'
         category: Category
         choose_license: 'Choose a License'


### PR DESCRIPTION
-   Ticket: [ENG-5049]
-   Feature flag: n/a

## Purpose
- Fix broken links to license help guides

## Summary of Changes
- Update license help guide link on draft registration metadata page
- Remove unneeded "License FAQ" link (previous link was broken anyway)
- Update "License FAQ" link on collection submission page

## Screenshot(s)
- On draft registration metadata page
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/3d130c9a-e9b7-45f3-b672-08ede2097e2b)

- On collection submissions's "Project metadata" panel
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/28abc4cf-a0f0-41f6-8097-d4d6b323f093)

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-5049]: https://openscience.atlassian.net/browse/ENG-5049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ