### PR TITLE
[ENG-5145] converge with gravyvalet backend

### DIFF
--- a/app/adapters/addon-service.ts
+++ b/app/adapters/addon-service.ts
@@ -9,4 +9,10 @@ export const addonServiceAPIUrl = `${addonServiceUrl}${addonServiceNamespace}/`;
 export default class AddonServiceAdapter extends JSONAPIAdapter {
     host = addonServiceUrl.replace(/\/$/, ''); // Remove trailing slash to avoid // in URLs
     namespace = addonServiceNamespace;
+
+    ajaxOptions(url: string, type: string, options?: any): object {
+        const _ajaxopts: any = super.ajaxOptions(url, type, options);
+        _ajaxopts.credentials = 'include';
+        return _ajaxopts;
+    }
 }

--- a/app/guid-node/addons/index/template.hbs
+++ b/app/guid-node/addons/index/template.hbs
@@ -20,8 +20,8 @@
         {{#if manager.selectedProvider}}
             {{#let manager.selectedProvider as |provider|}}
                 <div
-                    data-test-addon={{provider.provider.name}}
-                    data-analytics-scope='Addon - {{provider.provider.name}}'
+                    data-test-addon={{provider.provider.displayName}}
+                    data-analytics-scope='Addon - {{provider.provider.displayName}}'
                 >
                     {{#if (eq manager.pageMode 'terms')}}
                         <AddonsService::TermsOfService
@@ -206,7 +206,7 @@
                             as |dialog|
                         >
                             <dialog.heading>
-                                {{t 'addons.list.disconnect'}} {{provider.provider.name}}
+                                {{t 'addons.list.disconnect'}} {{provider.provider.displayName}}
                             </dialog.heading>
                             <dialog.main>
                                 {{t 'addons.list.confirm-remove-connected-location'}}

--- a/app/models/addon-operation-invocation.ts
+++ b/app/models/addon-operation-invocation.ts
@@ -2,20 +2,20 @@ import Model, { AsyncBelongsTo, attr, belongsTo } from '@ember-data/model';
 
 import UserReferenceModel from 'ember-osf-web/models/user-reference';
 import ConfiguredAddonModel from 'ember-osf-web/models/configured-addon';
+import AuthorizedAccountModel from 'ember-osf-web/models/authorized-account';
 import { ConnectedOperationNames } from 'ember-osf-web/models/configured-storage-addon';
 
 export enum InvocationStatus {
-     // TODO: are these right?
-    Success = 'SUCCESS',
-    Failure = 'FAILURE',
-    Pending = 'PENDING',
+    STARTING = 'STARTING',
+    GOING = 'GOING',
+    SUCCESS = 'SUCCESS',
+    ERROR = 'ERROR',
 }
 export enum ItemType {
     Folder = 'FOLDER',
     File = 'FILE',
 }
 
-export type OperationName = 'get_root_items' | 'get_child_items';
 export interface OperationResult{
     items: Item[];
     cursor?: string; // TODO: name??
@@ -40,6 +40,9 @@ export default class AddonOperationInvocationModel extends Model {
 
     @belongsTo('configured-addon', { inverse: null, polymorphic: true })
     thruAddon?: AsyncBelongsTo<ConfiguredAddonModel> | ConfiguredAddonModel;
+
+    @belongsTo('authorized-account', { inverse: null, polymorphic: true })
+    thruAccount?: AsyncBelongsTo<AuthorizedAccountModel> | AuthorizedAccountModel;
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/models/authorized-account.ts
+++ b/app/models/authorized-account.ts
@@ -1,18 +1,18 @@
 import Model, { attr } from '@ember-data/model';
 
 export interface AddonCredentialFields {
-    url: string;
-    username: string;
-    password: string;
-    token: string;
-    accessKey: string;
-    secretKey: string;
-    repo: string;
+    url?: string;
+    username?: string;
+    password?: string;
+    token?: string;
+    accessKey?: string;
+    secretKey?: string;
+    repo?: string;
 }
 
 export default class AuthorizedAccountModel extends Model {
     @attr('fixstring') displayName!: string;
-    @attr('fixstringarray') scopes!: string[];
+    @attr('fixstringarray') authorizedCapabilities!: string[];
     @attr('object') credentials?: AddonCredentialFields; // write-only
     @attr('boolean') initiateOauth!: boolean; // write-only
     @attr('fixstring') readonly authUrl!: string; // Only returned when POSTing to /authorized-xyz-accounts

--- a/app/models/authorized-citation-account.ts
+++ b/app/models/authorized-citation-account.ts
@@ -6,7 +6,7 @@ import UserReferenceModel from './user-reference';
 
 export default class AuthorizedCitationAccountModel extends AuthorizedAccountModel {
     @belongsTo('user-reference', { inverse: 'authorizedCitationAccounts' })
-    configuringUser!: AsyncBelongsTo<UserReferenceModel> & UserReferenceModel;
+    accountOwner!: AsyncBelongsTo<UserReferenceModel> & UserReferenceModel;
 
     @belongsTo('external-citation-service')
     citationService!: AsyncBelongsTo<ExternalCitationServiceModel> & ExternalCitationServiceModel;

--- a/app/models/authorized-computing-account.ts
+++ b/app/models/authorized-computing-account.ts
@@ -6,7 +6,7 @@ import UserReferenceModel from './user-reference';
 
 export default class AuthorizedComputingAccount extends AuthorizedAccountModel {
     @belongsTo('user-reference', { inverse: 'authorizedComputingAccounts' })
-    configuringUser!: AsyncBelongsTo<UserReferenceModel> & UserReferenceModel;
+    accountOwner!: AsyncBelongsTo<UserReferenceModel> & UserReferenceModel;
 
     @belongsTo('external-computing-service')
     computingService!: AsyncBelongsTo<ExternalComputingService> & ExternalComputingService;

--- a/app/models/authorized-storage-account.ts
+++ b/app/models/authorized-storage-account.ts
@@ -8,10 +8,10 @@ export default class AuthorizedStorageAccountModel extends AuthorizedAccountMode
     @attr('fixstring') apiBaseUrl!: string; // Only applicable when ExternalStorageService.configurableApiRoot === true
 
     @belongsTo('user-reference', { inverse: 'authorizedStorageAccounts' })
-    configuringUser!: AsyncBelongsTo<UserReferenceModel> & UserReferenceModel;
+    readonly accountOwner!: AsyncBelongsTo<UserReferenceModel> & UserReferenceModel;
 
     @belongsTo('external-storage-service')
-    storageProvider!: AsyncBelongsTo<ExternalStorageServiceModel> & ExternalStorageServiceModel;
+    externalStorageService!: AsyncBelongsTo<ExternalStorageServiceModel> & ExternalStorageServiceModel;
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/models/configured-addon.ts
+++ b/app/models/configured-addon.ts
@@ -4,7 +4,6 @@ import ResourceReferenceModel from './resource-reference';
 import UserReferenceModel from './user-reference';
 
 export default class ConfiguredAddonModel extends Model {
-    @attr('string') name!: string;
     @attr('string') displayName!: string;
     @attr('fixstring') externalUserId!: string;
     @attr('fixstring') externalUserDisplayName!: string;

--- a/app/models/configured-storage-addon.ts
+++ b/app/models/configured-storage-addon.ts
@@ -16,8 +16,8 @@ export enum ConnectedOperationNames {
     DownloadAsZip = 'download_as_zip',
     CopyInto = 'copy_into',
     HasRevisions = 'has_revisions',
-    GetRootItems = 'get_root_items',
-    GetChildItems = 'get_child_items',
+    ListRootItems = 'list_root_items',
+    ListChildItems = 'list_child_items',
 }
 
 export default class ConfiguredStorageAddonModel extends ConfiguredAddonModel {
@@ -29,7 +29,7 @@ export default class ConfiguredStorageAddonModel extends ConfiguredAddonModel {
     @attr('fixstring') rootFolder!: string;
 
     @belongsTo('external-storage-service', { inverse: null })
-    storageProvider!: AsyncBelongsTo<ExternalStorageServiceModel> & ExternalStorageServiceModel;
+    externalStorageService!: AsyncBelongsTo<ExternalStorageServiceModel> & ExternalStorageServiceModel;
 
     @belongsTo('authorized-storage-account')
     baseAccount!: AsyncBelongsTo<AuthorizedStorageAccountModel> & AuthorizedStorageAccountModel;
@@ -39,10 +39,10 @@ export default class ConfiguredStorageAddonModel extends ConfiguredAddonModel {
     async getFolderItems(this: ConfiguredStorageAddonModel, folderId?: string) {
         const newInvocation = this.store.createRecord('addon-operation-invocation', {
 
-            operationName: folderId ? ConnectedOperationNames.GetChildItems : ConnectedOperationNames.GetRootItems,
+            operationName: folderId ? ConnectedOperationNames.ListChildItems : ConnectedOperationNames.ListRootItems,
             operationKwargs: {
-                folderId,
-                type: ItemType.Folder,
+                itemId: folderId,
+                itemType: ItemType.Folder,
             },
             thruAddon: this,
             byUser: await this.accountOwner,

--- a/app/models/external-service.ts
+++ b/app/models/external-service.ts
@@ -26,7 +26,7 @@ export enum TermsOfServiceCapabilities {
 }
 
 export default class ExternalServiceModel extends Model {
-    @attr('fixstring') name!: string;
+    @attr('fixstring') displayName!: string;
     @attr('string') iconUrl!: string;
     @attr('string') credentialsFormat!: CredentialsFormat;
     @attr('array') termsOfService!: TermsOfServiceCapabilities[];

--- a/app/models/user-reference.ts
+++ b/app/models/user-reference.ts
@@ -1,4 +1,4 @@
-import Model, { AsyncHasMany, hasMany } from '@ember-data/model';
+import Model, { AsyncHasMany, attr, hasMany } from '@ember-data/model';
 
 import AuthorizedStorageAccountModel from './authorized-storage-account';
 import AuthorizedCitationAccount from './authorized-citation-account';
@@ -6,14 +6,16 @@ import AuthorizedComputingAccount from './authorized-computing-account';
 import ResourceReferenceModel from './resource-reference';
 
 export default class UserReferenceModel extends Model {
-    @hasMany('authorized-storage-account', { inverse: 'configuringUser' })
+    @attr('fixstring') userUri!: string;
+
+    @hasMany('authorized-storage-account', { inverse: 'accountOwner' })
     authorizedStorageAccounts!: AsyncHasMany<AuthorizedStorageAccountModel> & AuthorizedStorageAccountModel[];
 
-    @hasMany('authorized-citation-account', { inverse: 'configuringUser' })
+    @hasMany('authorized-citation-account', { inverse: 'accountOwner' })
     authorizedCitationAccounts!: AsyncHasMany<AuthorizedCitationAccount> &
         AuthorizedCitationAccount[];
 
-    @hasMany('authorized-computing-account', { inverse: 'configuringUser' })
+    @hasMany('authorized-computing-account', { inverse: 'accountOwner' })
     authorizedComputingAccounts!: AsyncHasMany<AuthorizedComputingAccount>
         & AuthorizedComputingAccount[];
 

--- a/app/settings/addons/template.hbs
+++ b/app/settings/addons/template.hbs
@@ -8,7 +8,7 @@
             <LoadingIndicator @dark={{true}} />
         {{else}}
             {{#if manager.selectedProvider}}
-                <div data-analytics-scope='{{manager.selectedProvider.name}}'>
+                <div data-analytics-scope='{{manager.selectedProvider.displayName}}'>
                     <Button
                         data-test-cancel-setup
                         data-analytics-name='Cancel Setup'
@@ -21,7 +21,7 @@
                     {{#if (eq manager.pageMode 'terms')}}
                         <div data-analytics-scope='Terms'>
                             <h3>
-                                {{t 'addons.terms.heading' providerName=manager.selectedProvider.provider.name}}
+                                {{t 'addons.terms.heading' providerName=manager.selectedProvider.provider.displayName}}
                             </h3>
                             <AddonsService::TermsOfService
                                 @provider={{manager.selectedProvider.provider}}
@@ -112,13 +112,13 @@
                             <ul local-class='addons-card-wrapper'>
                                 {{#each manager.filteredAddonProviders as |provider|}}
                                     <li
-                                        data-test-provider={{provider.name}}
+                                        data-test-provider={{provider.displayName}}
                                         local-class='provider-list-item'
                                     >
-                                        {{provider.name}}
+                                        {{provider.displayName}}
                                         <span>
                                             <Button
-                                                data-analytics-name='Connect Addon Button {{provider.name}}'
+                                                data-analytics-name='Connect Addon Button {{provider.displayName}}'
                                                 @type='create'
                                                 {{on 'click' (fn manager.connectNewProviderAccount provider)}}
                                             >

--- a/app/utils/get-href.ts
+++ b/app/utils/get-href.ts
@@ -3,5 +3,5 @@ import { Link } from 'jsonapi-typescript';
 import { RelatedLink } from 'osf-api';
 
 export default function getHref(link: Link | RelatedLink) {
-    return typeof link === 'string' ? link : link.href;
+    return (typeof link === 'string' ? link : link.href).toString();
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -82,7 +82,7 @@ const {
     OSF_MFR_URL: mfrUrl = 'http://localhost:4200',
     OSF_FILE_URL: waterbutlerUrl = 'http://localhost:7777/',
     // TODO: where shold this actually go?
-    ADDON_SERVICE_URL: addonServiceUrl = 'http://localhost:7979/',
+    ADDON_SERVICE_URL: addonServiceUrl = 'http://localhost:8004/',
     OSF_HELP_URL: helpUrl = 'http://localhost:4200/help',
     OSF_AUTHENTICATOR: osfAuthenticator = 'osf-cookie',
     PLAUDIT_WIDGET_URL: plauditWidgetUrl = 'https://osf-review.plaudit.pub/embed/endorsements.js',

--- a/lib/osf-components/addon/components/addon-card/template.hbs
+++ b/lib/osf-components/addon/components/addon-card/template.hbs
@@ -1,19 +1,19 @@
 <div
     local-class='card-wrapper'
-    data-test-addon-card={{@addon.provider.name}}
-    data-analytics-scope={{concat 'Addon card' @addon.provider.name}}
+    data-test-addon-card={{@addon.provider.displayName}}
+    data-analytics-scope={{concat 'Addon card' @addon.provider.displayName}}
 >
     <img
         data-test-addon-card-logo
         src={{this.assetLogo}}
-        alt={{t 'osf-components.addon-card.provider-logo-alt' provider=@addon.provider.name}}
+        alt={{t 'osf-components.addon-card.provider-logo-alt' provider=@addon.provider.displayName}}
         local-class='addon-card-logo'
     />
     <div
         data-test-addon-card-title
         local-class='provider-name'
     >
-        {{@addon.provider.name}}
+        {{@addon.provider.displayName}}
     </div>
     
     <div local-class='buttons-wrapper'>

--- a/lib/osf-components/addon/components/addons-service/manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/manager/component.ts
@@ -88,15 +88,7 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
     @tracked selectedProvider?: Provider;
     @tracked selectedConfiguration?: AllConfiguredAddonTypes;
     @tracked selectedAccount?: AllAuthorizedAccountTypes;
-    @tracked credentialsObject: AddonCredentialFields = {
-        url: '',
-        username: '',
-        password: '',
-        token: '',
-        accessKey: '',
-        secretKey: '',
-        repo: '',
-    };
+    @tracked credentialsObject: AddonCredentialFields = {};
     @tracked connectAccountError = false;
     @tracked displayName = '';
 
@@ -115,7 +107,7 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
         const activeFilterObject = this.filterTypeMapper[this.activeFilterType];
         const possibleProviders = activeFilterObject.list;
         const textFilteredAddons = possibleProviders.filter(
-            (provider: any) => provider.provider.name.toLowerCase().includes(this.filterText.toLowerCase()),
+            (provider: any) => provider.provider.displayName.toLowerCase().includes(this.filterText.toLowerCase()),
         );
 
         const configuredProviders = textFilteredAddons.filter((provider: Provider) => provider.isConfigured);
@@ -127,7 +119,7 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
         const activeFilterObject = this.filterTypeMapper[this.activeFilterType];
         const possibleProviders = activeFilterObject.list;
         const textFilteredAddons = possibleProviders.filter(
-            (provider: any) => provider.provider.name.toLowerCase().includes(this.filterText.toLowerCase()),
+            (provider: any) => provider.provider.displayName.toLowerCase().includes(this.filterText.toLowerCase()),
         );
 
         return textFilteredAddons;
@@ -304,7 +296,7 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
     @waitFor
     async getServiceNode() {
         const references = await this.store.query('resource-reference', {
-            filter: {'resource-uri': encodeURI(this.node.links.iri as string)},
+            filter: {resource_uri: this.node.links.iri},
         });
         if(references) {
             this.addonServiceNode = references.firstObject;
@@ -318,7 +310,7 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
 
         if (this.addonServiceNode) {
             const configuredAddons = await this.store.query('configured-storage-addon', {
-                'filter[authorized-resource-uri]': encodeURI(this.node.links.iri as string),
+                'filter[authorized_resource_uri]': encodeURI(this.node.links.iri as string),
                 'page[size]': 100,
             });
             activeFilterObject.configuredAddons = A(configuredAddons.toArray());
@@ -337,7 +329,7 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
 
         if (this.addonServiceNode) {
             const configuredAddons = await this.store.query('configured-computing-addon', {
-                'filter[authorized-resource-uri]': encodeURI(this.node.links.iri as string),
+                'filter[authorized_resource_uri]': encodeURI(this.node.links.iri as string),
                 'page[size]': 100,
             });
             activeFilterObject.configuredAddons = A(configuredAddons.toArray());
@@ -356,7 +348,7 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
 
         if (this.addonServiceNode) {
             const configuredAddons = await this.store.query('configured-citation-addon', {
-                'filter[authorized-resource-uri]': encodeURI(this.node.links.iri as string),
+                'filter[authorized_resource_uri]': encodeURI(this.node.links.iri as string),
                 'page[size]': 100,
             });
             activeFilterObject.configuredAddons = A(configuredAddons.toArray());

--- a/lib/osf-components/addon/components/addons-service/manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/manager/component.ts
@@ -309,10 +309,7 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
         const activeFilterObject = this.filterTypeMapper[FilterTypes.STORAGE];
 
         if (this.addonServiceNode) {
-            const configuredAddons = await this.store.query('configured-storage-addon', {
-                'filter[authorized_resource_uri]': encodeURI(this.node.links.iri as string),
-                'page[size]': 100,
-            });
+            const configuredAddons = await this.addonServiceNode.configuredStorageAddons;
             activeFilterObject.configuredAddons = A(configuredAddons.toArray());
         }
 
@@ -328,10 +325,7 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
         const activeFilterObject = this.filterTypeMapper[FilterTypes.CLOUD_COMPUTING];
 
         if (this.addonServiceNode) {
-            const configuredAddons = await this.store.query('configured-computing-addon', {
-                'filter[authorized_resource_uri]': encodeURI(this.node.links.iri as string),
-                'page[size]': 100,
-            });
+            const configuredAddons = await this.addonServiceNode.configuredComputingAddons;
             activeFilterObject.configuredAddons = A(configuredAddons.toArray());
         }
 
@@ -347,10 +341,7 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
         const activeFilterObject = this.filterTypeMapper[FilterTypes.CITATION_MANAGER];
 
         if (this.addonServiceNode) {
-            const configuredAddons = await this.store.query('configured-citation-addon', {
-                'filter[authorized_resource_uri]': encodeURI(this.node.links.iri as string),
-                'page[size]': 100,
-            });
+            const configuredAddons = await this.addonServiceNode.configuredCitationAddons;
             activeFilterObject.configuredAddons = A(configuredAddons.toArray());
         }
 
@@ -361,7 +352,7 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
     }
 
     providerSorter(a: Provider, b: Provider) {
-        return a.provider.name.localeCompare(b.provider.name);
+        return a.provider.displayName.localeCompare(b.provider.displayName);
     }
 
     get projectEnabledAddons(): ConfiguredStorageAddonModel[] {
@@ -369,7 +360,7 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
     }
 
     get headingText() {
-        const providerName = this.selectedProvider?.provider.name;
+        const providerName = this.selectedProvider?.provider.displayName;
         let heading;
         switch (this.pageMode) {
         case PageMode.TERMS:

--- a/lib/osf-components/addon/components/addons-service/terms-of-service/component.ts
+++ b/lib/osf-components/addon/components/addons-service/terms-of-service/component.ts
@@ -135,15 +135,15 @@ export default class UserAddonManagerComponent extends Component<Args> {
 
     get sections() {
         const providerCapabilities = this.args.provider.termsOfService;
-        const providerName = this.args.provider.name;
+        const providerName = this.args.provider.displayName;
         return this.applicableCapabilities.map((capability: CapabilityCategory) => {
             const textTranslationChoices = capabilitiesToTextKeyMap[this.baseTranslationKey][capability];
             let textTranslationKey = textTranslationChoices.false;
             let localClass='danger-bg';
-            if (providerCapabilities.includes(capability)) {
+            if (providerCapabilities?.includes(capability)) {
                 textTranslationKey = textTranslationChoices.true;
                 localClass = 'success-bg';
-            } else if (providerCapabilities.includes((capability + '_partial' as TermsOfServiceCapabilities))) {
+            } else if (providerCapabilities?.includes((capability + '_partial' as TermsOfServiceCapabilities))) {
                 textTranslationKey = textTranslationChoices.partial;
                 localClass = 'warning-bg';
             }

--- a/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
@@ -23,6 +23,7 @@ import ExternalStorageServiceModel from 'ember-osf-web/models/external-storage-s
 import ExternalComputingServiceModel from 'ember-osf-web/models/external-computing-service';
 import ExternalCitationServiceModel from 'ember-osf-web/models/external-citation-service';
 import captureException, { getApiErrorMessage } from 'ember-osf-web/utils/capture-exception';
+import getHref from 'ember-osf-web/utils/get-href';
 
 import { FilterTypes } from '../manager/component';
 
@@ -204,10 +205,13 @@ export default class UserAddonManagerComponent extends Component<Args> {
     @waitFor
     async getUserReference() {
         const { user } = this;
-        const userReferences = await this.store.query('user-reference', {
-            filter: {user_uri: user.links.iri?.toString()},
-        });
-        this.userReference = userReferences.firstObject;
+        const _iri = user.links.iri;
+        if (_iri) {
+            const userReferences = await this.store.query('user-reference', {
+                filter: {user_uri: getHref(_iri)},
+            });
+            this.userReference = userReferences.firstObject;
+        }
     }
 
     @task

--- a/lib/osf-components/addon/components/file-provider-menu/component.ts
+++ b/lib/osf-components/addon/components/file-provider-menu/component.ts
@@ -33,7 +33,7 @@ export default class FileProviderList extends Component<InputArgs> {
     @waitFor
     async configuredStorageProviders() {
         const _ref = await this.store.query('resource-reference', {
-            filter: {resource_uri: encodeURI(this.args.node.links.iri as string)},
+            filter: {resource_uri: this.args.node.links.iri},
         });
 
         if (_ref.toArray().length > 0) {

--- a/lib/osf-components/addon/components/file-provider-menu/component.ts
+++ b/lib/osf-components/addon/components/file-provider-menu/component.ts
@@ -2,13 +2,13 @@ import { inject as service } from '@ember/service';
 import { waitFor } from '@ember/test-waiters';
 import Store from '@ember-data/store';
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 
 
 import ConfiguredStorageAddonModel from 'ember-osf-web/models/configured-storage-addon';
 import NodeModel from 'ember-osf-web/models/node';
+import getHref from 'ember-osf-web/utils/get-href';
 import Features from 'ember-feature-flags';
 
 interface InputArgs {
@@ -19,25 +19,27 @@ export default class FileProviderList extends Component<InputArgs> {
     @service store!: Store;
     @service features!: Features;
 
-    @tracked configuredStorageAddons: ConfiguredStorageAddonModel[] = [];
-
-
     constructor(owner: any, args: InputArgs) {
         super(owner, args);
-        if (args.node && this.features.isEnabled('gravy_waffle')) {
-            taskFor(this.configuredStorageProviders).perform();
+        if (this.features.isEnabled('gravy_waffle')) {
+            taskFor(this.loadConfiguredAddons).perform(this._connectedResourceIri);
         }
+    }
+
+    get configuredStorageAddons() {
+        return taskFor(this.loadConfiguredAddons).lastSuccessful?.value || [];
+    }
+
+    get _connectedResourceIri(): string {
+        return getHref(this.args.node.links.iri!);
     }
 
     @task
     @waitFor
-    async configuredStorageProviders() {
-        const _ref = await this.store.query('resource-reference', {
-            filter: {resource_uri: this.args.node.links.iri},
+    async loadConfiguredAddons(resourceIri: string): Promise<ConfiguredStorageAddonModel[]> {
+        const _connectedResources = await this.store.query('resource-reference', {
+            filter: {resource_uri: resourceIri},
         });
-
-        if (_ref.toArray().length > 0) {
-            this.configuredStorageAddons = await _ref.toArray()[0].configuredStorageAddons;
-        }
+        return await _connectedResources.firstObject?.hasMany('configuredStorageAddons').load();
     }
 }

--- a/lib/osf-components/addon/components/file-provider-menu/template.hbs
+++ b/lib/osf-components/addon/components/file-provider-menu/template.hbs
@@ -29,8 +29,8 @@
         {{#each this.configuredStorageAddons as |provider|}}
             <div local-class='FileProvider'>
                 <OsfLink
-                    data-test-files-provider-link={{provider.name}}
-                    data-analytics-name={{concat 'Files - ' provider.name}} 
+                    data-test-files-provider-link={{provider.id}}
+                    data-analytics-name={{concat 'Files - ' provider.id}}
                     @route='guid-node.files.provider'
                     @models={{array @node.id provider.id}}
                 >

--- a/lib/osf-components/addon/components/storage-provider-manager/storage-manager/component.ts
+++ b/lib/osf-components/addon/components/storage-provider-manager/storage-manager/component.ts
@@ -97,7 +97,7 @@ export default class StorageManager extends Component<Args> {
     @service toast!: Toast;
     @service features!: Features;
 
-    @tracked storageProvider?: FileProviderModel;
+    @tracked externalStorageService?: FileProviderModel;
     @tracked folderLineage: Array<File | ProviderFile | ServiceProviderFile> = [];
     @tracked displayItems: File[] = [];
     @tracked filter = '';
@@ -146,16 +146,16 @@ export default class StorageManager extends Component<Args> {
     @waitFor
     async getRootFolder() {
         if (this.args.provider) {
-            this.storageProvider = this.args.provider;
+            this.externalStorageService = this.args.provider;
             let providerFile;
-            if(this.features.isEnabled('gravy_waffle') && this.storageProvider.name !== 'osfstorage') {
+            if(this.features.isEnabled('gravy_waffle') && this.externalStorageService.name !== 'osfstorage') {
                 providerFile = getServiceProviderFile(
                     this.currentUser,
-                    this.storageProvider,
+                    this.externalStorageService,
                     this.args.configuredStorageAddon,
                 );
             } else {
-                providerFile = getStorageProviderFile(this.currentUser, this.storageProvider);
+                providerFile = getStorageProviderFile(this.currentUser, this.externalStorageService);
             }
             if (!providerFile) {
                 // This should only be hit in development when we haven't set up a provider properly.

--- a/lib/osf-components/addon/components/storage-provider-manager/storage-manager/component.ts
+++ b/lib/osf-components/addon/components/storage-provider-manager/storage-manager/component.ts
@@ -108,7 +108,7 @@ export default class StorageManager extends Component<Args> {
     @tracked selectedFiles: File[] = [];
 
     get targetNode() {
-        return this.args.provider.target.content;
+        return this.args.provider?.target.content;
     }
     get rootFolder() {
         return this.folderLineage[0];

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -532,19 +532,19 @@ export default function(this: Server) {
     this.resource('external-citation-services', { only: ['index', 'show'] });
     this.resource('external-computing-services', { only: ['index', 'show'] });
     this.resource('user-references', { only: ['index', 'show'] });
-    this.get('/user-references/:userGuid/authorized-storage-accounts/',
+    this.get('/user-references/:userGuid/authorized_storage_accounts/',
         addons.userReferenceAuthorizedStorageAccountList);
-    this.get('/user-references/:userGuid/authorized-citation-accounts/',
+    this.get('/user-references/:userGuid/authorized_citation_accounts/',
         addons.userAuthorizedCitationAccountList);
-    this.get('/user-references/:userGuid/authorized-computing-accounts/',
+    this.get('/user-references/:userGuid/authorized_computing_accounts/',
         addons.userAuthorizedComputingAccountList);
     this.get('/resource-references/', addons.resourceReferencesList);
     this.resource('resource-references', { only: ['index', 'show'] });
-    this.get('/resource-references/:nodeGuid/configured-storage-addons',
+    this.get('/resource-references/:nodeGuid/configured_storage_addons',
         addons.resourceReferenceConfiguredStorageAddonList);
-    this.get('/resource-references/:nodeGuid/configured-citation-addons',
+    this.get('/resource-references/:nodeGuid/configured_citation_addons',
         addons.resourceConfiguredCitationAddonList);
-    this.get('/resource-references/:nodeGuid/configured-computing-addons',
+    this.get('/resource-references/:nodeGuid/configured_computing_addons',
         addons.resourceConfiguredComputingAddonList);
     this.resource('authorized-storage-accounts', { except: ['index', 'update'] });
     this.patch('authorized-storage-accounts/:id', addons.updateAuthorizedStorageAccount);

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -531,7 +531,7 @@ export default function(this: Server) {
     this.resource('external-storage-services', { only: ['index', 'show'] });
     this.resource('external-citation-services', { only: ['index', 'show'] });
     this.resource('external-computing-services', { only: ['index', 'show'] });
-    this.resource('user-references', { only: ['show'] });
+    this.resource('user-references', { only: ['index', 'show'] });
     this.get('/user-references/:userGuid/authorized-storage-accounts/',
         addons.userReferenceAuthorizedStorageAccountList);
     this.get('/user-references/:userGuid/authorized-citation-accounts/',
@@ -539,7 +539,7 @@ export default function(this: Server) {
     this.get('/user-references/:userGuid/authorized-computing-accounts/',
         addons.userAuthorizedComputingAccountList);
     this.get('/resource-references/', addons.resourceReferencesList);
-    this.resource('resource-references', { only: ['show'] });
+    this.resource('resource-references', { only: ['index', 'show'] });
     this.get('/resource-references/:nodeGuid/configured-storage-addons',
         addons.resourceReferenceConfiguredStorageAddonList);
     this.get('/resource-references/:nodeGuid/configured-citation-addons',

--- a/mirage/fixtures/external-citation-service.ts
+++ b/mirage/fixtures/external-citation-service.ts
@@ -3,7 +3,7 @@ import { CredentialsFormat, TermsOfServiceCapabilities } from 'ember-osf-web/mod
 export default [
     {
         id: 'mendeley',
-        name: 'Mendeley',
+        displayName: 'Mendeley',
         credentialsFormat: CredentialsFormat.OAUTH2,
         termsOfService: [
             TermsOfServiceCapabilities.FORKING_PARTIAL,
@@ -13,7 +13,7 @@ export default [
     },
     {
         id: 'zotero',
-        name: 'Zotero',
+        displayName: 'Zotero',
         credentialsFormat: CredentialsFormat.OAUTH,
         termsOfService: [
             TermsOfServiceCapabilities.FORKING_PARTIAL,

--- a/mirage/fixtures/external-computing-service.ts
+++ b/mirage/fixtures/external-computing-service.ts
@@ -3,7 +3,7 @@ import { CredentialsFormat, TermsOfServiceCapabilities } from 'ember-osf-web/mod
 export default [
     {
         id: 'boa',
-        name: 'Boa',
+        displayName: 'Boa',
         credentialsFormat: CredentialsFormat.USERNAME_PASSWORD,
         termsOfService: [
             TermsOfServiceCapabilities.ADD_UPDATE_FILES_PARTIAL,

--- a/mirage/fixtures/external-storage-services.ts
+++ b/mirage/fixtures/external-storage-services.ts
@@ -2,7 +2,7 @@ import { CredentialsFormat, TermsOfServiceCapabilities } from 'ember-osf-web/mod
 export default [
     {
         id: 'box',
-        name: 'Box',
+        displayName: 'Box',
         credentialsFormat: CredentialsFormat.OAUTH2,
         termsOfService: [
             TermsOfServiceCapabilities.ADD_UPDATE_FILES,
@@ -20,7 +20,7 @@ export default [
     },
     {
         id: 'bitbucket',
-        name: 'Bitbucket',
+        displayName: 'Bitbucket',
         credentialsFormat: CredentialsFormat.OAUTH2,
         termsOfService: [
             TermsOfServiceCapabilities.FORKING,
@@ -36,7 +36,7 @@ export default [
     },
     {
         id: 'dataverse',
-        name: 'Dataverse',
+        displayName: 'Dataverse',
         credentialsFormat: CredentialsFormat.REPO_TOKEN,
         termsOfService: [
             TermsOfServiceCapabilities.ADD_UPDATE_FILES,
@@ -53,7 +53,7 @@ export default [
     },
     {
         id: 'dropbox',
-        name: 'Dropbox',
+        displayName: 'Dropbox',
         credentialsFormat: CredentialsFormat.OAUTH2,
         termsOfService: [
             TermsOfServiceCapabilities.ADD_UPDATE_FILES,
@@ -71,7 +71,7 @@ export default [
     },
     {
         id: 'figshare',
-        name: 'figshare',
+        displayName: 'figshare',
         credentialsFormat: CredentialsFormat.OAUTH2,
         termsOfService: [
             TermsOfServiceCapabilities.ADD_UPDATE_FILES_PARTIAL,
@@ -88,7 +88,7 @@ export default [
     },
     {
         id: 'gitlab',
-        name: 'GitLab',
+        displayName: 'GitLab',
         credentialsFormat: CredentialsFormat.REPO_TOKEN,
         termsOfService: [
             TermsOfServiceCapabilities.FORKING,
@@ -103,7 +103,7 @@ export default [
     },
     {
         id: 'onedrive',
-        name: 'OneDrive',
+        displayName: 'OneDrive',
         credentialsFormat: CredentialsFormat.OAUTH2,
         termsOfService: [
             TermsOfServiceCapabilities.ADD_UPDATE_FILES,
@@ -121,7 +121,7 @@ export default [
     },
     {
         id: 'owncloud',
-        name: 'ownCloud',
+        displayName: 'ownCloud',
         credentialsFormat: CredentialsFormat.URL_USERNAME_PASSWORD,
         termsOfService: [
             TermsOfServiceCapabilities.ADD_UPDATE_FILES,
@@ -139,7 +139,7 @@ export default [
     },
     {
         id: 's3',
-        name: 'Amazon S3',
+        displayName: 'Amazon S3',
         credentialsFormat: CredentialsFormat.ACCESS_SECRET_KEYS,
         termsOfService: [
             TermsOfServiceCapabilities.ADD_UPDATE_FILES,

--- a/mirage/scenarios/dashboard.ts
+++ b/mirage/scenarios/dashboard.ts
@@ -102,32 +102,32 @@ export function dashboardScenario(server: Server, currentUser: ModelInstance<Use
     const boxAccount = server.create('authorized-storage-account', {
         displayName: 'My Box Account',
         scopes: ['write'], // TODO: This should be a from an enum?
-        storageProvider: boxAddon,
-        configuringUser: addonUser,
+        externalStorageService: boxAddon,
+        accountOwner: addonUser,
         credentialsAvailable: true,
     });
 
     server.create('authorized-storage-account', {
         displayName: 'My Dropbox Account',
         scopes: ['write'], // TODO: This should be a from an enum?
-        storageProvider: dropboxAddon,
-        configuringUser: addonUser,
+        externalStorageService: dropboxAddon,
+        accountOwner: addonUser,
         credentialsAvailable: true,
     });
     server.create('authorized-storage-account', {
         id: 'dropbox2',
         displayName: 'My Secret Dropbox Account',
         scopes: ['write'], // TODO: This should be a from an enum?
-        storageProvider: dropboxAddon,
-        configuringUser: addonUser,
+        externalStorageService: dropboxAddon,
+        accountOwner: addonUser,
         credentialsAvailable: false,
         authUrl: 'http://fake.com',
     });
     server.create('authorized-storage-account', {
         displayName: 'My AmazonS3 Account',
         scopes: ['write'], // TODO: This should be a from an enum?
-        storageProvider: s3Addon,
-        configuringUser: addonUser,
+        externalStorageService: s3Addon,
+        accountOwner: addonUser,
         credentialsAvailable: false,
     });
 
@@ -137,7 +137,7 @@ export function dashboardScenario(server: Server, currentUser: ModelInstance<Use
         displayName: 'Boxed Data',
         rootFolder: '/woot/',
         authorizedResourceUri: 'http://localhost:5000/file5',
-        storageProvider: boxAddon,
+        externalStorageService: boxAddon,
         accountOwner: addonUser,
         authorizedResource: addonFile5,
         baseAccount: boxAccount,

--- a/mirage/serializers/addon-service.ts
+++ b/mirage/serializers/addon-service.ts
@@ -31,16 +31,21 @@ export default class AddonServiceSerializer<T extends Model> extends JSONAPISeri
             self: `${addonServiceAPIUrl}${this.typeKeyForModel(model)}/${model.id}/`,
         };
     }
-    serialize(model: ModelInstance<T>, request: Request) {
+    serialize(model: any, request: Request) {
         const json = super.serialize(model, request);
-        json.data.links = this.buildNormalLinks(model);
-        json.data.relationships = Object
-            .entries(this.buildRelationships(model))
-            .reduce((acc, [key, value]) => {
-                acc[underscore(key)] = value as RelationshipObject;
-                return acc;
-            }, {} as Record<string, RelationshipObject>);
-
+        const _datas: any[] = Array.isArray(json.data) ? json.data : [json.data];
+        const _models: Arry<ModelInstance<T>> = Array.isArray(model.models) ? model.models : [model];
+        for (let i = 0; i < _models.length; i++) {
+            const _model = _models[i];
+            const _datum = _datas[i];
+            _datum.links = this.buildNormalLinks(_model);
+            _datum.relationships = Object
+                .entries(this.buildRelationships(_model))
+                .reduce((acc, [key, value]) => {
+                    acc[underscore(key)] = value as RelationshipObject;
+                    return acc;
+                }, {} as Record<string, RelationshipObject>);
+        }
         return json;
     }
 }

--- a/mirage/serializers/authorized-citation-account.ts
+++ b/mirage/serializers/authorized-citation-account.ts
@@ -13,7 +13,7 @@ interface MirageAuthorizedCitationAccount extends ModelInstance<AuthorizedCitati
 export default class AuthorizedCitationAccountSerializer extends AddonServiceSerializer<AuthorizedCitationAccount> {
     buildRelationships(model: MirageAuthorizedCitationAccount) {
         return {
-            configuringUser: {
+            accountOwner: {
                 links: {
                     related: {
                         href: `${addonServiceAPIUrl}user-references/${model.configuringUserId}/`,

--- a/mirage/serializers/authorized-citation-account.ts
+++ b/mirage/serializers/authorized-citation-account.ts
@@ -7,7 +7,7 @@ import AddonServiceSerializer from './addon-service';
 
 interface MirageAuthorizedCitationAccount extends ModelInstance<AuthorizedCitationAccount> {
     configuringUserId: string;
-    storageProviderId: string;
+    externalCitationServiceId: string;
 }
 
 export default class AuthorizedCitationAccountSerializer extends AddonServiceSerializer<AuthorizedCitationAccount> {
@@ -23,7 +23,7 @@ export default class AuthorizedCitationAccountSerializer extends AddonServiceSer
             externalCitationService: {
                 links: {
                     related: {
-                        href: `${addonServiceAPIUrl}external-citation-services/${model.storageProviderId}/`,
+                        href: `${addonServiceAPIUrl}external-citation-services/${model.externalCitationServiceId}/`,
                     },
                 },
             },

--- a/mirage/serializers/authorized-computing-account.ts
+++ b/mirage/serializers/authorized-computing-account.ts
@@ -13,7 +13,7 @@ interface MirageAuthorizedComputingAccount extends ModelInstance<AuthorizedCompu
 export default class AuthorizedComputingAccountSerializer extends AddonServiceSerializer<AuthorizedComputingAccount> {
     buildRelationships(model: MirageAuthorizedComputingAccount) {
         return {
-            configuringUser: {
+            accountOwner: {
                 links: {
                     related: {
                         href: `${addonServiceAPIUrl}user-references/${model.configuringUserId}/`,

--- a/mirage/serializers/authorized-storage-account.ts
+++ b/mirage/serializers/authorized-storage-account.ts
@@ -7,7 +7,7 @@ import AddonServiceSerializer from './addon-service';
 
 interface MirageAuthorizedStorageAccount extends ModelInstance<AuthorizedStorageAccount> {
     configuringUserId: string;
-    storageProviderId: string;
+    externalStorageServiceId: string;
 }
 
 export default class AuthorizedStorageAccountSerializer extends AddonServiceSerializer<AuthorizedStorageAccount> {
@@ -23,7 +23,7 @@ export default class AuthorizedStorageAccountSerializer extends AddonServiceSeri
             externalStorageService: {
                 links: {
                     related: {
-                        href: `${addonServiceAPIUrl}external-storage-services/${model.storageProviderId}/`,
+                        href: `${addonServiceAPIUrl}external-storage-services/${model.externalStorageServiceId}/`,
                     },
                 },
             },

--- a/mirage/serializers/authorized-storage-account.ts
+++ b/mirage/serializers/authorized-storage-account.ts
@@ -13,14 +13,14 @@ interface MirageAuthorizedStorageAccount extends ModelInstance<AuthorizedStorage
 export default class AuthorizedStorageAccountSerializer extends AddonServiceSerializer<AuthorizedStorageAccount> {
     buildRelationships(model: MirageAuthorizedStorageAccount) {
         return {
-            configuringUser: {
+            accountOwner: {
                 links: {
                     related: {
                         href: `${addonServiceAPIUrl}user-references/${model.configuringUserId}/`,
                     },
                 },
             },
-            storageProvider: {
+            externalStorageService: {
                 links: {
                     related: {
                         href: `${addonServiceAPIUrl}external-storage-services/${model.storageProviderId}/`,

--- a/mirage/serializers/configured-storage-addon.ts
+++ b/mirage/serializers/configured-storage-addon.ts
@@ -9,7 +9,7 @@ export interface MirageConfiguredStorageAddon extends ConfiguredStorageAddonMode
     accountOwnerId: string;
     authorizedResourceId: string;
     baseAccountId: string;
-    storageProviderId: string;
+    externalStorageServiceId: string;
 }
 
 export default class ConfiguredStorageAddonSerializer extends AddonServiceSerializer<ConfiguredStorageAddonModel> {
@@ -39,7 +39,7 @@ export default class ConfiguredStorageAddonSerializer extends AddonServiceSerial
             externalStorageService: {
                 links: {
                     related: {
-                        href: `${addonServiceAPIUrl}external-storage-services/${model.storageProviderId}/`,
+                        href: `${addonServiceAPIUrl}external-storage-services/${model.externalStorageServiceId}/`,
                     },
                 },
             },

--- a/mirage/serializers/configured-storage-addon.ts
+++ b/mirage/serializers/configured-storage-addon.ts
@@ -36,7 +36,7 @@ export default class ConfiguredStorageAddonSerializer extends AddonServiceSerial
                     },
                 },
             },
-            storageProvider: {
+            externalStorageService: {
                 links: {
                     related: {
                         href: `${addonServiceAPIUrl}external-storage-services/${model.storageProviderId}/`,

--- a/mirage/serializers/resource-reference.ts
+++ b/mirage/serializers/resource-reference.ts
@@ -10,21 +10,21 @@ export default class ResourceReferenceSerializer extends AddonServiceSerializer<
             configuredStorageAddons: {
                 links: {
                     related: {
-                        href: `${addonServiceAPIUrl}resource-references/${model.id}/configured-storage-addons`,
+                        href: `${addonServiceAPIUrl}resource-references/${model.id}/configured_storage_addons`,
                     },
                 },
             },
             configuredCitationAddons: {
                 links: {
                     related: {
-                        href: `${addonServiceAPIUrl}resource-references/${model.id}/configured-citation-addons`,
+                        href: `${addonServiceAPIUrl}resource-references/${model.id}/configured_citation_addons`,
                     },
                 },
             },
             configuredComputingAddons: {
                 links: {
                     related: {
-                        href: `${addonServiceAPIUrl}resource-references/${model.id}/configured-computing-addons`,
+                        href: `${addonServiceAPIUrl}resource-references/${model.id}/configured_computing_addons`,
                     },
                 },
             },

--- a/mirage/serializers/user-reference.ts
+++ b/mirage/serializers/user-reference.ts
@@ -11,28 +11,28 @@ export default class UserReferenceSerializer extends AddonServiceSerializer<User
             authorizedStorageAccounts: {
                 links: {
                     related: {
-                        href: `${addonServiceAPIUrl}user-references/${model.id}/authorized-storage-accounts/`,
+                        href: `${addonServiceAPIUrl}user-references/${model.id}/authorized_storage_accounts/`,
                     },
                 },
             },
             authorizedCitationAccounts: {
                 links: {
                     related: {
-                        href: `${addonServiceAPIUrl}user-references/${model.id}/authorized-citation-accounts/`,
+                        href: `${addonServiceAPIUrl}user-references/${model.id}/authorized_citation_accounts/`,
                     },
                 },
             },
             authorizedComputingAccounts: {
                 links: {
                     related: {
-                        href: `${addonServiceAPIUrl}user-references/${model.id}/authorized-computing-accounts/`,
+                        href: `${addonServiceAPIUrl}user-references/${model.id}/authorized_computing_accounts/`,
                     },
                 },
             },
             configuredResources: {
                 links: {
                     related: {
-                        href: `${addonServiceAPIUrl}user-references/${model.id}/configured-resources/`,
+                        href: `${addonServiceAPIUrl}user-references/${model.id}/configured_resources/`,
                     },
                 },
             },

--- a/mirage/views/addons.ts
+++ b/mirage/views/addons.ts
@@ -21,7 +21,7 @@ import { filter, process } from './utils';
 
 interface MirageAuthorizedStorageAccount extends AuthorizedStorageAccountModel {
     configuringUserId: string;
-    storageProviderId: string;
+    externalStorageServiceId: string;
 }
 interface MirageAuthorizedCitationAccount extends AuthorizedCitationAccountModel {
     configuringUserId: string;
@@ -277,7 +277,7 @@ export function createAuthorizedStorageAccount(this: HandlerContext, schema: Sch
         'authorized-storage-account',
     ) as NormalizedRequestAttrs<MirageAuthorizedStorageAccount>;
     const externalService = schema.externalStorageServices
-        .find(attrs.storageProviderId) as ModelInstance<ExternalStorageServiceModel>;
+        .find(attrs.externalStorageServiceId) as ModelInstance<ExternalStorageServiceModel>;
     try {
         const authorizedAttrs = prepareAuthorizedAccountAttrs(attrs, externalService);
         const newAuthorizedAccount = schema.authorizedStorageAccounts
@@ -343,7 +343,7 @@ export function updateAuthorizedStorageAccount(this: HandlerContext, schema: Sch
         'authorized-storage-account',
     ) as NormalizedRequestAttrs<MirageAuthorizedStorageAccount>;
     const externalService = schema.externalStorageServices
-        .find(attrs.storageProviderId) as ModelInstance<ExternalStorageServiceModel>;
+        .find(attrs.externalStorageServiceId) as ModelInstance<ExternalStorageServiceModel>;
     try {
         const authorizedAccount = schema.authorizedStorageAccounts.find(attrs.id);
         let authorizedAttrs = attrs;

--- a/tests/acceptance/guid-node/files-test.ts
+++ b/tests/acceptance/guid-node/files-test.ts
@@ -147,7 +147,7 @@ module('Acceptance | guid-node/files', hooks => {
             name: 'bitbucket',
             displayName: 'Bitbucket',
             rootFolder: '/woot/',
-            storageProvider: bitbucketAddon,
+            externalStorageService: bitbucketAddon,
             authorizedResource: addonFile,
         });
         await visit(`/${this.node.id}/files`);

--- a/tests/acceptance/guid-node/files-test.ts
+++ b/tests/acceptance/guid-node/files-test.ts
@@ -135,24 +135,17 @@ module('Acceptance | guid-node/files', hooks => {
     test('Switching providers', async function(this: GuidNodeTestContext, assert) {
         const bitbucketAddon = server.schema.externalStorageServices
             .find('bitbucket') as ModelInstance<ExternalStorageServiceModel>;
-        server.create('file-provider', {
-            provider: 'bitbucket',
-            name: 'bitbucket',
-            target: this.node,
-        });
-        server.create('resource-reference', { id: this.node.id });
         const addonFile = server.create('resource-reference', { id: this.node.id });
         server.create('configured-storage-addon', {
             id: 'bitbucket',
-            name: 'bitbucket',
             displayName: 'Bitbucket',
             rootFolder: '/woot/',
             externalStorageService: bitbucketAddon,
             authorizedResource: addonFile,
         });
         await visit(`/${this.node.id}/files`);
-        assert.dom('[data-test-files-provider-link="bitbucket"').exists('Bitbucket shown');
-        assert.dom('[data-test-files-provider-link="bitbucket"').hasAttribute('href',
+        assert.dom('[data-test-files-provider-link="bitbucket"]').exists('Bitbucket shown');
+        assert.dom('[data-test-files-provider-link="bitbucket"]').hasAttribute('href',
             `/${this.node.id}/files/bitbucket`, 'Links to bitbucket files');
     });
 });

--- a/tests/integration/components/addon-card/component-test.ts
+++ b/tests/integration/components/addon-card/component-test.ts
@@ -33,7 +33,7 @@ module('Integration | Component | addon-card', hooks => {
         this.addon = {
             provider: {
                 id: 'box',
-                name: 'Test Addon',
+                displayName: 'Test Addon',
                 iconUrl: 'https://some.url/from/addons/service/box.png',
             },
             disableProjectAddon: sinon.stub(),
@@ -72,7 +72,6 @@ module('Integration | Component | addon-card', hooks => {
         const addonObj = {
             provider: {
                 id: 'box',
-                name: 'Test Addon',
                 displayName: 'Test Addon',
                 iconUrl: 'https://some.url/from/addons/service/box.png',
             },

--- a/tests/integration/components/addons-service/manager/component-test.ts
+++ b/tests/integration/components/addons-service/manager/component-test.ts
@@ -46,7 +46,7 @@ module('Integration | Component | addons-service | manager', hooks => {
         {{/each}}
 
         {{#each manager.filteredAddonProviders as |provider index|}}
-            <span data-test-provider={{provider.provider.name}}>{{provider.provider.name}}</span>
+            <span data-test-provider={{provider.provider.displayName}}>{{provider.provider.displayName}}</span>
         {{/each}}
     {{/if}}
 </AddonsService::Manager>

--- a/tests/integration/components/addons-service/manager/component-test.ts
+++ b/tests/integration/components/addons-service/manager/component-test.ts
@@ -19,9 +19,10 @@ module('Integration | Component | addons-service | manager', hooks => {
         this.owner.register('service:current-user', CurrentUserStub);
         const store = this.owner.lookup('service:store');
         const mirageNode = server.create('node', { id: 'test' });
-        const user = server.create('user', { id: 'user' });
-        this.owner.lookup('service:current-user').setProperties({ testUser: user, currentUserId: user.id });
+        const mirageUser = server.create('user', { id: 'user' });
         const node = await store.findRecord('node', mirageNode.id);
+        const user = await store.findRecord('user', mirageUser.id);
+        this.owner.lookup('service:current-user').setProperties({ testUser: user, currentUserId: user.id });
         server.create('resource-reference',
             { id: mirageNode.id, configuredStorageAddons: [] });
         server.create('user-reference', { id: user.id });

--- a/tests/unit/packages/addons-service/provider-test.ts
+++ b/tests/unit/packages/addons-service/provider-test.ts
@@ -6,7 +6,7 @@ import { module, test } from 'qunit';
 
 import Provider from 'ember-osf-web/packages/addons-service/provider';
 import { CurrentUserStub } from 'ember-osf-web/tests/helpers/require-auth';
-import {AddonCredentialFields} from 'ember-osf-web/models/authorized-account';
+import { Permission } from 'ember-osf-web/models/osf-model';
 
 module('Unit | Packages | addons-service | provider', function(hooks) {
     setupTest(hooks);
@@ -21,14 +21,15 @@ module('Unit | Packages | addons-service | provider', function(hooks) {
         const user = await store.findRecord('user', mirageUser.id);
         currentUser.setProperties({ testUser: user, currentUserId: user.id });
 
-        const node = store.createRecord('node', {
+        const mirageNode = server.create('node', {
             id: 'wowza',
-            currentUserPermissions: [ 'read', 'write', 'admin' ],
+            currentUserPermissions: [ Permission.Read, Permission.Write, Permission.Admin ],
         });
+        const node = await store.findRecord('node', mirageNode.id);
         // Make the addons service stuff
         const mirageExternalStorageService = server.create('external-storage-service', {
             id: 'bropdox',
-            name: 'Bropdox',
+            displayName: 'Bropdox',
         });
         const resourceReference = server.create('resource-reference', {
             id: node.id,
@@ -40,7 +41,7 @@ module('Unit | Packages | addons-service | provider', function(hooks) {
         });
 
         server.create('configured-storage-addon', {
-            name: 'bropdox',
+            displayName: 'bropdox',
             externalUserId: user.id,
             externalUserDisplayName: user.fullName,
             rootFolder: '/rooty-tooty/',
@@ -70,14 +71,15 @@ module('Unit | Packages | addons-service | provider', function(hooks) {
         const user = await store.findRecord('user', mirageUser.id);
         currentUser.setProperties({ testUser: user, currentUserId: user.id });
 
-        const node = store.createRecord('node', {
+        const mirageNode = server.create('node', {
             id: 'wowza',
-            currentUserPermissions: [ 'read', 'write', 'admin' ],
+            currentUserPermissions: [ Permission.Read, Permission.Write, Permission.Admin ],
         });
+        const node = await store.findRecord('node', mirageNode.id);
         // Make the addons service stuff
         const mirageExternalStorageService = server.create('external-storage-service', {
             id: 'bropdox',
-            name: 'Bropdox',
+            displayName: 'Bropdox',
         });
         const resourceReference = server.create('resource-reference', {
             id: node.id,
@@ -89,7 +91,7 @@ module('Unit | Packages | addons-service | provider', function(hooks) {
         });
 
         server.create('configured-storage-addon', {
-            name: 'bropdox',
+            displayName: 'bropdox',
             externalUserId: user.id,
             externalUserDisplayName: user.fullName,
             rootFolder: '/',
@@ -104,7 +106,7 @@ module('Unit | Packages | addons-service | provider', function(hooks) {
         await settled();
 
         await taskFor(provider.createAuthorizedAccount)
-            .perform({} as AddonCredentialFields);
+            .perform({}, 'bropdox account');
 
         // TODO: Fix these with [ENG-5454]
         // assert.equal((provider.configuredAddon as ConfiguredStorageAddonModel)

--- a/tests/unit/packages/addons-service/provider-test.ts
+++ b/tests/unit/packages/addons-service/provider-test.ts
@@ -44,7 +44,7 @@ module('Unit | Packages | addons-service | provider', function(hooks) {
             externalUserId: user.id,
             externalUserDisplayName: user.fullName,
             rootFolder: '/rooty-tooty/',
-            storageProvider: mirageExternalStorageService,
+            externalStorageService: mirageExternalStorageService,
             accountOwner: userReference,
             authorizedResource: resourceReference,
         });
@@ -93,7 +93,7 @@ module('Unit | Packages | addons-service | provider', function(hooks) {
             externalUserId: user.id,
             externalUserDisplayName: user.fullName,
             rootFolder: '/',
-            storageProvider: mirageExternalStorageService,
+            externalStorageService: mirageExternalStorageService,
             accountOwner: userReference,
             authorizedResource: resourceReference,
         });


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-5145]
-   Feature flag: n/a

## Purpose
- converge with [gravyvalet backend](https://github.com/CenterForOpenScience/gravyvalet/pull/64)
<!-- Describe the purpose of your changes. -->

## Summary of Changes
- `addons_service` adapter: include auth cookies with requests
- consistent `displayName` attr on external services, authorized accounts, and configured addons
- add `thruAccount` relation to addon-operation-invocations (to allow the account owner to e.g. choose an authorized root folder without having configured an addon yet)
- some renames for consistency
- skip unused `credentials` members (allow/default to `{}`)
<!-- Briefly describe or list your changes. -->

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-5145]: https://openscience.atlassian.net/browse/ENG-5145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ