### PR TITLE
[ENG-5225] Update submit button label

### DIFF
--- a/app/preprints/index/template.hbs
+++ b/app/preprints/index/template.hbs
@@ -35,7 +35,7 @@
                             local-class='btn btn-success btn-lg'
                             @href={{concat this.theme.pathPrefix 'submit'}}
                         >
-                            {{t 'preprints.header.submit_label' documentType=this.theme.provider.content.documentType}}
+                            {{t 'preprints.header.submit_label' documentType=this.theme.provider.documentType.singular}}
                         </OsfLink>
                         <div local-class='example-container'>
                             <OsfLink

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1225,9 +1225,8 @@ preprints:
         search_help: 'Search help'
         powered_by: 'Powered by OSF Preprints'
         or: 'or'
-        submit_label: 'Submit a preprint'
+        submit_label: 'Submit a {documentType}'
         example: 'See an example'
-        authors_label: 
     subjects:
         heading:
             provider: 'Browse by provider'


### PR DESCRIPTION
-   Ticket: [ENG-5225]
-   Feature flag: n/a

## Purpose
- Update "Submit a preprint" button label on the preprint landing page to use the provider's preprintWord

## Summary of Changes
- Update translation string to use passed in `documentType`
- Remove unused translation string

## Screenshot(s)
- The green button here should have the appropriate preprint-word
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/dfecff76-fb31-45c9-8458-5b9f0ec1d923)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/5ff7cea6-af61-4b3f-a482-81197d44d511)

## Side Effects
- None

## QA Notes
- This button only shows up if the preprint provider is currently accepting submissions. Please check the `allow_submissions` flag in the admin app for preprint-providers
- Please verify that the different preprint words used in production ("preprint", "paper", "thesis", and "work") all show up.

[ENG-5225]: https://openscience.atlassian.net/browse/ENG-5225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ