### PR TITLE
[ENG-5149] Choose account workflow for addons

### DIFF
--- a/app/guid-node/addons/index/styles.scss
+++ b/app/guid-node/addons/index/styles.scss
@@ -49,3 +49,7 @@
 .back-button {
     float: right;
 }
+
+.account-select {
+    margin: 20px 0;
+}

--- a/app/guid-node/addons/index/template.hbs
+++ b/app/guid-node/addons/index/template.hbs
@@ -93,7 +93,7 @@
                                 data-test-addon-confirm-setup-button
                                 data-analytics-name='Confirm Setup'
                                 disabled={{manager.confirmAccountSetup.isRunning}}
-                                {{on 'click' (perform manager.confirmAccountSetup)}}
+                                {{on 'click' (perform manager.confirmAccountSetup manager.selectedAccount)}}
                             >
                                 {{if manager.confirmAccountSetup.isRunning (t 'addons.confirm.authorizing') (t 'general.confirm')}}
                             </Button>

--- a/app/guid-node/addons/index/template.hbs
+++ b/app/guid-node/addons/index/template.hbs
@@ -22,13 +22,6 @@
                             {{t 'general.back'}}
                         </Button>
                     </div>
-                    <Button
-                        data-test-addon-cancel-button
-                        data-analytics-name='Cancel'
-                        {{on 'click' manager.cancelSetup}}
-                    >
-                        {{t 'general.cancel'}}
-                    </Button>
                     {{#if (eq manager.pageMode 'terms')}}
                         <Button
                             data-test-addon-accept-terms-button
@@ -58,20 +51,33 @@
                             {{t 'addons.accountSelect.new-account'}}
                         </Button>
                     {{else if (eq manager.pageMode 'accountSelect')}}
-                        <ul>
+                        <fieldset>
                             {{#each provider.authorizedStorageAccounts as |account| }}
-                                <li>{{account.externalUserDisplayName}}</li>
+                                <div local-class='account-select'>
+                                    <label>
+                                        <Input
+                                            name='account-select'
+                                            @value={{account.id}}
+                                            @type='radio'
+                                            @checked={{eq manager.selectedAccount.id account.id}}
+                                            {{on 'change' (fn manager.selectAccount account)}}
+                                        />
+                                        {{account.externalUserDisplayName}}
+                                    </label>
+                                </div>
+                            {{else}}
+                                {{t 'addons.accountSelect.no-accounts'}}
                             {{/each}}
-                        </ul>
+                        </fieldset>
                         <Button
                             data-test-addon-authorize-button
                             data-analytics-name='Authorize'
+                            disabled={{not manager.selectedAccount.id}}
                             {{on 'click' manager.authorizeSelectedAccount}}
                         >
                             {{t 'general.authorize'}}
                         </Button>
                     {{else if (eq manager.pageMode 'accountCreate')}}
-                        
                         <Button
                             data-test-addon-authorize-button
                             data-analytics-name='Authorize'
@@ -80,13 +86,18 @@
                             {{t 'general.authorize'}}
                         </Button>
                     {{else if (eq manager.pageMode 'confirm')}}
-                        <Button
-                            data-test-addon-confirm-setup-button
-                            data-analytics-name='Confirm Setup'
-                            {{on 'click' manager.confirmAccountSetup}}
-                        >
-                            {{t 'general.confirm'}}
-                        </Button>
+                        {{t 'addons.confirm.verify'}}
+                        {{manager.selectedAccount.externalUserDisplayName}}
+                        <div>
+                            <Button
+                                data-test-addon-confirm-setup-button
+                                data-analytics-name='Confirm Setup'
+                                disabled={{manager.confirmAccountSetup.isRunning}}
+                                {{on 'click' (perform manager.confirmAccountSetup)}}
+                            >
+                                {{if manager.confirmAccountSetup.isRunning (t 'addons.confirm.authorizing') (t 'general.confirm')}}
+                            </Button>
+                        </div>
                     {{else if (eq manager.pageMode 'configure')}}
                         <Button
                             data-test-addon-save-button

--- a/app/packages/addons-service/provider.ts
+++ b/app/packages/addons-service/provider.ts
@@ -112,13 +112,14 @@ export default class Provider {
 
     @task
     @waitFor
-    async createConfiguredStorageAddon() {
+    async createConfiguredStorageAddon(account: AuthorizedStorageAccountModel) {
         if (!this.configuredStorageAddon) {
             const configuredStorageAddon = this.store.createRecord('configured-storage-addon', {
                 rootFolder: '',
                 storageProvider: this.provider,
                 accountOwner: this.userReference,
                 authorizedResource: this.serviceNode,
+                baseAccount: account,
             });
             await configuredStorageAddon.save();
             this.configuredStorageAddon = configuredStorageAddon;

--- a/app/packages/addons-service/provider.ts
+++ b/app/packages/addons-service/provider.ts
@@ -115,8 +115,6 @@ export default class Provider {
     async createConfiguredStorageAddon() {
         if (!this.configuredStorageAddon) {
             const configuredStorageAddon = this.store.createRecord('configured-storage-addon', {
-                externalUserId: this.currentUser.user?.id,
-                externalUserDisplayName: this.currentUser.user?.fullName,
                 rootFolder: '',
                 storageProvider: this.provider,
                 accountOwner: this.userReference,

--- a/app/packages/addons-service/provider.ts
+++ b/app/packages/addons-service/provider.ts
@@ -112,6 +112,23 @@ export default class Provider {
 
     @task
     @waitFor
+    async createConfiguredStorageAddon() {
+        if (!this.configuredStorageAddon) {
+            const configuredStorageAddon = this.store.createRecord('configured-storage-addon', {
+                externalUserId: this.currentUser.user?.id,
+                externalUserDisplayName: this.currentUser.user?.fullName,
+                rootFolder: '',
+                storageProvider: this.provider,
+                accountOwner: this.userReference,
+                authorizedResource: this.serviceNode,
+            });
+            await configuredStorageAddon.save();
+            this.configuredStorageAddon = configuredStorageAddon;
+        }
+    }
+
+    @task
+    @waitFor
     async setNodeAddonCredentials(account: AuthorizedStorageAccountModel) {
         if (this.configuredStorageAddon) {
             this.configuredStorageAddon.set('baseAccount', account);

--- a/lib/osf-components/addon/components/addons-service/manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/manager/component.ts
@@ -139,9 +139,9 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
 
     @task
     @waitFor
-    async confirmAccountSetup() {
+    async confirmAccountSetup(account: AuthorizedStorageAccountModel) {
         if (this.selectedProvider && this.selectedAccount) {
-            await taskFor(this.selectedProvider.createConfiguredStorageAddon).perform();
+            await taskFor(this.selectedProvider.createConfiguredStorageAddon).perform(account);
         }
         this.pageMode = PageMode.CONFIGURE;
     }

--- a/lib/osf-components/addon/components/addons-service/manager/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/manager/template.hbs
@@ -12,6 +12,8 @@
     configureProvider=this.configureProvider
     beginAccountSetup=this.beginAccountSetup
     acceptTerms=this.acceptTerms
+    selectedAccount=this.selectedAccount
+    selectAccount=this.selectAccount
     authorizeSelectedAccount=this.authorizeSelectedAccount
     chooseExistingAccount=this.chooseExistingAccount
     createNewAccount=this.createNewAccount

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -528,7 +528,7 @@ export default function(this: Server) {
     this.get('/resource-references/:nodeGuid/configured-storage-addons',
         addons.resourceReferenceConfiguredStorageAddonList);
     this.resource('authorized-storage-accounts', { only: ['show', 'update', 'create'] });
-    this.resource('configured-storage-addons', { only: ['show', 'update', 'delete'] });
+    this.resource('configured-storage-addons', { only: ['show', 'update', 'delete', 'create'] });
 
     // Reset API url and namespace to use v2 endpoints for tests
     this.urlPrefix = apiUrl;

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -528,7 +528,8 @@ export default function(this: Server) {
     this.get('/resource-references/:nodeGuid/configured-storage-addons',
         addons.resourceReferenceConfiguredStorageAddonList);
     this.resource('authorized-storage-accounts', { only: ['show', 'update', 'create'] });
-    this.resource('configured-storage-addons', { only: ['show', 'update', 'delete', 'create'] });
+    this.resource('configured-storage-addons', { only: ['show', 'update', 'delete'] });
+    this.post('configured-storage-addons', addons.createConfiguredStorageAddon);
 
     // Reset API url and namespace to use v2 endpoints for tests
     this.urlPrefix = apiUrl;

--- a/mirage/serializers/configured-storage-addon.ts
+++ b/mirage/serializers/configured-storage-addon.ts
@@ -5,7 +5,7 @@ import ConfiguredStorageAddonModel from 'ember-osf-web/models/configured-storage
 
 import AddonServiceSerializer from './addon-service-serializer';
 
-interface MirageConfiguredStorageAddon extends ConfiguredStorageAddonModel {
+export interface MirageConfiguredStorageAddon extends ConfiguredStorageAddonModel {
     accountOwnerId: string;
     authorizedResourceId: string;
     baseAccountId: string;

--- a/mirage/views/addons.ts
+++ b/mirage/views/addons.ts
@@ -1,4 +1,4 @@
-import { HandlerContext, ModelInstance, Request, Schema } from 'ember-cli-mirage';
+import { HandlerContext, ModelInstance, Request, Response, Schema } from 'ember-cli-mirage';
 
 import FileProviderModel from 'ember-osf-web/models/file-provider';
 
@@ -66,4 +66,20 @@ export function resourceReferenceConfiguredStorageAddonList(this: HandlerContext
     const data = filteredStorageAddons.map((addon: ModelInstance) => this.serialize(addon).data);
     const processed = process(schema, request, this, data);
     return processed;
+}
+
+export function createConfiguredStorageAddon(this: HandlerContext, schema: Schema) {
+    const attrs = this.normalizedRequestAttrs('configured-storage-addon');
+    const configuredStorageAddon = schema.configuredStorageAddons.create(attrs);
+
+    const { currentUser } = schema.roots.first();
+    if (!currentUser) {
+        return new Response(401, {}, { errors: [{ detail: 'Unauthorized' }] });
+    }
+    configuredStorageAddon.update({
+        externalUserId: currentUser.id,
+        externalUserDisplayName: currentUser.fullName,
+    });
+
+    return configuredStorageAddon;
 }

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -232,10 +232,13 @@ addons:
         accepting: 'Accepting terms…'
     accountSelect:
         heading: 'Log in to {providerName} or select an account'
+        no-accounts: 'No accounts available'
         new-account: 'Setup new account'
         existing-account: 'Choose existing account'
     confirm:
         heading: 'Confirm {providerName} Account'
+        verify: 'Authorize the following account:'
+        authorizing: 'Authorizing…'
     configure:
         heading: 'Configure {providerName}'
 


### PR DESCRIPTION
-   Ticket: [ENG-5149]
-   Feature flag: `gravy_waffle`

## Purpose
- Allow users to select an existing account to enable for a project

## Summary of Changes
- Update AccountSelect view of addons page to support selection of existing account
- Update Confirm view of addons page to support confirming selected account
  - Add `createConfiguredStorageAddon` on the Provider class when a user configures a storage-addon to a node

## Screenshot(s)
- Choosing an account
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/7e71b350-28a8-49fd-96d7-1998ba95f273)
- Confirming the chosen account
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/f1d64a1a-6f84-4b4d-b84e-0dfee5485bdc)


<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-5149]: https://openscience.atlassian.net/browse/ENG-5149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ