### PR TITLE
ENG-5482 Fix Redirect Issue for "See all subjects available" Link on Branded Preprint Landing Page

### DIFF
--- a/app/preprints/index/template.hbs
+++ b/app/preprints/index/template.hbs
@@ -67,7 +67,8 @@
                 <OsfLink
                     data-test-see-highlighted-subject example
                     data-analytics-name='See Highlighted Subject Example'
-                    @href='/discover/'
+                    @href={{concat '/preprints/' this.model.provider.id '/discover'}}
+
                 >
                     {{t 'preprints.subjects.links.seeAllSubjects'}}
                 </OsfLink>


### PR DESCRIPTION
-   Ticket: [ENG-5482](https://openscience.atlassian.net/browse/ENG-5482)
-   Feature flag: n/a

## Purpose

Fix Redirect Issue for "See all subjects available" Link on Branded Preprint Landing Page

## Summary of Changes

Adjusted the OsfLink component within the preprint landing page template to dynamically construct the redirect URL based on the preprint provider's id. 

## Screenshot(s)

## QA Notes



[ENG-5482]: https://openscience.atlassian.net/browse/ENG-5482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ