### PR TITLE
[ENG-5295] Branded Header

### DIFF
--- a/app/preprints/submit/route.ts
+++ b/app/preprints/submit/route.ts
@@ -7,6 +7,7 @@ import { inject as service } from '@ember/service';
 import PreprintProviderModel from 'ember-osf-web/models/preprint-provider';
 import MetaTags, { HeadTagDef } from 'ember-osf-web/services/meta-tags';
 import Theme from 'ember-osf-web/services/theme';
+// import { htmlSafe } from '@ember/template';
 
 export default class PreprintSubmitRoute extends Route {
     @service store!: Store;
@@ -31,9 +32,9 @@ export default class PreprintSubmitRoute extends Route {
             return {
                 provider,
                 brand: provider.brand.content,
+                // secondaryBackground: htmlSafe(provider.brand.secondaryColor),
             };
         } catch (e) {
-
             this.router.transitionTo('not-found', `preprints/${args.provider_id}/submit`);
             return null;
         }

--- a/app/preprints/submit/styles.scss
+++ b/app/preprints/submit/styles.scss
@@ -7,7 +7,7 @@
     justify-content: center;
     align-items: center;
     color: $color-text-white;
-    background: url('assets/images/preprints/preprints-detail-header-overlay.png') top center $color-bg-color-grey;
+    background: url('assets/images/default-brand/bg-dark.jpg') top center $color-bg-color-grey;
 
     .header {
         max-width: 1140px;

--- a/app/preprints/submit/styles.scss
+++ b/app/preprints/submit/styles.scss
@@ -7,7 +7,7 @@
     justify-content: center;
     align-items: center;
     color: $color-text-white;
-    background: url('assets/images/default-brand/bg-dark.jpg') top center $color-bg-color-grey;
+    background: url('assets/images/preprints/preprints-detail-header-overlay.png') top center $color-bg-color-grey;
 
     .header {
         max-width: 1140px;

--- a/app/preprints/submit/template.hbs
+++ b/app/preprints/submit/template.hbs
@@ -1,7 +1,7 @@
 {{page-title (t 'preprints.submit.title')}}
 
 <OsfLayout @backgroundClass={{local-class 'submit-page-container'}} as |layout|>
-    <Preprints::-Components::Submit::PreprintStateMachine 
+    <Preprints::-Components::Submit::PreprintStateMachine
         @provider={{this.model.provider}}
     as |manager|>
         <layout.heading local-class='header-container'
@@ -30,4 +30,3 @@
         </layout.right>
     </Preprints::-Components::Submit::PreprintStateMachine>
 </OsfLayout>
-

--- a/app/preprints/submit/template.hbs
+++ b/app/preprints/submit/template.hbs
@@ -1,11 +1,15 @@
+{{!-- template-lint-disable no-inline-styles style-concatenation --}}
 {{page-title (t 'preprints.submit.title')}}
 
 <OsfLayout @backgroundClass={{local-class 'submit-page-container'}} as |layout|>
     <Preprints::-Components::Submit::PreprintStateMachine
         @provider={{this.model.provider}}
     as |manager|>
-        <layout.heading local-class='header-container'
-         {{with-branding this.model.brand}}
+        <layout.heading
+            local-class='header-container'
+            style='background: {{this.model.provider.brand.secondaryColor}}'
+            {{!-- style='background: {{this.model.provider.secondaryBackground}}' --}}
+            {{with-branding this.model.brand}}
         >
             <div local-class='header'>
                 {{t 'preprints.submit.title-submit'


### PR DESCRIPTION
-   Ticket: [ENG-5295](https://openscience.atlassian.net/browse/ENG-5295)
-   Feature flag: n/a

## Purpose

TBD

## Summary of Changes

TBD

## Screenshot(s)

<img width="1680" alt="Screenshot 2024-04-02 at 10 05 13 AM" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/3750414/28db92be-31dc-4fa0-8090-856f9f6db4f8">

## Side Effects

TBD

## QA Notes

TBD


[ENG-5295]: https://openscience.atlassian.net/browse/ENG-5295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ