### PR TITLE
[ENG-5454] Addons/Multiple Configured Addons part 2 / 3

### DIFF
--- a/app/models/configured-citation-addon.ts
+++ b/app/models/configured-citation-addon.ts
@@ -11,6 +11,7 @@ export default class ConfiguredCitationAddonModel extends OsfModel {
     @attr('string') displayName!: string;
     @attr('fixstring') externalUserId!: string;
     @attr('fixstring') externalUserDisplayName!: string;
+    @attr('string') authorizedResourceUri!: string;
 
     @belongsTo('external-citation-service', { inverse: null })
     externalCitationService!: AsyncBelongsTo<ExternalCitationServiceModel> & ExternalCitationServiceModel;

--- a/app/models/configured-computing-addon.ts
+++ b/app/models/configured-computing-addon.ts
@@ -11,6 +11,7 @@ export default class ConfiguredComputingAddonModel extends OsfModel {
     @attr('string') displayName!: string;
     @attr('fixstring') externalUserId!: string;
     @attr('fixstring') externalUserDisplayName!: string;
+    @attr('string') authorizedResourceUri!: string;
 
     @belongsTo('external-computing-service', { inverse: null })
     externalComputingService!: AsyncBelongsTo<ExternalComputingService> & ExternalComputingService;

--- a/app/models/configured-storage-addon.ts
+++ b/app/models/configured-storage-addon.ts
@@ -11,7 +11,7 @@ export enum ConnectedCapabilities {
     Update = 'UPDATE',
 }
 
-export enum ConnectedOparationNames {
+export enum ConnectedOperationNames {
     DownloadAsZip = 'download_as_zip',
     CopyInto = 'copy_into',
     HasRevisions = 'has_revisions',
@@ -21,12 +21,13 @@ export default class ConfiguredStorageAddonModel extends OsfModel {
     @attr('string') name!: string;
     @attr('string') displayName!: string;
     @attr('array') connectedCapabilities!: ConnectedCapabilities[];
-    @attr('array') connectedOperationNames!: ConnectedOparationNames[];
+    @attr('array') connectedOperationNames!: ConnectedOperationNames[];
     @attr('fixstring') externalUserId!: string;
     @attr('fixstring') externalUserDisplayName!: string;
     @attr('number') concurrentUploads!: number;
     @attr('fixstring') rootFolder!: string;
     @attr('string') iconUrl!: string;
+    @attr('string') authorizedResourceUri!: string;
 
     @belongsTo('external-storage-service', { inverse: null })
     storageProvider!: AsyncBelongsTo<ExternalStorageServiceModel> & ExternalStorageServiceModel;

--- a/app/packages/files/service-file.ts
+++ b/app/packages/files/service-file.ts
@@ -5,7 +5,7 @@ import { waitFor } from '@ember/test-waiters';
 import { task } from 'ember-concurrency';
 import Intl from 'ember-intl/services/intl';
 import Toast from 'ember-toastr/services/toast';
-import ConfiguredStorageAddonModel, { ConnectedCapabilities, ConnectedOparationNames}
+import ConfiguredStorageAddonModel, { ConnectedCapabilities, ConnectedOperationNames}
     from 'ember-osf-web/models/configured-storage-addon';
 import FileModel from 'ember-osf-web/models/file';
 import NodeModel from 'ember-osf-web/models/node';
@@ -72,14 +72,14 @@ export default class ServiceFile {
         this.fileModel = fileModel;
         this.configuredStorageAddon = configuredStorageAddon;
         this.userCanDownloadAsZip = configuredStorageAddon.connectedOperationNames
-            .includes(ConnectedOparationNames.DownloadAsZip);
+            .includes(ConnectedOperationNames.DownloadAsZip);
         this.providerHandlesVersioning = configuredStorageAddon.connectedOperationNames
-            .includes(ConnectedOparationNames.HasRevisions);
+            .includes(ConnectedOperationNames.HasRevisions);
         this.shouldShowRevisions = configuredStorageAddon.connectedOperationNames
-            .includes(ConnectedOparationNames.HasRevisions);
+            .includes(ConnectedOperationNames.HasRevisions);
         this.parallelUploadsLimit = configuredStorageAddon.concurrentUploads;
         this.canMoveToThisProvider = configuredStorageAddon.connectedOperationNames
-            .includes(ConnectedOparationNames.CopyInto);
+            .includes(ConnectedOperationNames.CopyInto);
     }
 
     get isFile() {

--- a/app/packages/files/service-provider-file.ts
+++ b/app/packages/files/service-provider-file.ts
@@ -11,7 +11,7 @@ import { FileSortKey } from 'ember-osf-web/packages/files/file';
 import CurrentUserService from 'ember-osf-web/services/current-user';
 import captureException, { getApiErrorMessage } from 'ember-osf-web/utils/capture-exception';
 import { ErrorDocument } from 'osf-api';
-import ConfiguredStorageAddonModel, { ConnectedCapabilities, ConnectedOparationNames}
+import ConfiguredStorageAddonModel, { ConnectedCapabilities, ConnectedOperationNames}
     from 'ember-osf-web/models/configured-storage-addon';
 
 export default class ServiceProviderFile {
@@ -37,12 +37,12 @@ export default class ServiceProviderFile {
         this.fileModel = fileModel;
         this.configuredStorageAddon = configuredStorageAddon;
         this.userCanDownloadAsZip = configuredStorageAddon.connectedOperationNames
-            .includes(ConnectedOparationNames.DownloadAsZip);
+            .includes(ConnectedOperationNames.DownloadAsZip);
         this.providerHandlesVersioning = configuredStorageAddon.connectedOperationNames
-            .includes(ConnectedOparationNames.HasRevisions);
+            .includes(ConnectedOperationNames.HasRevisions);
         this.parallelUploadsLimit = configuredStorageAddon.concurrentUploads;
         this.canMoveToThisProvider = configuredStorageAddon.connectedOperationNames
-            .includes(ConnectedOparationNames.CopyInto);
+            .includes(ConnectedOperationNames.CopyInto);
     }
 
     get id() {

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -553,8 +553,11 @@ export default function(this: Server) {
     this.resource('authorized-computing-accounts', { except: ['index'] });
     this.post('authorized-computing-accounts', addons.createAuthorizedComputingAccount);
     this.resource('configured-storage-addons', { only: ['show', 'update', 'delete'] });
+    this.get('/configured-storage-addons/', addons.configuredStorageAddonList);
     this.resource('configured-citation-addons', { only: ['show', 'update', 'delete'] });
+    this.get('/configured-citation-addons/', addons.configuredCitationAddonList);
     this.resource('configured-computing-addons', { only: ['show', 'update', 'delete'] });
+    this.get('/configured-computing-addons/', addons.configuredComputingAddonList);
     this.post('configured-storage-addons', addons.createConfiguredStorageAddon);
     this.post('configured-citation-addons', addons.createConfiguredCitationAddon);
     this.post('configured-computing-addons', addons.createConfiguredComputingAddon);

--- a/mirage/scenarios/dashboard.ts
+++ b/mirage/scenarios/dashboard.ts
@@ -7,7 +7,7 @@ import NodeModel from 'ember-osf-web/models/node';
 import { Permission } from 'ember-osf-web/models/osf-model';
 import ExternalStorageServiceModel from 'ember-osf-web/models/external-storage-service';
 import User from 'ember-osf-web/models/user';
-import { ConnectedOparationNames, ConnectedCapabilities } from 'ember-osf-web/models/configured-storage-addon';
+import { ConnectedOperationNames, ConnectedCapabilities } from 'ember-osf-web/models/configured-storage-addon';
 
 const {
     dashboard: {
@@ -122,12 +122,13 @@ export function dashboardScenario(server: Server, currentUser: ModelInstance<Use
         name: 'Box',
         displayName: 'Boxed Data',
         rootFolder: '/woot/',
+        authorizedResourceUri: 'http://localhost:5000/file5',
         storageProvider: boxAddon,
         accountOwner: addonUser,
         authorizedResource: addonFile5,
         baseAccount: boxAccount,
         connectedCapabilities: [ConnectedCapabilities.Access, ConnectedCapabilities.Update],
-        connectedOperationNames: [ConnectedOparationNames.CopyInto],
+        connectedOperationNames: [ConnectedOperationNames.CopyInto],
         iconUrl: `${assetsPrefix}assets/images/addons/icons/box.png`,
     });
 

--- a/mirage/views/addons.ts
+++ b/mirage/views/addons.ts
@@ -176,6 +176,30 @@ export function resourceReferencesList(this: HandlerContext, schema: Schema, req
     return processed;
 }
 
+export function configuredStorageAddonList(this: HandlerContext, schema: Schema, request: Request) {
+    const models = schema.configuredStorageAddons.all().models;
+    const filteredModels = models.filter((addon: ModelInstance) => filter(addon, request));
+    const data = filteredModels.map((addon: ModelInstance) => this.serialize(addon).data);
+    const processed = process(schema, request, this, data);
+    return processed;
+}
+
+export function configuredComputingAddonList(this: HandlerContext, schema: Schema, request: Request) {
+    const models = schema.configuredComputingAddons.all().models;
+    const filteredModels = models.filter((addon: ModelInstance) => filter(addon, request));
+    const data = filteredModels.map((addon: ModelInstance) => this.serialize(addon).data);
+    const processed = process(schema, request, this, data);
+    return processed;
+}
+
+export function configuredCitationAddonList(this: HandlerContext, schema: Schema, request: Request) {
+    const models = schema.configuredCitationAddons.all().models;
+    const filteredModels = models.filter((addon: ModelInstance) => filter(addon, request));
+    const data = filteredModels.map((addon: ModelInstance) => this.serialize(addon).data);
+    const processed = process(schema, request, this, data);
+    return processed;
+}
+
 export function createConfiguredStorageAddon(this: HandlerContext, schema: Schema) {
     const attrs =
         this.normalizedRequestAttrs('configured-storage-addon') as NormalizedRequestAttrs<MirageConfiguredStorageAddon>;


### PR DESCRIPTION
-   Ticket: [ENG-5454]
-   Feature flag: n/a

## Purpose

Do better at getting the configured addons

## Summary of Changes

1. Fix typo for ConnectedOp~a~erationNames
2. Get all configured addons at once for a node
3. Mirage up some endpoints and views
4. Fix configuration
5. Move manager constructor tasks to an initialize function so they can be done synchronously


## Side Effects

This passed the addons-services tests locally, and it runs, so it probably doesn't have a lot of side effects.


[ENG-5454]: https://openscience.atlassian.net/browse/ENG-5454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ