### PR TITLE
[ENG-5312] Add the tag widget to the metadata preprint page

### DIFF
--- a/app/preprints/-components/submit/metadata/component.ts
+++ b/app/preprints/-components/submit/metadata/component.ts
@@ -60,7 +60,6 @@ export default class Metadata extends Component<MetadataArgs>{
     @tracked licenses = [] as LicenseModel[];
     @tracked license!: LicenseModel;
 
-
     constructor(owner: unknown, args: MetadataArgs) {
         super(owner, args);
 

--- a/app/preprints/-components/submit/metadata/template.hbs
+++ b/app/preprints/-components/submit/metadata/template.hbs
@@ -47,6 +47,22 @@
                     </form.select>
                 {{/let}}
 
+                <div local-class='input-container'>
+                    {{#let (unique-id) 'tags' as |tagsFieldId|}}
+                        <label for={{tagsFieldId}}
+                            data-test-tags-label
+                        >
+                            {{t 'preprints.submit.step-two.tags-input'}}
+                        </label>
+                        <TagsWidget
+                            @taggable={{@manager.preprint}}
+                            @readOnly={{false}}
+                            @inline={{true}}
+                            id={{tagsFieldId}}
+                        />
+                    {{/let}}
+                </div>
+
                 <form.text
                     data-test-publication-doi-input
                     @label={{t 'preprints.submit.step-two.publication-doi-input'}}

--- a/app/preprints/-components/submit/preprint-state-machine/component.ts
+++ b/app/preprints/-components/submit/preprint-state-machine/component.ts
@@ -47,6 +47,8 @@ export default class PreprintStateMachine extends Component<StateMachineArgs>{
         this.preprint = this.store.createRecord('preprint', {
             provider: this.provider,
         });
+
+        this.preprint.tags = [] as string[];
     }
 
     /**

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1178,6 +1178,7 @@ preprints:
             license-input: 'License'
             license-description: 'A license tells others how they can use your work in the future and only applies to the information and files submitted with the registration. For more information, see this help guide.'
             license-placeholder: 'Select one'
+            tags-input: 'Tags'
             publication-doi-input: 'Publication Doi'
             publication-year-input: 'Publication Year'
             publication-citation-input: 'Publication Citation'


### PR DESCRIPTION
-   Ticket: [ENG-5312]
-   Feature flag: n/a

## Purpose

Add the tags widget to the preprint metadata page

## Summary of Changes

Added the `TagsWidget`

## Screenshot(s)
![Screenshot 2024-04-02 at 10 36 56 AM](https://github.com/CenterForOpenScience/ember-osf-web/assets/113387478/a4a8a13f-13f6-408a-9b13-cfad84135d2f)

## Side Effects

Looks wonky and the font text is off. I'll see what Mark has to say

## QA Notes

None


[ENG-5312]: https://openscience.atlassian.net/browse/ENG-5312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ