### PR TITLE
[ENG-4887] Create new preprint provider route and template

### DIFF
--- a/app/preprints/select/route.ts
+++ b/app/preprints/select/route.ts
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+
+export default class PreprintSelectRoute extends Route {}

--- a/app/preprints/select/route.ts
+++ b/app/preprints/select/route.ts
@@ -1,4 +1,15 @@
+import Store from '@ember-data/store';
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 
-export default class PreprintSelectRoute extends Route {}
+export default class PreprintSelectRoute extends Route {
+    @service store!: Store;
+
+    async model(){
+        const allProviders = await this.store.findAll('preprint-provider', { reload: true });
+        return {
+            allProviders,
+        };
+    }
+}

--- a/app/preprints/select/styles.scss
+++ b/app/preprints/select/styles.scss
@@ -1,0 +1,28 @@
+.select-page-container {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+
+    .header-container {
+        padding: 30px 0;
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        color: $color-text-white;
+        background: url('assets/images/default-brand/bg-dark.jpg') top center $color-bg-color-grey;
+    }
+
+    .select-preprints-provider-container {
+        background-color: $color-bg-gray-lighter;
+        padding: 15px 0;
+        width: 100%;
+        flex-direction: column;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+}

--- a/app/preprints/select/template.hbs
+++ b/app/preprints/select/template.hbs
@@ -1,6 +1,6 @@
 {{page-title (t 'preprints.select.page_title')}}
 
-<div local-class='select-page-container'>
+<div local-class='select-page-container {{if (is-mobile) 'mobile'}}'>
     <div local-class='header-container'>
         {{!-- placehodler for header component --}}
     </div>

--- a/app/preprints/select/template.hbs
+++ b/app/preprints/select/template.hbs
@@ -1,13 +1,11 @@
 {{page-title (t 'preprints.select.page_title')}}
 
-<div>{{t 'preprints.select.title'}}</div>
-
-<div>{{t 'preprints.select.heading'}}</div>
-
-<div>{{t 'preprints.select.paragraph' link='' htmlSafe=true}}</div>
-
-{{#each this.model.allProviders as |provider| }}
-    <div>{{provider.name}}</div>
-{{/each}}
-
-<div>{{t 'preprints.select.create_button'}}</div>
+<div local-class='select-page-container'>
+    <div local-class='header-container'>
+        {{!-- placehodler for header component --}}
+    </div>
+    <div local-class='select-preprints-provider-container'>
+        {{!-- placehodler for select prerpint provider component --}}
+        {{!-- {{this.model.allProviders}} --}}
+    </div>
+</div>

--- a/app/preprints/select/template.hbs
+++ b/app/preprints/select/template.hbs
@@ -1,0 +1,3 @@
+{{page-title (t 'preprints.select.title')}}
+
+<div>{{t 'preprints.select.toy_text'}}</div>

--- a/app/preprints/select/template.hbs
+++ b/app/preprints/select/template.hbs
@@ -1,3 +1,13 @@
-{{page-title (t 'preprints.select.title')}}
+{{page-title (t 'preprints.select.page_title')}}
 
-<div>{{t 'preprints.select.toy_text'}}</div>
+<div>{{t 'preprints.select.title'}}</div>
+
+<div>{{t 'preprints.select.heading'}}</div>
+
+<div>{{t 'preprints.select.paragraph' link='' htmlSafe=true}}</div>
+
+{{#each this.model.allProviders as |provider| }}
+    <div>{{provider.name}}</div>
+{{/each}}
+
+<div>{{t 'preprints.select.create_button'}}</div>

--- a/app/router.ts
+++ b/app/router.ts
@@ -32,6 +32,7 @@ Router.map(function() {
         this.route('discover', { path: '/:provider_id/discover' });
         this.route('detail', { path: '/:provider_id/:guid' });
         this.route('submit', { path: '/:provider_id/submit' });
+        this.route('select');
     });
 
 

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1160,6 +1160,9 @@ preprints:
     discover:
         title: 'Search'
     title: 'Preprints'
+    select:
+        title: 'Select Providers'
+        toy_text: 'I am expect to see this text'
     submit:
         title: 'Submit New'
     detail:

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1161,8 +1161,11 @@ preprints:
         title: 'Search'
     title: 'Preprints'
     select:
-        title: 'Select Providers'
-        toy_text: 'I am expect to see this text'
+        page_title: 'Select Providers'
+        title: 'New Preprints'
+        heading: 'Select a preprint service'
+        paragraph: 'A preprint is a version of a scholarly or scientific paper that is posted online before it has undergone formal peer review and published in a scientific journal. <a href={link}>Learn More.</a>.'
+        create_button: 'Create Preprint'
     submit:
         title: 'Submit New'
     detail:


### PR DESCRIPTION
-   Ticket: [ENG-4887](https://openscience.atlassian.net/browse/ENG-4887)
-   Feature flag: n/a

## Purpose

Create new preprint provider route and template

## Summary of Changes

* Add `/select` route under `preprints`
* Implement the select page with components as placeholder and minimum SCSS
* Add `route.js` to retrieve all preprints providers
* Add new languages

## Screenshot(s)

N/A (Components to-be-implemented)

## Side Effects

N/A

## QA Notes

N/A (PR part of an epic)


[ENG-4887]: https://openscience.atlassian.net/browse/ENG-4887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ