### PR TITLE
ENG-5275 Fixed copy and paste from abstract on preprint detail pages

### DIFF
--- a/lib/osf-components/addon/components/expandable-preview/styles.scss
+++ b/lib/osf-components/addon/components/expandable-preview/styles.scss
@@ -9,6 +9,7 @@
     right: 0;
     width: 100%;
     height: 100%;
+    pointer-events: none;
 
     &.Wrapper__Collapsed {
         background-image: linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));


### PR DESCRIPTION
-   Ticket: [ENG-5275](https://openscience.atlassian.net/browse/ENG-5275)
-   Feature flag: n/a

## Purpose

Fixing copy and paste from abstract on preprint detail pages

## Summary of Changes

Added CSS property to ensure that the overlay does not interfere with text selection for unauthenticated users

## Screenshot(s)

<img width="1440" alt="Screenshot 2024-03-11 at 11 52 57 AM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/57388785/c213e512-e242-4e90-bf3b-76837ceef3fe">

## QA Notes

