### PR TITLE
Fixed the persist because the parent route was not run on an add or edit

### DIFF
--- a/app/guid-node/metadata/add/route.ts
+++ b/app/guid-node/metadata/add/route.ts
@@ -2,6 +2,7 @@ import Store from '@ember-data/store';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import GuidMetadataAdd from 'ember-osf-web/guid-node/metadata/add/controller';
+import CedarMetadataTemplateModel from 'ember-osf-web/models/cedar-metadata-template';
 
 
 export default class GuidMetadataAddRoute extends Route {
@@ -12,6 +13,17 @@ export default class GuidMetadataAddRoute extends Route {
         const templates = await this.store.query('cedar-metadata-template', {
             adapterOptions: { sort: 'schema_name' },
         });
+
+        const cedarMetadataRecords = await parentModel.target.queryHasMany('cedarMetadataRecords', {
+            // embed: 'template',
+            'page[size]': 20,
+        });
+
+        for(const cedarMetadataRecord of cedarMetadataRecords) {
+            const template = await cedarMetadataRecord.template as CedarMetadataTemplateModel;
+            template.recordCreated = true;
+            cedarMetadataRecord.templateName = template.schemaName;
+        }
 
         return {
             target: parentModel.target,

--- a/app/guid-node/metadata/detail/route.ts
+++ b/app/guid-node/metadata/detail/route.ts
@@ -2,6 +2,7 @@ import Store from '@ember-data/store';
 import Route from '@ember/routing/route'; import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 import CedarMetadataRecordModel from 'ember-osf-web/models/cedar-metadata-record';
+import CedarMetadataTemplateModel from 'ember-osf-web/models/cedar-metadata-template';
 
 export default class MetadataDetailRoute extends Route {
     @service store!: Store;
@@ -11,14 +12,25 @@ export default class MetadataDetailRoute extends Route {
         const parentModel = this.modelFor('guid-node.metadata');
         let defaultIndex = 0;
 
-        parentModel.cedarMetadataRecords.sort(
+        const cedarMetadataRecords = await parentModel.target.queryHasMany('cedarMetadataRecords', {
+            // embed: 'template',
+            'page[size]': 20,
+        });
+
+        for(const cedarMetadataRecord of cedarMetadataRecords) {
+            const template = await cedarMetadataRecord.template as CedarMetadataTemplateModel;
+            template.recordCreated = true;
+            cedarMetadataRecord.templateName = template.schemaName;
+        }
+
+        cedarMetadataRecords.sort(
             (a: CedarMetadataRecordModel, b: CedarMetadataRecordModel) =>
                 a.templateName > b.templateName ? 1 : -1,
         );
 
         if (params.recordId) {
             let index = 0;
-            for(const cedarMetadataRecord of parentModel.cedarMetadataRecords) {
+            for(const cedarMetadataRecord of cedarMetadataRecords) {
                 if (cedarMetadataRecord.id === params.recordId) {
                     defaultIndex = index + 1;
                 }
@@ -27,14 +39,14 @@ export default class MetadataDetailRoute extends Route {
         }
 
         if (defaultIndex > 0) {
-            const selected = parentModel.cedarMetadataRecords.splice(defaultIndex - 1, 1);
-            parentModel.cedarMetadataRecords.unshift(selected[0]);
+            const selected = cedarMetadataRecords.splice(defaultIndex - 1, 1);
+            cedarMetadataRecords.unshift(selected[0]);
             defaultIndex = 1;
         }
 
         return {
             target: parentModel.target,
-            cedarMetadataRecords: parentModel.cedarMetadataRecords,
+            cedarMetadataRecords,
             defaultIndex,
         };
     }

--- a/app/guid-node/metadata/route.ts
+++ b/app/guid-node/metadata/route.ts
@@ -2,7 +2,6 @@ import Store from '@ember-data/store';
 import Route from '@ember/routing/route';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
-import CedarMetadataTemplateModel from 'ember-osf-web/models/cedar-metadata-template';
 
 export default class MetadataDetailRoute extends Route {
     @service store!: Store;
@@ -12,20 +11,8 @@ export default class MetadataDetailRoute extends Route {
         const guidNode = this.modelFor('guid-node');
         const target = await guidNode.taskInstance;
 
-        const cedarMetadataRecords = await target.queryHasMany('cedarMetadataRecords', {
-            // embed: 'template',
-            'page[size]': 20,
-        });
-
-        for(const cedarMetadataRecord of cedarMetadataRecords) {
-            const template = await cedarMetadataRecord.template as CedarMetadataTemplateModel;
-            template.recordCreated = true;
-            cedarMetadataRecord.templateName = template.schemaName;
-        }
-
         return {
             target,
-            cedarMetadataRecords,
         };
     }
 }

--- a/lib/registries/addon/overview/metadata/add/route.ts
+++ b/lib/registries/addon/overview/metadata/add/route.ts
@@ -2,6 +2,7 @@ import Store from '@ember-data/store';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import GuidMetadataAdd from 'ember-osf-web/guid-node/metadata/add/controller';
+import CedarMetadataTemplateModel from 'ember-osf-web/models/cedar-metadata-template';
 
 
 export default class GuidMetadataAddRoute extends Route {
@@ -12,6 +13,17 @@ export default class GuidMetadataAddRoute extends Route {
         const templates = await this.store.query('cedar-metadata-template', {
             adapterOptions: { sort: 'schema_name' },
         });
+
+        const cedarMetadataRecords = await parentModel.target.queryHasMany('cedarMetadataRecords', {
+            // embed: 'template',
+            'page[size]': 20,
+        });
+
+        for(const cedarMetadataRecord of cedarMetadataRecords) {
+            const template = await cedarMetadataRecord.template as CedarMetadataTemplateModel;
+            template.recordCreated = true;
+            cedarMetadataRecord.templateName = template.schemaName;
+        }
 
         return {
             target: parentModel.target,

--- a/lib/registries/addon/overview/metadata/detail/route.ts
+++ b/lib/registries/addon/overview/metadata/detail/route.ts
@@ -3,6 +3,7 @@ import Route from '@ember/routing/route';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 import CedarMetadataRecordModel from 'ember-osf-web/models/cedar-metadata-record';
+import CedarMetadataTemplateModel from 'ember-osf-web/models/cedar-metadata-template';
 
 
 export default class MetadataDetailRoute extends Route {
@@ -13,14 +14,25 @@ export default class MetadataDetailRoute extends Route {
         const parentModel = this.modelFor('overview.metadata');
         let defaultIndex = 0;
 
-        parentModel.cedarMetadataRecords.sort(
+        const cedarMetadataRecords = await parentModel.target.queryHasMany('cedarMetadataRecords', {
+            // embed: 'template',
+            'page[size]': 20,
+        });
+
+        for(const cedarMetadataRecord of cedarMetadataRecords) {
+            const template = await cedarMetadataRecord.template as CedarMetadataTemplateModel;
+            template.recordCreated = true;
+            cedarMetadataRecord.templateName = template.schemaName;
+        }
+
+        cedarMetadataRecords.sort(
             (a: CedarMetadataRecordModel, b: CedarMetadataRecordModel) =>
                 a.templateName > b.templateName ? 1 : -1,
         );
 
         if (params.recordId) {
             let index = 0;
-            for(const cedarMetadataRecord of parentModel.cedarMetadataRecords) {
+            for(const cedarMetadataRecord of cedarMetadataRecords) {
                 if (cedarMetadataRecord.id === params.recordId) {
                     defaultIndex = index + 1;
                 }
@@ -29,14 +41,14 @@ export default class MetadataDetailRoute extends Route {
         }
 
         if (defaultIndex > 0) {
-            const selected = parentModel.cedarMetadataRecords.splice(defaultIndex - 1, 1);
-            parentModel.cedarMetadataRecords.unshift(selected[0]);
+            const selected = cedarMetadataRecords.splice(defaultIndex - 1, 1);
+            cedarMetadataRecords.unshift(selected[0]);
             defaultIndex = 1;
         }
 
         return {
             target: parentModel.target,
-            cedarMetadataRecords: parentModel.cedarMetadataRecords,
+            cedarMetadataRecords,
             defaultIndex,
         };
     }

--- a/lib/registries/addon/overview/metadata/route.ts
+++ b/lib/registries/addon/overview/metadata/route.ts
@@ -2,7 +2,6 @@ import Store from '@ember-data/store';
 import Route from '@ember/routing/route';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
-import CedarMetadataTemplateModel from 'ember-osf-web/models/cedar-metadata-template';
 
 export default class MetadataDetailRoute extends Route {
     @service store!: Store;
@@ -12,20 +11,8 @@ export default class MetadataDetailRoute extends Route {
         const guidNode = this.modelFor('overview');
         const target = await guidNode.taskInstance;
 
-        const cedarMetadataRecords = await target.queryHasMany('cedarMetadataRecords', {
-            // embed: 'template',
-            'page[size]': 20,
-        });
-
-        for(const cedarMetadataRecord of cedarMetadataRecords) {
-            const template = await cedarMetadataRecord.template as CedarMetadataTemplateModel;
-            template.recordCreated = true;
-            cedarMetadataRecord.templateName = template.schemaName;
-        }
-
         return {
             target,
-            cedarMetadataRecords,
         };
     }
 }


### PR DESCRIPTION
-   Ticket: [No Ticket]
-   Feature flag: n/a

## Purpose

Trying to be tricky and moving the cedar-metadata-record "queryHasMany" to the parent route worked for direct entry into with the detail or add routes. It failed when persisting a new record.

## Summary of Changes

I removed the cedar-metadata-record "queryHasMany" from the parent route and moved it to the detail and add route.ts file.

## Screenshot(s)


## Side Effects

More duplication of code. However, the store caches the records so there is not duplication of ajax requests.

## QA Notes

No Change
