### PR TITLE
Make preprint head tags show correct created/published dates

### DIFF
--- a/app/preprints/detail/route.ts
+++ b/app/preprints/detail/route.ts
@@ -119,7 +119,7 @@ export default class PreprintsDetail extends Route {
             const metaTagsData = {
                 title: preprint.title,
                 description: preprint.description,
-                publishedDate: moment(preprint.dateRegistered).format('YYYY-MM-DD'),
+                publishedDate: moment(preprint.datePublished).format('YYYY-MM-DD'),
                 modifiedDate: moment(preprint.dateModified).format('YYYY-MM-DD'),
                 identifier: preprint.id,
                 url: pathJoin(config.OSF.url, preprint.id),

--- a/mirage/factories/preprint.ts
+++ b/mirage/factories/preprint.ts
@@ -48,6 +48,9 @@ export default Factory.extend<PreprintMirageModel & PreprintTraits>({
     isPreprintOrphan: false,
 
     description: faker.lorem.sentence(),
+    dateCreated: new Date('2018-05-05T14:49:27.746938Z'),
+    dateModified: new Date('2018-07-02T11:51:07.837747Z'),
+    datePublished: new Date('2018-05-05T14:54:01.681202Z'),
 
     licenseRecord: {
         copyright_holders: [
@@ -137,9 +140,6 @@ export default Factory.extend<PreprintMirageModel & PreprintTraits>({
             subjects,
             files: [file],
             primaryFile: file,
-            date_created: new Date('2018-05-05T14:49:27.746938Z'),
-            date_modified: new Date('2018-07-02T11:51:07.837747Z'),
-            date_published: new Date('2018-05-05T14:54:01.681202Z'),
             node,
         });
     },

--- a/mirage/scenarios/preprints.ts
+++ b/mirage/scenarios/preprints.ts
@@ -92,6 +92,8 @@ function buildOSF(
         id: 'osf-approved',
         title: 'Preprint RWF: Pre-moderation, Non-Admin and Approved',
         currentUserPermissions: [],
+        datePublished: new Date('2016-12-25T16:00:00.000000Z'),
+        dateModified: new Date('2016-12-31T16:00:00.000000Z'),
         doi: '10.30822/artk.v1i1.79',
         reviewsState: ReviewsState.ACCEPTED,
         description: `${faker.lorem.sentence(200)}\n${faker.lorem.sentence(300)}`,


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Make sure preprint detail page head tags show correct date, and not show that all preprints were published today

## Summary of Changes
- Use `Preprint.datePublished` instead of non-existent `Preprint.dateRegistered`

## Screenshot(s)
- Before
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/be7d2652-08d1-4d01-9850-ccbdcc25f2da)

- After
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/5091fd24-f9bb-42b9-ad9d-43912bd60afe)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
