### PR TITLE
[ENG-5867] Added logic to update the file name when selecting a new file for a preprint

### DIFF
--- a/app/preprints/-components/preprint-file-display/styles.scss
+++ b/app/preprints/-components/preprint-file-display/styles.scss
@@ -21,6 +21,9 @@
         flex-direction: column;
         align-items: center;
         justify-content: center;
-    }
 
+        .blue-button {
+            color: $brand-info;
+        }
+    }
 }

--- a/app/preprints/-components/preprint-file-display/template.hbs
+++ b/app/preprints/-components/preprint-file-display/template.hbs
@@ -11,15 +11,16 @@
                 <DeleteButton
                     data-test-delete-button
                     @small={{true}}
-                    @icon='trash'
+                    @icon='edit'
                     @noBackground={{true}}
                     @delete={{action @addNewFile}}
                     @confirmButtonText = {{t 'preprints.submit.step-file.delete-modal-button'}}
                     @modalTitle={{t 'preprints.submit.step-file.delete-modal-title' singularPreprintWord = @preprintWord}}
                     @modalBody={{t 'preprints.submit.step-file.delete-warning' singularPreprintWord = @preprintWord}}
+                    local-class='blue-button'
                 />
                 <EmberTooltip>
-                    {{t 'preprints.submit.step-file.delete-modal-button'}}
+                    {{t 'preprints.submit.step-file.delete-modal-button-tooltip'}}
                 </EmberTooltip>
             </div>
         {{/if}}

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1197,6 +1197,7 @@ preprints:
             delete-modal-title: 'Add a new {singularPreprintWord} file'
             delete-warning: 'This will allow a new version of the {singularPreprintWord} file to be uploaded to the {singularPreprintWord}. The existing file will be retained as a version of the {singularPreprintWord}.'
             delete-modal-button: 'Continue'
+            delete-modal-button-tooltip: 'Version file'
         step-metadata:
             title: 'Metadata'
             contributors-input: 'Contributors'


### PR DESCRIPTION
-   Ticket: [ENG-5867]
-   Feature flag: n/a

## Purpose

[ENG-5867] Added logic to update the file name when selecting a new file for a p…

## Summary of Changes

Added some to store the primaryFile in memory.
Did a `rename` on the primary file
Added a new icon and color to the flow for adding a version for the file.

## Screenshot(s)
![Screenshot 2024-06-28 at 12 55 28 PM](https://github.com/CenterForOpenScience/ember-osf-web/assets/113387478/75417331-2665-4111-b654-f8af07b6b3c9)
![Screenshot 2024-06-28 at 12 55 42 PM](https://github.com/CenterForOpenScience/ember-osf-web/assets/113387478/8e7c4f2a-5364-4fdc-acfe-9bc55ce4e2fe)



## Side Effects

Unknown

## QA Notes

Test it


[ENG-5867]: https://openscience.atlassian.net/browse/ENG-5867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-5867]: https://openscience.atlassian.net/browse/ENG-5867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ