### PR TITLE
[ENG-5164] Addons - User settings page

### DIFF
--- a/app/config/environment.d.ts
+++ b/app/config/environment.d.ts
@@ -159,6 +159,7 @@ declare const config: {
             homePageHeroTextVersionB: string;
         };
         storageI18n: string;
+        gravyWaffle: string;
         enableInactiveSchemas: string;
         registrationFilesPage: string;
         verifyEmailModals: string;

--- a/app/router.ts
+++ b/app/router.ts
@@ -47,6 +47,7 @@ Router.map(function() {
             this.route('create');
         });
         this.route('account');
+        this.route('addons');
         this.route('tokens', function() {
             this.route('edit', { path: '/:token_id' });
             this.route('create');

--- a/app/settings/template.hbs
+++ b/app/settings/template.hbs
@@ -39,14 +39,24 @@
                                     {{t 'settings.account.title'}}
                                 </OsfLink>
                             </li>
-                            <li>
-                                <OsfLink
-                                    data-analytics-name='Configure add-on accounts'
-                                    data-test-addons-link
-                                    @href='/settings/addons'
-                                >
-                                    {{t 'settings.addons.title'}}
-                                </OsfLink>
+                            <li local-class={{if (eq this.router.currentRouteName 'settings.addons') 'active'}}>
+                                {{#if (feature-flag 'gravy_waffle')}}
+                                    <OsfLink
+                                        data-analytics-name='Configure add-on accounts'
+                                        data-test-addons-link
+                                        @route='settings.addons'
+                                    >
+                                        {{t 'settings.addons.title'}}
+                                    </OsfLink>
+                                {{else}}
+                                    <OsfLink
+                                        data-analytics-name='Configure add-on accounts'
+                                        data-test-addons-link
+                                        @href='/settings/addons'
+                                    >
+                                        {{t 'settings.addons.title'}}
+                                    </OsfLink>
+                                {{/if}}
                             </li>
                             <li>
                                 <OsfLink

--- a/config/environment.js
+++ b/config/environment.js
@@ -255,6 +255,7 @@ module.exports = function(environment) {
                 'settings.developer-apps.index': 'ember_user_settings_apps_page',
                 'settings.developer-apps.create': 'ember_user_settings_apps_page',
                 'settings.developer-apps.edit': 'ember_user_settings_apps_page',
+                'settings.addons': 'gravy_waffle',
                 register: 'ember_auth_register',
                 'registries.overview': 'ember_registries_detail_page',
                 'registries.overview.index': 'ember_registries_detail_page',
@@ -277,6 +278,7 @@ module.exports = function(environment) {
                 institutions: 'institutions_nav_bar',
             },
             storageI18n: 'storage_i18n',
+            gravyWaffle: 'gravy_waffle',
             enableInactiveSchemas: 'enable_inactive_schemas',
             verifyEmailModals: 'ember_verify_email_modals',
             ABTesting: {

--- a/mirage/factories/root.ts
+++ b/mirage/factories/root.ts
@@ -10,6 +10,7 @@ const {
         navigation,
         storageI18n,
         verifyEmailModals,
+        gravyWaffle,
     },
 } = config;
 
@@ -35,6 +36,7 @@ export const defaultRootAttrs = {
         ...Object.values(navigation),
         storageI18n,
         verifyEmailModals,
+        gravyWaffle,
     ])],
     message: 'Welcome to the OSF API.',
     version: '2.8',


### PR DESCRIPTION
-   Ticket: [ENG-5164]
-   Feature flag: `gravy_waffle`

## Purpose

Add a user settings addon page and start the waffling process.

## Summary of Changes

1. Add gravy_waffle flag
2. Add route to settings.addons
3. Add template to settings.addons
4. Adjust menu item for settings.addons to conditionally route to new page if the flag is set

## Screenshot(s)

<img width="1222" alt="Screenshot 2024-01-24 at 2 43 12 PM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/d8dd8180-6557-4208-adc8-30b89e3e5594">

## Side Effects

Should be side-effect free

## QA Notes

This should only route to the new page on environments where the waffle flag above is set.


[ENG-5164]: https://openscience.atlassian.net/browse/ENG-5164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ