### PR TITLE
[ENG-5455] User settings tab

### DIFF
--- a/app/models/authorized-citation-account.ts
+++ b/app/models/authorized-citation-account.ts
@@ -6,8 +6,7 @@ import UserReferenceModel from './user-reference';
 import OsfModel from './osf-model';
 
 export default class AuthorizedCitationAccountModel extends OsfModel {
-    @attr('fixstring') externalUserId!: string;
-    @attr('fixstring') externalUserDisplayName!: string;
+    @attr('fixstring') displayName!: string;
     @attr('fixstringarray') scopes!: string[];
     @attr('object') credentials?: AddonCredentialFields; // write-only
     @attr('fixstring') readonly authUrl!: string; // Only returned when POSTing to /authorized-citation-accounts

--- a/app/models/authorized-computing-account.ts
+++ b/app/models/authorized-computing-account.ts
@@ -6,8 +6,7 @@ import UserReferenceModel from './user-reference';
 import OsfModel from './osf-model';
 
 export default class AuthorizedComputingAccount extends OsfModel {
-    @attr('fixstring') externalUserId!: string;
-    @attr('fixstring') externalUserDisplayName!: string;
+    @attr('fixstring') displayName!: string;
     @attr('fixstringarray') scopes!: string[];
     @attr('object') credentials?: AddonCredentialFields; // write-only
     @attr('fixstring') readonly authUrl!: string; // Only returned when POSTing to /authorized-computing-accounts

--- a/app/models/authorized-storage-account.ts
+++ b/app/models/authorized-storage-account.ts
@@ -15,8 +15,7 @@ export interface AddonCredentialFields {
 }
 
 export default class AuthorizedStorageAccountModel extends OsfModel {
-    @attr('fixstring') externalUserId!: string;
-    @attr('fixstring') externalUserDisplayName!: string;
+    @attr('fixstring') displayName!: string;
     @attr('fixstringarray') scopes!: string[];
     @attr('object') credentials?: AddonCredentialFields; // write-only
     @attr('fixstring') apiBaseUrl!: string; // Only applicable when ExternalStorageService.configurableApiRoot

--- a/app/packages/addons-service/provider.ts
+++ b/app/packages/addons-service/provider.ts
@@ -211,7 +211,7 @@ export default class Provider {
 
     @task
     @waitFor
-    private async createAuthorizedStorageAccount(credentials: AddonCredentialFields) {
+    private async createAuthorizedStorageAccount(credentials: AddonCredentialFields, accountName: string) {
         const newAccount = this.store.createRecord('authorized-storage-account', {
             credentials,
             apiBaseUrl: (this.provider as ExternalStorageServiceModel).configurableApiRoot ? credentials.url : '',
@@ -219,6 +219,7 @@ export default class Provider {
             scopes: [],
             storageProvider: this.provider,
             configuringUser: this.userReference,
+            displayName: accountName,
         });
         await newAccount.save();
         return newAccount;
@@ -226,13 +227,14 @@ export default class Provider {
 
     @task
     @waitFor
-    private async createAuthorizedCitationAccount(credentials: AddonCredentialFields) {
+    private async createAuthorizedCitationAccount(credentials: AddonCredentialFields, accountName: string) {
         const newAccount = this.store.createRecord('authorized-citation-account', {
             credentials,
             externalUserId: this.currentUser.user?.id,
             scopes: [],
             citationService: this.provider,
             configuringUser: this.userReference,
+            displayName: accountName,
         });
         await newAccount.save();
         return newAccount;
@@ -240,13 +242,14 @@ export default class Provider {
 
     @task
     @waitFor
-    private async createAuthorizedComputingAccount(credentials: AddonCredentialFields) {
+    private async createAuthorizedComputingAccount(credentials: AddonCredentialFields, accountName: string) {
         const newAccount = this.store.createRecord('authorized-computing-account', {
             credentials,
             externalUserId: this.currentUser.user?.id,
             scopes: [],
             computingService: this.provider,
             configuringUser: this.userReference,
+            displayName: accountName,
         });
         await newAccount.save();
         return newAccount;

--- a/app/packages/addons-service/provider.ts
+++ b/app/packages/addons-service/provider.ts
@@ -56,6 +56,10 @@ export default class Provider {
         return this.provider.name;
     }
 
+    get id() {
+        return this.provider.id;
+    }
+
     providerTypeMapper: Record<string, ProviderTypeMapper>  = {
         externalStorageService: {
             getConfiguredAddon: taskFor(this.getConfiguredStorageAddon),

--- a/app/settings/addons/controller.ts
+++ b/app/settings/addons/controller.ts
@@ -1,8 +1,14 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
+import Media from 'ember-responsive';
 
 import CurrentUser from 'ember-osf-web/services/current-user';
 
 export default class SettingsAddonsController extends Controller {
     @service currentUser!: CurrentUser;
+    @service media!: Media;
+
+    get isMobile(): boolean {
+        return this.media.isMobile;
+    }
 }

--- a/app/settings/addons/controller.ts
+++ b/app/settings/addons/controller.ts
@@ -1,14 +1,8 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
-import Media from 'ember-responsive';
 
 import CurrentUser from 'ember-osf-web/services/current-user';
 
 export default class SettingsAddonsController extends Controller {
     @service currentUser!: CurrentUser;
-    @service media!: Media;
-
-    get isMobile(): boolean {
-        return this.media.isMobile;
-    }
 }

--- a/app/settings/addons/styles.scss
+++ b/app/settings/addons/styles.scss
@@ -35,7 +35,7 @@
     padding: 0 10px;
 
     &.active {
-        background-color: #f0f0f0;
+        background-color: $color-light;
     }
 }
 
@@ -78,9 +78,9 @@
 
 .tab-list {
     margin-bottom: 10px;
-    border-bottom: 1px solid #ddd;
+    border-bottom: 1px solid $color-border-gray;
     box-sizing: border-box;
-    color: rgb(51, 51, 51);
+    color: $color-grey;
     display: block;
     line-height: 20px;
     list-style-image: none;

--- a/app/settings/addons/styles.scss
+++ b/app/settings/addons/styles.scss
@@ -1,4 +1,5 @@
 .configured-addons-wrapper {
+    width: 100%;
     display: flex;
     flex-direction: column;
     padding-inline-start: 0;
@@ -6,9 +7,9 @@
 
 .addons-list-wrapper {
     display: flex;
-    margin-top: 20px;
 
     &.mobile {
+        width: 100%;
         flex-direction: column;
         flex-wrap: wrap;
     }
@@ -39,6 +40,7 @@
 }
 
 .addons-card-wrapper {
+    padding-inline-start: 0;
     flex-grow: 1;
     display: flex;
     flex-wrap: wrap;
@@ -60,6 +62,18 @@
 
 .float-right {
     float: right;
+}
+
+.tab-wrapper {
+    display: flex;
+
+    &.mobile {
+        flex-direction: column;
+    }
+
+    :global(.ember-tabs) {
+        flex-grow: 1;
+    }
 }
 
 .tab-list {

--- a/app/settings/addons/styles.scss
+++ b/app/settings/addons/styles.scss
@@ -1,6 +1,7 @@
 .configured-addons-wrapper {
     display: flex;
     flex-direction: column;
+    padding-inline-start: 0;
 }
 
 .addons-list-wrapper {
@@ -8,6 +9,7 @@
     margin-top: 20px;
 
     &.mobile {
+        flex-direction: column;
         flex-wrap: wrap;
     }
 }
@@ -36,19 +38,63 @@
     }
 }
 
-.provider-list-wrapper {
+.addons-card-wrapper {
     flex-grow: 1;
+    display: flex;
+    flex-wrap: wrap;
+    width: 100%;
+    justify-content: center;
 }
 
 .provider-list-item {
-    margin: 15px 10px;
+    padding: 15px 10px;
     border-bottom: solid 1px $color-border-gray;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
 
-    &:first-child {
-        border-top: solid 1px $color-border-gray;
+    &:last-child {
+        border-bottom: 0;
     }
 }
 
 .float-right {
     float: right;
+}
+
+.tab-list {
+    margin-bottom: 10px;
+    border-bottom: 1px solid #ddd;
+    box-sizing: border-box;
+    color: rgb(51, 51, 51);
+    display: block;
+    line-height: 20px;
+    list-style-image: none;
+    list-style-position: outside;
+    list-style-type: none;
+    height: 41px;
+    padding: 0;
+}
+
+.tab-list {
+    li {
+        cursor: pointer;
+        display: block;
+        position: relative;
+        margin-bottom: -1px;
+        float: left;
+        height: 41px;
+        padding: 10px 15px;
+    }
+
+    li:global(.ember-tabs__tab--selected) {
+        background-color: $bg-light;
+        border-bottom: 2px solid $color-blue;
+    }
+
+    li:hover {
+        text-decoration: none;
+        background-color: $bg-light;
+        color: var(--primary-color);
+    }
 }

--- a/app/settings/addons/template.hbs
+++ b/app/settings/addons/template.hbs
@@ -48,10 +48,10 @@
                     {{/if}}
                 </div>
             {{else}}
-                <div local-class='tab-wrapper {{if this.isMobile 'mobile'}}'>
+                <div local-class='tab-wrapper {{if (media 'isMobile') 'mobile'}}'>
                     <div
                         data-analytics-scope='Addon List Filter'
-                        local-class='filter-wrapper {{if this.isMobile 'mobile'}}'
+                        local-class='filter-wrapper {{if (media 'isMobile') 'mobile'}}'
                     >
                         <Input
                             data-test-user-addon-list-filter-input
@@ -85,7 +85,7 @@
                         <tab.tabPanel
                             data-test-all-addons-tab
                             data-analytics-scope='All addons tab'
-                            local-class='addons-list-wrapper {{if this.isMobile 'mobile'}}'
+                            local-class='addons-list-wrapper {{if (media 'isMobile') 'mobile'}}'
                         >
                             <ul local-class='addons-card-wrapper'>
                                 {{#each manager.filteredAddonProviders as |provider|}}
@@ -112,7 +112,7 @@
                         <tab.tabPanel
                             data-test-authorized-accounts-tab
                             data-analytics-scope='Authorized accounts tab'
-                            local-class='addons-list-wrapper {{if this.isMobile 'mobile'}}'
+                            local-class='addons-list-wrapper {{if (media 'isMobile') 'mobile'}}'
                         >
                             <ul local-class='configured-addons-wrapper'>
                                 {{#each manager.currentTypeAuthorizedAccounts as |account|}}

--- a/app/settings/addons/template.hbs
+++ b/app/settings/addons/template.hbs
@@ -124,10 +124,10 @@
                                             <DeleteButton
                                                 @secondary={{true}}
                                                 @delete={{perform manager.disconnectAccount account}}
-                                                @buttonLabel={{t 'addons.list.disconnect'}}
-                                                @modalTitle={{t 'osf-components.addon-card.disable-modal-header'}}
-                                                @modalBody={{t 'addons.list.disconnect-confirmation'}}
-                                                @confirmButtonText={{t 'addons.list.disconnect'}}
+                                                @buttonLabel={{t 'addons.list.disable'}}
+                                                @modalTitle={{t 'addons.list.disable-account-header'}}
+                                                @modalBody={{t 'addons.list.disable-confirmation'}}
+                                                @confirmButtonText={{t 'addons.list.disable'}}
                                             />
                                         </span>
                                     </li>

--- a/app/settings/addons/template.hbs
+++ b/app/settings/addons/template.hbs
@@ -48,97 +48,96 @@
                     {{/if}}
                 </div>
             {{else}}
-                <AriaTabs
-                    @defaultIndex={{0}}
-                    local-class='tabs'
-                    as |tab|
-                >
-                    <tab.tabList
-                        local-class='tab-list'
-                        as |tablist|
+                <div local-class='tab-wrapper {{if this.isMobile 'mobile'}}'>
+                    <div
+                        data-analytics-scope='Addon List Filter'
+                        local-class='filter-wrapper {{if this.isMobile 'mobile'}}'
                     >
-                        <tablist.tab data-analytics-name='All Addons Tab'>{{t 'addons.list.all-addons'}}</tablist.tab>
-                        <tablist.tab data-analytics-name='Authorized Accounts Tab'>{{t 'addons.list.authorized-accounts'}}</tablist.tab>
-                    </tab.tabList>
-                    <tab.tabPanel
-                        data-test-all-addons-tab
-                        data-analytics-scope='All addons tab'
-                        local-class='addons-list-wrapper {{if this.isMobile 'mobile'}}'
+                        <Input
+                            data-test-user-addon-list-filter-input
+                            placeholder={{t 'addons.list.filter-placeholder'}}
+                            @type='text'
+                            @value={{manager.filterText}}
+                        />
+                        {{#each manager.possibleFilterTypes as |type|}}
+                            <Button
+                                data-test-user-addon-list-filter={{type}}
+                                data-analytics-name={{t (concat 'addons.list.filter.' type)}}
+                                local-class='filter-button {{if (eq manager.activeFilterType type) 'active'}}'
+                                @layout='fake-link'
+                                {{on 'click' (fn manager.filterByAddonType type)}}
+                            >
+                                {{t (concat 'addons.list.filter.' type)}}
+                            </Button>
+                        {{/each}}
+                    </div>
+                    <AriaTabs
+                        @defaultIndex={{0}}
+                        as |tab|
                     >
-                        <div
-                            data-analytics-scope='Addon List Filter'
-                            local-class='filter-wrapper {{if this.isMobile 'mobile'}}'
+                        <tab.tabList
+                            local-class='tab-list'
+                            as |tablist|
                         >
-                            <Input
-                                data-test-user-addon-list-filter-input
-                                placeholder={{t 'addons.list.filter-placeholder'}}
-                                @type='text'
-                                @value={{manager.filterText}}
-                            />
-                            {{#each manager.possibleFilterTypes as |type|}}
-                                <Button
-                                    data-test-user-addon-list-filter={{type}}
-                                    data-analytics-name={{t (concat 'addons.list.filter.' type)}}
-                                    local-class='filter-button {{if (eq manager.activeFilterType type) 'active'}}'
-                                    @layout='fake-link'
-                                    {{on 'click' (fn manager.filterByAddonType type)}}
-                                >
-                                    {{t (concat 'addons.list.filter.' type)}}
-                                </Button>
-                            {{/each}}
-                        </div>
-                        <ul local-class='addons-card-wrapper'>
-                            {{#each manager.filteredAddonProviders as |provider|}}
-                                <li
-                                    data-test-provider={{provider.name}}
-                                    local-class='provider-list-item'
-                                >
-                                    {{provider.name}}
-                                    <span>
-                                        <Button
-                                            data-analytics-name='Connect Addon Button {{provider.name}}'
-                                            @type='create'
-                                            {{on 'click' (fn manager.connectNewProviderAccount provider)}}
-                                        >
-                                            {{t 'general.authorize'}}
-                                        </Button>
-                                    </span>
-                                </li>
-                            {{else}}
-                                <li local-class='provider-list-item'>{{t 'addons.list.no-results'}}</li>
-                            {{/each}}
-                        </ul>
-                    </tab.tabPanel>
-                    <tab.tabPanel
-                        data-test-authorized-accounts-tab
-                        data-analytics-scope='Authorized accounts tab'
-                    >
-                        <h3>
-                            {{t 'addons.list.all-authorized-accounts'}}
-                        </h3>
-                        <ul local-class='configured-addons-wrapper'>
-                            {{#each manager.currentTypeAuthorizedAccounts as |account|}}
-                                <li local-class='provider-list-item'>
-                                    <span>
-                                        {{account.displayName}}
-                                    </span>
-                                    <span>
-                                        <DeleteButton
-                                            @secondary={{true}}
-                                            @delete={{perform manager.disconnectAccount account}}
-                                            @buttonLabel={{t 'addons.list.disconnect'}}
-                                            @modalTitle={{t 'osf-components.addon-card.disable-modal-header'}}
-                                            @modalBody={{t 'addons.list.disconnect-confirmation'}}
-                                            @confirmButtonText={{t 'addons.list.disconnect'}}
-                                        />
-                                    </span>
-                                </li>
-                            {{else}}
-                                <li local-class='provider-list-item'>{{t 'addons.list.no-authorized-accounts'}}</li>
-                            {{/each}}
-                        </ul>
-                    </tab.tabPanel>
-                </AriaTabs>
+                            <tablist.tab data-analytics-name='All Addons Tab'>{{t 'addons.list.all-addons'}}</tablist.tab>
+                            <tablist.tab data-analytics-name='Authorized Accounts Tab'>{{t 'addons.list.authorized-accounts'}}</tablist.tab>
+                        </tab.tabList>
+                        <tab.tabPanel
+                            data-test-all-addons-tab
+                            data-analytics-scope='All addons tab'
+                            local-class='addons-list-wrapper {{if this.isMobile 'mobile'}}'
+                        >
+                            <ul local-class='addons-card-wrapper'>
+                                {{#each manager.filteredAddonProviders as |provider|}}
+                                    <li
+                                        data-test-provider={{provider.name}}
+                                        local-class='provider-list-item'
+                                    >
+                                        {{provider.name}}
+                                        <span>
+                                            <Button
+                                                data-analytics-name='Connect Addon Button {{provider.name}}'
+                                                @type='create'
+                                                {{on 'click' (fn manager.connectNewProviderAccount provider)}}
+                                            >
+                                                {{t 'general.authorize'}}
+                                            </Button>
+                                        </span>
+                                    </li>
+                                {{else}}
+                                    <li local-class='provider-list-item'>{{t 'addons.list.no-results'}}</li>
+                                {{/each}}
+                            </ul>
+                        </tab.tabPanel>
+                        <tab.tabPanel
+                            data-test-authorized-accounts-tab
+                            data-analytics-scope='Authorized accounts tab'
+                            local-class='addons-list-wrapper {{if this.isMobile 'mobile'}}'
+                        >
+                            <ul local-class='configured-addons-wrapper'>
+                                {{#each manager.currentTypeAuthorizedAccounts as |account|}}
+                                    <li local-class='provider-list-item'>
+                                        <span>
+                                            {{account.displayName}}
+                                        </span>
+                                        <span>
+                                            <DeleteButton
+                                                @secondary={{true}}
+                                                @delete={{perform manager.disconnectAccount account}}
+                                                @buttonLabel={{t 'addons.list.disconnect'}}
+                                                @modalTitle={{t 'osf-components.addon-card.disable-modal-header'}}
+                                                @modalBody={{t 'addons.list.disconnect-confirmation'}}
+                                                @confirmButtonText={{t 'addons.list.disconnect'}}
+                                            />
+                                        </span>
+                                    </li>
+                                {{else}}
+                                    <li local-class='provider-list-item'>{{t 'addons.list.no-authorized-accounts'}}</li>
+                                {{/each}}
+                            </ul>
+                        </tab.tabPanel>
+                    </AriaTabs>
+                </div>
             {{/if}}
         {{/if}}
     </AddonsService::UserAddonsManager>

--- a/app/settings/addons/template.hbs
+++ b/app/settings/addons/template.hbs
@@ -1,116 +1,150 @@
-<AddonsService::UserAddonsManager
-    @user={{this.currentUser.user}}
-    as |manager|
->
-    {{#if manager.currentListIsLoading}}
-        <LoadingIndicator @dark={{true}} />
-    {{else}}
-        {{#if manager.selectedProvider}}
-            <Button
-                data-test-cancel-account-setup
-                data-analytics-name='Cancel Account Setup'
-                local-class='float-right'
-                @layout='fake-link'
-                {{on 'click' manager.cancelAccountSetup}}
-            >
-                {{t 'general.back'}}
-            </Button>
-            {{#if (eq manager.pageMode 'terms')}}
-                <h3>
-                    {{t 'addons.terms.heading' providerName=manager.selectedProvider.provider.name}}
-                </h3>
-                <AddonsService::TermsOfService
-                    @provider={{manager.selectedProvider.provider}}
-                />
-                <Button
-                    local-class='float-right'
-                    @type='primary'
-                    {{on 'click' manager.acceptProviderTerms}}
-                >
-                    {{t 'general.confirm'}}
-                </Button>
-            {{else if (eq manager.pageMode 'accountCreate')}}
-                <h3 local-class='page-heading'>
-                    {{t 'addons.accountSelect.new-account'}}
-                </h3>
-                <AddonsService::AccountSetupManager
-                    @provider={{manager.selectedProvider.provider}}
-                    @manager={{manager}}
-                    @onConnect={{manager.connectAccount}}
-                    @onInput={{manager.onCredentialsInput}}
-                />
-            {{/if}}
+<div data-analytics-scope='User addons'>
+    <AddonsService::UserAddonsManager
+        @user={{this.currentUser.user}}
+        as |manager|
+    >
+        {{#if manager.currentListIsLoading}}
+            <LoadingIndicator @dark={{true}} />
         {{else}}
-            <div
-                data-analytics-scope='Addon List'
-                local-class='addons-list-wrapper'
-            >
-                <div
-                    data-analytics-scope='Addon List Filter'
-                    local-class='filter-wrapper {{if this.isMobile 'mobile'}}'
+            {{#if manager.selectedProvider}}
+                <Button
+                    data-test-cancel-account-setup
+                    data-analytics-name='Cancel Account Setup'
+                    local-class='float-right'
+                    @layout='fake-link'
+                    {{on 'click' manager.cancelAccountSetup}}
                 >
-                    <Input
-                        data-test-user-addon-list-filter-input
-                        placeholder={{t 'addons.list.filter-placeholder'}}
-                        @type='text'
-                        @value={{manager.filterText}}
+                    {{t 'general.back'}}
+                </Button>
+                {{#if (eq manager.pageMode 'terms')}}
+                    <h3>
+                        {{t 'addons.terms.heading' providerName=manager.selectedProvider.provider.name}}
+                    </h3>
+                    <AddonsService::TermsOfService
+                        @provider={{manager.selectedProvider.provider}}
                     />
-                    {{#each manager.possibleFilterTypes as |type|}}
-                        <Button
-                            data-test-user-addon-list-filter={{type}}
-                            data-analytics-name={{t (concat 'addons.list.filter.' type)}}
-                            local-class='filter-button {{if (eq manager.activeFilterType type) 'active'}}'
-                            @layout='fake-link'
-                            {{on 'click' (fn manager.filterByAddonType type)}}
-                        >
-                            {{t (concat 'addons.list.filter.' type)}}
-                        </Button>
-                    {{/each}}
-                </div>
-                <div
-                    local-class='provider-list-wrapper'
+                    <Button
+                        local-class='float-right'
+                        @type='primary'
+                        {{on 'click' manager.acceptProviderTerms}}
+                    >
+                        {{t 'general.confirm'}}
+                    </Button>
+                {{else if (eq manager.pageMode 'accountCreate')}}
+                    <h3 local-class='page-heading'>
+                        {{t 'addons.accountSelect.new-account'}}
+                    </h3>
+                    <AddonsService::AccountSetupManager
+                        @provider={{manager.selectedProvider.provider}}
+                        @manager={{manager}}
+                        @onConnect={{manager.connectAccount}}
+                        @onInput={{manager.onCredentialsInput}}
+                    />
+                {{/if}}
+            {{else}}
+                <AriaTabs
+                    @defaultIndex={{0}}
+                    local-class='tabs'
+                    as |tab|
                 >
-                    {{#each manager.filteredAddonProviders as |provider|}}
+                    <tab.tabList
+                        local-class='tab-list'
+                        as |tablist|
+                    >
+                        <tablist.tab>{{t 'addons.list.connected-accounts'}}</tablist.tab>
+                        <tablist.tab>{{t 'addons.list.all-addons'}}</tablist.tab>
+                    </tab.tabList>
+                    <tab.tabPanel
+                        data-test-configured-addons-tab
+                        data-analytics-scope='Configured addons tab'
+                    >
+                        {{!-- Some text here explaining this is a list of all the accounts associated with your OSF account? --}}
+                        <ul local-class='configured-addons-wrapper'>
+                            {{#each manager.currentTypeAuthorizedAccounts as |account|}}
+                                <li local-class='provider-list-item'>
+                                    <span>
+                                        {{account.storageProvider.name}}
+                                        {{account.externalUserDisplayName}}
+                                    </span>
+                                    <span>
+                                        <Button
+                                            data-test-configure-account
+                                            data-analytics-name='Configure Addon Button {{account.storageProvider.name}}'
+                                            {{on 'click' (fn manager.configureProvider account)}}
+                                        >
+                                            {{t 'osf-components.addon-card.configure'}}
+                                        </Button>
+                                        <DeleteButton
+                                            @secondary={{true}}
+                                            @delete={{perform manager.disconnectAddon account}}
+                                            @buttonLabel={{t 'addons.list.disconnect'}}
+                                            @modalTitle={{t 'osf-components.addon-card.disable-modal-header'}}
+                                            @modalBody={{t 'addons.list.disconnect-confirmation'}}
+                                            @confirmButtonText={{t 'osf-components.addon-card.disable'}}
+                                        />
+                                    </span>
+                                </li>
+                            {{else}}
+                                <li local-class='provider-list-item'>{{t 'addons.list.no-authorized-accounts'}}</li>
+                            {{/each}}
+                        </ul>
+                    </tab.tabPanel>
+                    <tab.tabPanel
+                        data-test-all-addons-tab
+                        data-analytics-scope='All addons tab'
+                    >
+                        {{!-- Some text here explaining this is a list of all the addons you can connect to your OSF account? --}}
                         <div
-                            data-test-provider={{provider.name}}
-                            local-class='provider-list-item'
+                            data-analytics-scope='Addon List'
+                            local-class='addons-list-wrapper {{if this.isMobile 'mobile'}}'
                         >
-                            {{provider.name}}
-                            <Button
-                                data-analytics-name='Connect Addon Button {{provider.name}}'
-                                local-class='float-right'
-                                @type='create'
-                                {{on 'click' (fn manager.selectProvider provider)}}
+                            <div
+                                data-analytics-scope='Addon List Filter'
+                                local-class='filter-wrapper {{if this.isMobile 'mobile'}}'
                             >
-                                {{t 'addons.list.connect'}}
-                            </Button>
+                                <Input
+                                    data-test-user-addon-list-filter-input
+                                    placeholder={{t 'addons.list.filter-placeholder'}}
+                                    @type='text'
+                                    @value={{manager.filterText}}
+                                />
+                                {{#each manager.possibleFilterTypes as |type|}}
+                                    <Button
+                                        data-test-user-addon-list-filter={{type}}
+                                        data-analytics-name={{t (concat 'addons.list.filter.' type)}}
+                                        local-class='filter-button {{if (eq manager.activeFilterType type) 'active'}}'
+                                        @layout='fake-link'
+                                        {{on 'click' (fn manager.filterByAddonType type)}}
+                                    >
+                                        {{t (concat 'addons.list.filter.' type)}}
+                                    </Button>
+                                {{/each}}
+                            </div>
+                            <ul local-class='addons-card-wrapper'>
+                                {{#each manager.filteredAddonProviders as |provider|}}
+                                    <li
+                                        data-test-provider={{provider.name}}
+                                        local-class='provider-list-item'
+                                    >
+                                        {{provider.name}}
+                                        <span>
+                                            <Button
+                                                data-analytics-name='Connect Addon Button {{provider.name}}'
+                                                @type='create'
+                                                {{on 'click' (fn manager.selectProvider provider)}}
+                                            >
+                                                {{t 'addons.list.connect'}}
+                                            </Button>
+                                        </span>
+                                    </li>
+                                {{else}}
+                                    <li local-class='provider-list-item'>{{t 'addons.list.no-results'}}</li>
+                                {{/each}}
+                            </ul>
                         </div>
-                    {{else}}
-                        {{t 'addons.list.no-results'}}
-                    {{/each}}
-                </div>
-            </div>
-
-            <ul local-class='configured-addons-wrapper'>
-                {{#each manager.currentTypeAuthorizedAccounts as |account|}}
-                    <li>
-                        {{account.storageProvider.name}}
-                        {{account.externalUserDisplayName}}
-                        <Button
-                            data-test-disconnect-account-button
-                            data-analytics-name='Disconnect Addon Button {{account.storageProvider.name}}'
-                            @type='destroy'
-                            @disabled={{manager.disconnectAddon.isRunning}}
-                            local-class='float-right'
-                            {{on 'click' (perform manager.disconnectAddon account)}}
-                        >
-                            {{t 'addons.list.disconnect'}}
-                        </Button>
-                    </li>
-                {{else}}
-                    <li>{{t 'addons.list.no-authorized-accounts'}}</li>
-                {{/each}}
-            </ul>
+                    </tab.tabPanel>
+                </AriaTabs>
+            {{/if}}
         {{/if}}
-    {{/if}}
-</AddonsService::UserAddonsManager>
+    </AddonsService::UserAddonsManager>
+</div>

--- a/app/settings/addons/template.hbs
+++ b/app/settings/addons/template.hbs
@@ -7,40 +7,82 @@
             <LoadingIndicator @dark={{true}} />
         {{else}}
             {{#if manager.selectedProvider}}
-                <Button
-                    data-test-cancel-account-setup
-                    data-analytics-name='Cancel Account Setup'
-                    local-class='float-right'
-                    @layout='fake-link'
-                    {{on 'click' manager.cancelAccountSetup}}
-                >
-                    {{t 'general.back'}}
-                </Button>
-                {{#if (eq manager.pageMode 'terms')}}
-                    <h3>
-                        {{t 'addons.terms.heading' providerName=manager.selectedProvider.provider.name}}
-                    </h3>
-                    <AddonsService::TermsOfService
-                        @provider={{manager.selectedProvider.provider}}
-                    />
+                <div data-analytics-scope='{{manager.selectedProvider.name}}'>
                     <Button
+                        data-test-cancel-account-setup
+                        data-analytics-name='Cancel Account Setup'
                         local-class='float-right'
-                        @type='primary'
-                        {{on 'click' manager.acceptProviderTerms}}
+                        @layout='fake-link'
+                        {{on 'click' manager.cancelAccountSetup}}
                     >
-                        {{t 'general.confirm'}}
+                        {{t 'general.back'}}
                     </Button>
-                {{else if (eq manager.pageMode 'accountCreate')}}
-                    <h3 local-class='page-heading'>
-                        {{t 'addons.accountSelect.new-account'}}
-                    </h3>
-                    <AddonsService::AccountSetupManager
-                        @provider={{manager.selectedProvider.provider}}
-                        @manager={{manager}}
-                        @onConnect={{manager.connectAccount}}
-                        @onInput={{manager.onCredentialsInput}}
-                    />
-                {{/if}}
+                    {{#if (eq manager.pageMode 'terms')}}
+                        <div data-analytics-scope='Terms'>
+                            <h3>
+                                {{t 'addons.terms.heading' providerName=manager.selectedProvider.provider.name}}
+                            </h3>
+                            <AddonsService::TermsOfService
+                                @provider={{manager.selectedProvider.provider}}
+                            />
+                            <Button
+                                local-class='float-right'
+                                @type='primary'
+                                {{on 'click' manager.acceptProviderTerms}}
+                            >
+                                {{t 'general.confirm'}}
+                            </Button>
+                        </div>
+                    {{else if (eq manager.pageMode 'accountCreate')}}
+                        <div data-analytics-scope='Account Create'>
+                            <h3 local-class='page-heading'>
+                                {{t 'addons.accountSelect.new-account'}}
+                            </h3>
+                            <AddonsService::AccountSetupManager
+                                @provider={{manager.selectedProvider.provider}}
+                                @manager={{manager}}
+                                @onConnect={{manager.connectAccount}}
+                                @onInput={{manager.onCredentialsInput}}
+                            />
+                        </div>
+                    {{else if (eq manager.pageMode 'configureProvider')}}
+                        <div data-analytics-scope='Configure Provider'>
+                            <h3>
+                                {{t 'addons.list.authorized-accounts-for-provider' providerName=manager.selectedProvider.provider.name}}
+                            </h3>
+                            <ul local-class='configured-addons-wrapper'>
+                                {{!-- loop through authorized accounts for the selected provider --}}
+                                {{#each (filter-by 'storageProvider.id' manager.selectedProvider.provider.id manager.currentTypeAuthorizedAccounts) as |account|}}
+                                    <li local-class='provider-list-item'>
+                                        <span>
+                                            {{account.storageProvider.name}}
+                                            {{account.externalUserDisplayName}}
+                                        </span>
+                                        <span>
+                                            <Button
+                                                data-test-configure-account
+                                                data-analytics-name='Configure Account Button {{account.storageProvider.name}}'
+                                                {{on 'click' (fn manager.configureAuthorizedAccount account)}}
+                                            >
+                                                {{t 'addons.list.configure'}}
+                                            </Button>
+                                            <DeleteButton
+                                                @secondary={{true}}
+                                                @delete={{perform manager.disconnectAccount account}}
+                                                @buttonLabel={{t 'addons.list.disconnect'}}
+                                                @modalTitle={{t 'osf-components.addon-card.disable-modal-header'}}
+                                                @modalBody={{t 'addons.list.disconnect-confirmation'}}
+                                                @confirmButtonText={{t 'osf-components.addon-card.disable'}}
+                                            />
+                                        </span>
+                                    </li>
+                                {{else}}
+                                    <li local-class='provider-list-item'>{{t 'addons.list.no-authorized-accounts'}}</li>
+                                {{/each}}
+                            </ul>
+                        </div>
+                    {{/if}}
+                </div>
             {{else}}
                 <AriaTabs
                     @defaultIndex={{0}}
@@ -51,36 +93,79 @@
                         local-class='tab-list'
                         as |tablist|
                     >
-                        <tablist.tab>{{t 'addons.list.connected-accounts'}}</tablist.tab>
-                        <tablist.tab>{{t 'addons.list.all-addons'}}</tablist.tab>
+                        <tablist.tab data-analytics-name='All Addons Tab'>{{t 'addons.list.all-addons'}}</tablist.tab>
+                        <tablist.tab data-analytics-name='Authorized Accounts Tab'>{{t 'addons.list.authorized-accounts'}}</tablist.tab>
                     </tab.tabList>
                     <tab.tabPanel
-                        data-test-configured-addons-tab
-                        data-analytics-scope='Configured addons tab'
+                        data-test-all-addons-tab
+                        data-analytics-scope='All addons tab'
+                        local-class='addons-list-wrapper {{if this.isMobile 'mobile'}}'
                     >
-                        {{!-- Some text here explaining this is a list of all the accounts associated with your OSF account? --}}
+                        <div
+                            data-analytics-scope='Addon List Filter'
+                            local-class='filter-wrapper {{if this.isMobile 'mobile'}}'
+                        >
+                            <Input
+                                data-test-user-addon-list-filter-input
+                                placeholder={{t 'addons.list.filter-placeholder'}}
+                                @type='text'
+                                @value={{manager.filterText}}
+                            />
+                            {{#each manager.possibleFilterTypes as |type|}}
+                                <Button
+                                    data-test-user-addon-list-filter={{type}}
+                                    data-analytics-name={{t (concat 'addons.list.filter.' type)}}
+                                    local-class='filter-button {{if (eq manager.activeFilterType type) 'active'}}'
+                                    @layout='fake-link'
+                                    {{on 'click' (fn manager.filterByAddonType type)}}
+                                >
+                                    {{t (concat 'addons.list.filter.' type)}}
+                                </Button>
+                            {{/each}}
+                        </div>
+                        <ul local-class='addons-card-wrapper'>
+                            {{#each manager.filteredAddonProviders as |provider|}}
+                                <li
+                                    data-test-provider={{provider.name}}
+                                    local-class='provider-list-item'
+                                >
+                                    {{provider.name}}
+                                    <span>
+                                        <Button
+                                            data-analytics-name='Connect Addon Button {{provider.name}}'
+                                            @type='create'
+                                            {{on 'click' (fn manager.connectNewProviderAccount provider)}}
+                                        >
+                                            {{t 'general.authorize'}}
+                                        </Button>
+                                    </span>
+                                </li>
+                            {{else}}
+                                <li local-class='provider-list-item'>{{t 'addons.list.no-results'}}</li>
+                            {{/each}}
+                        </ul>
+                    </tab.tabPanel>
+                    <tab.tabPanel
+                        data-test-authorized-accounts-tab
+                        data-analytics-scope='Authorized accounts tab'
+                    >
+                        <h3>
+                            {{t 'addons.list.all-authorized-accounts'}}
+                        </h3>
                         <ul local-class='configured-addons-wrapper'>
                             {{#each manager.currentTypeAuthorizedAccounts as |account|}}
                                 <li local-class='provider-list-item'>
                                     <span>
-                                        {{account.storageProvider.name}}
-                                        {{account.externalUserDisplayName}}
+                                        {{account.displayName}}
                                     </span>
                                     <span>
-                                        <Button
-                                            data-test-configure-account
-                                            data-analytics-name='Configure Addon Button {{account.storageProvider.name}}'
-                                            {{on 'click' (fn manager.configureProvider account)}}
-                                        >
-                                            {{t 'osf-components.addon-card.configure'}}
-                                        </Button>
                                         <DeleteButton
                                             @secondary={{true}}
-                                            @delete={{perform manager.disconnectAddon account}}
+                                            @delete={{perform manager.disconnectAccount account}}
                                             @buttonLabel={{t 'addons.list.disconnect'}}
                                             @modalTitle={{t 'osf-components.addon-card.disable-modal-header'}}
                                             @modalBody={{t 'addons.list.disconnect-confirmation'}}
-                                            @confirmButtonText={{t 'osf-components.addon-card.disable'}}
+                                            @confirmButtonText={{t 'addons.list.disconnect'}}
                                         />
                                     </span>
                                 </li>
@@ -88,60 +173,6 @@
                                 <li local-class='provider-list-item'>{{t 'addons.list.no-authorized-accounts'}}</li>
                             {{/each}}
                         </ul>
-                    </tab.tabPanel>
-                    <tab.tabPanel
-                        data-test-all-addons-tab
-                        data-analytics-scope='All addons tab'
-                    >
-                        {{!-- Some text here explaining this is a list of all the addons you can connect to your OSF account? --}}
-                        <div
-                            data-analytics-scope='Addon List'
-                            local-class='addons-list-wrapper {{if this.isMobile 'mobile'}}'
-                        >
-                            <div
-                                data-analytics-scope='Addon List Filter'
-                                local-class='filter-wrapper {{if this.isMobile 'mobile'}}'
-                            >
-                                <Input
-                                    data-test-user-addon-list-filter-input
-                                    placeholder={{t 'addons.list.filter-placeholder'}}
-                                    @type='text'
-                                    @value={{manager.filterText}}
-                                />
-                                {{#each manager.possibleFilterTypes as |type|}}
-                                    <Button
-                                        data-test-user-addon-list-filter={{type}}
-                                        data-analytics-name={{t (concat 'addons.list.filter.' type)}}
-                                        local-class='filter-button {{if (eq manager.activeFilterType type) 'active'}}'
-                                        @layout='fake-link'
-                                        {{on 'click' (fn manager.filterByAddonType type)}}
-                                    >
-                                        {{t (concat 'addons.list.filter.' type)}}
-                                    </Button>
-                                {{/each}}
-                            </div>
-                            <ul local-class='addons-card-wrapper'>
-                                {{#each manager.filteredAddonProviders as |provider|}}
-                                    <li
-                                        data-test-provider={{provider.name}}
-                                        local-class='provider-list-item'
-                                    >
-                                        {{provider.name}}
-                                        <span>
-                                            <Button
-                                                data-analytics-name='Connect Addon Button {{provider.name}}'
-                                                @type='create'
-                                                {{on 'click' (fn manager.selectProvider provider)}}
-                                            >
-                                                {{t 'addons.list.connect'}}
-                                            </Button>
-                                        </span>
-                                    </li>
-                                {{else}}
-                                    <li local-class='provider-list-item'>{{t 'addons.list.no-results'}}</li>
-                                {{/each}}
-                            </ul>
-                        </div>
                     </tab.tabPanel>
                 </AriaTabs>
             {{/if}}

--- a/app/settings/addons/template.hbs
+++ b/app/settings/addons/template.hbs
@@ -9,11 +9,11 @@
             {{#if manager.selectedProvider}}
                 <div data-analytics-scope='{{manager.selectedProvider.name}}'>
                     <Button
-                        data-test-cancel-account-setup
-                        data-analytics-name='Cancel Account Setup'
+                        data-test-cancel-setup
+                        data-analytics-name='Cancel Setup'
                         local-class='float-right'
                         @layout='fake-link'
-                        {{on 'click' manager.cancelAccountSetup}}
+                        {{on 'click' manager.cancelSetup}}
                     >
                         {{t 'general.back'}}
                     </Button>
@@ -25,13 +25,22 @@
                             <AddonsService::TermsOfService
                                 @provider={{manager.selectedProvider.provider}}
                             />
-                            <Button
-                                local-class='float-right'
-                                @type='primary'
-                                {{on 'click' manager.acceptProviderTerms}}
-                            >
-                                {{t 'general.confirm'}}
-                            </Button>
+                            <div local-class='float-right'>
+
+                                <Button
+                                    data-test-addon-cancel-button
+                                    data-analytics-name='Cancel'
+                                    {{on 'click' manager.cancelSetup}}
+                                >
+                                    {{t 'general.cancel'}}
+                                </Button>
+                                <Button
+                                    @type='primary'
+                                    {{on 'click' manager.acceptProviderTerms}}
+                                >
+                                    {{t 'general.confirm'}}
+                                </Button>
+                            </div>
                         </div>
                     {{else if (eq manager.pageMode 'accountCreate')}}
                         <div data-analytics-scope='Account Create'>

--- a/app/settings/addons/template.hbs
+++ b/app/settings/addons/template.hbs
@@ -45,42 +45,6 @@
                                 @onInput={{manager.onCredentialsInput}}
                             />
                         </div>
-                    {{else if (eq manager.pageMode 'configureProvider')}}
-                        <div data-analytics-scope='Configure Provider'>
-                            <h3>
-                                {{t 'addons.list.authorized-accounts-for-provider' providerName=manager.selectedProvider.provider.name}}
-                            </h3>
-                            <ul local-class='configured-addons-wrapper'>
-                                {{!-- loop through authorized accounts for the selected provider --}}
-                                {{#each (filter-by 'storageProvider.id' manager.selectedProvider.provider.id manager.currentTypeAuthorizedAccounts) as |account|}}
-                                    <li local-class='provider-list-item'>
-                                        <span>
-                                            {{account.storageProvider.name}}
-                                            {{account.externalUserDisplayName}}
-                                        </span>
-                                        <span>
-                                            <Button
-                                                data-test-configure-account
-                                                data-analytics-name='Configure Account Button {{account.storageProvider.name}}'
-                                                {{on 'click' (fn manager.configureAuthorizedAccount account)}}
-                                            >
-                                                {{t 'addons.list.configure'}}
-                                            </Button>
-                                            <DeleteButton
-                                                @secondary={{true}}
-                                                @delete={{perform manager.disconnectAccount account}}
-                                                @buttonLabel={{t 'addons.list.disconnect'}}
-                                                @modalTitle={{t 'osf-components.addon-card.disable-modal-header'}}
-                                                @modalBody={{t 'addons.list.disconnect-confirmation'}}
-                                                @confirmButtonText={{t 'osf-components.addon-card.disable'}}
-                                            />
-                                        </span>
-                                    </li>
-                                {{else}}
-                                    <li local-class='provider-list-item'>{{t 'addons.list.no-authorized-accounts'}}</li>
-                                {{/each}}
-                            </ul>
-                        </div>
                     {{/if}}
                 </div>
             {{else}}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -32,7 +32,10 @@ module.exports = function(defaults) {
             ],
         },
         'ember-composable-helpers': {
-            only: ['compose', 'contains', 'flatten', 'includes', 'range', 'queue', 'map-by', 'without', 'find-by'],
+            only: [
+                'compose', 'contains', 'filter-by', 'find-by', 'flatten',
+                'includes', 'map-by', 'range', 'queue', 'without',
+            ],
         },
         fingerprint: {
             enabled: true,

--- a/lib/osf-components/addon/components/addons-service/account-setup-manager/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/account-setup-manager/template.hbs
@@ -9,13 +9,30 @@
         {{else}}
             <div local-class='oauth-wrapper'>
                 {{t 'addons.accountCreate.oauth-description' providerName=@provider.name}}
-                <Button
-                    data-test-addon-oauth-button
-                    data-analytics-name='OAuth'
-                    {{on 'click' (perform this.startOauthFlow)}}
-                >
-                    {{t 'general.authorize'}}
-                </Button>
+                <label local-class='auth-text-input-label'>
+                    {{t 'addons.accountCreate.display-name-label'}}
+                    <Input
+                        placeholder={{t 'addons.accountCreate.display-name-placeholder'}}
+                        @value={{@manager.displayName}}
+                    />
+                </label>
+                <div local-class='button-wrapper'>
+                    <Button
+                        data-test-addon-cancel-button
+                        data-analytics-name='Cancel'
+                        {{on 'click' @manager.cancelSetup}}
+                    >
+                        {{t 'general.cancel'}}
+                    </Button>
+                    <Button
+                        data-test-addon-oauth-button
+                        data-analytics-name='Begin OAuth'
+                        @type='primary'
+                        {{on 'click' (perform this.startOauthFlow)}}
+                    >
+                        {{t 'general.authorize'}}
+                    </Button>
+                </div>
             </div>
         {{/if}}
     {{else}}
@@ -62,19 +79,36 @@
                 </label>
                 {{field.postText}}
             {{/each}}
+            <label local-class='auth-text-input-label'>
+                {{t 'addons.accountCreate.display-name-label'}}
+                <Input
+                    placeholder={{t 'addons.accountCreate.display-name-placeholder'}}
+                    @value={{@manager.displayName}}
+                />
+            </label>
             {{#if @manager.connectAccountError}}
                 <p local-class='connect-error'>
                     {{t 'addons.accountCreate.error'}}
                 </p>
             {{/if}}
-            <Button
-                data-test-addon-connect-account-button
-                data-analytics-name='Connect Account'
-                disabled={{@manager.connectAccount.isRunning}}
-                {{on 'click' (perform @manager.connectAccount)}}
-            >
-                {{t 'general.authorize'}}
-            </Button>
+            <div local-class='button-wrapper'>
+                <Button
+                    data-test-addon-cancel-button
+                    data-analytics-name='Cancel'
+                    {{on 'click' @manager.cancelSetup}}
+                >
+                    {{t 'general.cancel'}}
+                </Button>
+                <Button
+                    data-test-addon-connect-account-button
+                    data-analytics-name='Connect Account'
+                    @type='primary'
+                    disabled={{@manager.connectAccount.isRunning}}
+                    {{on 'click' (perform @manager.connectAccount this.displayName)}}
+                >
+                    {{t 'general.authorize'}}
+                </Button>
+            </div>
         </form>
     {{/if}}
 {{/if}}

--- a/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
@@ -47,7 +47,6 @@ export default class UserAddonManagerComponent extends Component<Args> {
     @tracked filterTypeMapper = {
         [FilterTypes.STORAGE]: {
             modelName: 'external-storage-service',
-            userRelationshipName: 'authorizedStorageAccounts',
             fetchProvidersTask: taskFor(this.getStorageAddonProviders),
             list: A([]) as EmberArray<Provider>,
             getAuthorizedAccountsTask: taskFor(this.getAuthorizedStorageAccounts),
@@ -129,6 +128,16 @@ export default class UserAddonManagerComponent extends Component<Args> {
     @action
     acceptProviderTerms() {
         this.pageMode = UserSettingPageModes.ACCOUNT_CREATE;
+    }
+
+    @action
+    beginAccountSetup(provider: Provider) {
+        this.selectProvider(provider);
+    }
+
+    @action
+    configureProvider() {
+        // TODO: Implement
     }
 
     @action

--- a/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
@@ -84,6 +84,8 @@ export default class UserAddonManagerComponent extends Component<Args> {
         secretKey: '',
         repo: '',
     };
+    @tracked displayName = '';
+
     @action
     onCredentialsInput(event: Event) {
         const input = event.target as HTMLInputElement;
@@ -145,7 +147,7 @@ export default class UserAddonManagerComponent extends Component<Args> {
     }
 
     @action
-    cancelAccountSetup() {
+    cancelSetup() {
         this.credentialsObject = {
             url: '',
             username: '',
@@ -155,6 +157,7 @@ export default class UserAddonManagerComponent extends Component<Args> {
             secretKey: '',
             repo: '',
         };
+        this.displayName = '';
         this.pageMode = undefined;
         this.selectedProvider = undefined;
     }
@@ -276,8 +279,8 @@ export default class UserAddonManagerComponent extends Component<Args> {
         if (this.selectedProvider) {
             try {
                 await taskFor(this.selectedProvider.providerMap!.createAccountForNodeAddon)
-                    .perform(this.credentialsObject);
-                this.cancelAccountSetup();
+                    .perform(this.credentialsObject, this.displayName);
+                this.cancelSetup();
                 await taskFor(this.getAuthorizedAccounts).perform();
             } catch (e) {
                 const errorMessage = this.intl.t('addons.accountCreate.error');
@@ -292,14 +295,14 @@ export default class UserAddonManagerComponent extends Component<Args> {
     async createAuthorizedAccount() {
         if (this.selectedProvider) {
             return await taskFor(this.selectedProvider.providerMap!.createAccountForNodeAddon)
-                .perform(this.credentialsObject);
+                .perform(this.credentialsObject, this.displayName);
         }
     }
 
     @task
     @waitFor
     async oauthFlowRefocus() {
-        this.cancelAccountSetup();
+        this.cancelSetup();
         await taskFor(this.getAuthorizedAccounts).perform();
     }
 

--- a/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
@@ -28,8 +28,6 @@ import { FilterTypes } from '../manager/component';
 enum UserSettingPageModes {
     TERMS = 'terms',
     ACCOUNT_CREATE = 'accountCreate',
-    CONFIGURE_PROVIDER = 'configureProvider',
-    CONFIGURE_ACCOUNT = 'configureAccount',
 }
 
 interface Args {
@@ -135,30 +133,8 @@ export default class UserAddonManagerComponent extends Component<Args> {
     }
 
     @action
-    configureProviderAccounts(provider: Provider) {
-        this.pageMode = UserSettingPageModes.CONFIGURE_PROVIDER;
-        this.selectedProvider = provider;
-    }
-
-    @action
-    configureAuthorizedAccount(account: AllAuthorizedAccountTypes) {
-        this.pageMode = UserSettingPageModes.CONFIGURE_ACCOUNT;
-        this.selectedAccount = account;
-    }
-
-    @action
     acceptProviderTerms() {
         this.pageMode = UserSettingPageModes.ACCOUNT_CREATE;
-    }
-
-    @action
-    beginAccountSetup(provider: Provider) {
-        this.connectNewProviderAccount(provider);
-    }
-
-    @action
-    configureProvider(_: Provider) {
-        // TODO: Implement
     }
 
     @action

--- a/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
@@ -105,7 +105,14 @@ export default class UserAddonManagerComponent extends Component<Args> {
     }
 
     get currentTypeAuthorizedAccounts() {
-        return this.filterTypeMapper[this.activeFilterType].authorizedAccounts;
+        const allAccounts = this.filterTypeMapper[this.activeFilterType].authorizedAccounts;
+        const filteredAccounts = (allAccounts as AllAuthorizedAccountTypes[]).filter(
+            (account: AllAuthorizedAccountTypes) => {
+                const lowerCaseDisplayName = account.displayName.toLowerCase();
+                return lowerCaseDisplayName.includes(this.filterText.toLowerCase());
+            },
+        );
+        return filteredAccounts;
     }
 
     get filteredAddonProviders() {

--- a/lib/osf-components/addon/components/addons-service/user-addons-manager/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/user-addons-manager/template.hbs
@@ -10,19 +10,15 @@
     currentTypeAuthorizedAccounts=this.currentTypeAuthorizedAccounts
     currentTypeAuthorizedServiceIds=this.currentTypeAuthorizedServiceIds
     credentialsObject=this.credentialsObject
+    pageMode=this.pageMode
 
     selectedProvider=this.selectedProvider
     connectNewProviderAccount=this.connectNewProviderAccount
-    configureProviderAccounts=this.configureProviderAccounts
-    configureAuthorizedAccount=this.configureAuthorizedAccount
-    pageMode=this.pageMode
     acceptProviderTerms=this.acceptProviderTerms
     cancelAccountSetup=this.cancelAccountSetup
     onCredentialsInput=this.onCredentialsInput
     createAuthorizedAccount=this.createAuthorizedAccount
     oauthFlowRefocus=this.oauthFlowRefocus
     connectAccount=this.connectAccount
-    beginAccountSetup=this.beginAccountSetup
-    configureProvider=this.configureProvider
     disconnectAccount=this.disconnectAccount
 )}}

--- a/lib/osf-components/addon/components/addons-service/user-addons-manager/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/user-addons-manager/template.hbs
@@ -8,10 +8,13 @@
     filteredAddonProviders=this.filteredAddonProviders
     currentListIsLoading=this.currentListIsLoading
     currentTypeAuthorizedAccounts=this.currentTypeAuthorizedAccounts
+    currentTypeAuthorizedServiceIds=this.currentTypeAuthorizedServiceIds
     credentialsObject=this.credentialsObject
 
     selectedProvider=this.selectedProvider
-    selectProvider=this.selectProvider
+    connectNewProviderAccount=this.connectNewProviderAccount
+    configureProviderAccounts=this.configureProviderAccounts
+    configureAuthorizedAccount=this.configureAuthorizedAccount
     pageMode=this.pageMode
     acceptProviderTerms=this.acceptProviderTerms
     cancelAccountSetup=this.cancelAccountSetup
@@ -21,5 +24,5 @@
     connectAccount=this.connectAccount
     beginAccountSetup=this.beginAccountSetup
     configureProvider=this.configureProvider
-    disconnectAddon=this.disconnectAddon
+    disconnectAccount=this.disconnectAccount
 )}}

--- a/lib/osf-components/addon/components/addons-service/user-addons-manager/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/user-addons-manager/template.hbs
@@ -10,12 +10,13 @@
     currentTypeAuthorizedAccounts=this.currentTypeAuthorizedAccounts
     currentTypeAuthorizedServiceIds=this.currentTypeAuthorizedServiceIds
     credentialsObject=this.credentialsObject
+    displayName=this.displayName
     pageMode=this.pageMode
 
     selectedProvider=this.selectedProvider
     connectNewProviderAccount=this.connectNewProviderAccount
     acceptProviderTerms=this.acceptProviderTerms
-    cancelAccountSetup=this.cancelAccountSetup
+    cancelSetup=this.cancelSetup
     onCredentialsInput=this.onCredentialsInput
     createAuthorizedAccount=this.createAuthorizedAccount
     oauthFlowRefocus=this.oauthFlowRefocus

--- a/lib/osf-components/addon/components/delete-button/component.ts
+++ b/lib/osf-components/addon/components/delete-button/component.ts
@@ -28,6 +28,7 @@ export default class DeleteButton extends Component {
 
     // Optional arguments
     small = false;
+    secondary = false;
     smallSecondary = false;
     noBackground = false;
     hardConfirm = false;

--- a/lib/osf-components/addon/components/delete-button/template.hbs
+++ b/lib/osf-components/addon/components/delete-button/template.hbs
@@ -10,14 +10,14 @@
     >
         <FaIcon @icon={{this.icon}} />
     </Button>
-{{else if this.smallSecondary}}
+{{else if (or this.secondary this.smallSecondary)}}
     <Button
         data-analytics-name='Delete button'
         data-test-delete-button-secondary-destroy
         local-class='Button__secondaryDestroy'
         disabled={{this.disabled}}
         @type='secondary'
-        @layout='small'
+        @layout={{if this.smallSecondary 'small' 'medium'}}
         {{on 'click' this._show}}
     >
         {{#if @icon}}

--- a/mirage/scenarios/dashboard.ts
+++ b/mirage/scenarios/dashboard.ts
@@ -98,16 +98,20 @@ export function dashboardScenario(server: Server, currentUser: ModelInstance<Use
     });
 
     const boxAccount = server.create('authorized-storage-account', {
-        externalUserId: currentUser.id,
-        externalUserDisplayName: currentUser.fullName,
+        displayName: 'My Box Account',
         scopes: ['write'], // TODO: This should be a from an enum?
         storageProvider: boxAddon,
         configuringUser: addonUser,
     });
 
     server.create('authorized-storage-account', {
-        externalUserId: currentUser.id,
-        externalUserDisplayName: currentUser.fullName,
+        displayName: 'My Dropbox Account',
+        scopes: ['write'], // TODO: This should be a from an enum?
+        storageProvider: dropboxAddon,
+        configuringUser: addonUser,
+    });
+    server.create('authorized-storage-account', {
+        displayName: 'My Secret Dropbox Account',
         scopes: ['write'], // TODO: This should be a from an enum?
         storageProvider: dropboxAddon,
         configuringUser: addonUser,

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -225,7 +225,6 @@ addons:
     list:
         authorized-accounts-for-provider: 'Authorized accounts for {providerName}'
         authorized-accounts: 'Authorized accounts'
-        all-authorized-accounts: 'All Authorized Accounts'
         connected-accounts: 'Connected Accounts'
         all-addons: 'All Add-ons'
         sync-details-1: 'Sync your projects with external services to help stay connected and organized. Select a category and browse the options.' 

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -291,6 +291,8 @@ addons:
         existing-account: 'Choose existing account'
         unauthenticated-account: 'Unauthenticated account'
     accountCreate:
+        display-name-label: 'Display name'
+        display-name-placeholder: 'Account name'
         url-label: 'Host URL'
         url-placeholder: 'owncloud.example.org'
         owncloud-url-post-text: 'Only ownCloud instances supporting <a href="https://doc.owncloud.com/">WebDAV</a> and <a href"https://www.freedesktop.org/wiki/Specifications/open-collaboration-services-1.7/">OCS v1.7</a> are supported.'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -239,8 +239,9 @@ addons:
         no-authorized-accounts: 'No authorized accounts'
         connect: 'Connect'
         configure: 'Configure'
-        disconnect: 'Disconnect'
-        disconnect-confirmation: 'Are you sure you want to disconnect this account? All projects connected to this account will be affected.'
+        disable: 'Disable'
+        disable-account-header: 'Disable Account'
+        disable-confirmation: 'Are you sure you want to disable this account? All projects connected to this account will be affected.'
     terms:
         heading: '{providerName} Terms'
         accepting: 'Accepting terms…'
@@ -2134,8 +2135,8 @@ routes:
         email: Email
 osf-components:
     addon-card:
-        enable: Enable
-        disable: Disable
+        connect: Connect
+        disconnect: Disconnect
         configure: Configure
         provider-logo-alt: '{provider} logo'
         disable-modal-header: 'Disable Add-on'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -223,6 +223,8 @@ dashboard:
 addons:
     heading: 'Add-ons'
     list:
+        connected-accounts: 'Connected Accounts'
+        all-addons: 'All Add-ons'
         sync-details-1: 'Sync your projects with external services to help stay connected and organized. Select a category and browse the options.' 
         sync-details-2: 'To manage all add-ons connected to your account, visit your profile settings.'
         filter-placeholder: 'Filter add-ons'
@@ -233,8 +235,10 @@ addons:
             cloud-computing: 'Cloud Computing'
         no-results: 'No results found'
         no-authorized-accounts: 'No authorized accounts'
-        connect: 'Connect new account'
-        disconnect: 'Disconnect Account'
+        connect: 'Connect'
+        configure: 'Configure'
+        disconnect: 'Disconnect'
+        disconnect-confirmation: 'Are you sure you want to disconnect this account? All projects connected to this account will be affected.'
     terms:
         heading: '{providerName} Terms'
         accepting: 'Accepting terms…'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -223,6 +223,9 @@ dashboard:
 addons:
     heading: 'Add-ons'
     list:
+        authorized-accounts-for-provider: 'Authorized accounts for {providerName}'
+        authorized-accounts: 'Authorized accounts'
+        all-authorized-accounts: 'All Authorized Accounts'
         connected-accounts: 'Connected Accounts'
         all-addons: 'All Add-ons'
         sync-details-1: 'Sync your projects with external services to help stay connected and organized. Select a category and browse the options.' 


### PR DESCRIPTION

-   Ticket: [ENG-5455]
-   Feature flag: n/a

## Purpose
- Add tabs on user settings addon page

## Summary of Changes
- Add tabs to User Settings Addons page
  - Hide whitespace is advised on the templates
- Update user-settings-manager to support these tabs, and update method names to make a bit more sense
- Update delete-button component to be able to render a new size
- 

## Screenshot(s)
- All Addons tab
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/97a5439c-ad94-4774-bfa2-27b1ccd5b97f)

- All Addons tab (mobile)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/825b3410-afc8-4a5e-800c-ef1075fa6f87)

- Terms  page with new "Cancel" button
<img width="1184" alt="image" src="https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/98d1392d-12b4-4367-9be3-f6bf9fe252e3">

- Authorized Accounts tab
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/ac299256-3571-469a-867a-4d2f5a42b88c)
- Authorized Accounts tab (mobile)
![image](https://github.com/CenterForOpenScience/ember-osf-web/assets/51409893/bc3c6003-09a3-4ecf-a3cf-16bcce412f9e)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-5455]: https://openscience.atlassian.net/browse/ENG-5455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ