### PR TITLE
[ENG-5298] [ENG-5317] Update "Add/Submit a preprint" button for OSF and branded providers

### DIFF
--- a/app/services/theme.ts
+++ b/app/services/theme.ts
@@ -86,7 +86,7 @@ export default class Theme extends Service {
         return this.isProvider && !this.isDomain;
     }
 
-    @computed('id', 'isDomain', 'isProvider', 'settings.routePath')
+    @computed('id', 'isDomain', 'settings.routePath')
     get pathPrefix(): string {
         let pathPrefix = '/';
 

--- a/app/services/theme.ts
+++ b/app/services/theme.ts
@@ -91,11 +91,7 @@ export default class Theme extends Service {
         let pathPrefix = '/';
 
         if (!this.isDomain) {
-            pathPrefix += `${this.settings.routePath}/`;
-
-            if (this.isProvider) {
-                pathPrefix += `${this.id}/`;
-            }
+            pathPrefix += `${this.settings.routePath}/${this.id}/`;
         }
 
         return pathPrefix;

--- a/lib/app-components/addon/components/branded-navbar/component.ts
+++ b/lib/app-components/addon/components/branded-navbar/component.ts
@@ -50,7 +50,7 @@ export default class BrandedNavbar extends Component {
     }
 
     get submitPreprintUrl() {
-        return this.theme.isProvider ? `${osfURL}preprints/${this.theme.id}/submit/` : `${osfURL}preprints/submit/`;
+        return `${this.theme.pathPrefix}/submit/`;
     }
 
     @alias('theme.provider') provider!: ProviderModel;

--- a/lib/app-components/addon/components/branded-navbar/component.ts
+++ b/lib/app-components/addon/components/branded-navbar/component.ts
@@ -49,10 +49,6 @@ export default class BrandedNavbar extends Component {
         return `${osfURL}reviews`;
     }
 
-    get submitPreprintUrl() {
-        return `${this.theme.pathPrefix}/submit/`;
-    }
-
     @alias('theme.provider') provider!: ProviderModel;
     @alias('theme.provider.id') providerId!: string;
     @alias('theme.provider.brand.primaryColor') brandPrimaryColor!: BrandModel;

--- a/lib/app-components/addon/components/branded-navbar/template.hbs
+++ b/lib/app-components/addon/components/branded-navbar/template.hbs
@@ -99,7 +99,8 @@
                             {{/if}}
                             <li>
                                 <OsfLink
-                                    {{!-- Adding data-test and data-analytics? --}}
+                                    data-test-add-a-preprint-branded-navbar
+                                    data-analytics-name='{{this.provider.id}}: add a {{this.provider.preprintWord}} link'
                                     @route='preprints.submit'
                                     @models={{array this.provider}}
                                 >

--- a/lib/app-components/addon/components/branded-navbar/template.hbs
+++ b/lib/app-components/addon/components/branded-navbar/template.hbs
@@ -9,7 +9,7 @@
     >
         <div local-class='nav-wrapper'>
             <div class='navbar-header'>
-                <LinkTo 
+                <LinkTo
                     @route={{@brandRoute}}
                     @model={{this.providerId}}
                     class='navbar-brand'
@@ -99,8 +99,9 @@
                             {{/if}}
                             <li>
                                 <OsfLink
-                                    {{!-- TODO Preprint emberization: make this an in-app transition --}}
-                                    @href={{this.submitPreprintUrl}}
+                                    {{!-- Adding data-test and data-analytics? --}}
+                                    @route='preprints.submit'
+                                    @models={{array this.provider}}
                                 >
                                     <span role='button'>{{t 'navbar.add_a_preprint' preprintWord=this.provider.preprintWord}}</span>
                                 </OsfLink>

--- a/lib/osf-components/addon/components/osf-navbar/preprint-links/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/preprint-links/template.hbs
@@ -20,9 +20,8 @@
 {{/if}}
 <li data-test-nav-submit-preprint-link>
     <OsfLink
-        @href='/preprints/osf/submit/'
         data-analytics-name='Add a preprint'
-        {{on 'click' @onLinkClicked}}
+        @route='preprints.select'
     >
         {{t 'navbar.add_a_preprint' preprintWord=(t 'documentType.preprint.singularCapitalized')}}
     </OsfLink>

--- a/lib/osf-components/addon/components/osf-navbar/preprint-links/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/preprint-links/template.hbs
@@ -20,6 +20,7 @@
 {{/if}}
 <li data-test-nav-submit-preprint-link>
     <OsfLink
+        data-test-add-a-preprint-osf-navbar
         data-analytics-name='Add a preprint'
         @route='preprints.select'
     >

--- a/lib/osf-components/addon/components/osf-navbar/preprint-links/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/preprint-links/template.hbs
@@ -20,7 +20,7 @@
 {{/if}}
 <li data-test-nav-submit-preprint-link>
     <OsfLink
-        @href='/preprints/submit/'
+        @href='/preprints/osf/submit/'
         data-analytics-name='Add a preprint'
         {{on 'click' @onLinkClicked}}
     >


### PR DESCRIPTION
-   Ticket: [ENG-5298](https://openscience.atlassian.net/browse/ENG-5298) and [ENG-5317](https://openscience.atlassian.net/browse/ENG-5317)
-   Feature flag: n/a

## Purpose

Update "Add/Submit a preprint" button for OSF and branded providers

This PR replaces https://github.com/CenterForOpenScience/ember-osf-web/pull/2186 and https://github.com/CenterForOpenScience/ember-osf-web/pull/2187

## Summary of Changes

* "Add a preprint/thesis/paper" in both branded and OSF nav-bar now use in-app transition
* "Add a preprint" in OSF nav-bar goes to the new preprints select provider page
* "Add a preprint/thesis/paper" in branded nav-bar goes directly to the branded submit page
* "Submit a preprint/thesis/paper" in both branded and OSF nav-bar goes directly to respective submit page
* Added `data-test` and/or `data-analytics` selectors

## Screenshot(s)

N/A

## Side Effects

N/A

## QA Notes

N/A


[ENG-5298]: https://openscience.atlassian.net/browse/ENG-5298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-5317]: https://openscience.atlassian.net/browse/ENG-5317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ