### PR TITLE
[ENG-5166] Show user enabled addons

### DIFF
--- a/app/settings/addons/styles.scss
+++ b/app/settings/addons/styles.scss
@@ -1,0 +1,8 @@
+.configured-addons-wrapper {
+    display: flex;
+    flex-direction: column;
+}
+
+.disconnect-button {
+    float: right;
+}

--- a/app/settings/addons/template.hbs
+++ b/app/settings/addons/template.hbs
@@ -13,4 +13,23 @@
             {{t 'addons.list.no-results'}}
         {{/each}}
     {{/if}}
+
+    <ul local-class='configured-addons-wrapper'>
+        {{#each manager.currentTypeAuthorizedAccounts as |account|}}
+            <li>
+                {{account.storageProvider.name}}
+                {{account.externalUserDisplayName}}
+                <Button
+                    @type='destroy'
+                    @disabled={{manager.disconnectAddon.isRunning}}
+                    local-class='disconnect-button'
+                    {{on 'click' (perform manager.disconnectAddon account)}}
+                >
+                    {{t 'addons.list.disconnect'}}
+                </Button>
+            </li>
+        {{else}}
+            <li>{{t 'addons.list.no-authorized-accounts'}}</li>
+        {{/each}}
+    </ul>
 </AddonsService::UserAddonsManager>

--- a/lib/osf-components/addon/components/addons-service/user-addons-manager/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/user-addons-manager/template.hbs
@@ -3,5 +3,9 @@
     authorizedStorageAccounts=this.authorizedStorageAccounts
     filteredAddonProviders=this.filteredAddonProviders
     currentListIsLoading=this.currentListIsLoading
+    currentTypeAuthorizedAccounts=this.currentTypeAuthorizedAccounts
     credentialsObject=this.credentialsObject
+    beginAccountSetup=this.beginAccountSetup
+    configureProvider=this.configureProvider
+    disconnectAddon=this.disconnectAddon
 )}}

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -527,7 +527,7 @@ export default function(this: Server) {
     this.resource('resource-references', { only: ['show'] });
     this.get('/resource-references/:nodeGuid/configured-storage-addons',
         addons.resourceReferenceConfiguredStorageAddonList);
-    this.resource('authorized-storage-accounts', { only: ['show', 'update', 'create'] });
+    this.resource('authorized-storage-accounts', { except: ['index'] });
     this.resource('configured-storage-addons', { only: ['show', 'update', 'delete'] });
     this.post('configured-storage-addons', addons.createConfiguredStorageAddon);
 

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -227,6 +227,8 @@ addons:
             citation-manager: 'Citation Manager'
             cloud-computing: 'Cloud Computing'
         no-results: 'No results found'
+        no-authorized-accounts: 'No authorized accounts'
+        disconnect: 'Disconnect Account'
     terms:
         heading: '{providerName} Terms'
         accepting: 'Accepting terms…'


### PR DESCRIPTION
-   Ticket: [ENG-5166]
-   Feature flag: n/a

## Purpose
- Show list of enabled addons in the user settings page

## Summary of Changes
- Add section to user settings page
- Update user-addons-manager
- Mirage and translation updates

## Screenshot(s)
- User settings > Addons page
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/2d04363d-6e7d-4123-a3f1-ea29d3a1d45b)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/178046a3-e5d9-47d6-9b38-187003c16532)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-5166]: https://openscience.atlassian.net/browse/ENG-5166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ