### PR TITLE
Fixed a double header on the registries contributors

### DIFF
--- a/app/preprints/-components/submit/metadata/template.hbs
+++ b/app/preprints/-components/submit/metadata/template.hbs
@@ -9,6 +9,9 @@
     {{else}}
         <div local-class='form-container'>
             <div local-class='input-container'>
+                <label data-test-contributors-label>
+                    {{t 'preprints.submit.step-metadata.contributors-input'}}
+                </label>
                 <Contributors::Widget
                     @preprint={{@manager.preprint}}
                     @shouldShowAdd={{this.showAddContributorWidget}}

--- a/lib/osf-components/addon/components/contributors/widget/template.hbs
+++ b/lib/osf-components/addon/components/contributors/widget/template.hbs
@@ -4,46 +4,41 @@
     @preprint={{@preprint}}
     as |manager|
 >
-    {{#let (unique-id 'current-contributors') as |currentContributorFieldId|}}
-        <label for={{currentContributorFieldId}}>
-            {{t 'osf-components.contributors.currentContributors'}}
-        </label>
-        {{#if @displayPermissionWarning}}
-            <div local-class='warning-container'>
-                {{t 'osf-components.contributors.permission-warning'}}
-            </div>
-        {{/if}}
-        <div local-class='display-container' ...attributes>
-            <div local-class='heading-container {{if (is-mobile) 'mobile'}}'>
-                <div data-test-heading-name local-class='name-title'>
-                    {{t 'osf-components.contributors.headings.name'}}
-                </div>
-                {{#if (not (is-mobile))}}
-                    <div data-test-heading-permission local-class='permission-title'>
-                        {{t 'osf-components.contributors.headings.permission'}}
-                    </div>
-                    <div data-test-heading-citation local-class='citation-title'>
-                        {{t 'osf-components.contributors.headings.citation'}}
-                    </div>
-                {{/if}}
-            </div>
-            <Contributors::List
-                @contributorsManager={{manager}}
-                @widgetMode={{@widgetMode}}
-            />
+    {{#if @displayPermissionWarning}}
+        <div local-class='warning-container'>
+            {{t 'osf-components.contributors.permission-warning'}}
         </div>
-        {{#if @shouldShowAdd}}
-            <div local-class='add-user-container {{if (is-mobile) 'mobile'}}'>
-                <label>
-                    {{t 'osf-components.contributors.addContributors'}}
-                </label>
-                <div local-class='user-search-container'>
-                    <Contributors::UserSearch::Widget
-                        @manager={{manager}}
-                        @toggleAddContributorWidget={{@toggleAddContributorWidget}}
-                    />
-                </div>
+    {{/if}}
+    <div local-class='display-container' ...attributes>
+        <div local-class='heading-container {{if (is-mobile) 'mobile'}}'>
+            <div data-test-heading-name local-class='name-title'>
+                {{t 'osf-components.contributors.headings.name'}}
             </div>
-        {{/if}}
-    {{/let}}
+            {{#if (not (is-mobile))}}
+                <div data-test-heading-permission local-class='permission-title'>
+                    {{t 'osf-components.contributors.headings.permission'}}
+                </div>
+                <div data-test-heading-citation local-class='citation-title'>
+                    {{t 'osf-components.contributors.headings.citation'}}
+                </div>
+            {{/if}}
+        </div>
+        <Contributors::List
+            @contributorsManager={{manager}}
+            @widgetMode={{@widgetMode}}
+        />
+    </div>
+    {{#if @shouldShowAdd}}
+        <div local-class='add-user-container {{if (is-mobile) 'mobile'}}'>
+            <label>
+                {{t 'osf-components.contributors.addContributors'}}
+            </label>
+            <div local-class='user-search-container'>
+                <Contributors::UserSearch::Widget
+                    @manager={{manager}}
+                    @toggleAddContributorWidget={{@toggleAddContributorWidget}}
+                />
+            </div>
+        </div>
+    {{/if}}
 </Contributors::Manager>

--- a/lib/osf-components/addon/components/form-controls/radio-button-group/radio-button/template.hbs
+++ b/lib/osf-components/addon/components/form-controls/radio-button-group/radio-button/template.hbs
@@ -16,7 +16,7 @@
             for={{uniqueId}}
         >
             {{ this.displayText }} 
-            <Registries::SchemaBlockRenderer::HelperTextIcon @helpText={{get @helpTextMapping (this.displayText)}} />
+            <Registries::SchemaBlockRenderer::HelperTextIcon @helpText={{get @helpTextMapping this.displayText}} />
         </label>
     {{/let}}
 </div>


### PR DESCRIPTION
-   Ticket: [N/A]
-   Feature flag: n/a

## Purpose

There was a double header found on the percy snapshots

## Summary of Changes

Removed the header from the widget template.hbs file and added it to the submit/metadata/template.hbs file

## Screenshot(s)
![Screenshot 2024-07-08 at 10 59 34 AM](https://github.com/CenterForOpenScience/ember-osf-web/assets/113387478/a68c4bc2-4bf3-4e2b-afb7-afcd17b6a5ea)
![Screenshot 2024-07-08 at 10 47 20 AM](https://github.com/CenterForOpenScience/ember-osf-web/assets/113387478/b5735826-cb28-4bfd-ae27-b177fd2f6744)



## Side Effects

Should not be any

## QA Notes

You should never even know this happened.
