### PR TITLE
[ENG-5168] User addon credentials

### DIFF
--- a/app/models/external-citation-service.ts
+++ b/app/models/external-citation-service.ts
@@ -1,11 +1,11 @@
 import { attr } from '@ember-data/model';
 
 import OsfModel from './osf-model';
-import { CredentialsFormat, ExternalServiceLinks } from './external-storage-service';
+import { CredentialsFormat } from './external-storage-service';
 
 export default class ExternalCitationServiceModel extends OsfModel {
     @attr('fixstring') name!: string;
-    @attr('links') links!: ExternalServiceLinks;
+    @attr('string') iconUrl!: string;
     @attr('string') credentialsFormat!: CredentialsFormat;
     // TODO: actually need some attrs here for citation service options
 }

--- a/app/models/external-computing-service.ts
+++ b/app/models/external-computing-service.ts
@@ -1,11 +1,11 @@
 import { attr } from '@ember-data/model';
 
 import OsfModel from './osf-model';
-import { CredentialsFormat, ExternalServiceLinks } from './external-storage-service';
+import { CredentialsFormat } from './external-storage-service';
 
 export default class ExternalComputingServiceModel extends OsfModel {
     @attr('fixstring') name!: string;
-    @attr('links') links!: ExternalServiceLinks;
+    @attr('string') iconUrl!: string;
     @attr('string') credentialsFormat!: CredentialsFormat;
     // TODO: actually need some attrs here for cloud computing options
 }

--- a/app/models/external-storage-service.ts
+++ b/app/models/external-storage-service.ts
@@ -1,6 +1,6 @@
 import { attr } from '@ember-data/model';
 
-import OsfModel, { OsfLinks } from './osf-model';
+import OsfModel from './osf-model';
 
 export enum CredentialsFormat {
     OAUTH = 'oauth',
@@ -11,14 +11,10 @@ export enum CredentialsFormat {
     ACCESS_SECRET_KEYS = 'access_secret_keys',
 }
 
-export interface ExternalServiceLinks extends OsfLinks {
-    icon: string;
-}
-
 export default class ExternalStorageServiceModel extends OsfModel {
     @attr('fixstring') name!: string;
-    @attr('object') links!: ExternalServiceLinks;
     @attr('string') credentialsFormat!: CredentialsFormat;
+    @attr('string') iconUrl!: string;
     // TODO: combine these boolean scopes into a single array of strings from some enum
     @attr('boolean') readOnly!: boolean;
     @attr('boolean') supportsCopy!: boolean;

--- a/app/packages/addons-service/provider.ts
+++ b/app/packages/addons-service/provider.ts
@@ -44,13 +44,17 @@ interface ProviderTypeMapper {
 
 
 export default class Provider {
-    @tracked node: NodeModel;
+    @tracked node?: NodeModel;
     @tracked serviceNode?: ResourceReferenceModel;
 
     currentUser: CurrentUserService;
-    @tracked userReference!: UserReferenceModel;
+    @tracked userReference?: UserReferenceModel;
     provider: AllProviderTypes;
     providerMap?: ProviderTypeMapper;
+
+    get name() {
+        return this.provider.name;
+    }
 
     providerTypeMapper: Record<string, ProviderTypeMapper>  = {
         externalStorageService: {
@@ -83,8 +87,8 @@ export default class Provider {
         return Boolean(this.configuredAddon);
     }
 
-    constructor(provider: any, currentUser: CurrentUserService, node: NodeModel) {
-        setOwner(this, getOwner(node));
+    constructor(provider: any, currentUser: CurrentUserService, node?: NodeModel) {
+        setOwner(this, getOwner(provider));
         this.node = node;
         this.currentUser = currentUser;
         this.provider = provider;
@@ -121,11 +125,13 @@ export default class Provider {
     @task
     @waitFor
     async getResourceReference() {
-        const serviceNode = this.store.peekRecord('resource-reference', this.node.id);
-        if (serviceNode) {
-            this.serviceNode = serviceNode;
-        } else {
-            this.serviceNode = await this.store.findRecord('resource-reference', this.node.id);
+        if (this.node) {
+            const serviceNode = this.store.peekRecord('resource-reference', this.node.id);
+            if (serviceNode) {
+                this.serviceNode = serviceNode;
+            } else {
+                this.serviceNode = await this.store.findRecord('resource-reference', this.node.id);
+            }
         }
     }
 
@@ -197,7 +203,7 @@ export default class Provider {
     }
 
     async userAddonAccounts() {
-        return await this.userReference.authorizedStorageAccounts;
+        return await this.userReference?.authorizedStorageAccounts;
     }
 
 

--- a/app/packages/addons-service/provider.ts
+++ b/app/packages/addons-service/provider.ts
@@ -48,7 +48,7 @@ export default class Provider {
     @tracked serviceNode?: ResourceReferenceModel;
 
     currentUser: CurrentUserService;
-    @tracked userReference?: UserReferenceModel;
+    @tracked userReference!: UserReferenceModel;
     provider: AllProviderTypes;
     providerMap?: ProviderTypeMapper;
 
@@ -197,13 +197,11 @@ export default class Provider {
     @task
     @waitFor
     async getAuthorizedAccounts(accountType: RelationshipsFor<UserReferenceModel>, filter: any) {
-        if (this.userReference){
-            this.authorizedAccounts = await this.userReference.queryHasMany(accountType, filter);
-        }
+        this.authorizedAccounts = await this.userReference.queryHasMany(accountType, filter);
     }
 
     async userAddonAccounts() {
-        return await this.userReference?.authorizedStorageAccounts;
+        return await this.userReference.authorizedStorageAccounts;
     }
 
 

--- a/app/settings/addons/styles.scss
+++ b/app/settings/addons/styles.scss
@@ -36,6 +36,19 @@
     }
 }
 
-.disconnect-button {
+.provider-list-wrapper {
+    flex-grow: 1;
+}
+
+.provider-list-item {
+    margin: 15px 10px;
+    border-bottom: solid 1px $color-border-gray;
+
+    &:first-child {
+        border-top: solid 1px $color-border-gray;
+    }
+}
+
+.float-right {
     float: right;
 }

--- a/app/settings/addons/template.hbs
+++ b/app/settings/addons/template.hbs
@@ -5,57 +5,107 @@
     {{#if manager.currentListIsLoading}}
         <LoadingIndicator @dark={{true}} />
     {{else}}
-        <div local-class='addons-list-wrapper {{if this.isMobile 'mobile'}}'>
-            <div
-                data-analytics-scope='Addon List Filter'
-                local-class='filter-wrapper {{if this.isMobile 'mobile'}}'
+        {{#if manager.selectedProvider}}
+            <Button
+                data-test-cancel-account-setup
+                data-analytics-name='Cancel Account Setup'
+                local-class='float-right'
+                @layout='fake-link'
+                {{on 'click' manager.cancelAccountSetup}}
             >
-                <Input
-                    data-test-user-addon-list-filter-input
-                    placeholder={{t 'addons.list.filter-placeholder'}}
-                    @type='text'
-                    @value={{manager.filterText}}
-                />
-                {{#each manager.possibleFilterTypes as |type|}}
-                    <Button
-                        data-test-user-addon-list-filter={{type}}
-                        data-analytics-name={{t (concat 'addons.list.filter.' type)}}
-                        local-class='filter-button {{if (eq manager.activeFilterType type) 'active'}}'
-                        @layout='fake-link'
-                        {{on 'click' (fn manager.filterByAddonType type)}}
-                    >
-                        {{t (concat 'addons.list.filter.' type)}}
-                    </Button>
-                {{/each}}
-            </div>
-            <div>
-                {{#each manager.filteredAddonProviders as |provider|}}
-                    <div>
-                        {{provider.name}}
-                    </div>
-                {{else}}
-                    {{t 'addons.list.no-results'}}
-                {{/each}}
-            </div>
-        </div>
-    {{/if}}
-
-    <ul local-class='configured-addons-wrapper'>
-        {{#each manager.currentTypeAuthorizedAccounts as |account|}}
-            <li>
-                {{account.storageProvider.name}}
-                {{account.externalUserDisplayName}}
+                {{t 'general.back'}}
+            </Button>
+            {{#if (eq manager.pageMode 'terms')}}
+                <h3 local-class='page-heading'>
+                    {{t 'addons.terms.heading' providerName=manager.selectedProvider.provider.name}}
+                </h3>
                 <Button
-                    @type='destroy'
-                    @disabled={{manager.disconnectAddon.isRunning}}
-                    local-class='disconnect-button'
-                    {{on 'click' (perform manager.disconnectAddon account)}}
+                    {{on 'click' manager.acceptProviderTerms}}
                 >
-                    {{t 'addons.list.disconnect'}}
+                    {{t 'general.ok'}}
                 </Button>
-            </li>
+            {{else if (eq manager.pageMode 'accountCreate')}}
+                <h3 local-class='page-heading'>
+                    {{t 'addons.accountSelect.new-account'}}
+                </h3>
+                <AddonsService::AccountSetupManager
+                    @provider={{manager.selectedProvider.provider}}
+                    @manager={{manager}}
+                    @onConnect={{manager.connectAccount}}
+                    @onInput={{manager.onCredentialsInput}}
+                />
+            {{/if}}
         {{else}}
-            <li>{{t 'addons.list.no-authorized-accounts'}}</li>
-        {{/each}}
-    </ul>
+            <div
+                data-analytics-scope='Addon List'
+                local-class='addons-list-wrapper'
+            >
+                <div
+                    data-analytics-scope='Addon List Filter'
+                    local-class='filter-wrapper {{if this.isMobile 'mobile'}}'
+                >
+                    <Input
+                        data-test-user-addon-list-filter-input
+                        placeholder={{t 'addons.list.filter-placeholder'}}
+                        @type='text'
+                        @value={{manager.filterText}}
+                    />
+                    {{#each manager.possibleFilterTypes as |type|}}
+                        <Button
+                            data-test-user-addon-list-filter={{type}}
+                            data-analytics-name={{t (concat 'addons.list.filter.' type)}}
+                            local-class='filter-button {{if (eq manager.activeFilterType type) 'active'}}'
+                            @layout='fake-link'
+                            {{on 'click' (fn manager.filterByAddonType type)}}
+                        >
+                            {{t (concat 'addons.list.filter.' type)}}
+                        </Button>
+                    {{/each}}
+                </div>
+                <div
+                    local-class='provider-list-wrapper'
+                >
+                    {{#each manager.filteredAddonProviders as |provider|}}
+                        <div
+                            data-test-provider={{provider.name}}
+                            local-class='provider-list-item'
+                        >
+                            {{provider.name}}
+                            <Button
+                                data-analytics-name='Connect Addon Button {{provider.name}}'
+                                local-class='float-right'
+                                @type='create'
+                                {{on 'click' (fn manager.selectProvider provider)}}
+                            >
+                                {{t 'addons.list.connect'}}
+                            </Button>
+                        </div>
+                    {{else}}
+                        {{t 'addons.list.no-results'}}
+                    {{/each}}
+                </div>
+            </div>
+
+            <ul local-class='configured-addons-wrapper'>
+                {{#each manager.currentTypeAuthorizedAccounts as |account|}}
+                    <li>
+                        {{account.storageProvider.name}}
+                        {{account.externalUserDisplayName}}
+                        <Button
+                            data-test-disconnect-account-button
+                            data-analytics-name='Disconnect Addon Button {{account.storageProvider.name}}'
+                            @type='destroy'
+                            @disabled={{manager.disconnectAddon.isRunning}}
+                            local-class='float-right'
+                            {{on 'click' (perform manager.disconnectAddon account)}}
+                        >
+                            {{t 'addons.list.disconnect'}}
+                        </Button>
+                    </li>
+                {{else}}
+                    <li>{{t 'addons.list.no-authorized-accounts'}}</li>
+                {{/each}}
+            </ul>
+        {{/if}}
+    {{/if}}
 </AddonsService::UserAddonsManager>

--- a/lib/osf-components/addon/components/addon-card/component.ts
+++ b/lib/osf-components/addon/components/addon-card/component.ts
@@ -30,7 +30,7 @@ export default class AddonsCardComponent extends Component<Args> {
     }
 
     get assetLogo() {
-        return this.args.addon.provider.links.icon;
+        return this.args.addon.provider.iconUrl;
     }
 
     get addonIsConfigured() {

--- a/lib/osf-components/addon/components/addons-service/account-setup-manager/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/account-setup-manager/template.hbs
@@ -37,8 +37,8 @@
                 {{#if this.otherRepoSelected}}
                     <Input
                         local-class='auth-text-input-label'
+                        placeholder={{t 'addons.accountCreate.repo-other-placeholder'}}
                         @value={{this.otherRepo}}
-                        @placeholder={{t 'addons.accountCreate.repo-other-placeholder'}}
                         {{on 'keyup' this.onOtherRepoChange}}
                     />
                     {{#if this.repoOtherPostText}}
@@ -53,11 +53,11 @@
                     {{field.labelText}}
                     <Input
                         name={{field.name}}
+                        placeholder={{field.inputPlaceholder}}
+                        autocomplete={{field.autocomplete}}
                         @type={{field.inputType}}
                         @value={{field.inputValue}}
-                        @placeholder={{field.inputPlaceholder}}
                         {{on 'keyup' @onInput}}
-                        autocomplete={{field.autocomplete}}
                     />
                 </label>
                 {{field.postText}}

--- a/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
@@ -41,7 +41,7 @@ export default class UserAddonManagerComponent extends Component<Args> {
     @service toast!: Toast;
 
     user = this.args.user;
-    @tracked userReference?: UserReferenceModel;
+    @tracked userReference!: UserReferenceModel;
 
     possibleFilterTypes = Object.values(FilterTypes);
     @tracked filterTypeMapper = {
@@ -170,11 +170,9 @@ export default class UserAddonManagerComponent extends Component<Args> {
     async getAuthorizedStorageAccounts() {
         const { userReference } = this;
         const mappedObject = this.filterTypeMapper[FilterTypes.STORAGE];
-        if (userReference) {
-            const accounts = (await userReference.authorizedStorageAccounts).toArray();
-            mappedObject.authorizedAccounts = accounts;
-            notifyPropertyChange(this, 'filterTypeMapper');
-        }
+        const accounts = (await userReference.authorizedStorageAccounts).toArray();
+        mappedObject.authorizedAccounts = accounts;
+        notifyPropertyChange(this, 'filterTypeMapper');
     }
 
     @task
@@ -182,11 +180,9 @@ export default class UserAddonManagerComponent extends Component<Args> {
     async getAuthorizedCitationAccounts() {
         const { userReference } = this;
         const mappedObject = this.filterTypeMapper[FilterTypes.CITATION_MANAGER];
-        if (userReference) {
-            const accounts = (await userReference.authorizedCitationAccounts).toArray();
-            mappedObject.authorizedAccounts = accounts;
-            notifyPropertyChange(this, 'filterTypeMapper');
-        }
+        const accounts = (await userReference.authorizedCitationAccounts).toArray();
+        mappedObject.authorizedAccounts = accounts;
+        notifyPropertyChange(this, 'filterTypeMapper');
     }
 
     @task
@@ -194,11 +190,9 @@ export default class UserAddonManagerComponent extends Component<Args> {
     async getAuthorizedComputingAccounts() {
         const { userReference } = this;
         const mappedObject = this.filterTypeMapper[FilterTypes.CLOUD_COMPUTING];
-        if (userReference) {
-            const accounts = (await userReference.authorizedComputingAccounts).toArray();
-            mappedObject.authorizedAccounts = accounts;
-            notifyPropertyChange(this, 'filterTypeMapper');
-        }
+        const accounts = (await userReference.authorizedComputingAccounts).toArray();
+        mappedObject.authorizedAccounts = accounts;
+        notifyPropertyChange(this, 'filterTypeMapper');
     }
 
     @task

--- a/lib/osf-components/addon/components/addons-service/user-addons-manager/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/user-addons-manager/template.hbs
@@ -9,6 +9,15 @@
     currentListIsLoading=this.currentListIsLoading
     currentTypeAuthorizedAccounts=this.currentTypeAuthorizedAccounts
     credentialsObject=this.credentialsObject
+
+    selectedProvider=this.selectedProvider
+    selectProvider=this.selectProvider
+    pageMode=this.pageMode
+    acceptProviderTerms=this.acceptProviderTerms
+    cancelAccountSetup=this.cancelAccountSetup
+    onCredentialsInput=this.onCredentialsInput
+    createAuthorizedAccount=this.createAuthorizedAccount
+    oauthFlowRefocus=this.oauthFlowRefocus
     connectAccount=this.connectAccount
     beginAccountSetup=this.beginAccountSetup
     configureProvider=this.configureProvider

--- a/mirage/fixtures/external-citation-service.ts
+++ b/mirage/fixtures/external-citation-service.ts
@@ -2,8 +2,6 @@ export default [
     {
         id: 'zotero',
         name: 'Zotero',
-        links: {
-            icon: 'https://zbib.org/static/favicon.ico',
-        },
+        iconUrl: 'https://zbib.org/static/favicon.ico',
     },
 ];

--- a/mirage/fixtures/external-computing-service.ts
+++ b/mirage/fixtures/external-computing-service.ts
@@ -5,8 +5,6 @@ export default [
         id: 'boa',
         name: 'Boa',
         credentialsFormat: CredentialsFormat.USERNAME_PASSWORD,
-        links: {
-            icon: 'https://boa.cs.iastate.edu/img/boa-white.png',
-        },
+        iconUrl: 'https://boa.cs.iastate.edu/img/boa-white.png',
     },
 ];

--- a/mirage/fixtures/external-storage-services.ts
+++ b/mirage/fixtures/external-storage-services.ts
@@ -11,10 +11,7 @@ export default [
         supportsBulkDownload: true,
         maxConcurrentDownloads: 1,
         maxUploadMb: 5,
-        links: {
-            auth: 'https://www.box.com/',
-            icon: 'https://www.box.com/favicon.ico',
-        },
+        iconUrl: 'https://www.box.com/favicon.ico',
     },
     {
         id: 'dataverse',
@@ -27,9 +24,7 @@ export default [
         supportsBulkDownload: true,
         maxConcurrentDownloads: 1,
         maxUploadMb: 5,
-        links: {
-            icon: 'https://dataverse.org/favicon.ico',
-        },
+        iconUrl: 'https://dataverse.org/favicon.ico',
     },
     {
         id: 'dropbox',
@@ -42,10 +37,7 @@ export default [
         supportsBulkDownload: true,
         maxConcurrentDownloads: 1,
         maxUploadMb: 5,
-        links: {
-            auth: 'https://www.dropbox.com/',
-            icon: 'https://www.dropbox.com/favicon.ico',
-        },
+        iconUrl: 'https://www.dropbox.com/favicon.ico',
     },
     {
         id: 'gitlab',
@@ -58,9 +50,7 @@ export default [
         supportsBulkDownload: true,
         maxConcurrentDownloads: 1,
         maxUploadMb: 5,
-        links: {
-            icon: 'https://gitlab.com/favicon.ico',
-        },
+        iconUrl: 'https://gitlab.com/favicon.ico',
     },
     {
         id: 'onedrive',
@@ -73,10 +63,7 @@ export default [
         supportsBulkDownload: true,
         maxConcurrentDownloads: 1,
         maxUploadMb: 5,
-        links: {
-            auth: 'https://onedrive.live.com/',
-            icon: 'https://onedrive.live.com/favicon.ico',
-        },
+        icon: 'https://onedrive.live.com/favicon.ico',
     },
     {
         id: 'owncloud',
@@ -89,9 +76,7 @@ export default [
         supportsBulkDownload: true,
         maxConcurrentDownloads: 1,
         maxUploadMb: 5,
-        links: {
-            icon: 'https://owncloud.com/favicon.ico',
-        },
+        iconUrl: 'https://owncloud.com/favicon.ico',
     },
     {
         id: 's3',
@@ -104,9 +89,6 @@ export default [
         supportsBulkDownload: true,
         maxConcurrentDownloads: 1,
         maxUploadMb: 5,
-        links: {
-            auth: 'https://aws.amazon.com/',
-            icon: 'https://aws.amazon.com/favicon.ico',
-        },
+        iconUrl: 'https://aws.amazon.com/favicon.ico',
     },
 ];

--- a/tests/integration/components/addon-card/component-test.ts
+++ b/tests/integration/components/addon-card/component-test.ts
@@ -34,9 +34,7 @@ module('Integration | Component | addon-card', hooks => {
             provider: {
                 id: 'box',
                 name: 'Test Addon',
-                links: {
-                    icon: 'https://some.url/from/addons/service/box.png',
-                },
+                iconUrl: 'https://some.url/from/addons/service/box.png',
             },
             disableProjectAddon: sinon.stub(),
             nodeAddon: { configured: false },
@@ -75,9 +73,7 @@ module('Integration | Component | addon-card', hooks => {
             provider: {
                 id: 'box',
                 name: 'Test Addon',
-                links: {
-                    icon: 'https://some.url/from/addons/service/box.png',
-                },
+                iconUrl: 'https://some.url/from/addons/service/box.png',
             },
             disableProjectAddon: { perform: sinon.stub() },
             nodeAddon: { configured: true },

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -233,6 +233,7 @@ addons:
             cloud-computing: 'Cloud Computing'
         no-results: 'No results found'
         no-authorized-accounts: 'No authorized accounts'
+        connect: 'Connect new account'
         disconnect: 'Disconnect Account'
     terms:
         heading: '{providerName} Terms'


### PR DESCRIPTION
-   Ticket: [ENG-5168]
-   Feature flag: n/a

## Purpose
- Allow users to add new addon accounts in their user settings page

## Summary of Changes
- Make node argument optional for Provider class
- Update user-addons-manager to handle auth workflows
- Update external-service models
- Update user-settings addon page to allow for auth workflows

## Screenshot(s)
- Desktop (adding new Amazon S3 account)
<img width="1311" alt="image" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/19fd48a1-4071-42d9-988d-56232e26238a">

- Mobile (adding new Dataverse account)
<img width="313" alt="image" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/126c58dc-b4b1-43ad-89ff-03486326b76f">

## Side Effects
- Hopefully none and the auth workflow for project addons works great still

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-5168]: https://openscience.atlassian.net/browse/ENG-5168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ