### PR TITLE
[ENG-5624] Add mirage endpoint for addon-operation-invocation

### DIFF
--- a/app/adapters/addon-operation-invocation.ts
+++ b/app/adapters/addon-operation-invocation.ts
@@ -1,0 +1,10 @@
+import AddonServiceAdapter from './addon-service';
+
+export default class AddonOperationInvocationAdapter extends AddonServiceAdapter {
+}
+
+declare module 'ember-data/types/registries/adapter' {
+    export default interface AdapterRegistry {
+        'addon-operation-invocation': AddonOperationInvocationAdapter;
+    } // eslint-disable-line semi
+}

--- a/app/models/addon-operation-invocation.ts
+++ b/app/models/addon-operation-invocation.ts
@@ -1,0 +1,49 @@
+import Model, { AsyncBelongsTo, attr, belongsTo } from '@ember-data/model';
+
+import UserReferenceModel from 'ember-osf-web/models/user-reference';
+import ConfiguredAddonModel from 'ember-osf-web/models/configured-addon';
+import { ConnectedOperationNames } from 'ember-osf-web/models/configured-storage-addon';
+
+export enum InvocationStatus {
+     // TODO: are these right?
+    Success = 'SUCCESS',
+    Failure = 'FAILURE',
+    Pending = 'PENDING',
+}
+export enum ItemType {
+    Folder = 'FOLDER',
+    File = 'FILE',
+}
+
+export type OperationName = 'get_root_items' | 'get_child_items';
+export interface OperationResult{
+    items: Item[];
+    cursor?: string; // TODO: name??
+}
+export interface Item {
+    itemId: string;
+    itemName: string;
+    itemType: ItemType;
+    itemPath?: string;
+}
+
+export default class AddonOperationInvocationModel extends Model {
+    @attr('string') invocationStatus!: InvocationStatus;
+    @attr('string') operationName!: ConnectedOperationNames;
+    @attr('object') operationKwargs!: any;
+    @attr('object') operationResult!: OperationResult;
+    @attr('date') created!: Date;
+    @attr('date') modified!: Date;
+
+    @belongsTo('user-reference', { inverse: null })
+    byUser!: AsyncBelongsTo<UserReferenceModel> | UserReferenceModel;
+
+    @belongsTo('configured-addon', { inverse: null, polymorphic: true })
+    thruAddon?: AsyncBelongsTo<ConfiguredAddonModel> | ConfiguredAddonModel;
+}
+
+declare module 'ember-data/types/registries/model' {
+    export default interface ModelRegistry {
+        'addon-operation-invocation': AddonOperationInvocationModel;
+    } // eslint-disable-line semi
+}

--- a/app/models/configured-addon.ts
+++ b/app/models/configured-addon.ts
@@ -18,19 +18,4 @@ export default class ConfiguredAddonModel extends Model {
 
     @belongsTo('resource-reference', { inverse: 'configuredStorageAddons' })
     authorizedResource!: AsyncBelongsTo<ResourceReferenceModel> & ResourceReferenceModel;
-
-    async getFolderItems(this: ConfiguredAddonModel) {
-        const data = await fetch('http://localhost:7979/v1/addon-operation-invocations', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-                operationName: 'list_folder',
-                thruAddon: this,
-                byUser: this.accountOwner.id,
-            }),
-        });
-        return data;
-    }
 }

--- a/app/models/configured-storage-addon.ts
+++ b/app/models/configured-storage-addon.ts
@@ -1,8 +1,11 @@
 import { AsyncBelongsTo, attr, belongsTo } from '@ember-data/model';
+import { waitFor } from '@ember/test-waiters';
+import { task } from 'ember-concurrency';
 
 import AuthorizedStorageAccountModel from './authorized-storage-account';
 import ConfiguredAddonModel from './configured-addon';
 import ExternalStorageServiceModel from './external-storage-service';
+import { ItemType } from './addon-operation-invocation';
 
 export enum ConnectedCapabilities {
     Access = 'ACCESS',
@@ -13,6 +16,8 @@ export enum ConnectedOperationNames {
     DownloadAsZip = 'download_as_zip',
     CopyInto = 'copy_into',
     HasRevisions = 'has_revisions',
+    GetRootItems = 'get_root_items',
+    GetChildItems = 'get_child_items',
 }
 
 export default class ConfiguredStorageAddonModel extends ConfiguredAddonModel {
@@ -28,6 +33,22 @@ export default class ConfiguredStorageAddonModel extends ConfiguredAddonModel {
 
     @belongsTo('authorized-storage-account')
     baseAccount!: AsyncBelongsTo<AuthorizedStorageAccountModel> & AuthorizedStorageAccountModel;
+
+    @task
+    @waitFor
+    async getFolderItems(this: ConfiguredStorageAddonModel, folderId?: string) {
+        const newInvocation = this.store.createRecord('addon-operation-invocation', {
+
+            operationName: folderId ? ConnectedOperationNames.GetChildItems : ConnectedOperationNames.GetRootItems,
+            operationKwargs: {
+                folderId,
+                type: ItemType.Folder,
+            },
+            thruAddon: this,
+            byUser: await this.accountOwner,
+        });
+        return await newInvocation.save();
+    }
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/serializers/addon-operation-invocation.ts
+++ b/app/serializers/addon-operation-invocation.ts
@@ -1,0 +1,10 @@
+import GravyValetSerializer from './gravy-valet-serializer';
+
+export default class AddonOperationInvocationSerializer extends GravyValetSerializer {
+}
+
+declare module 'ember-data/types/registries/serializer' {
+    export default interface SerializerRegistry {
+        'addon-operation-invocation': AddonOperationInvocationSerializer;
+    } // eslint-disable-line semi
+}

--- a/lib/osf-components/addon/components/addons-service/manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/manager/component.ts
@@ -143,7 +143,9 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
         this.cancelSetup();
         this.selectedProvider = provider;
         this.selectedConfiguration = configuredAddon;
-        // const rootItems = await configuredAddon.getFolderItems();
+        // if (configuredAddon instanceof ConfiguredStorageAddonModel) {
+        //     const rootItems = await taskFor(configuredAddon.getFolderItems).perform();
+        // }
         this.pageMode = PageMode.CONFIGURE;
     }
 

--- a/mirage/serializers/addon-operation-invocation.ts
+++ b/mirage/serializers/addon-operation-invocation.ts
@@ -1,0 +1,52 @@
+import { ModelInstance } from 'ember-cli-mirage';
+
+import { addonServiceAPIUrl } from 'ember-osf-web/adapters/addon-service';
+import AddonOperationInvocations from 'ember-osf-web/models/addon-operation-invocation';
+
+import AddonServiceSerializer from './addon-service';
+
+interface PolyMorphicAccountType {
+    type: 'authorized-storage-account' | 'authorized-citation-account' | 'authorized-computing-account';
+    id: string;
+}
+
+interface PolyMorphicAddonType {
+    type: 'configured-storage-addon' | 'configured-citation-addon' | 'configured-computing-addon';
+    id: string;
+}
+
+export interface MirageAddonOperationInvocation extends AddonOperationInvocations {
+    byUserId: string;
+    thruAccountId: PolyMorphicAccountType;
+    thruAddonId: PolyMorphicAddonType;
+}
+
+export default class AddonOperationInvocationSerializer extends AddonServiceSerializer<MirageAddonOperationInvocation> {
+    buildRelationships(model: ModelInstance<MirageAddonOperationInvocation>) {
+        const thruAddonType = model.thruAddonId.type;
+        return {
+            byUser: {
+                links: {
+                    related: {
+                        href: `${addonServiceAPIUrl}user-references/${model.byUserId}/`,
+                    },
+                },
+                data: {
+                    type: 'user-references',
+                    id: model.byUserId,
+                },
+            },
+            thruAddon: {
+                links: {
+                    related: {
+                        href: `${addonServiceAPIUrl}${thruAddonType}/${model.thruAddonId}/`,
+                    },
+                },
+                data: {
+                    type: thruAddonType,
+                    id: model.thruAddonId,
+                },
+            },
+        };
+    }
+}

--- a/mirage/views/addons.ts
+++ b/mirage/views/addons.ts
@@ -1,7 +1,7 @@
 import { HandlerContext, ModelInstance, NormalizedRequestAttrs, Request, Response, Schema } from 'ember-cli-mirage';
 import { timeout } from 'ember-concurrency';
 
-import { addonServiceAPIUrl } from 'ember-osf-web/adapters/addon-service';
+import { InvocationStatus, ItemType } from 'ember-osf-web/models/addon-operation-invocation';
 import AuthorizedCitationAccountModel from 'ember-osf-web/models/authorized-citation-account';
 import AuthorizedComputingAccountModel from 'ember-osf-web/models/authorized-computing-account';
 import { AddonCredentialFields} from 'ember-osf-web/models/authorized-account';
@@ -13,6 +13,7 @@ import ExternalComputingServiceModel from 'ember-osf-web/models/external-computi
 import FileProviderModel from 'ember-osf-web/models/file-provider';
 import { AllAuthorizedAccountTypes, AllProviderTypes } from 'ember-osf-web/packages/addons-service/provider';
 
+import { MirageAddonOperationInvocation } from '../serializers/addon-operation-invocation';
 import { MirageConfiguredComputingAddon } from '../serializers/configured-computing-addon';
 import { MirageConfiguredCitationAddon } from '../serializers/configured-citation-addon';
 import { MirageConfiguredStorageAddon } from '../serializers/configured-storage-addon';
@@ -250,104 +251,25 @@ export function createConfiguredComputingAddon(this: HandlerContext, schema: Sch
     return configuredComputingAddon;
 }
 
-export function createAddonOperationInvocation(this: HandlerContext, _: Schema) {
-    type ItemType = 'FILE' | 'FOLDER';
-    return new Response(201, {}, {
-        data: {
-            id: '1234',
-            type: 'addon-operation-invocation',
-            attributes: {
-                invocation_status: 'done',
-                operation_name: 'get_root_items',
-                operation_results: {
-                    items: [
-                        {
-                            type: 'FOLDER' as ItemType,
-                            path: ['root'],
-                            name: 'Folder1',
-                            id: 'folder1',
-                        },
-                        {
-                            type: 'FOLDER' as ItemType,
-                            path: ['root'],
-                            name: 'Folder2',
-                            id: 'folder2',
-                        },
-                        {
-                            type: 'FILE' as ItemType,
-                            path: ['root'],
-                            name: 'File1',
-                            id: 'file1',
-                        },
-                        {
-                            type: 'FOLDER' as ItemType,
-                            path: ['root'],
-                            name: 'Folder3',
-                            id: 'folder3',
-                        },
-                        {
-                            type: 'FOLDER' as ItemType,
-                            path: ['root'],
-                            name: 'Folder4',
-                            id: 'folder4',
-                        },
-                        {
-                            type: 'FILE' as ItemType,
-                            path: ['root'],
-                            name: 'File1',
-                            id: 'file1',
-                        },
-                    ],
-                },
-                total_count: 5,
-                // TODO: page cursors
-                created: new Date().toISOString(),
-                modified: new Date().toISOString(),
-            },
-            links: {
-                self: `${addonServiceAPIUrl}addon-operation-invocations/1234`,
-            },
-            relationships: {
-                // TODO: Get relationship id and hrefs from the request
-                operation: {
-                    links: {
-                        related: {
-                            href: `${addonServiceAPIUrl}addon-operations/1234`,
-                            meta: {},
-                        },
-                    },
-                    data: {
-                        id: '1234',
-                        type: 'addon-operations',
-                    },
-                },
-                by_user: {
-                    links: {
-                        related: {
-                            href: `${addonServiceAPIUrl}user-references/1234`,
-                            meta: {},
-                        },
-                    },
-                    data: {
-                        id: '1234',
-                        type: 'user-references',
-                    },
-                },
-                thru_addon: {
-                    links: {
-                        related: {
-                            href: `${addonServiceAPIUrl}configured-storage-addons/1234`,
-                            meta: {},
-                        },
-                    },
-                    data: {
-                        id: '1234',
-                        type: 'configured-storage-addons',
-                    },
-                },
-            },
-        },
+export function createAddonOperationInvocation(this: HandlerContext, schema: Schema) {
+    const attrs = this.normalizedRequestAttrs(
+        'addon-operation-invocation',
+    ) as NormalizedRequestAttrs<MirageAddonOperationInvocation>;
+    const invocation = schema.addonOperationInvocations.create(attrs) as ModelInstance<MirageAddonOperationInvocation>;
+    const { folderId } = invocation.operationKwargs;
+    const items = '12345'.split('').map(i => ({
+        itemId: i,
+        itemName: `Folder${i}`,
+        itemType: ItemType.Folder,
+        itemPath: folderId,
+    }));
+    invocation.update({
+        invocationStatus: InvocationStatus.Success,
+        created: new Date(),
+        modified: new Date(),
+        operationResult: { items },
     });
+    return invocation;
 }
 
 export function createAuthorizedStorageAccount(this: HandlerContext, schema: Schema) {


### PR DESCRIPTION
-   Ticket: [ENG-5624]
-   Feature flag: `gravy_waffle`

## Purpose
- Add mirage support for addon-operations

## Summary of Changes
- Add mirage endpoint for POSTing addon-operation-invocation

## Screenshot(s)
- NA

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-5624]: https://openscience.atlassian.net/browse/ENG-5624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ