### PR TITLE
[ENG-5155] Pretend check addon auth credentials in mirage

### DIFF
--- a/lib/osf-components/addon/components/addons-service/account-setup-manager/styles.scss
+++ b/lib/osf-components/addon/components/addons-service/account-setup-manager/styles.scss
@@ -10,3 +10,7 @@
 .repo-select {
     width: 250px;
 }
+
+.connect-error {
+    color: #a94442;
+}

--- a/lib/osf-components/addon/components/addons-service/account-setup-manager/styles.scss
+++ b/lib/osf-components/addon/components/addons-service/account-setup-manager/styles.scss
@@ -12,5 +12,5 @@
 }
 
 .connect-error {
-    color: #a94442;
+    color: $brand-danger;
 }

--- a/lib/osf-components/addon/components/addons-service/account-setup-manager/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/account-setup-manager/template.hbs
@@ -59,6 +59,11 @@
                 </label>
                 {{field.postText}}
             {{/each}}
+            {{#if @manager.connectAccountError}}
+                <p local-class='connect-error'>
+                    {{t 'addons.accountCreate.error'}}
+                </p>
+            {{/if}}
             <Button
                 data-test-addon-connect-account-button
                 data-analytics-name='Connect Account'

--- a/lib/osf-components/addon/components/addons-service/manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/manager/component.ts
@@ -160,7 +160,6 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
                 await taskFor(this.selectedProvider.providerMap!.createConfiguredAddon).perform(newAccount);
             }
             this.clearCredentials();
-            this.connectAccountError = false;
             this.pageMode = PageMode.CONFIGURE;
         } catch (e) {
             this.connectAccountError = true;
@@ -195,6 +194,7 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
 
     @action
     clearCredentials() {
+        this.connectAccountError = false;
         this.credentialsObject = {
             url: '',
             username: '',

--- a/lib/osf-components/addon/components/addons-service/manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/manager/component.ts
@@ -85,6 +85,7 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
         secretKey: '',
         repo: '',
     };
+    @tracked connectAccountError = false;
 
     @action
     filterByAddonType(type: FilterTypes) {
@@ -159,8 +160,10 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
                 await taskFor(this.selectedProvider.providerMap!.createConfiguredAddon).perform(newAccount);
             }
             this.clearCredentials();
+            this.connectAccountError = false;
             this.pageMode = PageMode.CONFIGURE;
         } catch (e) {
+            this.connectAccountError = true;
             const errorMessage = this.intl.t('addons.accountCreate.error');
             captureException(e, { errorMessage });
             this.toast.error(getApiErrorMessage(e), errorMessage);

--- a/lib/osf-components/addon/components/addons-service/manager/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/manager/template.hbs
@@ -18,6 +18,7 @@
     chooseExistingAccount=this.chooseExistingAccount
     createNewAccount=this.createNewAccount
     connectAccount=this.connectAccount
+    connectAccountError=this.connectAccountError
     credentialsObject=this.credentialsObject
     onCredentialsInput=this.onCredentialsInput
     confirmAccountSetup=this.confirmAccountSetup

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -547,8 +547,11 @@ export default function(this: Server) {
     this.get('/resource-references/:nodeGuid/configured-computing-addons',
         addons.resourceConfiguredComputingAddonList);
     this.resource('authorized-storage-accounts', { except: ['index'] });
+    this.post('authorized-storage-accounts', addons.createAuthorizedStorageAccount);
     this.resource('authorized-citation-accounts', { except: ['index'] });
+    this.post('authorized-citation-accounts', addons.createAuthorizedCitationAccount);
     this.resource('authorized-computing-accounts', { except: ['index'] });
+    this.post('authorized-computing-accounts', addons.createAuthorizedComputingAccount);
     this.resource('configured-storage-addons', { only: ['show', 'update', 'delete'] });
     this.resource('configured-citation-addons', { only: ['show', 'update', 'delete'] });
     this.resource('configured-computing-addons', { only: ['show', 'update', 'delete'] });

--- a/mirage/views/addons.ts
+++ b/mirage/views/addons.ts
@@ -275,35 +275,23 @@ export function createAuthorizedComputingAccount(this: HandlerContext, schema: S
 function fakeCheckCredentials(credentials: AddonCredentialFields, credentialsFormat: CredentialsFormat) {
     switch (credentialsFormat) {
     case CredentialsFormat.REPO_TOKEN:
-        if (!credentials.token) {
-            throw new Error('Token is required');
-        }
-        if (credentials.token.indexOf('token') < 0) {
-            throw new Error('Invalid token');
+        if (!credentials.token || !credentials.repo) {
+            throw new Error('Token and repo is required');
         }
         break;
     case CredentialsFormat.ACCESS_SECRET_KEYS:
         if (!credentials.accessKey || !credentials.secretKey) {
-            throw new Error('Access key is required');
-        }
-        if (credentials.accessKey.indexOf('key') < 0 || credentials.secretKey.indexOf('key') < 0) {
-            throw new Error('Invalid access key or secret key');
+            throw new Error('Access key and secret key is required');
         }
         break;
     case CredentialsFormat.USERNAME_PASSWORD:
         if (!credentials.username || !credentials.password) {
             throw new Error('Username and password are required');
         }
-        if (credentials.username.indexOf('user') < 0 || credentials.password.indexOf('pass') < 0) {
-            throw new Error('Invalid username or password');
-        }
         break;
     case CredentialsFormat.URL_USERNAME_PASSWORD:
         if (!credentials.url || !credentials.username || !credentials.password) {
             throw new Error('URL, username, and password are required');
-        }
-        if (credentials.username.indexOf('user') < 0 || credentials.password.indexOf('pass') < 0) {
-            throw new Error('Invalid username or password');
         }
         if (credentials.url.indexOf('http') < 0) {
             throw new Error('Invalid URL');

--- a/mirage/views/addons.ts
+++ b/mirage/views/addons.ts
@@ -2,13 +2,29 @@ import { HandlerContext, ModelInstance, NormalizedRequestAttrs, Request, Respons
 
 import AuthorizedCitationAccountModel from 'ember-osf-web/models/authorized-citation-account';
 import AuthorizedComputingAccountModel from 'ember-osf-web/models/authorized-computing-account';
-import AuthorizedStorageAccountModel from 'ember-osf-web/models/authorized-storage-account';
+import AuthorizedStorageAccountModel, { AddonCredentialFields } from 'ember-osf-web/models/authorized-storage-account';
+import ExternalStorageServiceModel, { CredentialsFormat } from 'ember-osf-web/models/external-storage-service';
+import ExternalCitationServiceModel from 'ember-osf-web/models/external-citation-service';
+import ExternalComputingServiceModel from 'ember-osf-web/models/external-computing-service';
 import FileProviderModel from 'ember-osf-web/models/file-provider';
 
 import { MirageConfiguredComputingAddon } from '../serializers/configured-computing-addon';
 import { MirageConfiguredCitationAddon } from '../serializers/configured-citation-addon';
 import { MirageConfiguredStorageAddon } from '../serializers/configured-storage-addon';
 import { filter, process } from './utils';
+
+interface MirageAuthorizedStorageAccount extends AuthorizedStorageAccountModel {
+    configuringUserId: string;
+    storageProviderId: string;
+}
+interface MirageAuthorizedCitationAccount extends AuthorizedCitationAccountModel {
+    configuringUserId: string;
+    citationServiceId: string;
+}
+interface MirageAuthorizedComputingAccount extends AuthorizedComputingAccountModel {
+    configuringUserId: string;
+    computingServiceId: string;
+}
 
 // This is the handler for the unofficial node/addons endpoint
 // It is only being used by the file-action-menu component to determine if a node has the BoA addon enabled
@@ -203,4 +219,96 @@ export function createConfiguredComputingAddon(this: HandlerContext, schema: Sch
     });
 
     return configuredComputingAddon;
+}
+
+export async function createAuthorizedStorageAccount(this: HandlerContext, schema: Schema) {
+    const attrs = this.normalizedRequestAttrs(
+        'authorized-storage-account',
+    ) as NormalizedRequestAttrs<MirageAuthorizedStorageAccount>;
+    const externalService = schema.externalStorageServices
+        .find(attrs.storageProviderId) as ModelInstance<ExternalStorageServiceModel>;
+    try {
+        fakeCheckCredentials(attrs.credentials!, externalService.credentialsFormat);
+    } catch (e) {
+        return new Response(403, {}, {
+            errors: [{ detail: e.message }],
+        });
+    }
+    attrs.credentials = undefined;
+    return schema.authorizedStorageAccounts.create(attrs);
+}
+
+export function createAuthorizedCitationAccount(this: HandlerContext, schema: Schema) {
+    const attrs = this.normalizedRequestAttrs(
+        'authorized-citation-account',
+    ) as NormalizedRequestAttrs<MirageAuthorizedCitationAccount>;
+    const externalService = schema.externalCitationServices
+        .find(attrs.citationServiceId) as ModelInstance<ExternalCitationServiceModel>;
+    try {
+        fakeCheckCredentials(attrs.credentials!, externalService.credentialsFormat);
+    } catch (e) {
+        return new Response(403, {}, {
+            errors: [{ detail: e.message }],
+        });
+    }
+    attrs.credentials = undefined;
+    return schema.authorizedCitationAccounts.create(attrs);
+}
+
+export function createAuthorizedComputingAccount(this: HandlerContext, schema: Schema) {
+    const attrs = this.normalizedRequestAttrs(
+        'authorized-computing-account',
+    ) as NormalizedRequestAttrs<MirageAuthorizedComputingAccount>;
+    const externalService = schema.externalComputingServices
+        .find(attrs.computingServiceId) as ModelInstance<ExternalComputingServiceModel>;
+    try {
+        fakeCheckCredentials(attrs.credentials!, externalService.credentialsFormat);
+    } catch (e) {
+        return new Response(403, {}, {
+            errors: [{ detail: e.message }],
+        });
+    }
+    attrs.credentials = undefined;
+    return schema.authorizedComputingAccounts.create(attrs);
+}
+
+function fakeCheckCredentials(credentials: AddonCredentialFields, credentialsFormat: CredentialsFormat) {
+    switch (credentialsFormat) {
+    case CredentialsFormat.REPO_TOKEN:
+        if (!credentials.token) {
+            throw new Error('Token is required');
+        }
+        if (credentials.token.indexOf('token') < 0) {
+            throw new Error('Invalid token');
+        }
+        break;
+    case CredentialsFormat.ACCESS_SECRET_KEYS:
+        if (!credentials.accessKey || !credentials.secretKey) {
+            throw new Error('Access key is required');
+        }
+        if (credentials.accessKey.indexOf('key') < 0 || credentials.secretKey.indexOf('key') < 0) {
+            throw new Error('Invalid access key or secret key');
+        }
+        break;
+    case CredentialsFormat.USERNAME_PASSWORD:
+        if (!credentials.username || !credentials.password) {
+            throw new Error('Username and password are required');
+        }
+        if (credentials.username.indexOf('user') < 0 || credentials.password.indexOf('pass') < 0) {
+            throw new Error('Invalid username or password');
+        }
+        break;
+    case CredentialsFormat.URL_USERNAME_PASSWORD:
+        if (!credentials.url || !credentials.username || !credentials.password) {
+            throw new Error('URL, username, and password are required');
+        }
+        if (credentials.username.indexOf('user') < 0 || credentials.password.indexOf('pass') < 0) {
+            throw new Error('Invalid username or password');
+        }
+        if (credentials.url.indexOf('http') < 0) {
+            throw new Error('Invalid URL');
+        }
+        break;
+    default: // no-op on OAuth or OAuth2
+    }
 }


### PR DESCRIPTION
-   Ticket: [ENG-5155]
-   Feature flag: n/a

## Purpose
- Show validation messages and errors in addon auth flow
## Summary of Changes
- Update mirage view to pretend to validate auth credentials
- Show toast with backend error message
- Add validation message if account connect task fails

## Screenshot(s)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/3c1f61bb-50ad-4dfb-94b7-6718f68bc9f0)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/2323a737-27d0-4fa0-bfbc-7c60f65eee90)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-5155]: https://openscience.atlassian.net/browse/ENG-5155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ