### PR TITLE
Update metadata page tooltip styling

### DIFF
--- a/lib/osf-components/addon/components/cedar-metadata-editor/styles.scss
+++ b/lib/osf-components/addon/components/cedar-metadata-editor/styles.scss
@@ -60,6 +60,10 @@
             .cancel-button-container {
                 margin-right: 20px;
             }
+
+            :global(.tooltip) {
+                white-space: normal;
+            }
         }
 
 
@@ -94,4 +98,3 @@
         max-width: 100% !important;
     }
 }
-

--- a/lib/osf-components/addon/components/cedar-metadata-renderer/styles.scss
+++ b/lib/osf-components/addon/components/cedar-metadata-renderer/styles.scss
@@ -49,6 +49,10 @@
             svg {
                 height: 1.5em;
             }
+
+            :global(.tooltip) {
+                white-space: normal;
+            }
         }
     }
 


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [[NotionCard](https://www.notion.so/cos/Hint-box-is-comically-large-601a05d2349d49ccb5b06a003ea9d810?pvs=4)]
-   Feature flag: n/a

## Purpose
- Fix big tooltips on cedar metadata pages

## Summary of Changes
- Overwrite style from CEDAR widget that is conflicting with EmberTooltip class name

## Screenshot(s)
- Before
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/feba76b1-379a-48e7-b6d9-b60c4c54187b)

- After
  - on Project metadata page:
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/200a152d-57c6-4823-8d75-8e89994c0300)
  - CSS for tooltip where `.tooltip` is the rule coming from CEDAR that we want to overwrite
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/6d7d193b-1858-45af-83ae-e8b9d8b20dbe)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
