### PR TITLE
Enabled the embedding of templates on cedar records

### DIFF
--- a/app/guid-node/metadata/add/route.ts
+++ b/app/guid-node/metadata/add/route.ts
@@ -15,7 +15,7 @@ export default class GuidMetadataAddRoute extends Route {
         });
 
         const cedarMetadataRecords = await parentModel.target.queryHasMany('cedarMetadataRecords', {
-            // embed: 'template',
+            embed: 'template',
             'page[size]': 20,
         });
 

--- a/app/guid-node/metadata/detail/route.ts
+++ b/app/guid-node/metadata/detail/route.ts
@@ -13,7 +13,7 @@ export default class MetadataDetailRoute extends Route {
         let defaultIndex = 0;
 
         const cedarMetadataRecords = await parentModel.target.queryHasMany('cedarMetadataRecords', {
-            // embed: 'template',
+            embed: 'template',
             'page[size]': 20,
         });
 

--- a/lib/osf-components/addon/components/metadata/metadata-tab-view/styles.scss
+++ b/lib/osf-components/addon/components/metadata/metadata-tab-view/styles.scss
@@ -1,7 +1,8 @@
 .draft {
     color: $brand-danger;
 
-    &.dark {
-        font-weight: bold;
-    }
+}
+
+.dark {
+    font-weight: bold;
 }

--- a/lib/osf-components/addon/components/metadata/metadata-tab-view/template.hbs
+++ b/lib/osf-components/addon/components/metadata/metadata-tab-view/template.hbs
@@ -1,5 +1,7 @@
 {{#if @cedarMetadataRecord.isPublished}}
-    {{@cedarMetadataRecord.templateName}}
+    <span local-class='{{if this.isActive 'dark'}}'>
+        {{@cedarMetadataRecord.templateName}}
+    </span>
 {{else}}
     <span local-class='draft {{if this.isActive 'dark'}}'>
         {{@cedarMetadataRecord.templateName}} ({{t 'cedar.renderer.draft'}}) 

--- a/lib/osf-components/addon/components/metadata/metadata-tabs/component.ts
+++ b/lib/osf-components/addon/components/metadata/metadata-tabs/component.ts
@@ -53,6 +53,10 @@ export default class MetadataTabs extends Component<TabArgs> {
         return this.media.isMobile;
     }
 
+    get isActive() {
+        return this.activeId === 0;
+    }
+
     @action
     didRenderList(element: HTMLElement): boolean {
         this.showTabs = element.scrollHeight > element.clientHeight ||

--- a/lib/osf-components/addon/components/metadata/metadata-tabs/styles.scss
+++ b/lib/osf-components/addon/components/metadata/metadata-tabs/styles.scss
@@ -53,15 +53,9 @@
         .tab-list {
             overflow: hidden;
 
-            .draft {
-                color: lighten($brand-danger, 25%);
-
-                &.dark {
-                    color: $brand-danger;
-                    font-weight: bold;
-                }
+            .dark {
+                font-weight: bold;
             }
-
 
             li {
                 display: block;

--- a/lib/osf-components/addon/components/metadata/metadata-tabs/template.hbs
+++ b/lib/osf-components/addon/components/metadata/metadata-tabs/template.hbs
@@ -15,7 +15,11 @@
 
             {{did-insert this.didRenderList}}
         >
-            <tablist.tab>{{t 'metadata.main-tab'}}</tablist.tab>
+            <tablist.tab>
+                <span local-class='{{if this.isActive 'dark'}}'>
+                    {{t 'metadata.main-tab'}}
+                </span>
+            </tablist.tab>
             {{#each this.cedarMetadataRecords as |cedarMetadataRecord index| }}
                 <tablist.tab
                     data-analytics-name='changed to: {{cedarMetadataRecord.templateName }}'

--- a/lib/registries/addon/overview/metadata/add/route.ts
+++ b/lib/registries/addon/overview/metadata/add/route.ts
@@ -15,7 +15,7 @@ export default class GuidMetadataAddRoute extends Route {
         });
 
         const cedarMetadataRecords = await parentModel.target.queryHasMany('cedarMetadataRecords', {
-            // embed: 'template',
+            embed: 'template',
             'page[size]': 20,
         });
 

--- a/lib/registries/addon/overview/metadata/detail/route.ts
+++ b/lib/registries/addon/overview/metadata/detail/route.ts
@@ -15,7 +15,7 @@ export default class MetadataDetailRoute extends Route {
         let defaultIndex = 0;
 
         const cedarMetadataRecords = await parentModel.target.queryHasMany('cedarMetadataRecords', {
-            // embed: 'template',
+            embed: 'template',
             'page[size]': 20,
         });
 


### PR DESCRIPTION
-   Ticket: [N/A]
-   Feature flag: n/a

## Purpose

Speed up loading of the metadata detail and add pages

## Summary of Changes

Added the `embed` attribute for the cedar record template. This downloads the template and then stores it in the cache.

Now that I think about it, this is a good change and a red herring. I have set-up the mirage scenario to add 2 to 10 cedars with the same template which is impossible in production. So locally, the page speed was a lot longer than likely possible in production. 

At the end of the day, this change will still be beneficial overall.

## Screenshot(s)

N/A

## Side Effects

Page loading speed up

## QA Notes

No difference
