### PR TITLE
ENG-4839 Implement Visibility Control for Preprint Providers on Discover Page

### DIFF
--- a/app/models/preprint-provider.ts
+++ b/app/models/preprint-provider.ts
@@ -24,6 +24,9 @@ export default class PreprintProviderModel extends ProviderModel {
     @attr('string') shareSource!: string;
     @attr('string') preprintWord!: PreprintWord;
 
+    // New attribute to control visibility on the discovery page
+    @attr('boolean', { defaultValue: true }) advertiseOnDiscoverPage!: boolean;
+
     // Reviews settings
     @attr('array') permissions!: ReviewPermissions[];
     @attr('boolean', { allowNull: true }) reviewsCommentsPrivate!: boolean | null;

--- a/app/models/preprint-provider.ts
+++ b/app/models/preprint-provider.ts
@@ -24,7 +24,6 @@ export default class PreprintProviderModel extends ProviderModel {
     @attr('string') shareSource!: string;
     @attr('string') preprintWord!: PreprintWord;
 
-    // New attribute to control visibility on the discovery page
     @attr('boolean', { defaultValue: true }) advertiseOnDiscoverPage!: boolean;
 
     // Reviews settings

--- a/app/preprints/index/route.ts
+++ b/app/preprints/index/route.ts
@@ -48,7 +48,10 @@ export default class Preprints extends Route {
             let brandedProviders = [];
 
             if (this.theme.id === 'osf') {
-                const allProviders = await this.store.findAll('preprint-provider', { reload: true });
+                const allProviders = await this.store.query('preprint-provider', {
+                    reload: true,
+                    filter: { advertiseOnDiscoverPage: true },
+                });
                 brandedProviders = allProviders.filter(item => item.id !== 'osf');
             }
 

--- a/app/preprints/index/route.ts
+++ b/app/preprints/index/route.ts
@@ -50,7 +50,7 @@ export default class Preprints extends Route {
             if (this.theme.id === 'osf') {
                 const allProviders = await this.store.query('preprint-provider', {
                     reload: true,
-                    filter: { advertiseOnDiscoverPage: true },
+                    filter: { advertise_on_discover_page: true },
                 });
                 brandedProviders = allProviders.filter(item => item.id !== 'osf');
             }

--- a/app/preprints/index/template.hbs
+++ b/app/preprints/index/template.hbs
@@ -96,16 +96,14 @@
                 </p>
                 <div local-class='preprint-logos-container'>
                     {{#each this.model.brandedProviders as |provider| }}
-                        {{#if (and provider.advertiseOnDiscoverPage (not-eq provider.id 'livedata'))}}
-                            <OsfLink
-                                data-test-see-branded-providers-example
-                                data-analytics-name='See Branded Providers Example'
-                                @href={{concat '/preprints/' provider.id }}
-                                title='{{provider.name}}'
-                                local-class='provider-logo'
-                                style={{html-safe (concat 'background-image: url(' provider.assets.wide_white ')' )}}
-                            ></OsfLink>
-                        {{/if}}
+                        <OsfLink
+                            data-test-see-branded-providers-example
+                            data-analytics-name='See Branded Providers Example'
+                            @href={{concat '/preprints/' provider.id }}
+                            title='{{provider.name}}'
+                            local-class='provider-logo'
+                            style={{html-safe (concat 'background-image: url(' provider.assets.wide_white ')' )}}
+                        ></OsfLink>
                     {{/each}}
                 </div>
                 <div local-class='preprint-contact-container'>

--- a/app/preprints/index/template.hbs
+++ b/app/preprints/index/template.hbs
@@ -96,7 +96,7 @@
                 </p>
                 <div local-class='preprint-logos-container'>
                     {{#each this.model.brandedProviders as |provider| }}
-                        {{#if (not-eq provider.id 'livedata') }}
+                        {{#if (and provider.advertiseOnDiscoverPage (not-eq provider.id 'livedata'))}}
                             <OsfLink
                                 data-test-see-branded-providers-example
                                 data-analytics-name='See Branded Providers Example'

--- a/mirage/fixtures/preprint-providers.ts
+++ b/mirage/fixtures/preprint-providers.ts
@@ -16,6 +16,7 @@ const preprintProviders: Array<Partial<PreprintProvider>> = [
     {
         id: 'osf',
         name: 'Open Science Framework',
+        advertiseOnDiscoverPage: true,
         preprintWord: 'preprint',
         assets: randomAssets(1),
         footerLinks: 'fake footer links',
@@ -25,6 +26,7 @@ const preprintProviders: Array<Partial<PreprintProvider>> = [
     {
         id: 'thesiscommons',
         name: 'Thesis Commons',
+        advertiseOnDiscoverPage: true,
         preprintWord: 'thesis',
         assets: randomAssets(2),
         // eslint-disable-next-line max-len
@@ -33,6 +35,7 @@ const preprintProviders: Array<Partial<PreprintProvider>> = [
     {
         id: 'preprintrxiv',
         name: 'PreprintrXiv',
+        advertiseOnDiscoverPage: false,
         preprintWord: 'preprint',
         assets: randomAssets(3),
         // eslint-disable-next-line max-len
@@ -43,6 +46,7 @@ const preprintProviders: Array<Partial<PreprintProvider>> = [
     {
         id: 'paperxiv',
         name: 'PaperXiv',
+        advertiseOnDiscoverPage: true,
         preprintWord: 'paper',
         assets: randomAssets(4),
         // eslint-disable-next-line max-len
@@ -51,6 +55,7 @@ const preprintProviders: Array<Partial<PreprintProvider>> = [
     {
         id: 'thesisrxiv',
         name: 'ThesisrXiv',
+        advertiseOnDiscoverPage: true,
         preprintWord: 'thesis',
         assets: randomAssets(5),
         // eslint-disable-next-line max-len
@@ -59,6 +64,7 @@ const preprintProviders: Array<Partial<PreprintProvider>> = [
     {
         id: 'workrxiv',
         name: 'WorkrXiv',
+        advertiseOnDiscoverPage: true,
         preprintWord: 'work',
         assets: randomAssets(6),
         footerLinks: 'fake footer links',
@@ -66,6 +72,7 @@ const preprintProviders: Array<Partial<PreprintProvider>> = [
     {
         id: 'docrxiv',
         name: 'DocrXiv',
+        advertiseOnDiscoverPage: true,
         preprintWord: 'default',
         assets: randomAssets(7),
         footerLinks: 'fake footer links',
@@ -73,6 +80,7 @@ const preprintProviders: Array<Partial<PreprintProvider>> = [
     {
         id: 'agrixiv',
         name: 'AgriXiv',
+        advertiseOnDiscoverPage: true,
         preprintWord: 'preprint',
         assets: randomAssets(8),
         reviewsWorkflow: PreprintProviderReviewsWorkFlow.POST_MODERATION,
@@ -80,24 +88,28 @@ const preprintProviders: Array<Partial<PreprintProvider>> = [
     {
         id: 'biohackrxiv',
         name: 'BioHackrXiv',
+        advertiseOnDiscoverPage: true,
         preprintWord: 'preprint',
         assets: randomAssets(9),
     },
     {
         id: 'nutrixiv',
         name: 'NutriXiv',
+        advertiseOnDiscoverPage: true,
         preprintWord: 'preprint',
         assets: randomAssets(10),
     },
     {
         id: 'paleorxiv',
         name: 'PaleoRrxiv',
+        advertiseOnDiscoverPage: true,
         preprintWord: 'preprint',
         assets: randomAssets(10, false),
     },
     {
         id: 'sportrxiv',
         name: 'Sport-Rxiv',
+        advertiseOnDiscoverPage: true,
         preprintWord: 'paper',
         assets: randomAssets(10),
     },

--- a/tests/acceptance/preprints/index-test.ts
+++ b/tests/acceptance/preprints/index-test.ts
@@ -22,6 +22,7 @@ module('Acceptance | preprints | index', hooks => {
         provider.update({
             brand,
             description: 'This is the description for OSF',
+            advertiseOnDiscoverPage: true,
         });
         this.provider = provider;
     });


### PR DESCRIPTION
-   Ticket: [[ENG-4839]](https://openscience.atlassian.net/browse/ENG-4839)
-   Feature flag: n/a

## Purpose

Implement Visibility Control for Preprint Providers on Discover Page

## Summary of Changes

- Added a new attribute to track whether a preprint provider should be advertised on the discover page.
- Integrated the advertiseOnDiscoverPage attribute in the condition to render preprint provider logos.

## Screenshot(s)

## Side Effects

## QA Notes

[ENG-4839]: https://openscience.atlassian.net/browse/ENG-4839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ