### PR TITLE
Addons/waffle files menu

### DIFF
--- a/app/guid-node/styles.scss
+++ b/app/guid-node/styles.scss
@@ -45,29 +45,3 @@
         width: 100%;
     }
 }
-
-.FileProviders {
-    display: flex;
-    flex-direction: column;
-}
-
-.FileProvider {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    border-left: 2px solid $color-border-gray-darker;
-    padding-left: 17px;
-    margin: 0 18px;
-    padding-top: 2px;
-
-    :global(.active) {
-        border-left: 4px solid $color-black;
-        font-weight: 700;
-        padding-left: 16px;
-        margin-left: -20px;
-    }
-}
-
-.FileProviderIcon {
-    font-size: 16px;
-}

--- a/app/guid-node/template.hbs
+++ b/app/guid-node/template.hbs
@@ -50,38 +50,7 @@
                 @label={{t 'node.left_nav.files'}}
             />
             {{#if this.onFilesRoute}}
-                <div
-                    data-test-file-providers-list
-                    local-class='FileProvidersList'
-                >
-                    {{#each this.model.taskInstance.value.files as |provider|}}
-                        <div local-class='FileProvider'>
-                            <OsfLink
-                                data-test-files-provider-link={{provider.name}}
-                                data-analytics-name={{concat 'Files - ' provider.name}} 
-                                @route='guid-node.files.provider'
-                                @models={{array this.model.taskInstance.value.id provider.name}}
-                            >
-                                {{t (concat 'osf-components.file-browser.storage_providers.' provider.name)}}
-                            </OsfLink>
-                            {{#if (eq provider.name 'osfstorage')}}
-                                <span>
-                                    <FaIcon
-                                        local-class='FileProviderIcon'
-                                        @icon='globe'
-                                    >
-                                    </FaIcon>
-                                    <EmberTooltip
-                                        @side='right'
-                                    >
-                                        {{t 'osf-components.file-browser.storage_location'}}
-                                        {{this.model.taskInstance.value.region.name}}
-                                    </EmberTooltip>
-                                </span>
-                            {{/if}}
-                        </div>
-                    {{/each}}
-                </div>
+                <FileProviderMenu @node={{this.model.taskInstance.value}} />
             {{/if}}
             {{#if this.model.taskInstance.value.wikiEnabled }}
                 <leftNav.link

--- a/app/models/configured-storage-addon.ts
+++ b/app/models/configured-storage-addon.ts
@@ -7,6 +7,8 @@ import OsfModel from './osf-model';
 import ExternalStorageServiceModel from './external-storage-service';
 
 export default class ConfiguredStorageAddonModel extends OsfModel {
+    @attr('string') name!: string;
+    @attr('string') displayName!: string;
     @attr('fixstring') externalUserId!: string;
     @attr('fixstring') externalUserDisplayName!: string;
     @attr('fixstring') rootFolder!: string;

--- a/app/models/resource-reference.ts
+++ b/app/models/resource-reference.ts
@@ -1,4 +1,4 @@
-import { AsyncHasMany, hasMany } from '@ember-data/model';
+import { AsyncHasMany, attr, hasMany } from '@ember-data/model';
 
 import OsfModel from './osf-model';
 import ConfiguredStorageAddonModel from './configured-storage-addon';
@@ -6,6 +6,9 @@ import ConfiguredCitationServiceAddonModel from './configured-citation-service-a
 import ConfiguredCloudComputingAddonModel from './configured-cloud-computing-addon';
 
 export default class ResourceReferenceModel extends OsfModel {
+
+    @attr('fixstring') resourceUri!: string;
+
     @hasMany('configured-storage-addon', { inverse: 'authorizedResource' })
     configuredStorageAddons!: AsyncHasMany<ConfiguredStorageAddonModel> & ConfiguredStorageAddonModel[];
 

--- a/lib/osf-components/addon/components/addons-service/manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/manager/component.ts
@@ -193,7 +193,12 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
     @task
     @waitFor
     async getStorageServiceNode() {
-        this.addonServiceNode = await this.store.findRecord('resource-reference', this.node.id);
+        const references = await this.store.query('resource-reference', {
+            filter: {'resource-uri': encodeURI(this.node.links.iri as string)},
+        });
+        if(references) {
+            this.addonServiceNode = references[0];
+        }
     }
 
     @task

--- a/lib/osf-components/addon/components/file-provider-menu/component.ts
+++ b/lib/osf-components/addon/components/file-provider-menu/component.ts
@@ -1,0 +1,41 @@
+import { inject as service } from '@ember/service';
+import { waitFor } from '@ember/test-waiters';
+import Store from '@ember-data/store';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { task } from 'ember-concurrency';
+import { taskFor } from 'ember-concurrency-ts';
+
+
+import ConfiguredStorageAddonModel from 'ember-osf-web/models/configured-storage-addon';
+import NodeModel from 'ember-osf-web/models/node';
+
+interface InputArgs {
+    node: NodeModel;
+}
+
+export default class FileProviderList extends Component<InputArgs> {
+    @service store!: Store;
+
+    @tracked configuredStorageAddons: ConfiguredStorageAddonModel[] = [];
+
+
+    constructor(owner: any, args: InputArgs) {
+        super(owner, args);
+        if (args.node) {
+            taskFor(this.configuredStorageProviders).perform();
+        }
+    }
+
+    @task
+    @waitFor
+    async configuredStorageProviders() {
+        const _ref = await this.store.query('resource-reference', {
+            filter: {resource_uri: encodeURI(this.args.node.links.iri as string)},
+        });
+
+        if (_ref) {
+            this.configuredStorageAddons = await _ref.toArray()[0].configuredStorageAddons;
+        }
+    }
+}

--- a/lib/osf-components/addon/components/file-provider-menu/component.ts
+++ b/lib/osf-components/addon/components/file-provider-menu/component.ts
@@ -34,7 +34,7 @@ export default class FileProviderList extends Component<InputArgs> {
             filter: {resource_uri: encodeURI(this.args.node.links.iri as string)},
         });
 
-        if (_ref) {
+        if (_ref.toArray().length > 0) {
             this.configuredStorageAddons = await _ref.toArray()[0].configuredStorageAddons;
         }
     }

--- a/lib/osf-components/addon/components/file-provider-menu/styles.scss
+++ b/lib/osf-components/addon/components/file-provider-menu/styles.scss
@@ -1,0 +1,25 @@
+.FileProviders {
+    display: flex;
+    flex-direction: column;
+}
+
+.FileProvider {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-left: 2px solid $color-border-gray-darker;
+    padding-left: 17px;
+    margin: 0 18px;
+    padding-top: 2px;
+
+    :global(.active) {
+        border-left: 4px solid $color-black;
+        font-weight: 700;
+        padding-left: 16px;
+        margin-left: -20px;
+    }
+}
+
+.FileProviderIcon {
+    font-size: 16px;
+}

--- a/lib/osf-components/addon/components/file-provider-menu/template.hbs
+++ b/lib/osf-components/addon/components/file-provider-menu/template.hbs
@@ -1,0 +1,70 @@
+<div
+    data-test-file-providers-list
+    local-class='FileProviders'
+>
+    {{#if (feature-flag 'gravy_waffle')}}
+        <div local-class='FileProvider'>
+            <OsfLink
+                data-test-files-provider-link={{'osfstorage'}}
+                data-analytics-name={{concat 'Files - osfstorage' }} 
+                @route='guid-node.files.provider'
+                @models={{array 'osfstorage'}}
+            >
+                {{t (concat 'osf-components.file-browser.storage_providers.osfstorage')}}
+            </OsfLink>
+            <span>
+                <FaIcon
+                    local-class='FileProviderIcon'
+                    @icon='globe'
+                >
+                </FaIcon>
+                <EmberTooltip
+                    @side='right'
+                >
+                    {{t 'osf-components.file-browser.storage_location'}}
+                    {{@node.region.name}}
+                </EmberTooltip>
+            </span>
+        </div>
+        {{#each this.configuredStorageAddons as |provider|}}
+            <div local-class='FileProvider'>
+                <OsfLink
+                    data-test-files-provider-link={{provider.name}}
+                    data-analytics-name={{concat 'Files - ' provider.name}} 
+                    @route='guid-node.files.provider'
+                    @models={{array @node.id provider.id}}
+                >
+                    {{t (concat 'osf-components.file-browser.storage_providers.' provider.name)}}
+                </OsfLink>
+            </div>
+        {{/each}}
+    {{else}}
+        {{#each @node.files as |provider|}}
+            <div local-class='FileProvider'>
+                <OsfLink
+                    data-test-files-provider-link={{provider.name}}
+                    data-analytics-name={{concat 'Files - ' provider.name}} 
+                    @route='guid-node.files.provider'
+                    @models={{array @node.id provider.name}}
+                >
+                    {{t (concat 'osf-components.file-browser.storage_providers.' provider.name)}}
+                </OsfLink>
+                {{#if (eq provider.name 'osfstorage')}}
+                    <span>
+                        <FaIcon
+                            local-class='FileProviderIcon'
+                            @icon='globe'
+                        >
+                        </FaIcon>
+                        <EmberTooltip
+                            @side='right'
+                        >
+                            {{t 'osf-components.file-browser.storage_location'}}
+                            {{@node.region.name}}
+                        </EmberTooltip>
+                    </span>
+                {{/if}}
+            </div>
+        {{/each}}
+    {{/if}}
+</div>

--- a/lib/osf-components/app/components/file-provider-menu/component.js
+++ b/lib/osf-components/app/components/file-provider-menu/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/file-provider-menu/component';

--- a/lib/osf-components/app/components/file-provider-menu/template.js
+++ b/lib/osf-components/app/components/file-provider-menu/template.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/file-provider-menu/template';

--- a/lib/registries/addon/overview/template.hbs
+++ b/lib/registries/addon/overview/template.hbs
@@ -97,26 +97,22 @@
                             data-test-file-providers-list
                             local-class='FileProvidersList'
                         >
-                            {{#each this.registration.files as |provider|}}
-                                <div local-class='FileProvider'>
-                                    {{t (concat 'osf-components.file-browser.storage_providers.' provider.name)}}
-                                    {{#if (eq provider.name 'osfstorage')}}
-                                        <span>
-                                            <FaIcon
-                                                local-class='FileProviderIcon'
-                                                @icon='globe'
-                                            >
-                                            </FaIcon>
-                                            <EmberTooltip
-                                                @side='right'
-                                            >
-                                                {{t 'osf-components.file-browser.storage_location'}}
-                                                {{this.registration.region.name}}
-                                            </EmberTooltip>
-                                        </span>
-                                    {{/if}}
-                                </div>
-                            {{/each}}
+                            <div local-class='FileProvider'>
+                                {{t 'osf-components.file-browser.storage_providers.osfstorage'}}
+                                <span>
+                                    <FaIcon
+                                        local-class='FileProviderIcon'
+                                        @icon='globe'
+                                    >
+                                    </FaIcon>
+                                    <EmberTooltip
+                                        @side='right'
+                                    >
+                                        {{t 'osf-components.file-browser.storage_location'}}
+                                        {{this.registration.region.name}}
+                                    </EmberTooltip>
+                                </span>
+                            </div>
                         </div>
                     {{/if}}
                     {{#if this.registration.resourcesVisible}}

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -528,6 +528,7 @@ export default function(this: Server) {
         addons.userAuthorizedCitationServiceAccountList);
     this.get('/user-references/:userGuid/authorized-cloud-computing-accounts/',
         addons.userAuthorizedCloudComputingAccountList);
+    this.get('/resource-references/', addons.resourceReferencesList);
     this.resource('resource-references', { only: ['show'] });
     this.get('/resource-references/:nodeGuid/configured-storage-addons',
         addons.resourceReferenceConfiguredStorageAddonList);

--- a/mirage/factories/resource-reference.ts
+++ b/mirage/factories/resource-reference.ts
@@ -1,8 +1,17 @@
 import { Factory } from 'ember-cli-mirage';
 
+import config from 'ember-osf-web/config/environment';
 import ResourceReferenceModel from 'ember-osf-web/models/resource-reference';
 
+const { OSF: { url } } = config;
+
 export default Factory.extend<ResourceReferenceModel>({
+    resourceUri: '',
+    afterCreate(resourceReference){
+        const guid = resourceReference.id;
+        resourceReference.resourceUri = `${url}${guid}`;
+        resourceReference.save();
+    },
 });
 
 declare module 'ember-cli-mirage/types/registries/model' {

--- a/mirage/scenarios/dashboard.ts
+++ b/mirage/scenarios/dashboard.ts
@@ -98,6 +98,9 @@ export function dashboardScenario(server: Server, currentUser: ModelInstance<Use
     });
 
     server.create('configured-storage-addon', {
+        id: 'box',
+        name: 'box',
+        displayName: 'Box',
         rootFolder: '/woot/',
         storageProvider: boxAddon,
         accountOwner: addonUser,

--- a/mirage/serializers/application.ts
+++ b/mirage/serializers/application.ts
@@ -5,7 +5,7 @@ import { RelationshipsFor } from 'ember-data';
 import config from 'ember-osf-web/config/environment';
 import { BaseMeta, RelatedLinkMeta, Relationship } from 'osf-api';
 
-const { OSF: { apiUrl } } = config;
+const { OSF: { apiUrl, url } } = config;
 
 export type SerializedRelationships<T extends Model> = {
     [relName in Exclude<RelationshipsFor<T>, 'toString'>]?: Relationship;
@@ -37,6 +37,7 @@ export default class ApplicationSerializer<T extends Model> extends JSONAPISeria
     buildNormalLinks(model: ModelInstance<T>) {
         return {
             self: `${apiUrl}/v2/${this.typeKeyForModel(model)}/${model.id}/`,
+            iri: `${url}${model.id}`,
         };
     }
 

--- a/mirage/views/addons.ts
+++ b/mirage/views/addons.ts
@@ -101,6 +101,14 @@ export function resourceReferenceConfiguredStorageAddonList(this: HandlerContext
     return processed;
 }
 
+export function resourceReferencesList(this: HandlerContext, schema: Schema, request: Request) {
+    const resourceReferences = schema.resourceReferences.all().models;
+    const filteredresourceReferences = resourceReferences.filter((addon: ModelInstance) => filter(addon, request));
+    const data = filteredresourceReferences.map((addon: ModelInstance) => this.serialize(addon).data);
+    const processed = process(schema, request, this, data);
+    return processed;
+}
+
 export function createConfiguredStorageAddon(this: HandlerContext, schema: Schema) {
     const attrs =
         this.normalizedRequestAttrs('configured-storage-addon') as NormalizedRequestAttrs<MirageConfiguredStorageAddon>;

--- a/mirage/views/utils/index.ts
+++ b/mirage/views/utils/index.ts
@@ -20,7 +20,7 @@ export function process(
 }
 
 export function filter(model: ModelInstance, request: Request) {
-    const filterRegex = /^filter\[((?:\w+(?:\.\w+)*,?)+)\](?:\[([a-z]+)\])?/;
+    const filterRegex = /^filter\[((?:\w+(?:\.\w+)*,*-?)+)\](?:\[([a-z]+)\])?/;
     return Object.entries(request.queryParams)
         .filter(([key]) => filterRegex.test(key))
         .every(([key, val]) => {

--- a/tests/acceptance/guid-node/files-test.ts
+++ b/tests/acceptance/guid-node/files-test.ts
@@ -11,6 +11,7 @@ import NodeModel from 'ember-osf-web/models/node';
 import FileModel from 'ember-osf-web/models/file';
 import FileProviderModel from 'ember-osf-web/models/file-provider';
 import { Permission } from 'ember-osf-web/models/osf-model';
+import ExternalStorageServiceModel from 'ember-osf-web/models/external-storage-service';
 
 interface GuidNodeTestContext extends TestContext {
     node: ModelInstance<NodeModel>;
@@ -132,10 +133,22 @@ module('Acceptance | guid-node/files', hooks => {
     });
 
     test('Switching providers', async function(this: GuidNodeTestContext, assert) {
+        const bitbucketAddon = server.schema.externalStorageServices
+            .find('bitbucket') as ModelInstance<ExternalStorageServiceModel>;
         server.create('file-provider', {
             provider: 'bitbucket',
             name: 'bitbucket',
             target: this.node,
+        });
+        server.create('resource-reference', { id: this.node.id });
+        const addonFile = server.create('resource-reference', { id: this.node.id });
+        server.create('configured-storage-addon', {
+            id: 'bitbucket',
+            name: 'bitbucket',
+            displayName: 'Bitbucket',
+            rootFolder: '/woot/',
+            storageProvider: bitbucketAddon,
+            authorizedResource: addonFile,
         });
         await visit(`/${this.node.id}/files`);
         assert.dom('[data-test-files-provider-link="bitbucket"').exists('Bitbucket shown');

--- a/yarn.lock
+++ b/yarn.lock
@@ -9136,9 +9136,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001214, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001286, caniuse-lite@^1.0.30001332, caniuse-lite@^1.0.30001503:
-  version "1.0.30001523"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001523.tgz"
-  integrity sha512-I5q5cisATTPZ1mc588Z//pj/Ox80ERYDfR71YnvY7raS/NOk8xXlZcB0sF7JdqaV//kOaa6aus7lRfpdnt1eBA==
+  version "1.0.30001593"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001593.tgz"
+  integrity sha512-UWM1zlo3cZfkpBysd7AS+z+v007q9G1+fLTUU42rQnY6t2axoogPW/xol6T7juU5EUoOhML4WgBIdG+9yYqAjQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
-   Ticket: [ENG-5163]
-   Feature flag: `gravy_waffle`

## Purpose

Make the file menu on the node files page use the configured storage addons as the source of truth rather than the api v2 guid-node/files endpoint.

## Summary of Changes

1. Componentize the file provider list
2. Add in waffled section for checking vs. configured storage addons
3. Simplify registrations, which only and always have osfstorage, to just show osfstorage in the files menu
4. Fix tests
5. Update the caniuse-lite database (incidentally)

## Screenshot(s)

<img width="1150" alt="Screenshot 2024-03-05 at 1 55 46 PM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/2d0b519a-d069-425f-b9d8-711a4bfcc988">
<img width="1147" alt="Screenshot 2024-03-05 at 1 55 16 PM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/4676af7f-25fe-43e7-9c3a-7142b499d2ac">


## Side Effects

You can't actually use non-osfstorage file providers yet. More tickets need to be completed to do that.


[ENG-5163]: https://openscience.atlassian.net/browse/ENG-5163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ