### PR TITLE
[ENG-5159] Oauth

### DIFF
--- a/app/guid-node/addons/index/template.hbs
+++ b/app/guid-node/addons/index/template.hbs
@@ -62,21 +62,36 @@
                                             @checked={{eq manager.selectedAccount.id account.id}}
                                             {{on 'change' (fn manager.selectAccount account)}}
                                         />
-                                        {{account.externalUserDisplayName}}
+                                        {{#if account.externalUserDisplayName}}
+                                            {{account.externalUserDisplayName}}
+                                        {{else if (not account.isAuthorized)}}
+                                            {{t 'addons.accountSelect.unauthenticated-account'}}
+                                        {{/if}}
                                     </label>
                                 </div>
                             {{else}}
                                 {{t 'addons.accountSelect.no-accounts'}}
                             {{/each}}
                         </fieldset>
-                        <Button
-                            data-test-addon-authorize-button
-                            data-analytics-name='Authorize'
-                            disabled={{not manager.selectedAccount.id}}
-                            {{on 'click' manager.authorizeSelectedAccount}}
-                        >
-                            {{t 'general.authorize'}}
-                        </Button>
+                        {{#if (or (not manager.selectedAccount) manager.selectedAccount.externalUserDisplayName)}}
+                            <Button
+                                data-test-addon-authorize-button
+                                data-analytics-name='Authorize'
+                                disabled={{not manager.selectedAccount.id}}
+                                {{on 'click' manager.authorizeSelectedAccount}}
+                            >
+                                {{t 'general.authorize'}}
+                            </Button>
+                        {{else if (not manager.selectedAccount.isAuthorized)}}
+                            <Button
+                                data-test-addon-authenticate-button
+                                data-analytics-name='Authenticate'
+                                disabled={{not manager.selectedAccount.id}}
+                                {{on 'click' manager.createNewAccount}}
+                            >
+                                {{t 'general.authenticate'}}
+                            </Button>
+                        {{/if}}
                     {{else if (eq manager.pageMode 'accountCreate')}}
                         <AddonsService::AccountSetupManager
                             @provider={{provider.provider}}

--- a/app/models/authorized-citation-account.ts
+++ b/app/models/authorized-citation-account.ts
@@ -1,7 +1,7 @@
 import { AsyncBelongsTo, attr, belongsTo } from '@ember-data/model';
 
 import ExternalCitationServiceModel from './external-citation-service';
-import { AddonCredentialFields } from './authorized-storage-account';
+import { AddonCredentialFields, AuthorizedAccountLinks } from './authorized-storage-account';
 import UserReferenceModel from './user-reference';
 import OsfModel from './osf-model';
 
@@ -9,6 +9,7 @@ export default class AuthorizedCitationAccountModel extends OsfModel {
     @attr('fixstring') externalUserId!: string;
     @attr('fixstring') externalUserDisplayName!: string;
     @attr('fixstringarray') scopes!: string[];
+    @attr('object') links!: AuthorizedAccountLinks;
     @attr('object') credentials?: AddonCredentialFields; // write-only
 
     @belongsTo('external-citation-service')

--- a/app/models/authorized-citation-account.ts
+++ b/app/models/authorized-citation-account.ts
@@ -11,6 +11,7 @@ export default class AuthorizedCitationAccountModel extends OsfModel {
     @attr('fixstringarray') scopes!: string[];
     @attr('object') links!: AuthorizedAccountLinks;
     @attr('object') credentials?: AddonCredentialFields; // write-only
+    @attr('boolean') readonly isAuthorized!: boolean;
 
     @belongsTo('external-citation-service')
     citationService!: AsyncBelongsTo<ExternalCitationServiceModel> & ExternalCitationServiceModel;

--- a/app/models/authorized-citation-account.ts
+++ b/app/models/authorized-citation-account.ts
@@ -1,7 +1,7 @@
 import { AsyncBelongsTo, attr, belongsTo } from '@ember-data/model';
 
 import ExternalCitationServiceModel from './external-citation-service';
-import { AddonCredentialFields, AuthorizedAccountLinks } from './authorized-storage-account';
+import { AddonCredentialFields } from './authorized-storage-account';
 import UserReferenceModel from './user-reference';
 import OsfModel from './osf-model';
 
@@ -9,8 +9,8 @@ export default class AuthorizedCitationAccountModel extends OsfModel {
     @attr('fixstring') externalUserId!: string;
     @attr('fixstring') externalUserDisplayName!: string;
     @attr('fixstringarray') scopes!: string[];
-    @attr('object') links!: AuthorizedAccountLinks;
     @attr('object') credentials?: AddonCredentialFields; // write-only
+    @attr('fixstring') readonly authUrl!: string; // Only returned when POSTing to /authorized-citation-accounts
     @attr('boolean') readonly isAuthorized!: boolean;
 
     @belongsTo('external-citation-service')

--- a/app/models/authorized-computing-account.ts
+++ b/app/models/authorized-computing-account.ts
@@ -11,6 +11,7 @@ export default class AuthorizedComputingAccount extends OsfModel {
     @attr('fixstringarray') scopes!: string[];
     @attr('object') links!: AuthorizedAccountLinks;
     @attr('object') credentials?: AddonCredentialFields; // write-only
+    @attr('boolean') readonly isAuthorized!: boolean;
 
     @belongsTo('external-computing-service')
     computingService!: AsyncBelongsTo<ExternalComputingService> & ExternalComputingService;

--- a/app/models/authorized-computing-account.ts
+++ b/app/models/authorized-computing-account.ts
@@ -1,7 +1,7 @@
 import { AsyncBelongsTo, attr, belongsTo } from '@ember-data/model';
 
 import ExternalComputingService from './external-computing-service';
-import { AddonCredentialFields, AuthorizedAccountLinks } from './authorized-storage-account';
+import { AddonCredentialFields } from './authorized-storage-account';
 import UserReferenceModel from './user-reference';
 import OsfModel from './osf-model';
 
@@ -9,8 +9,8 @@ export default class AuthorizedComputingAccount extends OsfModel {
     @attr('fixstring') externalUserId!: string;
     @attr('fixstring') externalUserDisplayName!: string;
     @attr('fixstringarray') scopes!: string[];
-    @attr('object') links!: AuthorizedAccountLinks;
     @attr('object') credentials?: AddonCredentialFields; // write-only
+    @attr('fixstring') readonly authUrl!: string; // Only returned when POSTing to /authorized-computing-accounts
     @attr('boolean') readonly isAuthorized!: boolean;
 
     @belongsTo('external-computing-service')

--- a/app/models/authorized-computing-account.ts
+++ b/app/models/authorized-computing-account.ts
@@ -1,7 +1,7 @@
 import { AsyncBelongsTo, attr, belongsTo } from '@ember-data/model';
 
 import ExternalComputingService from './external-computing-service';
-import { AddonCredentialFields } from './authorized-storage-account';
+import { AddonCredentialFields, AuthorizedAccountLinks } from './authorized-storage-account';
 import UserReferenceModel from './user-reference';
 import OsfModel from './osf-model';
 
@@ -9,6 +9,7 @@ export default class AuthorizedComputingAccount extends OsfModel {
     @attr('fixstring') externalUserId!: string;
     @attr('fixstring') externalUserDisplayName!: string;
     @attr('fixstringarray') scopes!: string[];
+    @attr('object') links!: AuthorizedAccountLinks;
     @attr('object') credentials?: AddonCredentialFields; // write-only
 
     @belongsTo('external-computing-service')

--- a/app/models/authorized-storage-account.ts
+++ b/app/models/authorized-storage-account.ts
@@ -1,5 +1,6 @@
 import { AsyncBelongsTo, attr, belongsTo } from '@ember-data/model';
 
+import { OsfLinks } from './osf-model';
 import ExternalStorageServiceModel from './external-storage-service';
 import UserReferenceModel from './user-reference';
 import OsfModel from './osf-model';
@@ -14,10 +15,16 @@ export interface AddonCredentialFields {
     repo: string;
 }
 
+export interface AuthorizedAccountLinks extends OsfLinks {
+    auth?: string; // Returned when POSTing to /authorized-xyz-accounts
+}
+
+
 export default class AuthorizedStorageAccountModel extends OsfModel {
     @attr('fixstring') externalUserId!: string;
     @attr('fixstring') externalUserDisplayName!: string;
     @attr('fixstringarray') scopes!: string[];
+    @attr('object') links!: AuthorizedAccountLinks;
     @attr('object') credentials?: AddonCredentialFields; // write-only
 
     @belongsTo('external-storage-service')

--- a/app/models/authorized-storage-account.ts
+++ b/app/models/authorized-storage-account.ts
@@ -26,6 +26,7 @@ export default class AuthorizedStorageAccountModel extends OsfModel {
     @attr('fixstringarray') scopes!: string[];
     @attr('object') links!: AuthorizedAccountLinks;
     @attr('object') credentials?: AddonCredentialFields; // write-only
+    @attr('boolean') readonly isAuthorized!: boolean;
 
     @belongsTo('external-storage-service')
     storageProvider!: AsyncBelongsTo<ExternalStorageServiceModel> & ExternalStorageServiceModel;

--- a/app/models/authorized-storage-account.ts
+++ b/app/models/authorized-storage-account.ts
@@ -1,6 +1,5 @@
 import { AsyncBelongsTo, attr, belongsTo } from '@ember-data/model';
 
-import { OsfLinks } from './osf-model';
 import ExternalStorageServiceModel from './external-storage-service';
 import UserReferenceModel from './user-reference';
 import OsfModel from './osf-model';
@@ -15,17 +14,12 @@ export interface AddonCredentialFields {
     repo: string;
 }
 
-export interface AuthorizedAccountLinks extends OsfLinks {
-    auth?: string; // Returned when POSTing to /authorized-xyz-accounts
-}
-
-
 export default class AuthorizedStorageAccountModel extends OsfModel {
     @attr('fixstring') externalUserId!: string;
     @attr('fixstring') externalUserDisplayName!: string;
     @attr('fixstringarray') scopes!: string[];
-    @attr('object') links!: AuthorizedAccountLinks;
     @attr('object') credentials?: AddonCredentialFields; // write-only
+    @attr('fixstring') readonly authUrl!: string; // Only returned when POSTing to /authorized-storage-accounts
     @attr('boolean') readonly isAuthorized!: boolean;
 
     @belongsTo('external-storage-service')

--- a/app/models/external-storage-service.ts
+++ b/app/models/external-storage-service.ts
@@ -13,7 +13,6 @@ export enum CredentialsFormat {
 
 export interface ExternalServiceLinks extends OsfLinks {
     icon: string;
-    auth?: string; // Returned when POSTing to /authorized-xyz-accounts
 }
 
 export default class ExternalStorageServiceModel extends OsfModel {

--- a/lib/osf-components/addon/components/addons-service/account-setup-manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/account-setup-manager/component.ts
@@ -207,7 +207,7 @@ export default class AccountSetupManagerComponent extends Component<Args> {
     async startOauthFlow() {
         this.account = await taskFor(this.args.manager.createAuthorizedAccount).perform();
         if (this.account) {
-            const oauthWindow = window.open(this.account.links.auth, '_blank');
+            const oauthWindow = window.open(this.account.authUrl, '_blank');
             if (oauthWindow) {
                 document.addEventListener('visibilitychange', this.onVisibilityChange);
                 this.pendingOauth = true;

--- a/lib/osf-components/addon/components/addons-service/account-setup-manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/account-setup-manager/component.ts
@@ -1,12 +1,18 @@
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { waitFor } from '@ember/test-waiters';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { task } from 'ember-concurrency';
+import { taskFor } from 'ember-concurrency-ts';
 import IntlService from 'ember-intl/services/intl';
-import ExternalStorageServiceModel, { CredentialsFormat } from 'ember-osf-web/models/external-storage-service';
-import { AddonCredentialFields } from 'ember-osf-web/models/authorized-storage-account';
+import Toast from 'ember-toastr/services/toast';
+
 import AddonsServiceManagerComponent from 'ember-osf-web/components/addons-service/manager/component';
 import UserAddonsManagerComponent from 'ember-osf-web/components/addons-service/user-addons-manager/component';
+import { AddonCredentialFields } from 'ember-osf-web/models/authorized-storage-account';
+import ExternalStorageServiceModel, { CredentialsFormat } from 'ember-osf-web/models/external-storage-service';
+import { AllAuthorizedAccountTypes } from 'ember-osf-web/packages/addons-service/provider';
 
 // TODO: Get this from GravyValet??
 const repoOptionsObject: Record<string, string[]> = {
@@ -37,9 +43,12 @@ interface Args {
 
 export default class AccountSetupManagerComponent extends Component<Args> {
     @service intl!: IntlService;
+    @service toast!: Toast;
 
     @tracked selectedRepo?: string;
     @tracked otherRepo = '';
+    @tracked account?: AllAuthorizedAccountTypes;
+    @tracked pendingOauth = false;
 
     get useOauth() {
         return [CredentialsFormat.OAUTH, CredentialsFormat.OAUTH2].includes(this.args.provider.credentialsFormat);
@@ -182,6 +191,29 @@ export default class AccountSetupManagerComponent extends Component<Args> {
         }
         default: // OAUTH, OAUTH2
             return [];
+        }
+    }
+
+    @action
+    onVisibilityChange() {
+        if (document.visibilityState === 'visible') {
+            taskFor(this.args.manager.oauthFlowRefocus).perform(this.account!);
+            this.pendingOauth = false;
+            document.removeEventListener('visibilitychange', this.onVisibilityChange);
+        }
+    }
+    @task
+    @waitFor
+    async startOauthFlow() {
+        this.account = await taskFor(this.args.manager.createAuthorizedAccount).perform();
+        if (this.account) {
+            const oauthWindow = window.open(this.account.links.auth, '_blank');
+            if (oauthWindow) {
+                document.addEventListener('visibilitychange', this.onVisibilityChange);
+                this.pendingOauth = true;
+            } else {
+                this.toast.error(this.intl.t('addons.accountCreate.oauth-window-blocked'));
+            }
         }
     }
 }

--- a/lib/osf-components/addon/components/addons-service/account-setup-manager/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/account-setup-manager/template.hbs
@@ -2,19 +2,22 @@
     <LoadingIndicator @dark={{true}} />
 {{else}}
     {{#if this.useOauth}}
-        {{!-- TODO: need clientId, callback and other fields to actually make this work --}}
-        <div local-class='oauth-wrapper'>
-            {{t 'addons.accountCreate.oauth-description' providerName=@provider.name}}
-            <a
-                data-test-addon-oauth-link
-                data-analytics-name='OAuth'
-                href={{@provider.links.auth}}
-                target='_blank'
-                rel='noopener noreferrer'
-            >
-                {{t 'addons.accountCreate.oauth-link' providerName=@provider.name}}
-            </a>
-        </div>
+        {{#if this.pendingOauth}}
+            <p>
+                {{t 'addons.accountCreate.oauth-pending'}}
+            </p>
+        {{else}}
+            <div local-class='oauth-wrapper'>
+                {{t 'addons.accountCreate.oauth-description' providerName=@provider.name}}
+                <Button
+                    data-test-addon-oauth-button
+                    data-analytics-name='OAuth'
+                    {{on 'click' (perform this.startOauthFlow)}}
+                >
+                    {{t 'general.authorize'}}
+                </Button>
+            </div>
+        {{/if}}
     {{else}}
         <form>
             {{#if this.showRepoOptions}}

--- a/lib/osf-components/addon/components/addons-service/manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/manager/component.ts
@@ -152,21 +152,51 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
 
     @task
     @waitFor
+    async createAuthorizedAccount() {
+        if (this.selectedProvider) {
+            const newAccount = await taskFor(this.selectedProvider.providerMap!
+                .createAccountForNodeAddon).perform(this.credentialsObject);
+            return newAccount;
+        }
+        return undefined;
+    }
+
+    @task
+    @waitFor
+    async createConfiguredAddon(newAccount: AllAuthorizedAccountTypes) {
+        if (this.selectedProvider) {
+            await taskFor(this.selectedProvider.providerMap!.createConfiguredAddon).perform(newAccount);
+        }
+    }
+
+    @task
+    @waitFor
     async connectAccount() {
         try {
             if (this.selectedProvider) {
-                const newAccount = await taskFor(this.selectedProvider.providerMap!
-                    .createAccountForNodeAddon).perform(this.credentialsObject);
-                await taskFor(this.selectedProvider.providerMap!.createConfiguredAddon).perform(newAccount);
+                const newAccount = await taskFor(this.createAuthorizedAccount).perform();
+                if (newAccount) {
+                    await taskFor(this.createConfiguredAddon).perform(newAccount);
+                    this.clearCredentials();
+                    this.pageMode = PageMode.CONFIGURE;
+                }
             }
-            this.clearCredentials();
-            this.pageMode = PageMode.CONFIGURE;
         } catch (e) {
             this.connectAccountError = true;
             const errorMessage = this.intl.t('addons.accountCreate.error');
             captureException(e, { errorMessage });
             this.toast.error(getApiErrorMessage(e), errorMessage);
         }
+    }
+
+    @task
+    @waitFor
+    async oauthFlowRefocus(newAccount: AllAuthorizedAccountTypes) {
+        await newAccount.reload();
+        this.clearCredentials();
+        await taskFor(this.selectedProvider!.providerMap!.getAuthorizedAccounts).perform();
+        this.selectedAccount = undefined;
+        this.chooseExistingAccount();
     }
 
     @action
@@ -177,9 +207,9 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
 
     @task
     @waitFor
-    async confirmAccountSetup(account: AuthorizedStorageAccountModel) {
+    async confirmAccountSetup(account: AllAuthorizedAccountTypes) {
         if (this.selectedProvider && this.selectedAccount) {
-            await taskFor(this.selectedProvider.createConfiguredStorageAddon).perform(account);
+            await taskFor(this.selectedProvider.createConfiguredAddon).perform(account);
         }
         this.pageMode = PageMode.CONFIGURE;
     }

--- a/lib/osf-components/addon/components/addons-service/manager/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/manager/template.hbs
@@ -17,6 +17,10 @@
     authorizeSelectedAccount=this.authorizeSelectedAccount
     chooseExistingAccount=this.chooseExistingAccount
     createNewAccount=this.createNewAccount
+
+    createAuthorizedAccount=this.createAuthorizedAccount
+    createConfiguredAddon=this.createConfiguredAddon
+    oauthFlowRefocus=this.oauthFlowRefocus
     connectAccount=this.connectAccount
     connectAccountError=this.connectAccountError
     credentialsObject=this.credentialsObject

--- a/mirage/views/addons.ts
+++ b/mirage/views/addons.ts
@@ -235,7 +235,7 @@ export function createAuthorizedStorageAccount(this: HandlerContext, schema: Sch
             .create(authorizedAttrs) as ModelInstance<AuthorizedStorageAccountModel>;
         if (!authorizedAttrs.isAuthorized &&
             [CredentialsFormat.OAUTH, CredentialsFormat.OAUTH2].includes(externalService.credentialsFormat)) {
-            emulateUserDoingOAuthFlow(newAuthorizedAccount);
+            emulateUserDoingOAuthFlow(newAuthorizedAccount, schema);
         }
         return newAuthorizedAccount;
     } catch (e) {
@@ -257,7 +257,7 @@ export function createAuthorizedCitationAccount(this: HandlerContext, schema: Sc
             .create(authorizedAttrs) as ModelInstance<AuthorizedCitationAccountModel>;
         if (!authorizedAttrs.isAuthorized &&
             [CredentialsFormat.OAUTH, CredentialsFormat.OAUTH2].includes(externalService.credentialsFormat)) {
-            emulateUserDoingOAuthFlow(newAuthorizedAccount);
+            emulateUserDoingOAuthFlow(newAuthorizedAccount, schema);
         }
         return newAuthorizedAccount;
     } catch (e) {
@@ -279,7 +279,7 @@ export function createAuthorizedComputingAccount(this: HandlerContext, schema: S
             .create(authorizedAttrs) as ModelInstance<AuthorizedComputingAccountModel>;
         if (!authorizedAttrs.isAuthorized &&
             [CredentialsFormat.OAUTH, CredentialsFormat.OAUTH2].includes(externalService.credentialsFormat)) {
-            emulateUserDoingOAuthFlow(newAuthorizedAccount);
+            emulateUserDoingOAuthFlow(newAuthorizedAccount, schema);
         }
         return newAuthorizedAccount;
     } catch (e) {
@@ -331,9 +331,13 @@ function fakeCheckCredentials(credentials: AddonCredentialFields, credentialsFor
     return true;
 }
 
-async function emulateUserDoingOAuthFlow(authorizedAccount: ModelInstance<AllAuthorizedAccountTypes>) {
-    await timeout(2000);
+async function emulateUserDoingOAuthFlow(authorizedAccount: ModelInstance<AllAuthorizedAccountTypes>, schema: Schema) {
+    await timeout(5000);
     // eslint-disable-next-line no-console
-    console.log('Mirage addons view: emulateOAuthFlow done');
-    authorizedAccount.update({ isAuthorized: true });
+    console.log('Mirage addons view: emulateUserDoingOAuthFlow done');
+    const currentUser = schema.roots.first().currentUser;
+    authorizedAccount.update({
+        isAuthorized: true,
+        externalUserDisplayName: currentUser?.fullName,
+    });
 }

--- a/mirage/views/addons.ts
+++ b/mirage/views/addons.ts
@@ -293,8 +293,9 @@ function prepareAuthorizedAccountAttrs(
     attrs: NormalizedRequestAttrs<AllAuthorizedAccountTypes>, externalService: ModelInstance<AllProviderTypes>,
 ) {
     const authorized = fakeCheckCredentials(attrs.credentials!, externalService.credentialsFormat);
-    attrs.links = !authorized ? { auth: 'https://www.fake.com' } : {};
     attrs.credentials = undefined;
+    // @ts-ignore: authUrl is set by the backend
+    attrs.authUrl = !authorized ? 'https://www.fake.com' : '';
     // @ts-ignore: isAuthorized is set by the backend
     attrs.isAuthorized = authorized;
     return attrs;
@@ -325,14 +326,14 @@ function fakeCheckCredentials(credentials: AddonCredentialFields, credentialsFor
             throw new Error('Invalid URL');
         }
         break;
-    default: // OAuth or OAuth2 should be authorized using the address found in links.auth. Faked below for mirage
+    default: // OAuth or OAuth2 should be authorized using the address found in authUrl. Faked below for mirage
         return false;
     }
     return true;
 }
 
 async function emulateUserDoingOAuthFlow(authorizedAccount: ModelInstance<AllAuthorizedAccountTypes>, schema: Schema) {
-    await timeout(5000);
+    await timeout(1000);
     // eslint-disable-next-line no-console
     console.log('Mirage addons view: emulateUserDoingOAuthFlow done');
     const currentUser = schema.roots.first().currentUser;

--- a/mirage/views/addons.ts
+++ b/mirage/views/addons.ts
@@ -1,4 +1,5 @@
 import { HandlerContext, ModelInstance, NormalizedRequestAttrs, Request, Response, Schema } from 'ember-cli-mirage';
+import { timeout } from 'ember-concurrency';
 
 import AuthorizedCitationAccountModel from 'ember-osf-web/models/authorized-citation-account';
 import AuthorizedComputingAccountModel from 'ember-osf-web/models/authorized-computing-account';
@@ -7,6 +8,7 @@ import ExternalStorageServiceModel, { CredentialsFormat } from 'ember-osf-web/mo
 import ExternalCitationServiceModel from 'ember-osf-web/models/external-citation-service';
 import ExternalComputingServiceModel from 'ember-osf-web/models/external-computing-service';
 import FileProviderModel from 'ember-osf-web/models/file-provider';
+import { AllAuthorizedAccountTypes, AllProviderTypes } from 'ember-osf-web/packages/addons-service/provider';
 
 import { MirageConfiguredComputingAddon } from '../serializers/configured-computing-addon';
 import { MirageConfiguredCitationAddon } from '../serializers/configured-citation-addon';
@@ -221,21 +223,26 @@ export function createConfiguredComputingAddon(this: HandlerContext, schema: Sch
     return configuredComputingAddon;
 }
 
-export async function createAuthorizedStorageAccount(this: HandlerContext, schema: Schema) {
+export function createAuthorizedStorageAccount(this: HandlerContext, schema: Schema) {
     const attrs = this.normalizedRequestAttrs(
         'authorized-storage-account',
     ) as NormalizedRequestAttrs<MirageAuthorizedStorageAccount>;
     const externalService = schema.externalStorageServices
         .find(attrs.storageProviderId) as ModelInstance<ExternalStorageServiceModel>;
     try {
-        fakeCheckCredentials(attrs.credentials!, externalService.credentialsFormat);
+        const authorizedAttrs = prepareAuthorizedAccountAttrs(attrs, externalService);
+        const newAuthorizedAccount = schema.authorizedStorageAccounts
+            .create(authorizedAttrs) as ModelInstance<AuthorizedStorageAccountModel>;
+        if (!authorizedAttrs.isAuthorized &&
+            [CredentialsFormat.OAUTH, CredentialsFormat.OAUTH2].includes(externalService.credentialsFormat)) {
+            emulateUserDoingOAuthFlow(newAuthorizedAccount);
+        }
+        return newAuthorizedAccount;
     } catch (e) {
         return new Response(403, {}, {
             errors: [{ detail: e.message }],
         });
     }
-    attrs.credentials = undefined;
-    return schema.authorizedStorageAccounts.create(attrs);
 }
 
 export function createAuthorizedCitationAccount(this: HandlerContext, schema: Schema) {
@@ -245,14 +252,19 @@ export function createAuthorizedCitationAccount(this: HandlerContext, schema: Sc
     const externalService = schema.externalCitationServices
         .find(attrs.citationServiceId) as ModelInstance<ExternalCitationServiceModel>;
     try {
-        fakeCheckCredentials(attrs.credentials!, externalService.credentialsFormat);
+        const authorizedAttrs = prepareAuthorizedAccountAttrs(attrs, externalService);
+        const newAuthorizedAccount = schema.authorizedCitationAccounts
+            .create(authorizedAttrs) as ModelInstance<AuthorizedCitationAccountModel>;
+        if (!authorizedAttrs.isAuthorized &&
+            [CredentialsFormat.OAUTH, CredentialsFormat.OAUTH2].includes(externalService.credentialsFormat)) {
+            emulateUserDoingOAuthFlow(newAuthorizedAccount);
+        }
+        return newAuthorizedAccount;
     } catch (e) {
         return new Response(403, {}, {
             errors: [{ detail: e.message }],
         });
     }
-    attrs.credentials = undefined;
-    return schema.authorizedCitationAccounts.create(attrs);
 }
 
 export function createAuthorizedComputingAccount(this: HandlerContext, schema: Schema) {
@@ -262,14 +274,30 @@ export function createAuthorizedComputingAccount(this: HandlerContext, schema: S
     const externalService = schema.externalComputingServices
         .find(attrs.computingServiceId) as ModelInstance<ExternalComputingServiceModel>;
     try {
-        fakeCheckCredentials(attrs.credentials!, externalService.credentialsFormat);
+        const authorizedAttrs = prepareAuthorizedAccountAttrs(attrs, externalService);
+        const newAuthorizedAccount = schema.authorizedComputingAccounts
+            .create(authorizedAttrs) as ModelInstance<AuthorizedComputingAccountModel>;
+        if (!authorizedAttrs.isAuthorized &&
+            [CredentialsFormat.OAUTH, CredentialsFormat.OAUTH2].includes(externalService.credentialsFormat)) {
+            emulateUserDoingOAuthFlow(newAuthorizedAccount);
+        }
+        return newAuthorizedAccount;
     } catch (e) {
         return new Response(403, {}, {
             errors: [{ detail: e.message }],
         });
     }
+}
+
+function prepareAuthorizedAccountAttrs(
+    attrs: NormalizedRequestAttrs<AllAuthorizedAccountTypes>, externalService: ModelInstance<AllProviderTypes>,
+) {
+    const authorized = fakeCheckCredentials(attrs.credentials!, externalService.credentialsFormat);
+    attrs.links = !authorized ? { auth: 'https://www.fake.com' } : {};
     attrs.credentials = undefined;
-    return schema.authorizedComputingAccounts.create(attrs);
+    // @ts-ignore: isAuthorized is set by the backend
+    attrs.isAuthorized = authorized;
+    return attrs;
 }
 
 function fakeCheckCredentials(credentials: AddonCredentialFields, credentialsFormat: CredentialsFormat) {
@@ -297,6 +325,15 @@ function fakeCheckCredentials(credentials: AddonCredentialFields, credentialsFor
             throw new Error('Invalid URL');
         }
         break;
-    default: // no-op on OAuth or OAuth2
+    default: // OAuth or OAuth2 should be authorized using the address found in links.auth. Faked below for mirage
+        return false;
     }
+    return true;
+}
+
+async function emulateUserDoingOAuthFlow(authorizedAccount: ModelInstance<AllAuthorizedAccountTypes>) {
+    await timeout(2000);
+    // eslint-disable-next-line no-console
+    console.log('Mirage addons view: emulateOAuthFlow done');
+    authorizedAccount.update({ isAuthorized: true });
 }

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -264,8 +264,9 @@ addons:
         access-key-placeholder: 'Access Key'
         secret-key-label: 'Secret Key'
         secret-key-placeholder: 'Secret Key'
+        oauth-pending: 'Complete the OAuth process in the pop-up window before returning to this page.'
+        oauth-window-blocked: 'The pop-up window was blocked. Please enable pop-ups for this site and try again.'
         oauth-description: 'Use OAuth to connect your {providerName} account'
-        oauth-link: 'Connect with {providerName}'
         error: 'Error creating account'
     confirm:
         heading: 'Confirm {providerName} Account'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -40,6 +40,7 @@ general:
     add: Add
     confirm: Confirm
     authorize: Authorize
+    authenticate: Authenticate
     ok: OK
     apply: Apply
     revisions: Revisions
@@ -266,6 +267,7 @@ addons:
         secret-key-placeholder: 'Secret Key'
         oauth-pending: 'Complete the OAuth process in the pop-up window before returning to this page.'
         oauth-window-blocked: 'The pop-up window was blocked. Please enable pop-ups for this site and try again.'
+        unauthenticated-account: 'Unauthenticated account'
         oauth-description: 'Use OAuth to connect your {providerName} account'
         error: 'Error creating account'
     confirm:

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -242,6 +242,7 @@ addons:
         no-accounts: 'No accounts available'
         new-account: 'Setup new account'
         existing-account: 'Choose existing account'
+        unauthenticated-account: 'Unauthenticated account'
     accountCreate:
         url-label: 'Host URL'
         url-placeholder: 'owncloud.example.org'
@@ -267,7 +268,6 @@ addons:
         secret-key-placeholder: 'Secret Key'
         oauth-pending: 'Complete the OAuth process in the new window before returning to this page.'
         oauth-window-blocked: "The OAuth window was blocked. Please disable adblock for this site or check your browser's security setting and try again."
-        unauthenticated-account: 'Unauthenticated account'
         oauth-description: 'Use OAuth to connect your {providerName} account'
         error: 'Error creating account'
     confirm:

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -265,8 +265,8 @@ addons:
         access-key-placeholder: 'Access Key'
         secret-key-label: 'Secret Key'
         secret-key-placeholder: 'Secret Key'
-        oauth-pending: 'Complete the OAuth process in the pop-up window before returning to this page.'
-        oauth-window-blocked: 'The pop-up window was blocked. Please enable pop-ups for this site and try again.'
+        oauth-pending: 'Complete the OAuth process in the new window before returning to this page.'
+        oauth-window-blocked: "The OAuth window was blocked. Please disable adblock for this site or check your browser's security setting and try again."
         unauthenticated-account: 'Unauthenticated account'
         oauth-description: 'Use OAuth to connect your {providerName} account'
         error: 'Error creating account'


### PR DESCRIPTION
-   Ticket: [ENG-5159]
-   Feature flag: `gravy_waffle`

## Purpose
- Support OAuth workflow on Node Addons page

## Summary of Changes
- Add `authUrl` and `isAuthorized` attributes to AuthorizedStorageAccount models and its friends
- Update account-setup-manager component to handle OAuth workflow
- Update addons-service/manager component to handle OAuth workflow
- Update Node Addons page to handle OAuth workflow
- Add mirage views
- Fix some bad patterns I introduced into Provider class

## Screenshot(s)
- This doesn't translate to screenshots very well. Probably best to check it out locally and go through it

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-5159]: https://openscience.atlassian.net/browse/ENG-5159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ