### PR TITLE
[ENG-5605] Fixed the formatting on the user-search cancel widget

### DIFF
--- a/lib/osf-components/addon/components/contributors/user-search/widget/styles.scss
+++ b/lib/osf-components/addon/components/contributors/user-search/widget/styles.scss
@@ -4,7 +4,7 @@
     border: 1px solid $color-border-gray;
     margin-top: 10px;
     overflow-y: scroll;
-    max-height: 500px;
+    max-height: 285px;
 
     p {
         padding: 10px 20px 5px;

--- a/lib/osf-components/addon/components/contributors/user-search/widget/template.hbs
+++ b/lib/osf-components/addon/components/contributors/user-search/widget/template.hbs
@@ -26,16 +26,6 @@
     </div>
     {{#if this.displayResults}}
         <div
-            local-class='user-search-cancel-container'
-        >
-            <Button
-                data-test-user-search-cancel-button
-                {{on 'click' this.cancelSearch}}
-            >
-                {{t 'general.cancel'}}
-            </Button>
-        </div>
-        <div
             local-class='user-search-results-container {{if (is-mobile) 'mobile'}}'
             data-test-user-search-results
         >
@@ -46,6 +36,16 @@
                 @shouldShowLoadMoreUsers={{this.shouldShowLoadMoreUsers}}
                 @isLoadingUsers={{this.fetchUsers.isRunning}}
             />
+        </div>
+        <div
+            local-class='user-search-cancel-container'
+        >
+            <Button
+                data-test-user-search-cancel-button
+                {{on 'click' this.cancelSearch}}
+            >
+                {{t 'general.cancel'}}
+            </Button>
         </div>
     {{/if}}
 </div>


### PR DESCRIPTION
-   Ticket: [ENG-5605]
-   Feature flag: n/a

## Purpose

The button was above the results

## Summary of Changes

Moved the button below the results and reduced the height of the results.

## Screenshot(s)

![Screenshot 2024-05-14 at 8 51 40 AM](https://github.com/CenterForOpenScience/ember-osf-web/assets/113387478/a95adf12-f8d2-44a9-a5f0-01a89f469d8e)


## Side Effects

None

## QA Notes

Non


[ENG-5605]: https://openscience.atlassian.net/browse/ENG-5605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ