### PR TITLE
ENG-3769: Fix a11y issue on draft registration pages

### DIFF
--- a/lib/osf-components/addon/components/registries/schema-block-renderer/helper-text-icon/template.hbs
+++ b/lib/osf-components/addon/components/registries/schema-block-renderer/helper-text-icon/template.hbs
@@ -5,7 +5,8 @@
             tabindex='0'
             id={{id}}
             @icon='question-circle'
-            @ariaHidden={{false}}
+            aria-hidden='false'
+            aria-label={{this.helpText}}
             ...attributes
         />
         <EmberPopover


### PR DESCRIPTION
-   Ticket: [ENG-3769](https://openscience.atlassian.net/browse/ENG-3769)
-   Feature flag: n/a

## Purpose

Fix a11y of an SVG icon on draft registration pages

## Summary of Changes

- Changed @ariaHidden to ensures the SVG icon is not hidden.
- Added aria-label.

## Screenshot(s)

## Side Effects

## QA Notes


[ENG-3769]: https://openscience.atlassian.net/browse/ENG-3769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ