### PR TITLE
[ENG-5950]Configured addon bugs

### DIFF
--- a/app/packages/addons-service/provider.ts
+++ b/app/packages/addons-service/provider.ts
@@ -317,7 +317,9 @@ export default class Provider {
     @task
     @waitFor
     public async createConfiguredAddon(account: AllAuthorizedAccountTypes) {
-        return await taskFor(this.providerMap!.createConfiguredAddon).perform(account);
+        const newConfiguredAddon = await taskFor(this.providerMap!.createConfiguredAddon).perform(account);
+        this.configuredAddons!.pushObject(newConfiguredAddon);
+        return newConfiguredAddon;
     }
 
     @task

--- a/app/packages/addons-service/provider.ts
+++ b/app/packages/addons-service/provider.ts
@@ -86,7 +86,6 @@ export default class Provider {
 
     @tracked configuredAddon?: AllConfiguredAddonTypes;
     @tracked configuredAddons?: AllConfiguredAddonTypes[];
-    @tracked allConfiguredAddons?: EmberArray<AllConfiguredAddonTypes>;
     @tracked authorizedAccount?: AllAuthorizedAccountTypes;
     @tracked authorizedAccounts?: AllAuthorizedAccountTypes[];
 
@@ -100,13 +99,13 @@ export default class Provider {
         provider: any,
         currentUser: CurrentUserService,
         node?: NodeModel,
-        configuredAddons?: EmberArray<AllConfiguredAddonTypes>,
+        allConfiguredAddons?: EmberArray<AllConfiguredAddonTypes>,
     ) {
         setOwner(this, getOwner(provider));
         this.node = node;
         this.currentUser = currentUser;
         this.provider = provider;
-        this.allConfiguredAddons = configuredAddons;
+        this.configuredAddons = allConfiguredAddons?.filter(addon => addon.externalServiceId === this.provider.id);
 
         if (provider instanceof ExternalStorageServiceModel) {
             this.providerMap = this.providerTypeMapper.externalStorageService;
@@ -123,7 +122,6 @@ export default class Provider {
     async initialize() {
         await taskFor(this.getUserReference).perform();
         await taskFor(this.getResourceReference).perform();
-        this.getProviderConfiguredAddons();
     }
 
     @task
@@ -163,10 +161,6 @@ export default class Provider {
             });
             this.serviceNode = resourceRefs.firstObject;
         }
-    }
-
-    getProviderConfiguredAddons() {
-        this.configuredAddons = this.allConfiguredAddons?.filter(addon => addon.externalServiceId === this.provider.id);
     }
 
     @task
@@ -329,11 +323,6 @@ export default class Provider {
             await this.configuredAddon.destroyRecord();
             this.configuredAddon = undefined;
         }
-    }
-
-    listOfFolders() {
-        // TODO
-        return;
     }
 
     @task


### PR DESCRIPTION
-   Ticket: [ENG-5950]
-   Feature flag: n/a

## Purpose
- Address a bug where adding a new configured account for a provider with no configured account does not update the Addon-card to indicate it has a configured account

## Summary of Changes
- After creating a configured addon, add this new configuredAddon to the list of Provider's `configuredAddons` list
- Remove unused `listOfFolders` method
- Rewrite how `Provider.configuredAddons` gets set to make it less weird and confusing

## Screenshot(s)
- On the node addons page, the addon cards should be change from `Connect` to `Configure` when you add a new configured account to a provider that previously had no configured account
![image](https://github.com/user-attachments/assets/e026422f-9f57-466c-9686-1fa360efe1b1)

## Side Effects
- NA

## QA Notes
- Adding/removing a configured addon for a given provider should update the language on the addon-card in the screenshot above

[ENG-5950]: https://openscience.atlassian.net/browse/ENG-5950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ