### PR TITLE
[ENG-4891] Added buttons to the supplements page

### DIFF
--- a/app/preprints/-components/submit/preprint-state-machine/component.ts
+++ b/app/preprints/-components/submit/preprint-state-machine/component.ts
@@ -35,12 +35,13 @@ export default class PreprintStateMachine extends Component<StateMachineArgs>{
     titleAndFieldValidation = false;
     metadataValidation = false;
     authorAssertionValidation = false;
+    supplementValidation = false;
     nextButtonIsDisabled = true;
 
     provider = this.args.provider;
     @tracked preprint: PreprintModel;
     displayAuthorAssertions = true;
-    @tracked statusFlowIndex = 1;
+    @tracked statusFlowIndex = 4;
 
     constructor(owner: unknown, args: StateMachineArgs) {
         super(owner, args);
@@ -101,6 +102,11 @@ export default class PreprintStateMachine extends Component<StateMachineArgs>{
         ) {
             await this.saveOnStep();
             return;
+        } else if (this.statusFlowIndex === this.getTypeIndex(PreprintStatusTypeEnum.supplements) &&
+            this.supplementValidation
+        ) {
+            await this.saveOnStep();
+            return;
         }
     }
 
@@ -137,6 +143,15 @@ export default class PreprintStateMachine extends Component<StateMachineArgs>{
             this.preprint.whyNoPrereg = null;
         }
         this.authorAssertionValidation = valid;
+        this.nextButtonIsDisabled = !valid;
+    }
+
+    /**
+     * Callback for the action-flow component
+     */
+    @action
+    public validateSupplements(valid: boolean): void {
+        this.supplementValidation= valid;
         this.nextButtonIsDisabled = !valid;
     }
 

--- a/app/preprints/-components/submit/preprint-state-machine/template.hbs
+++ b/app/preprints/-components/submit/preprint-state-machine/template.hbs
@@ -16,6 +16,7 @@
     validateTitleAndFile=this.validateTitleAndFile
     validateMetadata=this.validateMetadata
     validateAuthorAssertions=this.validateAuthorAssertions
+    validateSupplements=this.validateSupplements
 
     shouldDisplayStatusType=this.shouldDisplayStatusType
     getStatusTitle=this.getStatusTitle

--- a/app/preprints/-components/submit/supplements/component.ts
+++ b/app/preprints/-components/submit/supplements/component.ts
@@ -1,5 +1,8 @@
 import Component from '@glimmer/component';
 import PreprintStateMachine from 'ember-osf-web/preprints/-components/submit/preprint-state-machine/component';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Intl from 'ember-intl/services/intl';
 
 /**
  * The Supplements Args
@@ -12,7 +15,20 @@ interface SupplementsArgs {
  * The Supplements Component
  */
 export default class Supplements extends Component<SupplementsArgs>{
-    constructor(owner: unknown, args: SupplementsArgs) {
-        super(owner, args);
+    @service intl!: Intl;
+
+    @action
+    public onConnectOsfProject(): void {
+        this.validate();
+    }
+
+    @action
+    public onCreateOsfProject(): void {
+        this.validate();
+    }
+
+    @action
+    public validate(): void {
+        this.args.manager.validateSupplements(true);
     }
 }

--- a/app/preprints/-components/submit/supplements/styles.scss
+++ b/app/preprints/-components/submit/supplements/styles.scss
@@ -1,13 +1,29 @@
 // stylelint-disable max-nesting-depth, selector-max-compound-selectors
 
-
 .preprint-input-container {
     width: 100%;
     display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: center;
-    font-size: 16px;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-start;
+
+    .title {
+        font-weight: bold;
+        margin-bottom: 20px;
+    }
+
+    .button-container {
+        margin-top: 10px;
+        width: 100%;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+
+        .btn-width {
+            width: calc(50% - 20px);
+        }
+    }
 
     &.mobile {
         height: fit-content;

--- a/app/preprints/-components/submit/supplements/template.hbs
+++ b/app/preprints/-components/submit/supplements/template.hbs
@@ -1,3 +1,32 @@
 <div local-class='preprint-input-container  {{if (is-mobile) 'mobile'}}'>
-    {{t 'preprints.submit.step-four.title'}}
+    <h3 local-class='title'
+        data-test-title
+    >
+        {{t 'preprints.submit.step-four.title'}}
+    </h3>
+    <p>
+        {{t 'preprints.submit.step-four.description'}}
+    </p>
+
+    <div local-class='button-container'>
+        <Button
+            data-test-existing-osf-button
+            data-analytics-name='Connect to an existing OSF preprint'
+            {{on 'click' this.onConnectOsfProject}}
+            local-class='btn-width'
+            class='btn btn-secondary btn-large'
+        >
+            {{t 'preprints.submit.step-four.connect-button'}}
+        </Button>
+
+        <Button
+            data-test-create-osf-button
+            data-analytics-name='Create a new OSF preprint'
+            {{on 'click' this.onCreateOsfProject}}
+            local-class='btn-width'
+            class='btn btn-secondary btn-large'
+        >
+            {{t 'preprints.submit.step-four.create-button'}}
+        </Button>
+    </div>
 </div>

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1216,6 +1216,9 @@ preprints:
             public-preregistration-link-info-both: 'Both'
         step-four:
             title: 'Supplements'
+            description: 'Connect an OSF project to share data, code, protocols, or other supplemental materials.'
+            connect-button: 'Connect an existing OSF project'
+            create-button: 'Create a new OSF project'
         step-five:
             title: 'Review'
         data-analytics: 'Goto {statusType} tab'


### PR DESCRIPTION
-   Ticket: [ENG-4891]
-   Feature flag: n/a

## Purpose

Start the initial process to allow users to connect to an existing project or create a new project

## Summary of Changes

Add 2 buttons to the supplements page and methods to support the clicking on those buttons.

## Screenshot(s)
![Screenshot 2024-04-15 at 11 37 33 AM](https://github.com/CenterForOpenScience/ember-osf-web/assets/113387478/310d2e58-1733-488c-89f4-9f46a6135062)


## Side Effects

The button allow the user to click "next" without any input. This is expected for this ticket.

## QA Notes

None


[ENG-4891]: https://openscience.atlassian.net/browse/ENG-4891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ