### PR TITLE
[ENG-5316] Update "edit preprint" link

### DIFF
--- a/app/preprints/detail/template.hbs
+++ b/app/preprints/detail/template.hbs
@@ -17,7 +17,8 @@
                             data-test-edit-preprint-button
                             data-analytics-name='Edit preprint button'
                             local-class='btn btn-primary'
-                            @href={{concat '/' this.model.preprint.id '/edit'}}
+                            @route='preprints.edit'
+                            @models={{array this.provider.id this.model.preprint.id}}
                         >
                             {{this.editButtonLabel}}
 
@@ -124,11 +125,11 @@
                         </div>
                         <div>
                             <span data-test-view-count-label>
-                                {{t 'preprints.detail.share.views'}}: 
+                                {{t 'preprints.detail.share.views'}}:
                             </span>
-                            <span data-test-view-count> {{this.model.preprint.apiMeta.metrics.views}} </span> | 
+                            <span data-test-view-count> {{this.model.preprint.apiMeta.metrics.views}} </span> |
                             <span data-test-download-count-label>
-                                {{t 'preprints.detail.share.downloads'}}: 
+                                {{t 'preprints.detail.share.downloads'}}:
                             </span>
                             <span data-test-download-count>{{this.model.preprint.apiMeta.metrics.downloads}}</span>
                             <EmberTooltip>

--- a/app/preprints/detail/template.hbs
+++ b/app/preprints/detail/template.hbs
@@ -18,7 +18,7 @@
                             data-analytics-name='Edit preprint button'
                             local-class='btn btn-primary'
                             @route='preprints.edit'
-                            @models={{array this.provider.id this.model.preprint.id}}
+                            @models={{array this.model.provider.id this.model.preprint.id}}
                         >
                             {{this.editButtonLabel}}
 


### PR DESCRIPTION
-   Ticket: [ENG-5316](https://openscience.atlassian.net/browse/ENG-5316)
-   Feature flag: n/a

## Purpose

Update "edit preprint" link

* Replace `href` with in-app transition
* This PR has two assumptions:
  *  First, the new route for edit a preprint is `preprints.edit` (to-be implemented)
  *  Seconde, the new route needs two models, one is provider and the other is the preprint (since the to-be-implemented URL is `/preprints/<provider_id>/<preprint_id>/edit`) 

## Summary of Changes

See **Purpose**

## Screenshot(s)

N/A

## Side Effects

N/A

## QA Notes

N/A


[ENG-5316]: https://openscience.atlassian.net/browse/ENG-5316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ