### PR TITLE
[ENG-5174] Service files

### DIFF
--- a/app/guid-node/controller.ts
+++ b/app/guid-node/controller.ts
@@ -1,12 +1,14 @@
 import Controller from '@ember/controller';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
+import Features from 'ember-feature-flags';
 import Media from 'ember-responsive';
 
 
 export default class GuidNode extends Controller {
     @service router!: RouterService;
     @service media!: Media;
+    @service features!: Features;
 
     get onFilesRoute() {
         return (
@@ -17,5 +19,9 @@ export default class GuidNode extends Controller {
 
     get isDesktop() {
         return this.media.isDesktop;
+    }
+
+    get useGravyWaffle() {
+        return this.features.isEnabled('gravy_waffle');
     }
 }

--- a/app/guid-node/files/provider/route.ts
+++ b/app/guid-node/files/provider/route.ts
@@ -1,8 +1,10 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { waitFor } from '@ember/test-waiters';
+import Store from '@ember-data/store';
 import { task } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
+import Features from 'ember-feature-flags/services/features';
 
 import Intl from 'ember-intl/services/intl';
 import Toast from 'ember-toastr/services/toast';
@@ -14,6 +16,8 @@ import captureException, { getApiErrorMessage } from 'ember-osf-web/utils/captur
 export default class GuidNodeFilesProviderRoute extends Route.extend({}) {
     @service intl!: Intl;
     @service toast!: Toast;
+    @service features!: Features;
+    @service store!: Store;
 
     @task
     @waitFor
@@ -39,10 +43,38 @@ export default class GuidNodeFilesProviderRoute extends Route.extend({}) {
         }
     }
 
+    @task
+    @waitFor
+    async configuredStorageAddonTask(providerId: string) {
+        if(providerId === 'osfstorage') {
+            return undefined;
+        }
+        try {
+            return await this.store.findRecord('configured-storage-addon', providerId);
+        } catch (e) {
+            const errorMessage = this.intl.t(
+                'osf-components.file-browser.errors.load_configured_storage_addon',
+            );
+            captureException(e, { errorMessage });
+            this.toast.error(getApiErrorMessage(e), errorMessage);
+            return undefined;
+        }
+    }
+
     model(params: { providerId: string }) {
         const node = this.modelFor('guid-node');
-        const fileProviderId = node.guid + ':' + params.providerId;
+        let configuredStorageAddonTask;
+        let fileProviderId = params.providerId;
+        if(this.features.isEnabled('gravy_waffle')){
+            configuredStorageAddonTask = taskFor(this.configuredStorageAddonTask).perform(params.providerId);
+            if (params.providerId === 'osfstorage'){
+                fileProviderId = node.guid + ':' + params.providerId;
+            }
+        } else {
+            fileProviderId = node.guid + ':' + params.providerId;
+        }
         return {
+            configuredStorageAddonTask,
             node,
             providerName: params.providerId,
             providerTask: taskFor(this.fileProviderTask).perform(node, fileProviderId),

--- a/app/guid-node/files/provider/template.hbs
+++ b/app/guid-node/files/provider/template.hbs
@@ -1,21 +1,16 @@
 {{#unless this.model.providerTask.isRunning}}
-    <StorageProviderManager::ProviderMapper
-        as |mapper|
+    <StorageProviderManager::StorageManager
+        @provider={{this.model.providerTask.value.provider}}
+        @isViewOnly={{this.model.providerTask.value.currentUser.viewOnlyToken}}
+        @configuredStorageAddon={{this.model.configuredStorageAddonTask.value}}
+        as |manager|
     >
-        {{#let (get mapper this.model.providerName) as |ProviderManager|}}
-            <ProviderManager
-                @provider={{this.model.providerTask.value.provider}}
-                @isViewOnly={{this.model.providerTask.value.currentUser.viewOnlyToken}}
-                as |manager|
-            >
-                <div local-class='FileBrowser'>
-                    <FileBrowser
-                        @manager={{manager}}
-                        @selectable={{not this.model.providerTask.value.currentUser.viewOnlyToken}}
-                        @enableUpload={{true}}
-                    />
-                </div>
-            </ProviderManager>
-        {{/let}}
-    </StorageProviderManager::ProviderMapper>
+        <div local-class='FileBrowser'>
+            <FileBrowser
+                @manager={{manager}}
+                @selectable={{not this.model.providerTask.value.currentUser.viewOnlyToken}}
+                @enableUpload={{true}}
+            />
+        </div>
+    </StorageProviderManager::StorageManager>
 {{/unless}}

--- a/app/guid-node/template.hbs
+++ b/app/guid-node/template.hbs
@@ -93,7 +93,7 @@
                     />
                 {{/if}}
                 {{#if this.model.taskInstance.value.userHasWritePermission}}
-                    {{#if (this.useGravyWaffle)}}
+                    {{#if this.useGravyWaffle}}
                         <leftNav.link
                             data-test-addons-link
                             data-analytics-name='Add-ons'

--- a/app/guid-node/template.hbs
+++ b/app/guid-node/template.hbs
@@ -93,7 +93,7 @@
                     />
                 {{/if}}
                 {{#if this.model.taskInstance.value.userHasWritePermission}}
-                    {{#if (feature-flag 'gravy_waffle')}}
+                    {{#if (this.useGravyWaffle)}}
                         <leftNav.link
                             data-test-addons-link
                             data-analytics-name='Add-ons'

--- a/app/models/configured-storage-addon.ts
+++ b/app/models/configured-storage-addon.ts
@@ -6,12 +6,27 @@ import UserReferenceModel from './user-reference';
 import OsfModel from './osf-model';
 import ExternalStorageServiceModel from './external-storage-service';
 
+export enum ConnectedCapabilities {
+    Access = 'ACCESS',
+    Update = 'UPDATE',
+}
+
+export enum ConnectedOparationNames {
+    DownloadAsZip = 'download_as_zip',
+    CopyInto = 'copy_into',
+    HasRevisions = 'has_revisions',
+}
+
 export default class ConfiguredStorageAddonModel extends OsfModel {
     @attr('string') name!: string;
     @attr('string') displayName!: string;
+    @attr('array') connectedCapabilities!: ConnectedCapabilities[];
+    @attr('array') connectedOperationNames!: ConnectedOparationNames[];
     @attr('fixstring') externalUserId!: string;
     @attr('fixstring') externalUserDisplayName!: string;
+    @attr('number') concurrentUploads!: number;
     @attr('fixstring') rootFolder!: string;
+    @attr('string') iconUrl!: string;
 
     @belongsTo('external-storage-service', { inverse: null })
     storageProvider!: AsyncBelongsTo<ExternalStorageServiceModel> & ExternalStorageServiceModel;

--- a/app/packages/files/service-file.ts
+++ b/app/packages/files/service-file.ts
@@ -1,0 +1,256 @@
+import { getOwner, setOwner } from '@ember/application';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+import { waitFor } from '@ember/test-waiters';
+import { task } from 'ember-concurrency';
+import Intl from 'ember-intl/services/intl';
+import Toast from 'ember-toastr/services/toast';
+import ConfiguredStorageAddonModel, { ConnectedCapabilities, ConnectedOparationNames}
+    from 'ember-osf-web/models/configured-storage-addon';
+import FileModel from 'ember-osf-web/models/file';
+import NodeModel from 'ember-osf-web/models/node';
+import { Permission } from 'ember-osf-web/models/osf-model';
+import CurrentUserService from 'ember-osf-web/services/current-user';
+import captureException, { getApiErrorMessage } from 'ember-osf-web/utils/capture-exception';
+import humanFileSize from 'ember-osf-web/utils/human-file-size';
+
+
+export enum FileSortKey {
+    AscDateModified = 'date_modified',
+    DescDateModified = '-date_modified',
+    AscName = 'name',
+    DescName = '-name',
+}
+
+// Waterbutler file version
+export interface WaterButlerRevision {
+    id: string;
+    type: 'file_versions';
+    attributes: {
+        extra: {
+            downloads: number,
+            hashes: {
+                md5: string,
+                sha256: string,
+            },
+            user: {
+                name: string,
+                url: string,
+            },
+        },
+        version: number,
+        modified: Date,
+        modified_utc: Date,
+        versionIdentifier: 'version',
+    };
+}
+
+export default class ServiceFile {
+    @tracked fileModel: FileModel;
+    @tracked configuredStorageAddon: ConfiguredStorageAddonModel;
+    @tracked totalFileCount = 0;
+    @tracked waterButlerRevisions?: WaterButlerRevision[];
+    userCanDownloadAsZip: boolean;
+    shouldShowTags = false;
+    shouldShowRevisions: boolean;
+    providerHandlesVersioning: boolean;
+    canMoveToThisProvider: boolean;
+    parallelUploadsLimit = 2;
+
+    currentUser: CurrentUserService;
+    @service intl!: Intl;
+    @service toast!: Toast;
+
+
+    constructor(
+        currentUser: CurrentUserService,
+        fileModel: FileModel,
+        configuredStorageAddon: ConfiguredStorageAddonModel,
+    ) {
+        setOwner(this, getOwner(fileModel));
+        this.currentUser = currentUser;
+        this.fileModel = fileModel;
+        this.configuredStorageAddon = configuredStorageAddon;
+        this.userCanDownloadAsZip = configuredStorageAddon.connectedOperationNames
+            .includes(ConnectedOparationNames.DownloadAsZip);
+        this.providerHandlesVersioning = configuredStorageAddon.connectedOperationNames
+            .includes(ConnectedOparationNames.HasRevisions);
+        this.shouldShowRevisions = configuredStorageAddon.connectedOperationNames
+            .includes(ConnectedOparationNames.HasRevisions);
+        this.parallelUploadsLimit = configuredStorageAddon.concurrentUploads;
+        this.canMoveToThisProvider = configuredStorageAddon.connectedOperationNames
+            .includes(ConnectedOparationNames.CopyInto);
+    }
+
+    get isFile() {
+        return this.fileModel.isFile;
+    }
+
+    get isFolder() {
+        return this.fileModel.isFolder;
+    }
+
+    get showAsUnviewed() {
+        return this.fileModel.showAsUnviewed;
+    }
+
+    get size() {
+        return humanFileSize(this.fileModel.size);
+    }
+
+    get currentUserPermission(): string {
+        if (
+            this.fileModel.target.get('currentUserPermissions').includes(Permission.Write) &&
+            this.configuredStorageAddon.connectedCapabilities.includes(ConnectedCapabilities.Update)
+        ) {
+            return 'write';
+        }
+        return 'read';
+    }
+
+    get targetIsRegistration(){
+        return this.fileModel.target.get('modelName') === 'registration';
+    }
+
+    get currentUserCanDelete() {
+        return (this.fileModel.target.get('modelName') !== 'registration' && this.currentUserPermission === 'write');
+    }
+
+    get name() {
+        return this.fileModel.name;
+    }
+
+    get displayName() {
+        return this.fileModel.name;
+    }
+
+    get id() {
+        return this.fileModel.id;
+    }
+
+    get path() {
+        return this.fileModel.path;
+    }
+
+    get links() {
+        const links = this.fileModel.links;
+        if (this.isFolder) {
+            const uploadLink = new URL(links.upload as string);
+            uploadLink.searchParams.set('zip', '');
+
+            links.download = uploadLink.toString();
+        }
+        return links;
+    }
+
+    get userCanEditMetadata() {
+        return this.fileModel.target.get('currentUserPermissions').includes(Permission.Write);
+    }
+
+    get dateModified() {
+        return this.fileModel.dateModified;
+    }
+
+    get userCanMoveToHere() {
+        return (
+            this.currentUserPermission === 'write' &&
+            this.canMoveToThisProvider &&
+            this.fileModel.target.get('modelName') !== 'registration' &&
+            this.isFolder
+        );
+    }
+
+    get userCanUploadToHere() {
+        return (
+            this.currentUserPermission === 'write' &&
+            this.fileModel.target.get('modelName') !== 'registration' &&
+            this.isFolder
+        );
+    }
+
+    get userCanDeleteFromHere() {
+        return (
+            this.isFolder &&
+            this.currentUserPermission === 'write' &&
+            this.fileModel.target.get('modelName') !== 'registration'
+        );
+    }
+
+    get isBoaFile() {
+        return this.fileModel.name.endsWith('.boa');
+    }
+
+    get providerIsOsfstorage() {
+        return false;
+    }
+
+    async createFolder(newFolderName: string) {
+        if (this.fileModel.isFolder) {
+            await this.fileModel.createFolder(newFolderName);
+        }
+    }
+
+    async getFolderItems(page: number, sort: FileSortKey, filter: string ) {
+        if (this.fileModel.isFolder) {
+            try {
+                const queryResult = await this.fileModel.queryHasMany('files',
+                    {
+                        page,
+                        sort,
+                        'filter[name]': filter,
+                    });
+                this.totalFileCount = queryResult.meta.total;
+                return queryResult.map(fileModel => Reflect.construct(this.constructor, [
+                    this.currentUser,
+                    fileModel,
+                    this.configuredStorageAddon,
+                ]));
+            } catch (e) {
+                const errorMessage = this.intl.t(
+                    'osf-components.file-browser.errors.load_file_list',
+                );
+                captureException(e, { errorMessage });
+                this.toast.error(getApiErrorMessage(e), errorMessage);
+                return [];
+            }
+        }
+        return [];
+    }
+
+    async updateContents(data: string) {
+        await this.fileModel.updateContents(data);
+    }
+
+    async rename(newName: string, conflict = 'replace') {
+        await this.fileModel.rename(newName, conflict);
+    }
+
+    @task
+    @waitFor
+    async move(node: NodeModel, path: string, provider: string, options?: { conflict: string }) {
+        return await this.fileModel.move(node, path, provider, options);
+    }
+
+    @task
+    @waitFor
+    async copy(node: NodeModel, path: string, provider: string, options?: { conflict: string }) {
+        return await this.fileModel.copy(node, path, provider, options);
+    }
+
+    @task
+    @waitFor
+    async delete() {
+        return await this.fileModel.delete();
+    }
+
+    @task
+    @waitFor
+    async getRevisions() {
+        const revisionsLink = new URL(this.links.upload as string);
+        revisionsLink.searchParams.set('revisions', '');
+
+        const responseObject = await this.currentUser.authenticatedAJAX({ url: revisionsLink.toString() });
+        this.waterButlerRevisions = responseObject.data;
+        return this.waterButlerRevisions;
+    }
+}

--- a/lib/osf-components/addon/components/file-browser/breadcrumbs/crumb/component.ts
+++ b/lib/osf-components/addon/components/file-browser/breadcrumbs/crumb/component.ts
@@ -1,6 +1,6 @@
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
-import Features from 'ember-feature-flags';
+import Features from 'ember-feature-flags/services/features';
 import config from 'ember-osf-web/config/environment';
 
 export default class CrumbComponent extends Component {

--- a/lib/osf-components/addon/components/file-browser/breadcrumbs/crumb/component.ts
+++ b/lib/osf-components/addon/components/file-browser/breadcrumbs/crumb/component.ts
@@ -1,8 +1,17 @@
+import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
+import Features from 'ember-feature-flags';
 import config from 'ember-osf-web/config/environment';
 
 export default class CrumbComponent extends Component {
+    @service features!: Features;
+
+
     get assetPrefix() {
         return config.assetsPrefix;
+    }
+
+    get useGravyWaffle() {
+        return this.features.isEnabled('gravy_waffle');
     }
 }

--- a/lib/osf-components/addon/components/file-browser/breadcrumbs/crumb/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/breadcrumbs/crumb/template.hbs
@@ -1,5 +1,5 @@
 {{#if @isProvider}}
-    {{#if (and (this.useGravyWaffle) (not (eq @name 'osfstorage')))}}
+    {{#if (and this.useGravyWaffle (not (eq @name 'osfstorage')))}}
         <img
             data-test-provider-icon
             src={{@icon}}

--- a/lib/osf-components/addon/components/file-browser/breadcrumbs/crumb/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/breadcrumbs/crumb/template.hbs
@@ -1,10 +1,19 @@
 {{#if @isProvider}}
-    <img
-        data-test-provider-icon
-        src={{concat this.assetPrefix 'assets/images/addons/icons/' @name '.png'}}
-        alt={{t 'osf-components.move_file_modal.icon_alt' provider=(t (concat 'osf-components.file-browser.storage_providers.' @name))}}
-    >
-    {{t (concat 'osf-components.file-browser.storage_providers.' @name)}}
+    {{#if (and (this.useGravyWaffle) (not (eq @name 'osfstorage')))}}
+        <img
+            data-test-provider-icon
+            src={{@icon}}
+            alt={{t 'osf-components.move_file_modal.icon_alt' provider=(@name)}}
+        >
+        {{@name}}
+    {{else}}
+        <img
+            data-test-provider-icon
+            src={{@icon}}
+            alt={{t 'osf-components.move_file_modal.icon_alt' provider=(t (concat 'osf-components.file-browser.storage_providers.' @name))}}
+        >
+        {{t (concat 'osf-components.file-browser.storage_providers.' @name)}}
+    {{/if}}
 {{else}}
     {{@name}}
 {{/if}}

--- a/lib/osf-components/addon/components/file-browser/breadcrumbs/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/breadcrumbs/template.hbs
@@ -4,7 +4,11 @@
             <li>
                 {{#if (eq breadcrumb @currentFolder)}}
                     <span data-test-breadcrumb={{breadcrumb.name}}>
-                        <FileBrowser::Breadcrumbs::Crumb @name={{breadcrumb.name}} @isProvider={{eq index 0}} />
+                        <FileBrowser::Breadcrumbs::Crumb
+                            @name={{breadcrumb.name}}
+                            @icon={{breadcrumb.iconLocation}}
+                            @isProvider={{eq index 0}}
+                        />
                     </span>
                 {{else}}
                     <OsfLink
@@ -13,7 +17,11 @@
                         @href='#'
                         {{on 'click' (fn @goToFolder breadcrumb)}}
                     >
-                        <FileBrowser::Breadcrumbs::Crumb @name={{breadcrumb.name}} @isProvider={{eq index 0}} />
+                        <FileBrowser::Breadcrumbs::Crumb
+                            @name={{breadcrumb.name}}
+                            @icon={{breadcrumb.iconLocation}}
+                            @isProvider={{eq index 0}}
+                        />
                     </OsfLink>
                 {{/if}}
             </li>

--- a/lib/osf-components/addon/components/file-provider-menu/component.ts
+++ b/lib/osf-components/addon/components/file-provider-menu/component.ts
@@ -9,6 +9,7 @@ import { taskFor } from 'ember-concurrency-ts';
 
 import ConfiguredStorageAddonModel from 'ember-osf-web/models/configured-storage-addon';
 import NodeModel from 'ember-osf-web/models/node';
+import Features from 'ember-feature-flags';
 
 interface InputArgs {
     node: NodeModel;
@@ -16,13 +17,14 @@ interface InputArgs {
 
 export default class FileProviderList extends Component<InputArgs> {
     @service store!: Store;
+    @service features!: Features;
 
     @tracked configuredStorageAddons: ConfiguredStorageAddonModel[] = [];
 
 
     constructor(owner: any, args: InputArgs) {
         super(owner, args);
-        if (args.node) {
+        if (args.node && this.features.isEnabled('gravy_waffle')) {
             taskFor(this.configuredStorageProviders).perform();
         }
     }

--- a/lib/osf-components/addon/components/file-provider-menu/template.hbs
+++ b/lib/osf-components/addon/components/file-provider-menu/template.hbs
@@ -34,7 +34,7 @@
                     @route='guid-node.files.provider'
                     @models={{array @node.id provider.id}}
                 >
-                    {{t (concat 'osf-components.file-browser.storage_providers.' provider.name)}}
+                    {{provider.displayName}}
                 </OsfLink>
             </div>
         {{/each}}

--- a/lib/osf-components/addon/components/move-file-modal/component.ts
+++ b/lib/osf-components/addon/components/move-file-modal/component.ts
@@ -7,7 +7,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { allSettled, task, TaskInstance } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
-import Features from 'ember-feature-flags';
+import Features from 'ember-feature-flags/services/features';
 import Intl from 'ember-intl/services/intl';
 import Toast from 'ember-toastr/services/toast';
 

--- a/lib/osf-components/addon/components/move-file-modal/list-item/template.hbs
+++ b/lib/osf-components/addon/components/move-file-modal/list-item/template.hbs
@@ -24,12 +24,21 @@
         >
             <span local-class='DestinationName'>
                 {{#if @isProvider}}
-                    <img
-                        data-test-provider-icon
-                        src={{concat this.assetPrefix 'assets/images/addons/icons/' @item.name '.png'}}
-                        alt={{t 'osf-components.move_file_modal.icon_alt' provider=(t (concat 'osf-components.file-browser.storage_providers.' @item.name))}}
-                    >
-                    {{t (concat 'osf-components.file-browser.storage_providers.' @item.name)}}
+                    {{#if (and (feature-flag 'gravy_waffle') (not (eq @item.name 'osfstorage')))}}
+                        <img
+                            data-test-provider-icon
+                            src={{@item.iconLocation}}
+                            alt={{t 'osf-components.move_file_modal.icon_alt' provider=@item.name}}
+                        >
+                        {{@item.name}}
+                    {{else}}
+                        <img
+                            data-test-provider-icon
+                            src={{concat this.assetPrefix 'assets/images/addons/icons/' @item.name '.png'}}
+                            alt={{t 'osf-components.move_file_modal.icon_alt' provider=(t (concat 'osf-components.file-browser.storage_providers.' @item.name))}}
+                        >
+                        {{t (concat 'osf-components.file-browser.storage_providers.' @item.name)}}
+                    {{/if}}
                     {{#if this.isReadOnlyProvider}}
                         <span>
                             {{t 'osf-components.move_file_modal.read_only_provider'}}

--- a/lib/osf-components/addon/components/storage-provider-manager/storage-manager/component.ts
+++ b/lib/osf-components/addon/components/storage-provider-manager/storage-manager/component.ts
@@ -4,6 +4,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { restartableTask, task, timeout } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
+import Features from 'ember-feature-flags/services/features';
 import FileProviderModel from 'ember-osf-web/models/file-provider';
 import { FileSortKey } from 'ember-osf-web/packages/files/file';
 import File from 'ember-osf-web/packages/files/file';
@@ -26,9 +27,21 @@ import OneDriveProviderFile from 'ember-osf-web/packages/files/one-drive-provide
 import OsfStorageProviderFile from 'ember-osf-web/packages/files/osf-storage-provider-file';
 import OwnCloudProviderFile from 'ember-osf-web/packages/files/own-cloud-provider-file';
 import S3ProviderFile from 'ember-osf-web/packages/files/s3-provider-file';
+import ConfiguredStorageAddonModel from 'ember-osf-web/models/configured-storage-addon';
+import ServiceProviderFile from 'ember-osf-web/packages/files/service-provider-file';
 
 interface Args {
     provider: FileProviderModel;
+    configuredStorageAddon: ConfiguredStorageAddonModel;
+}
+
+export function getServiceProviderFile(
+    currentUser: CurrentUserService,
+    providerFileModel: FileProviderModel,
+    configuredStorageAddon: ConfiguredStorageAddonModel,
+) {
+    const providerFile = new ServiceProviderFile(currentUser, providerFileModel, configuredStorageAddon);
+    return providerFile as ProviderFile;
 }
 
 export function getStorageProviderFile(currentUser: CurrentUserService, providerFileModel: FileProviderModel) {
@@ -82,9 +95,10 @@ export default class StorageManager extends Component<Args> {
     @service router!: RouterService;
     @service intl!: Intl;
     @service toast!: Toast;
+    @service features!: Features;
 
     @tracked storageProvider?: FileProviderModel;
-    @tracked folderLineage: Array<File | ProviderFile> = [];
+    @tracked folderLineage: Array<File | ProviderFile | ServiceProviderFile> = [];
     @tracked displayItems: File[] = [];
     @tracked filter = '';
     @tracked sort = FileSortKey.AscName;
@@ -133,7 +147,16 @@ export default class StorageManager extends Component<Args> {
     async getRootFolder() {
         if (this.args.provider) {
             this.storageProvider = this.args.provider;
-            const providerFile = getStorageProviderFile(this.currentUser, this.storageProvider);
+            let providerFile;
+            if(this.features.isEnabled('gravy_waffle') && this.storageProvider.name !== 'osfstorage') {
+                providerFile = getServiceProviderFile(
+                    this.currentUser,
+                    this.storageProvider,
+                    this.args.configuredStorageAddon,
+                );
+            } else {
+                providerFile = getStorageProviderFile(this.currentUser, this.storageProvider);
+            }
             if (!providerFile) {
                 // This should only be hit in development when we haven't set up a provider properly.
                 this.router.transitionTo('not-found');

--- a/mirage/scenarios/dashboard.ts
+++ b/mirage/scenarios/dashboard.ts
@@ -7,12 +7,14 @@ import NodeModel from 'ember-osf-web/models/node';
 import { Permission } from 'ember-osf-web/models/osf-model';
 import ExternalStorageServiceModel from 'ember-osf-web/models/external-storage-service';
 import User from 'ember-osf-web/models/user';
+import { ConnectedOparationNames, ConnectedCapabilities } from 'ember-osf-web/models/configured-storage-addon';
 
 const {
     dashboard: {
         noteworthyNode,
         popularNode,
     },
+    assetsPrefix,
 } = config;
 
 export function dashboardScenario(server: Server, currentUser: ModelInstance<User>) {
@@ -68,6 +70,15 @@ export function dashboardScenario(server: Server, currentUser: ModelInstance<Use
         parentFolder: filesNodeOsfStorage.rootFolder,
     });
 
+    server.create('file-provider', {
+        id: 'box1',
+        name: 'Box',
+        provider: 'box',
+        target: filesNode,
+    });
+    // const boxFiles = server.createList('file', 3, { target: filesNode });
+    // filesNodeBoxStorage.rootFolder.update({ boxFiles });
+
     server.create('contributor', {
         node: filesNode,
         users: currentUser,
@@ -103,14 +114,17 @@ export function dashboardScenario(server: Server, currentUser: ModelInstance<Use
     });
 
     server.create('configured-storage-addon', {
-        id: 'box',
+        id: 'box1',
         name: 'box',
-        displayName: 'Box',
+        displayName: 'Boxed Data',
         rootFolder: '/woot/',
         storageProvider: boxAddon,
         accountOwner: addonUser,
         authorizedResource: addonFile5,
         baseAccount: boxAccount,
+        connectedCapabilities: [ConnectedCapabilities.Access, ConnectedCapabilities.Update],
+        connectedOperationNames: [ConnectedOparationNames.CopyInto],
+        iconUrl: `${assetsPrefix}assets/images/addons/icons/box.png`,
     });
 
     create0CedarMetadataFile(server, currentUser, filesNode, filesNodeOsfStorage);

--- a/tests/engines/registries/acceptance/overview/files-test.ts
+++ b/tests/engines/registries/acceptance/overview/files-test.ts
@@ -1,5 +1,6 @@
 import { currentRouteName } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import Features from 'ember-feature-flags';
 import { percySnapshot } from 'ember-percy';
 import { module, test } from 'qunit';
 import { t } from 'ember-intl/test-support';
@@ -28,6 +29,9 @@ module('Registries | Acceptance | overview.files', hooks => {
     });
 
     test('Files list view', async function(assert) {
+        const features = this.owner.lookup('service:features') as Features;
+        features.disable('gravy_waffle');
+
         const registration = server.create(
             'registration',
             { currentUserPermissions: [Permission.Admin] },
@@ -70,6 +74,9 @@ module('Registries | Acceptance | overview.files', hooks => {
     });
 
     test('No files', async function(assert) {
+        const features = this.owner.lookup('service:features') as Features;
+        features.disable('gravy_waffle');
+
         const registration = server.create('registration');
 
         await visit(`/${registration.id}/files`);

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -2358,6 +2358,7 @@ osf-components:
         select_provider: 'Please select a file provider'
         no_children: 'No children'
         no_folders: 'No files or folders'
+        no_csa: 'Could not find a matching Configured Storage Addon'
         read_only_provider: '- Cannot move or copy to this file provider'
         is_being_moved: '- This folder is being moved'
         is_being_copied: '- This folder is being copied'
@@ -2390,6 +2391,7 @@ osf-components:
         delete_folder: 'Delete folder'
         delete_fail: 'Failed to delete "{fileName}"'
         errors:
+            load_configured_storage_addon: 'Failed to load configured storage addon'
             load_file_list: 'Failed to load files'
             load_file_provider: 'Failed to load the file provider'
             load_file_provider_title: 'Provider error'


### PR DESCRIPTION
-   Ticket: [ENG-5174]
-   Feature flag:`gravy_waffle`

## Purpose

Allow the files page to work with the addons service.

## Summary of Changes

1. Add service-file and service-provider-file classes to take advantage of having configuredStorageAddons
2. Use service-file and service-provider-file classes when `gravy_waffle` flag is active and not using `osfstorage` as a provider.
3. Update mirage
4. Add ConnectedCapabilities and ConnectedOperationNames enums and use them
5. Fix breadcrumbs
6. Fix move/copy dialog
7. Fix left sidebar menu
8. Fix tests

## Screenshot(s)

<img width="933" alt="Screenshot 2024-04-01 at 1 10 00 PM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/9a3117ce-373a-45b2-89fe-754e0cbc9909">
<img width="1218" alt="Screenshot 2024-04-01 at 1 09 46 PM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/6599111/b022d1b9-b243-4bd5-bbd4-2946d1039f3f">


## Side Effects

The worst is that I might have broken functionality for non-gravy-waffled environments, but I thiiiink it's okay? 

## QA Notes

Make sure this doesn't break environments that are not running the feature flag.


[ENG-5174]: https://openscience.atlassian.net/browse/ENG-5174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ