### PR TITLE
[ENG-5153] Support logging into addon service using username/password creds

### DIFF
--- a/app/guid-node/addons/index/template.hbs
+++ b/app/guid-node/addons/index/template.hbs
@@ -82,6 +82,7 @@
                             @provider={{provider.provider}}
                             @manager={{manager}}
                             @onConnect={{manager.connectAccount}}
+                            @onInput={{manager.onCredentialsInput}}
                         />
                     {{else if (eq manager.pageMode 'confirm')}}
                         {{t 'addons.confirm.verify'}}

--- a/app/models/authorized-storage-account.ts
+++ b/app/models/authorized-storage-account.ts
@@ -4,6 +4,16 @@ import ExternalStorageServiceModel from './external-storage-service';
 import UserReferenceModel from './user-reference';
 import OsfModel from './osf-model';
 
+export interface AddonCredentialFields {
+    url: string;
+    username: string;
+    password: string;
+    token: string;
+    accessKey: string;
+    secretKey: string;
+    repo: string;
+}
+
 export default class AuthorizedStorageAccountModel extends OsfModel {
     @attr('fixstring') externalUserId!: string;
     @attr('fixstring') externalUserDisplayName!: string;

--- a/app/models/citation-service.ts
+++ b/app/models/citation-service.ts
@@ -1,11 +1,13 @@
 import { attr } from '@ember-data/model';
 
 import OsfModel from './osf-model';
+import { CredentialsFormat } from './external-storage-service';
 
 export default class CitationServiceModel extends OsfModel {
     @attr('fixstring') name!: string;
     @attr('fixstring') iconUri!: string;
     @attr('fixstring') authUri!: string;
+    @attr('string') credentialsFormat!: CredentialsFormat;
     // TODO: actually need some attrs here for citation service options
 }
 

--- a/app/models/cloud-computing-service.ts
+++ b/app/models/cloud-computing-service.ts
@@ -1,11 +1,13 @@
 import { attr } from '@ember-data/model';
 
 import OsfModel from './osf-model';
+import { CredentialsFormat } from './external-storage-service';
 
 export default class CloudComputingServiceModel extends OsfModel {
     @attr('fixstring') name!: string;
     @attr('string') iconUri!: string;
     @attr('fixstring') authUri!: string;
+    @attr('string') credentialsFormat!: CredentialsFormat;
     // TODO: actually need some attrs here for cloud computing options
 }
 

--- a/app/models/configured-citation-service-addon.ts
+++ b/app/models/configured-citation-service-addon.ts
@@ -7,6 +7,8 @@ import ResourceReferenceModel from './resource-reference';
 import UserReferenceModel from './user-reference';
 
 export default class ConfiguredCitationServiceAddonModel extends OsfModel {
+    @attr('string') name!: string;
+    @attr('string') displayName!: string;
     @attr('fixstring') externalUserId!: string;
     @attr('fixstring') externalUserDisplayName!: string;
 

--- a/app/models/configured-cloud-computing-addon.ts
+++ b/app/models/configured-cloud-computing-addon.ts
@@ -7,6 +7,8 @@ import ResourceReferenceModel from './resource-reference';
 import UserReferenceModel from './user-reference';
 
 export default class ConfiguredCloudComputingAddonModel extends OsfModel {
+    @attr('string') name!: string;
+    @attr('string') displayName!: string;
     @attr('fixstring') externalUserId!: string;
     @attr('fixstring') externalUserDisplayName!: string;
 

--- a/app/packages/addons-service/provider.ts
+++ b/app/packages/addons-service/provider.ts
@@ -97,7 +97,7 @@ export default class Provider {
     async initialize() {
         await taskFor(this.getUserReference).perform();
         await taskFor(this.getResourceReference).perform();
-        await taskFor(this.getConfiguredStorageAddon).perform();
+        await taskFor(this.providerMap!.getConfiguredAddon).perform();
     }
 
     @task

--- a/app/packages/addons-service/provider.ts
+++ b/app/packages/addons-service/provider.ts
@@ -15,7 +15,7 @@ import ResourceReferenceModel from 'ember-osf-web/models/resource-reference';
 import ConfiguredStorageAddonModel from 'ember-osf-web/models/configured-storage-addon';
 import ConfiguredCitationServiceAddonModel from 'ember-osf-web/models/configured-citation-service-addon';
 import ConfiguredCloudComputingAddonModel from 'ember-osf-web/models/configured-cloud-computing-addon';
-import AuthorizedStorageAccountModel from 'ember-osf-web/models/authorized-storage-account';
+import AuthorizedStorageAccountModel, {AddonCredentialFields} from 'ember-osf-web/models/authorized-storage-account';
 import AuthorizedCitationServiceAccountModel from 'ember-osf-web/models/authorized-citation-service-account';
 import AuthorizedCloudComputingAccount from 'ember-osf-web/models/authorized-cloud-computing-account';
 import ExternalStorageServiceModel from 'ember-osf-web/models/external-storage-service';
@@ -200,26 +200,30 @@ export default class Provider {
 
     @task
     @waitFor
-    async createAuthorizedStorageAccount() {
-        return await taskFor(this.createAccountForNodeAddon).perform('authorized-storage-account');
+    async createAuthorizedStorageAccount(credentials: AddonCredentialFields) {
+        return await taskFor(this.createAccountForNodeAddon)
+            .perform('authorized-storage-account', credentials);
     }
 
     @task
     @waitFor
-    async createAuthorizedCitationServiceAccount() {
-        return await taskFor(this.createAccountForNodeAddon).perform('authorized-citation-service-account');
+    async createAuthorizedCitationServiceAccount(credentials: AddonCredentialFields) {
+        return await taskFor(this.createAccountForNodeAddon)
+            .perform('authorized-citation-service-account', credentials);
     }
 
     @task
     @waitFor
-    async createAuthorizedCloudComputingAccount() {
-        return await taskFor(this.createAccountForNodeAddon).perform('authorized-cloud-computing-account');
+    async createAuthorizedCloudComputingAccount(credentials: AddonCredentialFields) {
+        return await taskFor(this.createAccountForNodeAddon)
+            .perform('authorized-cloud-computing-account', credentials);
     }
 
     @task
     @waitFor
-    async createAccountForNodeAddon(authorizedAccountType: string) {
+    async createAccountForNodeAddon(authorizedAccountType: string, credentials: AddonCredentialFields) {
         const account = this.store.createRecord(authorizedAccountType, {
+            credentials,
             externalUserId: this.currentUser.user?.id,
             scopes: [],
             storageProvider: this.provider,

--- a/app/packages/addons-service/provider.ts
+++ b/app/packages/addons-service/provider.ts
@@ -36,6 +36,7 @@ interface ProviderTypeMapper {
     getConfiguredAddon: Task<any, any>;
     getAuthorizedAccounts: Task<any, any>;
     createAccountForNodeAddon: Task<any, any>;
+    createConfiguredAddon: Task<any, any>;
 }
 
 
@@ -52,17 +53,20 @@ export default class Provider {
         externalStorageService: {
             getConfiguredAddon: taskFor(this.getConfiguredStorageAddon),
             getAuthorizedAccounts: taskFor(this.getAuthorizedStorageAccounts),
-            createAccountForNodeAddon: taskFor(this.createAccountForNodeAddon),
+            createAccountForNodeAddon: taskFor(this.createAuthorizedStorageAccount),
+            createConfiguredAddon: taskFor(this.createConfiguredStorageAddon),
         },
         cloudComputingService: {
             getConfiguredAddon: taskFor(this.getConfiguredCloudComputingAddon),
             getAuthorizedAccounts: taskFor(this.getAuthorizedCloudComputingAccounts),
-            createAccountForNodeAddon: taskFor(this.createAccountForNodeAddon),
+            createAccountForNodeAddon: taskFor(this.createAuthorizedCloudComputingAccount),
+            createConfiguredAddon: taskFor(this.createConfiguredCloudComputingAddon),
         },
         citationService: {
             getConfiguredAddon: taskFor(this.getConfiguredCitationServiceAddon),
             getAuthorizedAccounts: taskFor(this.getAuthorizedCitationServiceAccounts),
-            createAccountForNodeAddon: taskFor(this.createAccountForNodeAddon),
+            createAccountForNodeAddon: taskFor(this.createAuthorizedCitationServiceAccount),
+            createConfiguredAddon: taskFor(this.createConfiguredCitationAddon),
         },
     };
 
@@ -193,10 +197,29 @@ export default class Provider {
         return await this.userReference.authorizedStorageAccounts;
     }
 
+
     @task
     @waitFor
-    async createAccountForNodeAddon() {
-        const account = this.store.createRecord('authorized-storage-account', {
+    async createAuthorizedStorageAccount() {
+        return await taskFor(this.createAccountForNodeAddon).perform('authorized-storage-account');
+    }
+
+    @task
+    @waitFor
+    async createAuthorizedCitationServiceAccount() {
+        return await taskFor(this.createAccountForNodeAddon).perform('authorized-citation-service-account');
+    }
+
+    @task
+    @waitFor
+    async createAuthorizedCloudComputingAccount() {
+        return await taskFor(this.createAccountForNodeAddon).perform('authorized-cloud-computing-account');
+    }
+
+    @task
+    @waitFor
+    async createAccountForNodeAddon(authorizedAccountType: string) {
+        const account = this.store.createRecord(authorizedAccountType, {
             externalUserId: this.currentUser.user?.id,
             scopes: [],
             storageProvider: this.provider,

--- a/app/serializers/citation-service.ts
+++ b/app/serializers/citation-service.ts
@@ -1,6 +1,10 @@
 import JSONAPISerializer from '@ember-data/serializer/json-api';
+import { underscore } from '@ember/string';
 
 export default class CitationServiceSerializer extends JSONAPISerializer {
+    keyForAttribute(key: string) {
+        return underscore(key);
+    }
 }
 
 declare module 'ember-data/types/registries/serializer' {

--- a/app/serializers/cloud-computing-service.ts
+++ b/app/serializers/cloud-computing-service.ts
@@ -1,6 +1,10 @@
 import JSONAPISerializer from '@ember-data/serializer/json-api';
+import { underscore } from '@ember/string';
 
 export default class CloudComputingServiceSerializer extends JSONAPISerializer {
+    keyForAttribute(key: string) {
+        return underscore(key);
+    }
 }
 
 declare module 'ember-data/types/registries/serializer' {

--- a/lib/osf-components/addon/components/addons-service/account-setup-manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/account-setup-manager/component.ts
@@ -3,8 +3,8 @@ import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import IntlService from 'ember-intl/services/intl';
-
 import ExternalStorageServiceModel, { CredentialsFormat } from 'ember-osf-web/models/external-storage-service';
+import { AddonCredentialFields } from 'ember-osf-web/models/authorized-storage-account';
 import AddonsServiceManagerComponent from 'ember-osf-web/components/addons-service/manager/component';
 import UserAddonsManagerComponent from 'ember-osf-web/components/addons-service/user-addons-manager/component';
 
@@ -19,7 +19,7 @@ const repoOptionsObject: Record<string, string[]> = {
     ],
 };
 interface InputFieldObject {
-    name: string;
+    name: keyof AddonCredentialFields;
     labelText: string;
     inputType: string;
     inputPlaceholder: string;

--- a/lib/osf-components/addon/components/addons-service/account-setup-manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/account-setup-manager/component.ts
@@ -19,6 +19,7 @@ const repoOptionsObject: Record<string, string[]> = {
     ],
 };
 interface InputFieldObject {
+    name: string;
     labelText: string;
     inputType: string;
     inputPlaceholder: string;
@@ -31,6 +32,7 @@ interface Args {
     onConnect: () => void;
     provider: ExternalStorageServiceModel; // Type?
     manager: AddonsServiceManagerComponent | UserAddonsManagerComponent;
+    onInput: (event: Event) => void;
 }
 
 export default class AccountSetupManagerComponent extends Component<Args> {
@@ -95,6 +97,7 @@ export default class AccountSetupManagerComponent extends Component<Args> {
             const passwordPostText = t('addons.accountCreate.password-post-text');
             return [
                 {
+                    name: 'url',
                     labelText: t('addons.accountCreate.url-label'),
                     inputType: 'text',
                     inputPlaceholder: t('addons.accountCreate.url-placeholder'),
@@ -102,6 +105,7 @@ export default class AccountSetupManagerComponent extends Component<Args> {
                     postText: urlPostText,
                 },
                 {
+                    name: 'username',
                     labelText: t('addons.accountCreate.username-label'),
                     inputType: 'text',
                     inputPlaceholder: t('addons.accountCreate.username-placeholder'),
@@ -109,6 +113,7 @@ export default class AccountSetupManagerComponent extends Component<Args> {
                     autocomplete: 'username',
                 },
                 {
+                    name: 'password',
                     labelText: t('addons.accountCreate.password-label'),
                     inputType: 'password',
                     inputPlaceholder: t('addons.accountCreate.password-placeholder'),
@@ -122,6 +127,7 @@ export default class AccountSetupManagerComponent extends Component<Args> {
             const passwordPostText = t('addons.accountCreate.password-post-text');
             return [
                 {
+                    name: 'username',
                     labelText: t('addons.accountCreate.username-label'),
                     inputType: 'text',
                     inputPlaceholder: t('addons.accountCreate.username-placeholder'),
@@ -129,6 +135,7 @@ export default class AccountSetupManagerComponent extends Component<Args> {
                     autocomplete: 'username',
                 },
                 {
+                    name: 'password',
                     labelText: t('addons.accountCreate.password-label'),
                     inputType: 'password',
                     inputPlaceholder: t('addons.accountCreate.password-placeholder'),
@@ -147,6 +154,7 @@ export default class AccountSetupManagerComponent extends Component<Args> {
                 t('addons.accountCreate.personal-access-token-placeholder');
             return [
                 {
+                    name: 'token',
                     labelText: label,
                     inputType: 'text',
                     inputPlaceholder: placeholder,
@@ -157,12 +165,14 @@ export default class AccountSetupManagerComponent extends Component<Args> {
         case CredentialsFormat.ACCESS_SECRET_KEYS: {
             return [
                 {
+                    name: 'accessKey',
                     labelText: t('addons.accountCreate.access-key-label'),
                     inputType: 'text',
                     inputPlaceholder: t('addons.accountCreate.access-key-placeholder'),
                     inputValue: credentials.accessKey,
                 },
                 {
+                    name: 'secretKey',
                     labelText: t('addons.accountCreate.secret-key-label'),
                     inputType: 'password',
                     inputPlaceholder: t('addons.accountCreate.secret-key-placeholder'),

--- a/lib/osf-components/addon/components/addons-service/account-setup-manager/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/account-setup-manager/template.hbs
@@ -49,9 +49,11 @@
                 <label local-class='auth-text-input-label'>
                     {{field.labelText}}
                     <Input
+                        name={{field.name}}
                         @type={{field.inputType}}
                         @value={{field.inputValue}}
                         @placeholder={{field.inputPlaceholder}}
+                        {{on 'keyup' @onInput}}
                         autocomplete={{field.autocomplete}}
                     />
                 </label>

--- a/lib/osf-components/addon/components/addons-service/account-setup-manager/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/account-setup-manager/template.hbs
@@ -8,7 +8,7 @@
             <a
                 data-test-addon-oauth-link
                 data-analytics-name='OAuth'
-                href={{@provider.oauthUrl}}
+                href={{@provider.authUri}}
                 target='_blank'
                 rel='noopener noreferrer'
             >

--- a/lib/osf-components/addon/components/addons-service/manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/manager/component.ts
@@ -156,6 +156,12 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
         this.pageMode = PageMode.CONFIGURE;
     }
 
+    @action
+    onCredentialsInput(event: Event) {
+        const input = event.target as HTMLInputElement;
+        this.credentialsObject[input.name] = input.value;
+    }
+
     @task
     @waitFor
     async confirmAccountSetup(account: AuthorizedStorageAccountModel) {
@@ -187,7 +193,6 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
         super(owner, args);
         taskFor(this.getServiceNode).perform();
         taskFor(this.getStorageAddonProviders).perform();
-        taskFor(this.getConfiguredAddonProviders).perform();
     }
 
     @task
@@ -203,20 +208,15 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
 
     @task
     @waitFor
-    async getConfiguredAddonProviders() {
-        if (this.addonServiceNode) {
-            await this.addonServiceNode.get('configuredStorageAddons');
-        }
-        return [];
-    }
-
-    @task
-    @waitFor
     async getStorageAddonProviders() {
         const activeFilterObject = this.filterTypeMapper[FilterTypes.STORAGE];
         const serviceStorageProviders: Provider[] =
             await taskFor(this.getExternalProviders).perform(activeFilterObject.modelName);
         activeFilterObject.list = A(serviceStorageProviders.sort(this.providerSorter));
+
+        if (this.addonServiceNode) {
+            await this.addonServiceNode.get('configuredStorageAddons');
+        }
     }
 
     @task
@@ -226,6 +226,10 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
         const cloudComputingProviders: Provider[] =
             await taskFor(this.getExternalProviders).perform(activeFilterObject.modelName);
         activeFilterObject.list = cloudComputingProviders.sort(this.providerSorter);
+
+        if (this.addonServiceNode) {
+            await this.addonServiceNode.get('configuredCloudComputingAddons');
+        }
     }
 
     @task
@@ -235,6 +239,10 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
         const serviceCloudComputingProviders: Provider[] =
             await taskFor(this.getExternalProviders).perform(activeFilterObject.modelName);
         activeFilterObject.list = serviceCloudComputingProviders.sort(this.providerSorter);
+
+        if (this.addonServiceNode) {
+            await this.addonServiceNode.get('configuredCitationServiceAddons');
+        }
     }
 
     providerSorter(a: Provider, b: Provider) {

--- a/lib/osf-components/addon/components/addons-service/manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/manager/component.ts
@@ -150,8 +150,8 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
     @waitFor
     async connectAccount() {
         if (this.selectedProvider) {
-            const newAccount = await taskFor(this.selectedProvider.createAccountForNodeAddon).perform();
-            await taskFor(this.selectedProvider.createConfiguredStorageAddon).perform(newAccount);
+            const newAccount = await taskFor(this.selectedProvider.providerMap!.createAccountForNodeAddon).perform();
+            await taskFor(this.selectedProvider.providerMap!.createConfiguredAddon).perform(newAccount);
         }
         this.pageMode = PageMode.CONFIGURE;
     }

--- a/lib/osf-components/addon/components/addons-service/manager/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/manager/template.hbs
@@ -19,6 +19,7 @@
     createNewAccount=this.createNewAccount
     connectAccount=this.connectAccount
     credentialsObject=this.credentialsObject
+    onCredentialsInput=this.onCredentialsInput
     confirmAccountSetup=this.confirmAccountSetup
     cancelSetup=this.cancelSetup
     save=this.save

--- a/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
@@ -177,6 +177,15 @@ export default class UserAddonManagerComponent extends Component<Args> {
 
     @task
     @waitFor
+    async connectAccount() {
+        if (this.selectedProvider) {
+            const newAccount = await taskFor(this.selectedProvider.providerMap!.createAccountForNodeAddon).perform();
+            await taskFor(this.selectedProvider.providerMap!.createConfiguredAddon).perform(newAccount);
+        }
+    }
+
+    @task
+    @waitFor
     async disconnectAddon(account: AllAuthorizedAccountTypes) {
         try {
             const authorizedAccounts = this.filterTypeMapper[this.activeFilterType]

--- a/lib/osf-components/addon/components/addons-service/user-addons-manager/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/user-addons-manager/template.hbs
@@ -9,6 +9,7 @@
     currentListIsLoading=this.currentListIsLoading
     currentTypeAuthorizedAccounts=this.currentTypeAuthorizedAccounts
     credentialsObject=this.credentialsObject
+    connectAccount=this.connectAccount
     beginAccountSetup=this.beginAccountSetup
     configureProvider=this.configureProvider
     disconnectAddon=this.disconnectAddon

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -542,6 +542,10 @@ export default function(this: Server) {
     this.resource('resource-references', { only: ['show'] });
     this.get('/resource-references/:nodeGuid/configured-storage-addons',
         addons.resourceReferenceConfiguredStorageAddonList);
+    this.get('/resource-references/:nodeGuid/configured-citation-service-addons',
+        addons.resourceConfiguredCitationServiceAddonList);
+    this.get('/resource-references/:nodeGuid/configured-cloud-computing-addons',
+        addons.resourceConfiguredCloudComputingAddonList);
     this.resource('authorized-storage-accounts', { except: ['index'] });
     this.resource('authorized-citation-service-accounts', { except: ['index'] });
     this.resource('authorized-cloud-computing-accounts', { except: ['index'] });

--- a/mirage/views/addons.ts
+++ b/mirage/views/addons.ts
@@ -54,7 +54,11 @@ export function addonsList(this: HandlerContext, schema: Schema, request: Reques
 export function userReferenceAuthorizedStorageAccountList(this: HandlerContext, schema: Schema, request: Request) {
     const { userGuid } = request.params;
     const userReference = schema.userReferences.find(userGuid);
-    const authorizedStorageAccounts = userReference.attrs.authorizedStorageAccountIds.map(
+    const { authorizedStorageAccountIds } = userReference.attrs;
+    if (!authorizedStorageAccountIds) {
+        return process(schema, request, this, []);
+    }
+    const authorizedStorageAccounts = authorizedStorageAccountIds.map(
         (id: string) => schema.authorizedStorageAccounts.find(id),
     );
     const filteredStorageAccounts = authorizedStorageAccounts.filter((addon: ModelInstance) => filter(addon, request));
@@ -65,7 +69,11 @@ export function userReferenceAuthorizedStorageAccountList(this: HandlerContext, 
 export function userAuthorizedCitationServiceAccountList(this: HandlerContext, schema: Schema, request: Request) {
     const { userGuid } = request.params;
     const userReference = schema.userReferences.find(userGuid);
-    const authorizedCitationAccounts = userReference.attrs.authorizedCitationServiceAccountIds.map(
+    const { authorizedCitationServiceAccountIds } = userReference.attrs;
+    if (!authorizedCitationServiceAccountIds) {
+        return process(schema, request, this, []);
+    }
+    const authorizedCitationAccounts = authorizedCitationServiceAccountIds.map(
         (id: string) => schema.authorizedCitationServiceAccounts.find(id),
     );
     const filteredCitationAccounts = authorizedCitationAccounts.filter(
@@ -78,7 +86,11 @@ export function userAuthorizedCitationServiceAccountList(this: HandlerContext, s
 export function userAuthorizedCloudComputingAccountList(this: HandlerContext, schema: Schema, request: Request) {
     const { userGuid } = request.params;
     const userReference = schema.userReferences.find(userGuid);
-    const authorizedCloudComputingAccounts = userReference.attrs.authorizedCloudComputingAccountIds.map(
+    const { authorizedCloudComputingAccountIds } = userReference.attrs;
+    if (!authorizedCloudComputingAccountIds) {
+        return process(schema, request, this, []);
+    }
+    const authorizedCloudComputingAccounts = authorizedCloudComputingAccountIds.map(
         (id: string) => schema.authorizedCloudComputingAccounts.find(id),
     );
     const filteredCitationAccounts = authorizedCloudComputingAccounts.filter(
@@ -92,11 +104,48 @@ export function userAuthorizedCloudComputingAccountList(this: HandlerContext, sc
 export function resourceReferenceConfiguredStorageAddonList(this: HandlerContext, schema: Schema, request: Request) {
     const { nodeGuid } = request.params;
     const resourceReference = schema.resourceReferences.find(nodeGuid);
-    const configuredStorageAddons = resourceReference.attrs.configuredStorageAddonIds.map(
+    const { configuredStorageAddonIds } = resourceReference.attrs;
+    if (!configuredStorageAddonIds) {
+        return process(schema, request, this, []);
+    }
+    const configuredStorageAddons = configuredStorageAddonIds.map(
         (id: string) => schema.configuredStorageAddons.find(id),
     );
     const filteredStorageAddons = configuredStorageAddons.filter((addon: ModelInstance) => filter(addon, request));
     const data = filteredStorageAddons.map((addon: ModelInstance) => this.serialize(addon).data);
+    const processed = process(schema, request, this, data);
+    return processed;
+}
+
+export function resourceConfiguredCitationServiceAddonList(this: HandlerContext, schema: Schema, request: Request) {
+    const { nodeGuid } = request.params;
+    const resourceReference = schema.resourceReferences.find(nodeGuid);
+    const { configuredCitationServiceAddonIds } = resourceReference.attrs;
+    if (!configuredCitationServiceAddonIds) {
+        return process(schema, request, this, []);
+    }
+    const configuredCitationAddons = configuredCitationServiceAddonIds.map(
+        (id: string) => schema.configuredCitationServiceAddons.find(id),
+    );
+    const filteredCitationAddons = configuredCitationAddons.filter((addon: ModelInstance) => filter(addon, request));
+    const data = filteredCitationAddons.map((addon: ModelInstance) => this.serialize(addon).data);
+    const processed = process(schema, request, this, data);
+    return processed;
+}
+
+export function resourceConfiguredCloudComputingAddonList(this: HandlerContext, schema: Schema, request: Request) {
+    const { nodeGuid } = request.params;
+    const resourceReference = schema.resourceReferences.find(nodeGuid);
+    const { configuredCloudComputingAddonIds } = resourceReference.attrs;
+    if (!configuredCloudComputingAddonIds) {
+        return process(schema, request, this, []);
+    }
+    const configuredCloudComputingAddons = configuredCloudComputingAddonIds.map(
+        (id: string) => schema.configuredCloudComputingAddons.find(id),
+    );
+    const filteredCloudComputingAddons = configuredCloudComputingAddons
+        .filter((addon: ModelInstance) => filter(addon, request));
+    const data = filteredCloudComputingAddons.map((addon: ModelInstance) => this.serialize(addon).data);
     const processed = process(schema, request, this, data);
     return processed;
 }

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -266,6 +266,7 @@ addons:
         secret-key-placeholder: 'Secret Key'
         oauth-description: 'Use OAuth to connect your {providerName} account'
         oauth-link: 'Connect with {providerName}'
+        error: 'Error creating account'
     confirm:
         heading: 'Confirm {providerName} Account'
         verify: 'Authorize the following account:'


### PR DESCRIPTION
-   Ticket: [ENG-5153]
-   Feature flag: n/a

## Purpose
- Support addon service login using username/password

## Summary of Changes
- Generalize how login is handled between provider types
- 

## Screenshot(s)
- Node addons page, setting up Boa account
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/30f1edc1-31ae-4f79-b578-9f1d97ec6b41)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
