### PR TITLE
[ENG-5819] Added logic for browsing away from the create and edit flow

### DIFF
--- a/app/preprints/-components/submit/preprint-state-machine/component.ts
+++ b/app/preprints/-components/submit/preprint-state-machine/component.ts
@@ -28,6 +28,8 @@ export enum PreprintStatusTypeEnum {
 interface StateMachineArgs {
     provider: PreprintProviderModel;
     preprint: PreprintModel;
+    setPageDirty: () => void;
+    resetPageDirty: () => void;
 }
 
 /**
@@ -129,6 +131,7 @@ export default class PreprintStateMachine extends Component<StateMachineArgs>{
     @task
     @waitFor
     public async onSubmit(): Promise<void> {
+        this.args.resetPageDirty();
         if (!this.isEditFlow) {
             if (this.provider.reviewsWorkflow) {
                 const reviewAction = this.store.createRecord('review-action', {
@@ -151,6 +154,11 @@ export default class PreprintStateMachine extends Component<StateMachineArgs>{
     @task
     @waitFor
     public async onNext(): Promise<void> {
+        if (this.isEditFlow) {
+            this.args.resetPageDirty();
+        } else {
+            this.args.setPageDirty();
+        }
         this.isNextButtonDisabled = true;
         if (this.statusFlowIndex === this.getTypeIndex(PreprintStatusTypeEnum.titleAndAbstract) &&
             this.titleAndAbstractValidation
@@ -189,6 +197,12 @@ export default class PreprintStateMachine extends Component<StateMachineArgs>{
         }
     }
 
+    private setPageDirty(): void {
+        if (this.isEditFlow) {
+            this.args.setPageDirty();
+        }
+    }
+
     /**
      * Callback for the action-flow component
      */
@@ -196,6 +210,7 @@ export default class PreprintStateMachine extends Component<StateMachineArgs>{
     public validateTitleAndAbstract(valid: boolean): void {
         this.titleAndAbstractValidation = valid;
         this.isNextButtonDisabled = !valid;
+        this.setPageDirty();
     }
 
     /**
@@ -205,6 +220,7 @@ export default class PreprintStateMachine extends Component<StateMachineArgs>{
     public validateFile(valid: boolean): void {
         this.fileValidation = valid;
         this.isNextButtonDisabled = !valid;
+        this.setPageDirty();
     }
 
     /**
@@ -214,6 +230,7 @@ export default class PreprintStateMachine extends Component<StateMachineArgs>{
     public validateMetadata(valid: boolean): void {
         this.metadataValidation = valid;
         this.isNextButtonDisabled = !valid;
+        this.setPageDirty();
     }
 
     /**
@@ -232,6 +249,7 @@ export default class PreprintStateMachine extends Component<StateMachineArgs>{
         }
         this.authorAssertionValidation = valid;
         this.isNextButtonDisabled = !valid;
+        this.setPageDirty();
     }
 
     /**
@@ -241,6 +259,7 @@ export default class PreprintStateMachine extends Component<StateMachineArgs>{
     public validateSupplements(valid: boolean): void {
         this.supplementValidation = valid;
         this.isNextButtonDisabled = !valid;
+        this.setPageDirty();
     }
 
     @action

--- a/app/preprints/-components/submit/submission-flow/template.hbs
+++ b/app/preprints/-components/submit/submission-flow/template.hbs
@@ -3,6 +3,8 @@
 <Preprints::-Components::Submit::PreprintStateMachine 
     @provider={{@provider}}
     @preprint={{@preprint}}
+    @setPageDirty={{@setPageDirty}}
+    @resetPageDirty={{@resetPageDirty}}
 as |manager|>
     <OsfLayout @backgroundClass={{local-class 'submit-page-container'}} as |layout|>
         <layout.heading local-class='header-container'

--- a/app/preprints/edit/controller.ts
+++ b/app/preprints/edit/controller.ts
@@ -1,0 +1,17 @@
+import Controller from '@ember/controller';
+import { action} from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class PreprintEdit extends Controller {
+    @tracked isPageDirty = false;
+
+    @action
+    setPageDirty() {
+        this.isPageDirty = true;
+    }
+
+    @action
+    resetPageDirty() {
+        this.isPageDirty = false;
+    }
+}

--- a/app/preprints/edit/route.ts
+++ b/app/preprints/edit/route.ts
@@ -2,18 +2,28 @@ import Store from '@ember-data/store';
 import Route from '@ember/routing/route';
 import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
+// eslint-disable-next-line ember/no-mixins
+import ConfirmationMixin from 'ember-onbeforeunload/mixins/confirmation';
 import PreprintProviderModel from 'ember-osf-web/models/preprint-provider';
 import MetaTags, { HeadTagDef } from 'ember-osf-web/services/meta-tags';
 import Theme from 'ember-osf-web/services/theme';
 import requireAuth from 'ember-osf-web/decorators/require-auth';
+import { action, computed } from '@ember/object';
+import PreprintEdit from 'ember-osf-web/preprints/edit/controller';
+import Intl from 'ember-intl/services/intl';
+import Transition from '@ember/routing/-private/transition';
 
 @requireAuth()
-export default class PreprintEditRoute extends Route {
+export default class PreprintEditRoute extends Route.extend(ConfirmationMixin, {}) {
     @service store!: Store;
     @service theme!: Theme;
     @service router!: RouterService;
+    @service intl!: Intl;
     @service metaTags!: MetaTags;
     headTags?: HeadTagDef[];
+
+    // This does NOT work on chrome and I'm going to leave it just in case
+    confirmationMessage = this.intl.t('preprints.submit.action-flow.save-before-exit');
 
     buildRouteInfoMetadata() {
         return {
@@ -54,6 +64,25 @@ export default class PreprintEditRoute extends Route {
                 },
             }];
             this.set('headTags', headTags);
+        }
+    }
+
+    // This tells ember-onbeforeunload's ConfirmationMixin whether or not to stop transitions
+    // This is for when the user leaves the site or does a full app reload
+    @computed('controller.isPageDirty')
+    get isPageDirty() {
+        const controller = this.controller as PreprintEdit;
+        return () => controller.isPageDirty;
+    }
+
+    // This is for when the user leaves the page via the router
+    @action
+    willTransition(transition: Transition) {
+        const controller = this.controller as PreprintEdit;
+        if (controller.isPageDirty) {
+            if (!window.confirm(this.intl.t('preprints.submit.action-flow.save-before-exit'))) {
+                transition.abort();
+            }
         }
     }
 }

--- a/app/preprints/edit/template.hbs
+++ b/app/preprints/edit/template.hbs
@@ -3,4 +3,6 @@
     @brand={{this.model.brand}}
     @preprint={{this.model.preprint}}
     @header='preprints.submit.title-edit'
+    @setPageDirty={{this.setPageDirty}}
+    @resetPageDirty={{this.resetPageDirty}}
 />

--- a/app/preprints/submit/controller.ts
+++ b/app/preprints/submit/controller.ts
@@ -1,0 +1,17 @@
+import Controller from '@ember/controller';
+import { action} from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class PreprintSubmit extends Controller {
+    @tracked isPageDirty = false;
+
+    @action
+    setPageDirty() {
+        this.isPageDirty = true;
+    }
+
+    @action
+    resetPageDirty() {
+        this.isPageDirty = false;
+    }
+}

--- a/app/preprints/submit/template.hbs
+++ b/app/preprints/submit/template.hbs
@@ -3,6 +3,8 @@
         @provider={{this.model.provider}}
         @brand={{this.model.brand}}
         @header='preprints.submit.title-submit'
+        @setPageDirty={{this.setPageDirty}}
+        @resetPageDirty={{this.resetPageDirty}}
     />
 {{else}}
     <LoadingIndicator data-test-loading-indicator @dark={{true}} />

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1280,6 +1280,7 @@ preprints:
             delete-modal-body: 'Are you sure you want to delete this {singularPreprintWord}? This action CANNOT be undone.'
             success: '{singularPreprintWord} saved.'
             error: 'Error saving {singularPreprintWord}.'
+            save-before-exit: 'Unsaved changes present. Are you sure you want to leave this page?'
     detail:
         abstract: 'Abstract'
         article_doi: 'Peer-reviewed Publication DOI'


### PR DESCRIPTION
-   Ticket: [ENG-5819]
-   Feature flag: n/a

## Purpose

Added logic for browsing away from the create and edit flow

## Summary of Changes

Add the confirmationMix and the WillTransition to the submit and edit route files.
Added a new controller for both
Updated the state machine

## Screenshot(s)
![Screenshot 2024-06-21 at 12 00 20 PM](https://github.com/CenterForOpenScience/ember-osf-web/assets/113387478/8015fdc3-2b85-4822-8036-b1ecc79f4a78)



## Side Effects

The confirmationMessage doesn't customize in all browsers

## QA Notes

Enjoy!


[ENG-5819]: https://openscience.atlassian.net/browse/ENG-5819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ