### PR TITLE
[ENG-5165] Filter user addons

### DIFF
--- a/app/guid-node/addons/index/template.hbs
+++ b/app/guid-node/addons/index/template.hbs
@@ -27,9 +27,9 @@
                             data-test-addon-accept-terms-button
                             data-analytics-name='Accept Terms'
                             {{on 'click' manager.acceptTerms}}
-                            disabled={{provider.getAuthorizedStorageAccounts.isRunning}}
+                            disabled={{provider.getAuthorizedAccounts.isRunning}}
                         >
-                            {{#if provider.getAuthorizedStorageAccounts.isRunning}}
+                            {{#if provider.getAuthorizedAccounts.isRunning}}
                                 {{t 'addons.terms.accepting'}}
                             {{else}}
                                 {{t 'general.confirm'}}
@@ -52,7 +52,7 @@
                         </Button>
                     {{else if (eq manager.pageMode 'accountSelect')}}
                         <fieldset>
-                            {{#each provider.authorizedStorageAccounts as |account| }}
+                            {{#each provider.authorizedAccounts as |account| }}
                                 <div local-class='account-select'>
                                     <label>
                                         <Input

--- a/app/settings/addons/styles.scss
+++ b/app/settings/addons/styles.scss
@@ -3,6 +3,39 @@
     flex-direction: column;
 }
 
+.addons-list-wrapper {
+    display: flex;
+    margin-top: 20px;
+
+    &.mobile {
+        flex-wrap: wrap;
+    }
+}
+
+.filter-wrapper {
+    max-width: 200px;
+    display: flex;
+    flex-direction: column;
+    margin-top: 6px;
+
+    &.mobile {
+        max-width: 100%;
+        width: 100%;
+        margin-right: 20px;
+    }
+}
+
+.filter-button {
+    width: 100%;
+    height: 40px;
+    text-align: left;
+    padding: 0 10px;
+
+    &.active {
+        background-color: #f0f0f0;
+    }
+}
+
 .disconnect-button {
     float: right;
 }

--- a/app/settings/addons/template.hbs
+++ b/app/settings/addons/template.hbs
@@ -5,13 +5,39 @@
     {{#if manager.currentListIsLoading}}
         <LoadingIndicator @dark={{true}} />
     {{else}}
-        {{#each manager.filteredAddonProviders as |provider|}}
-            <div>
-                {{provider.name}}
+        <div local-class='addons-list-wrapper {{if this.isMobile 'mobile'}}'>
+            <div
+                data-analytics-scope='Addon List Filter'
+                local-class='filter-wrapper {{if this.isMobile 'mobile'}}'
+            >
+                <Input
+                    data-test-user-addon-list-filter-input
+                    placeholder={{t 'addons.list.filter-placeholder'}}
+                    @type='text'
+                    @value={{manager.filterText}}
+                />
+                {{#each manager.possibleFilterTypes as |type|}}
+                    <Button
+                        data-test-user-addon-list-filter={{type}}
+                        data-analytics-name={{t (concat 'addons.list.filter.' type)}}
+                        local-class='filter-button {{if (eq manager.activeFilterType type) 'active'}}'
+                        @layout='fake-link'
+                        {{on 'click' (fn manager.filterByAddonType type)}}
+                    >
+                        {{t (concat 'addons.list.filter.' type)}}
+                    </Button>
+                {{/each}}
             </div>
-        {{else}}
-            {{t 'addons.list.no-results'}}
-        {{/each}}
+            <div>
+                {{#each manager.filteredAddonProviders as |provider|}}
+                    <div>
+                        {{provider.name}}
+                    </div>
+                {{else}}
+                    {{t 'addons.list.no-results'}}
+                {{/each}}
+            </div>
+        </div>
     {{/if}}
 
     <ul local-class='configured-addons-wrapper'>

--- a/lib/osf-components/addon/components/addon-card/component.ts
+++ b/lib/osf-components/addon/components/addon-card/component.ts
@@ -34,6 +34,6 @@ export default class AddonsCardComponent extends Component<Args> {
     }
 
     get addonIsConfigured() {
-        return this.args.addon.configuredStorageAddon;
+        return this.args.addon.isConfigured;
     }
 }

--- a/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
@@ -11,7 +11,7 @@ import IntlService from 'ember-intl/services/intl';
 import Toast from 'ember-toastr/services/toast';
 
 import UserReferenceModel from 'ember-osf-web/models/user-reference';
-import Provider from 'ember-osf-web/packages/addons-service/provider';
+import Provider, {AllProviderTypes, AllAuthorizedAccountTypes} from 'ember-osf-web/packages/addons-service/provider';
 import CurrentUserService from 'ember-osf-web/services/current-user';
 import AuthorizedStorageAccountModel from 'ember-osf-web/models/authorized-storage-account';
 import AuthorizedCitationServiceAccountModel from 'ember-osf-web/models/authorized-citation-service-account';
@@ -24,12 +24,6 @@ import CitationServiceModel from 'ember-osf-web/models/citation-service';
 import captureException, { getApiErrorMessage } from 'ember-osf-web/utils/capture-exception';
 
 import { FilterTypes } from '../manager/component';
-
-type AllProviderTypes = ExternalStorageServiceModel | CloudComputingServiceModel | CitationServiceModel;
-type AllAuthorizedAccountTypes =
-    AuthorizedStorageAccountModel |
-    AuthorizedCitationServiceAccountModel |
-    AuthorizedCloudComputingAccount;
 
 interface Args {
     user: UserModel;

--- a/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
@@ -143,16 +143,15 @@ export default class UserAddonManagerComponent extends Component<Args> {
         const activeFilterObject = this.filterTypeMapper[FilterTypes.STORAGE];
         const serviceStorageProviders = await taskFor(this.getExternalProviders)
             .perform(activeFilterObject.modelName) as ExternalStorageServiceModel[];
-        const sortedList = serviceStorageProviders.sort(this.providerSorter);
-        activeFilterObject.list = sortedList;
+        activeFilterObject.list = serviceStorageProviders.sort(this.providerSorter);
     }
 
     @task
     @waitFor
     async getCloudComputingProviders() {
         const activeFilterObject = this.filterTypeMapper[FilterTypes.CLOUD_COMPUTING];
-        const cloudComputingProviders: CloudComputingServiceModel[] =
-            await taskFor(this.getExternalProviders).perform(activeFilterObject.modelName);
+        const cloudComputingProviders = await taskFor(this.getExternalProviders)
+            .perform(activeFilterObject.modelName) as CloudComputingServiceModel[];
         activeFilterObject.list = cloudComputingProviders.sort(this.providerSorter);
     }
 
@@ -160,9 +159,9 @@ export default class UserAddonManagerComponent extends Component<Args> {
     @waitFor
     async getCitationAddonProviders() {
         const activeFilterObject = this.filterTypeMapper[FilterTypes.CITATION_MANAGER];
-        const serviceCloudComputingProviders: CitationServiceModel[] =
-            await taskFor(this.getExternalProviders).perform(activeFilterObject.modelName);
-        activeFilterObject.list = A(serviceCloudComputingProviders.sort(this.providerSorter));
+        const serviceCloudComputingProviders = await taskFor(this.getExternalProviders)
+            .perform(activeFilterObject.modelName) as CitationServiceModel[];
+        activeFilterObject.list = serviceCloudComputingProviders.sort(this.providerSorter);
     }
 
     providerSorter(a: AllProviderTypes, b: AllProviderTypes) {

--- a/lib/osf-components/addon/components/addons-service/user-addons-manager/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/user-addons-manager/template.hbs
@@ -1,6 +1,10 @@
 {{yield (hash
     user=this.user
     authorizedStorageAccounts=this.authorizedStorageAccounts
+    possibleFilterTypes=this.possibleFilterTypes
+    activeFilterType=this.activeFilterType
+    filterByAddonType=this.filterByAddonType
+    filterText=this.filterText
     filteredAddonProviders=this.filteredAddonProviders
     currentListIsLoading=this.currentListIsLoading
     currentTypeAuthorizedAccounts=this.currentTypeAuthorizedAccounts

--- a/tests/integration/components/addon-card/component-test.ts
+++ b/tests/integration/components/addon-card/component-test.ts
@@ -77,7 +77,7 @@ module('Integration | Component | addon-card', hooks => {
             },
             disableProjectAddon: { perform: sinon.stub() },
             nodeAddon: { configured: true },
-            configuredStorageAddon: { id: 'testaddon' },
+            isConfigured: true,
         };
         this.addon = addonObj;
         this.manager = {

--- a/tests/unit/packages/addons-service/provider-test.ts
+++ b/tests/unit/packages/addons-service/provider-test.ts
@@ -6,6 +6,7 @@ import { module, test } from 'qunit';
 
 import Provider from 'ember-osf-web/packages/addons-service/provider';
 import { CurrentUserStub } from 'ember-osf-web/tests/helpers/require-auth';
+import ConfiguredStorageAddonModel from 'ember-osf-web/models/configured-storage-addon';
 
 module('Unit | Packages | addons-service | provider', function(hooks) {
     setupTest(hooks);
@@ -39,6 +40,7 @@ module('Unit | Packages | addons-service | provider', function(hooks) {
         });
 
         server.create('configured-storage-addon', {
+            name: 'bropdox',
             externalUserId: user.id,
             externalUserDisplayName: user.fullName,
             rootFolder: '/rooty-tooty/',
@@ -52,8 +54,8 @@ module('Unit | Packages | addons-service | provider', function(hooks) {
 
         assert.equal(provider.userReference.id, currentUser.user.id, 'Provider userReference is set after initialize');
         assert.equal(provider.serviceNode?.id, node.id, 'Provider serviceNode is set after initialize');
-        assert.ok(provider.configuredStorageAddon,
-            'Provider configuredStorageAddon is set after initialize');
+        assert.ok(provider.configuredAddon,
+            'Provider configuredAddon is set after initialize');
     });
 
     test('sets rootFolder and disables addon', async function(assert) {
@@ -84,6 +86,7 @@ module('Unit | Packages | addons-service | provider', function(hooks) {
         });
 
         server.create('configured-storage-addon', {
+            name: 'bropdox',
             externalUserId: user.id,
             externalUserDisplayName: user.fullName,
             rootFolder: '/',
@@ -97,13 +100,16 @@ module('Unit | Packages | addons-service | provider', function(hooks) {
 
         const account = await taskFor(provider.createAccountForNodeAddon).perform();
         await taskFor(provider.setNodeAddonCredentials).perform(account);
-        assert.equal(provider.configuredStorageAddon?.baseAccount?.get('id'), account.id, 'Base account is set');
-        assert.equal(provider.configuredStorageAddon?.rootFolder, '/', 'Root folder is default');
+        assert.equal((provider.configuredAddon as ConfiguredStorageAddonModel)
+            .baseAccount?.get('id'), account.id, 'Base account is set');
+        assert.equal((provider.configuredAddon as ConfiguredStorageAddonModel)
+            .rootFolder, '/', 'Root folder is default');
 
         await taskFor(provider.setRootFolder).perform('/groot/');
-        assert.equal(provider.configuredStorageAddon?.rootFolder, '/groot/', 'Root folder is set');
+        assert.equal((provider.configuredAddon as ConfiguredStorageAddonModel)
+            .rootFolder, '/groot/', 'Root folder is set');
 
         await taskFor(provider.disableProjectAddon).perform();
-        assert.notOk(provider.configuredStorageAddon, 'Project addon is disabled');
+        assert.notOk(provider.configuredAddon, 'Project addon is disabled');
     });
 });


### PR DESCRIPTION
-   Ticket: [ENG-5165]
-   Feature flag: `gravy_waffle`

## Purpose
- Allow users to filter addons on user settings page

## Summary of Changes
- Add filter logic to user addons manager
- Update user settings addon page template
- Update user-addon-manager component to support different addon types
- Update addon manager component to support different addon types
- Update Provider class to support differnt addon types

## Screenshot(s)
- User settings, addons page
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/cdbafaa5-e026-49b5-8ee5-31919a451799)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-5165]: https://openscience.atlassian.net/browse/ENG-5165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ