### PR TITLE
Removed all the spaces around the ember tooltips

### DIFF
--- a/app/guid-file/metadata/add/route.ts
+++ b/app/guid-file/metadata/add/route.ts
@@ -15,6 +15,7 @@ export default class GuidMetadataAddRoute extends Route {
         });
 
         const cedarMetadataRecords = await file.fileModel.queryHasMany('cedarMetadataRecords', {
+            embed: 'template',
             'page[size]': 20,
         });
 

--- a/lib/osf-components/addon/components/metadata/file-metadata-layout/template.hbs
+++ b/lib/osf-components/addon/components/metadata/file-metadata-layout/template.hbs
@@ -16,11 +16,7 @@
                             local-class='spacer'
                         >
                             <FaIcon @icon='download' />
-                            <EmberTooltip
-                                @side='right'
-                            >
-                                {{t 'general.download'}}
-                            </EmberTooltip>
+                            <EmberTooltip @side='right' >{{t 'general.download'}}</EmberTooltip>
                         </OsfLink>
                     {{/unless}}
                     {{#if manager.userCanEdit}}
@@ -32,11 +28,7 @@
                             {{on 'click' manager.edit}}
                         >
                             <FaIcon @icon='pencil-alt' />
-                            <EmberTooltip
-                                @side='right'
-                            >
-                                {{t 'general.edit'}}
-                            </EmberTooltip>
+                            <EmberTooltip @side='right'>{{t 'general.edit'}}</EmberTooltip>
                         </Button>
                     {{/if}}
                 {{/unless}}

--- a/lib/osf-components/addon/components/metadata/metadata-detail/template.hbs
+++ b/lib/osf-components/addon/components/metadata/metadata-detail/template.hbs
@@ -19,11 +19,7 @@
                     >
                         {{#if @displayFileMetadata}}
                             {{t 'file-detail.metadata.add-record'}}
-                            <EmberTooltip
-                                @side='right'
-                            >
-                                {{t 'file-detail.metadata.add-record-tooltip'}}
-                            </EmberTooltip>
+                            <EmberTooltip @side='right' >{{t 'file-detail.metadata.add-record-tooltip'}} </EmberTooltip>
                         {{else}}
                             {{t 'metadata.add-record'}}
                         {{/if}}

--- a/lib/osf-components/addon/components/metadata/metadata-select/template.hbs
+++ b/lib/osf-components/addon/components/metadata/metadata-select/template.hbs
@@ -20,12 +20,7 @@
         </Button>
 
         {{#unless @template.canSelect}}
-            <EmberTooltip
-                @autoPlacement={{true}}
-                @targetId={{this.elementId}}
-            >
-                {{t 'metadata.add-flow.template-exists'}}
-            </EmberTooltip>
+            <EmberTooltip @autoPlacement={{true}} @targetId={{this.elementId}} > {{t 'metadata.add-flow.template-exists'}} </EmberTooltip>
         {{/unless}}
     </div>
 </div>

--- a/lib/osf-components/addon/components/metadata/metadata-tabs/template.hbs
+++ b/lib/osf-components/addon/components/metadata/metadata-tabs/template.hbs
@@ -67,22 +67,14 @@
                     aria-label={{t 'metadata.see-less'}}
                     {{on 'click' (action this.clickIcon)}}
                 />
-                <EmberTooltip
-                    @side='right'
-                >
-                    {{t 'metadata.see-less'}}
-                </EmberTooltip>
+                <EmberTooltip @side='right' > {{t 'metadata.see-less'}} </EmberTooltip>
             {{else}}
                 <FaIcon @icon='plus' 
                     data-test-show-more
                     aria-label={{t 'metadata.see-more'}}
                     {{on 'click' (action this.clickIcon)}}
                 />
-                <EmberTooltip
-                    @side='right'
-                >
-                    {{t 'metadata.see-more'}}
-                </EmberTooltip>
+                <EmberTooltip @side='right' > {{t 'metadata.see-more'}} </EmberTooltip>
             {{/if}}
         </div>
     {{/if}}


### PR DESCRIPTION
-   Ticket: [https://www.notion.so/cos/c3237e5865944c2386756410276de285?v=218f67f11819497392fad8dc600ae7ee&p=601a05d2349d49ccb5b06a003ea9d810&pm=s]
-   Feature flag: n/a

## Purpose

Attempt to fix the crazy white spaces in the bug

## Summary of Changes

Removed all the white space around the tooltip.

Also forgot an `embed` on the file-guid

## Screenshot(s)
![Screenshot 2024-02-14 at 9 58 20 AM](https://github.com/CenterForOpenScience/ember-osf-web/assets/113387478/cde12be1-d042-4e83-b6eb-f893acc6edd7)

## Side Effects

Not 100% certain that it will fix it since there are numerous places in the code where there is space around the text.

## QA Notes

Should fix it? 
