### PR TITLE
[ENG-5606] Changed the background color of the disabled date picker

### DIFF
--- a/app/preprints/-components/submit/metadata/styles.scss
+++ b/app/preprints/-components/submit/metadata/styles.scss
@@ -23,11 +23,17 @@
             margin-bottom: 20px;
 
             .tags-border {
-                * > input {
+                input {
                     padding: 6px 12px;
                     border: 1px solid $color-border-gray;
                     font-size: 14px;
                     height: 34px;
+                }
+            }
+
+            .read-only {
+                input {
+                    background-color: $color-bg-white;
                 }
             }
         }

--- a/app/preprints/-components/submit/metadata/template.hbs
+++ b/app/preprints/-components/submit/metadata/template.hbs
@@ -105,9 +105,9 @@
 
                 <div local-class='input-container'>
                     <ValidatedInput::Date
+                        local-class='read-only'
                         @label={{t 'preprints.submit.step-two.publication-date-input'}}
                         @ariaLabel={{t 'preprints.submit.step-two.publication-date-input'}}
-                        @readOnly={{false}}
                         data-test-publication-date-input
                         @value={{@manager.preprint.originalPublicationDate}}
                         @placeholder={{t 'preprints.submit.step-two.publication-date-input'}}


### PR DESCRIPTION
-   Ticket: [ENG-5606]
-   Feature flag: n/a

## Purpose

Changed the background color of the disabled date picker

## Summary of Changes

Added a class to the component and updated the css to change the input background color to be white.

## Screenshot(s)

![Screenshot 2024-05-14 at 9 55 37 AM](https://github.com/CenterForOpenScience/ember-osf-web/assets/113387478/1f3b7380-0dc1-4bdc-b7bb-be9c35c7bf22)


## Side Effects

None

## QA Notes

It's now white!


[ENG-5606]: https://openscience.atlassian.net/browse/ENG-5606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ