### PR TITLE
Fix color contrast issue

### DIFF
--- a/lib/osf-components/addon/components/metadata/metadata-tab-view/styles.scss
+++ b/lib/osf-components/addon/components/metadata/metadata-tab-view/styles.scss
@@ -1,8 +1,7 @@
 .draft {
-    color: lighten($brand-danger, 25%);
+    color: $brand-danger;
 
     &.dark {
-        color: $brand-danger;
         font-weight: bold;
     }
 }


### PR DESCRIPTION
-   Ticket: [Notion card](https://www.notion.so/cos/A11y-Color-contrast-0fd3e4a4bf724a6bb1357a063236f3dc?pvs=4)
-   Feature flag: n/a

## Purpose
- Address color contrast issue

## Summary of Changes
- Update color for draft metadata records 

## Screenshot(s)
- Before (2.84 color contrast)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/53c0e0b8-e552-40c6-928f-9f3d301ec624)

- After (6.28 color contrast)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/16d2a200-e7b3-4392-9a4e-68a096a79d25)


## Side Effects
- None

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
