### PR TITLE
Fix Search Text and Filter-Value Issues on OSF Search Page

### DIFF
--- a/app/search/controller.ts
+++ b/app/search/controller.ts
@@ -6,7 +6,7 @@ import {
 } from 'osf-components/components/search-page/component';
 
 export default class SearchController extends Controller {
-    @tracked cardSearchText?: string = '';
+    @tracked q?: string = '';
     @tracked sort?: string =  '-relevance';
     @tracked resourceType?: ResourceTypeFilterValue | null = null;
     @tracked activeFilters?: Filter[] = [];

--- a/lib/registries/addon/branded/discover/template.hbs
+++ b/lib/registries/addon/branded/discover/template.hbs
@@ -9,7 +9,7 @@
         @defaultQueryOptions={{this.defaultQueryOptions}}
         @resourceType={{'Registration,RegistrationComponent'}}
         @queryParams={{this.queryParams}}
-        @query={{this.q}}
+        @cardsearchText={{this.q}}
         @sort={{this.sort}}
         @onQueryParamChange={{action this.onQueryParamChange}}
         @showResourceTypeFilter={{false}}

--- a/mirage/views/search.ts
+++ b/mirage/views/search.ts
@@ -469,7 +469,7 @@ export function valueSearch(_: Schema, __: Request) {
                             matchingHighlight: 'National <em>Institute of Health</em>',
                         },
                     ],
-                    cardSearchResultCount: 2134,
+                    cardSearchResultCount: 3,
                 },
                 relationships: {
                     indexCard: {


### PR DESCRIPTION
-   Ticket: https://openscience.atlassian.net/browse/ENG-5228
-   Feature flag: n/a

## Purpose

Fix search text not populating as query parameter and correct filter-value preview counts.

## Summary of Changes

- Renamed cardSearchText to q and @query to @cardSearchText in the search page controller and templates.
- Adjusted filter-value preview counts to reflect the current search context's result count.


