### PR TITLE
[ENG-5951] Authorized account bugs

### DIFF
--- a/app/guid-node/addons/index/template.hbs
+++ b/app/guid-node/addons/index/template.hbs
@@ -129,7 +129,6 @@
                             @provider={{provider.provider}}
                             @manager={{manager}}
                             @onConnect={{manager.connectAccount}}
-                            @onInput={{manager.onCredentialsInput}}
                         />
                     {{else if (eq manager.pageMode 'confirm')}}
                         {{t 'addons.confirm.verify'}}

--- a/app/models/authorized-account.ts
+++ b/app/models/authorized-account.ts
@@ -1,19 +1,24 @@
 import Model, { attr } from '@ember-data/model';
 
 export interface AddonCredentialFields {
-    url?: string;
     username?: string;
     password?: string;
     token?: string;
     accessKey?: string;
     secretKey?: string;
-    repo?: string;
+}
+
+export interface AccountCreationArgs {
+    credentials?: AddonCredentialFields;
+    apiBaseUrl?: string;
+    displayName: string;
+    initiateOauth?: boolean;
 }
 
 export default class AuthorizedAccountModel extends Model {
     @attr('fixstring') displayName!: string;
     @attr('fixstringarray') authorizedCapabilities!: string[];
-    @attr('fixstring') apiBaseUrl!: string; // Only applicable when ExternalService.configurableApiRoot === true
+    @attr('fixstring') apiBaseUrl?: string; // Only applicable when ExternalService.configurableApiRoot === true
     @attr('object') credentials?: AddonCredentialFields; // write-only
     @attr('boolean') initiateOauth!: boolean; // write-only
     @attr('fixstring') readonly authUrl!: string; // Only returned when POSTing to /authorized-xyz-accounts

--- a/app/models/authorized-account.ts
+++ b/app/models/authorized-account.ts
@@ -13,6 +13,7 @@ export interface AddonCredentialFields {
 export default class AuthorizedAccountModel extends Model {
     @attr('fixstring') displayName!: string;
     @attr('fixstringarray') authorizedCapabilities!: string[];
+    @attr('fixstring') apiBaseUrl!: string; // Only applicable when ExternalService.configurableApiRoot === true
     @attr('object') credentials?: AddonCredentialFields; // write-only
     @attr('boolean') initiateOauth!: boolean; // write-only
     @attr('fixstring') readonly authUrl!: string; // Only returned when POSTing to /authorized-xyz-accounts

--- a/app/models/authorized-storage-account.ts
+++ b/app/models/authorized-storage-account.ts
@@ -1,12 +1,10 @@
-import { AsyncBelongsTo, attr, belongsTo } from '@ember-data/model';
+import { AsyncBelongsTo, belongsTo } from '@ember-data/model';
 
 import ExternalStorageServiceModel from './external-storage-service';
 import AuthorizedAccountModel from './authorized-account';
 import UserReferenceModel from './user-reference';
 
 export default class AuthorizedStorageAccountModel extends AuthorizedAccountModel {
-    @attr('fixstring') apiBaseUrl!: string; // Only applicable when ExternalStorageService.configurableApiRoot === true
-
     @belongsTo('user-reference', { inverse: 'authorizedStorageAccounts' })
     readonly accountOwner!: AsyncBelongsTo<UserReferenceModel> & UserReferenceModel;
 

--- a/app/models/external-service.ts
+++ b/app/models/external-service.ts
@@ -30,4 +30,5 @@ export default class ExternalServiceModel extends Model {
     @attr('string') iconUrl!: string;
     @attr('string') credentialsFormat!: CredentialsFormat;
     @attr('array') termsOfService!: TermsOfServiceCapabilities[];
+    @attr('boolean') configurableApiRoot!: boolean;
 }

--- a/app/models/external-storage-service.ts
+++ b/app/models/external-storage-service.ts
@@ -3,7 +3,6 @@ import { attr } from '@ember-data/model';
 import ExternalServiceModel from './external-service';
 
 export default class ExternalStorageServiceModel extends ExternalServiceModel {
-    @attr('boolean') configurableApiRoot!: boolean;
     @attr('number') maxConcurrentDownloads!: number;
     @attr('number') maxUploadMb!: number;
 }

--- a/app/packages/addons-service/provider.ts
+++ b/app/packages/addons-service/provider.ts
@@ -16,7 +16,7 @@ import ResourceReferenceModel from 'ember-osf-web/models/resource-reference';
 import ConfiguredStorageAddonModel from 'ember-osf-web/models/configured-storage-addon';
 import ConfiguredCitationAddonModel from 'ember-osf-web/models/configured-citation-addon';
 import ConfiguredComputingAddonModel from 'ember-osf-web/models/configured-computing-addon';
-import { AddonCredentialFields} from 'ember-osf-web/models/authorized-account';
+import { AccountCreationArgs } from 'ember-osf-web/models/authorized-account';
 import AuthorizedStorageAccountModel from 'ember-osf-web/models/authorized-storage-account';
 import AuthorizedCitationAccountModel from 'ember-osf-web/models/authorized-citation-account';
 import AuthorizedComputingAccount from 'ember-osf-web/models/authorized-computing-account';
@@ -200,17 +200,16 @@ export default class Provider {
 
     @task
     @waitFor
-    private async createAuthorizedStorageAccount(
-        credentials: AddonCredentialFields, accountName: string, initiateOauth?: boolean,
-    ) {
+    private async createAuthorizedStorageAccount(arg: AccountCreationArgs) {
+        const { credentials, apiBaseUrl, displayName, initiateOauth } = arg;
         const newAccount = this.store.createRecord('authorized-storage-account', {
             credentials,
-            initiateOauth: initiateOauth || false,
-            apiBaseUrl: (this.provider as ExternalStorageServiceModel).configurableApiRoot ? credentials.url : '',
+            initiateOauth,
+            apiBaseUrl,
             externalUserId: this.currentUser.user?.id,
             authorizedCapabilities: ['ACCESS', 'UPDATE'],
             externalStorageService: this.provider,
-            displayName: accountName,
+            displayName,
             accountOwner: this.userReference,
         });
         await newAccount.save();
@@ -219,17 +218,17 @@ export default class Provider {
 
     @task
     @waitFor
-    private async createAuthorizedCitationAccount(
-        credentials: AddonCredentialFields, accountName: string, initiateOauth?: boolean,
-    ) {
+    private async createAuthorizedCitationAccount(arg: AccountCreationArgs) {
+        const { credentials, apiBaseUrl, displayName, initiateOauth } = arg;
         const newAccount = this.store.createRecord('authorized-citation-account', {
             credentials,
-            initiateOauth: initiateOauth || false,
+            apiBaseUrl,
+            initiateOauth,
             externalUserId: this.currentUser.user?.id,
             scopes: [],
             citationService: this.provider,
             accountOwner: this.userReference,
-            displayName: accountName,
+            displayName,
         });
         await newAccount.save();
         return newAccount;
@@ -237,17 +236,17 @@ export default class Provider {
 
     @task
     @waitFor
-    private async createAuthorizedComputingAccount(
-        credentials: AddonCredentialFields, accountName: string, initiateOauth?: boolean,
-    ) {
+    private async createAuthorizedComputingAccount(arg: AccountCreationArgs) {
+        const { credentials, apiBaseUrl, displayName, initiateOauth } = arg;
         const newAccount = this.store.createRecord('authorized-computing-account', {
             credentials,
-            initiateOauth: initiateOauth || false,
+            apiBaseUrl,
+            initiateOauth,
             externalUserId: this.currentUser.user?.id,
             scopes: [],
             computingService: this.provider,
             accountOwner: this.userReference,
-            displayName: accountName,
+            displayName,
         });
         await newAccount.save();
         return newAccount;
@@ -255,17 +254,18 @@ export default class Provider {
 
     @task
     @waitFor
-    public async createAuthorizedAccount(
-        credentials: AddonCredentialFields, accountName: string, initiateOauth?: boolean,
-    ) {
+    public async createAuthorizedAccount(arg: AccountCreationArgs) {
         return await taskFor(this.providerMap!.createAuthorizedAccount)
-            .perform(credentials, accountName, initiateOauth);
+            .perform(arg);
     }
 
     @task
     @waitFor
-    public async reconnectAuthorizedAccount(account: AllAuthorizedAccountTypes, credentials: AddonCredentialFields) {
+    public async reconnectAuthorizedAccount(args: AccountCreationArgs, account: AllAuthorizedAccountTypes) {
+        const { credentials, apiBaseUrl, displayName } = args;
         account.credentials = credentials;
+        account.apiBaseUrl = apiBaseUrl;
+        account.displayName = displayName;
         await account.save();
         await account.reload();
     }

--- a/app/settings/addons/template.hbs
+++ b/app/settings/addons/template.hbs
@@ -53,7 +53,6 @@
                                 @provider={{manager.selectedProvider.provider}}
                                 @manager={{manager}}
                                 @onConnect={{manager.connectAccount}}
-                                @onInput={{manager.onCredentialsInput}}
                             />
                         </div>
                     {{else if (eq manager.pageMode 'accountReconnect')}}
@@ -64,8 +63,8 @@
                             <AddonsService::AddonAccountSetup
                                 @provider={{manager.selectedProvider.provider}}
                                 @manager={{manager}}
+                                @account={{manager.selectedAccount}}
                                 @onReconnect={{manager.reconnectAccount}}
-                                @onInput={{manager.onCredentialsInput}}
                                 @reconnect={{true}}
                             />
                         </div>

--- a/app/settings/addons/template.hbs
+++ b/app/settings/addons/template.hbs
@@ -65,7 +65,6 @@
                                 @manager={{manager}}
                                 @account={{manager.selectedAccount}}
                                 @onReconnect={{manager.reconnectAccount}}
-                                @reconnect={{true}}
                             />
                         </div>
                     {{/if}}

--- a/lib/osf-components/addon/components/addons-service/addon-account-setup/component.ts
+++ b/lib/osf-components/addon/components/addons-service/addon-account-setup/component.ts
@@ -14,17 +14,19 @@ import { AddonCredentialFields } from 'ember-osf-web/models/authorized-account';
 import { CredentialsFormat } from 'ember-osf-web/models/external-service';
 import ExternalStorageServiceModel from 'ember-osf-web/models/external-storage-service';
 import { AllAuthorizedAccountTypes } from 'ember-osf-web/packages/addons-service/provider';
+import captureException, { getApiErrorMessage } from 'ember-osf-web/utils/capture-exception';
 
 // TODO: Get this from GravyValet??
 const repoOptionsObject: Record<string, string[]> = {
     dataverse: [
-        'dataverse.harvard.edu',
-        'dataverse.lib.virginia.edu',
+        'https://dataverse.harvard.edu',
+        'https://dataverse.lib.virginia.edu',
     ],
     gitlab: [
         'https://gitlab.com',
     ],
 };
+
 interface InputFieldObject {
     name: keyof AddonCredentialFields;
     labelText: string;

--- a/lib/osf-components/addon/components/addons-service/addon-account-setup/component.ts
+++ b/lib/osf-components/addon/components/addons-service/addon-account-setup/component.ts
@@ -187,7 +187,7 @@ export default class AddonAccountSetupComponent extends Component<Args> {
             initiateOauth: this.useOauth,
         };
         try {
-            await taskFor(manager.connectAccount).perform(accountCreationArgs);
+            await taskFor(manager.connectAccount).unlinked().perform(accountCreationArgs);
             this.toast.success(this.intl.t('addons.accountCreate.connect-success'));
         } catch (e) {
             this.connectAccountError = true;

--- a/lib/osf-components/addon/components/addons-service/addon-account-setup/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/addon-account-setup/template.hbs
@@ -10,23 +10,21 @@
             {{else}}
                 <div local-class='oauth-wrapper'>
                     {{t 'addons.accountCreate.oauth-description' providerName=@provider.name}}
-                    {{#unless @reconnect}}
-                        {{#let (unique-id 'display-name-label') as |displayNameId|}}
-                            <label for={{displayNameId}} local-class='auth-text-input-label'>
-                                {{t 'addons.accountCreate.display-name-label'}}
-                            </label>
-                            <div local-class='post-text'>
-                                {{t 'addons.accountCreate.display-name-help'}}
-                            </div>
-                            <Input
-                                data-test-oauth-display-name-input
-                                local-class='input'
-                                id={{displayNameId}}
-                                placeholder={{t 'addons.accountCreate.display-name-placeholder'}}
-                                @value={{@manager.displayName}}
-                            />
-                        {{/let}}
-                    {{/unless}}
+                    {{#let (unique-id 'display-name-label') as |displayNameId|}}
+                        <label for={{displayNameId}} local-class='auth-text-input-label'>
+                            {{t 'addons.accountCreate.display-name-label'}}
+                        </label>
+                        <div local-class='post-text'>
+                            {{t 'addons.accountCreate.display-name-help'}}
+                        </div>
+                        <Input
+                            data-test-oauth-display-name-input
+                            local-class='input'
+                            id={{displayNameId}}
+                            placeholder={{t 'addons.accountCreate.display-name-placeholder'}}
+                            @value={{this.displayName}}
+                        />
+                    {{/let}}
                     <div local-class='button-wrapper'>
                         <Button
                             data-test-addon-cancel-button
@@ -37,11 +35,11 @@
                         </Button>
                         <Button
                             data-test-addon-oauth-button
-                            data-analytics-name={{if @reconnect 'Reconnect account' 'Begin OAuth'}}
+                            data-analytics-name={{if @account 'Reconnect account' 'Begin OAuth'}}
                             @type='primary'
-                            {{on 'click' (if @reconnect (perform this.startOauthReconnectFlow) (perform this.startOauthFlow))}}
+                            {{on 'click' (if @account (perform this.startOauthReconnectFlow) (perform this.startOauthFlow))}}
                         >
-                            {{if @reconnect (t 'addons.accountCreate.reconnect') (t 'general.authorize')}}
+                            {{if @account (t 'addons.accountCreate.reconnect') (t 'general.authorize')}}
                         </Button>
                     </div>
                 </div>
@@ -68,7 +66,6 @@
                             local-class='auth-text-input-label'
                             placeholder={{t 'addons.accountCreate.repo-other-placeholder'}}
                             @value={{this.otherRepo}}
-                            {{on 'keyup' this.onOtherRepoChange}}
                         />
                         {{#if this.repoOtherPostText}}
                             <p>
@@ -76,6 +73,24 @@
                             </p>
                         {{/if}}
                     {{/if}}
+                {{else if this.showUrlField}}
+                    {{#let (unique-id 'url') as |url-id|}}
+                        <label for={{url-id}} local-class='auth-text-input-label'>
+                            {{t 'addons.accountCreate.url-label'}}
+                        </label>
+                        <div local-class='post-text'>
+                            {{t 'addons.accountCreate.owncloud-url-post-text' htmlSafe=true }}
+                        </div>
+                        <Input
+                            id={{url-id}}
+                            data-test-input='url'
+                            local-class='input'
+                            name='url'
+                            placeholder={{t 'addons.accountCreate.url-placeholder'}}
+                            @type='text'
+                            @value={{this.url}}
+                        />
+                    {{/let}}
                 {{/if}}
                 {{#each this.inputFields as |field|}}
                     {{#let (unique-id (field.name)) as |id|}}
@@ -94,28 +109,26 @@
                             autocomplete={{field.autocomplete}}
                             @type={{field.inputType}}
                             @value={{field.inputValue}}
-                            {{on 'input' @onInput}}
+                            {{on 'input' this.inputFieldChanged}}
                         />
                     {{/let}}
                 {{/each}}
-                {{#unless @reconnect}}
-                    {{#let (unique-id 'displayNameField') as |id|}}
-                        <label for={{id}} local-class='auth-text-input-label'>
-                            {{t 'addons.accountCreate.display-name-label'}}
-                        </label>
-                        <div local-class='post-text'>
-                            {{t 'addons.accountCreate.display-name-help'}}
-                        </div>
-                        <Input
-                            data-test-display-name-input
-                            id={{id}}
-                            local-class='input'
-                            placeholder={{t 'addons.accountCreate.display-name-placeholder'}}
-                            @value={{@manager.displayName}}
-                        />
-                    {{/let}}
-                {{/unless}}
-                {{#if @manager.connectAccountError}}
+                {{#let (unique-id 'displayNameField') as |id|}}
+                    <label for={{id}} local-class='auth-text-input-label'>
+                        {{t 'addons.accountCreate.display-name-label'}}
+                    </label>
+                    <div local-class='post-text'>
+                        {{t 'addons.accountCreate.display-name-help'}}
+                    </div>
+                    <Input
+                        data-test-display-name-input
+                        id={{id}}
+                        local-class='input'
+                        placeholder={{t 'addons.accountCreate.display-name-placeholder'}}
+                        @value={{this.displayName}}
+                    />
+                {{/let}}
+                {{#if this.connectAccountError}}
                     <p local-class='connect-error'>
                         {{t 'addons.accountCreate.error'}}
                     </p>
@@ -128,13 +141,13 @@
                     >
                         {{t 'general.cancel'}}
                     </Button>
-                    {{#if @reconnect}}
+                    {{#if @account}}
                         <Button
                             data-test-addon-reconnect-account-button
                             data-analytics-name='Reconnect Account'
                             @type='primary'
                             disabled={{@manager.reconnectAccount.isRunning}}
-                            {{on 'click' (perform @manager.reconnectAccount)}}
+                            {{on 'click' (perform this.reconnectAccount)}}
                         >
                             {{t 'addons.accountCreate.reconnect'}}
                         </Button>
@@ -144,7 +157,7 @@
                             data-analytics-name='Connect Account'
                             @type='primary'
                             disabled={{@manager.connectAccount.isRunning}}
-                            {{on 'click' (perform @manager.connectAccount this.displayName)}}
+                            {{on 'click' (perform this.connectAccount)}}
                         >
                             {{t 'addons.accountCreate.connect'}}
                         </Button>

--- a/lib/osf-components/addon/components/addons-service/manager/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/manager/template.hbs
@@ -23,10 +23,6 @@
     createConfiguredAddon=this.createConfiguredAddon
     oauthFlowRefocus=this.oauthFlowRefocus
     connectAccount=this.connectAccount
-    connectAccountError=this.connectAccountError
-    credentialsObject=this.credentialsObject
-    displayName=this.displayName
-    onCredentialsInput=this.onCredentialsInput
     confirmAccountSetup=this.confirmAccountSetup
     cancelSetup=this.cancelSetup
     saveConfiguration=this.saveConfiguration

--- a/lib/osf-components/addon/components/addons-service/user-addons-manager/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/user-addons-manager/template.hbs
@@ -8,8 +8,6 @@
     currentListIsLoading=this.currentListIsLoading
     currentTypeAuthorizedAccounts=this.currentTypeAuthorizedAccounts
     currentTypeAuthorizedServiceIds=this.currentTypeAuthorizedServiceIds
-    credentialsObject=this.credentialsObject
-    displayName=this.displayName
     pageMode=this.pageMode
     tabIndex=this.tabIndex
     changeTab=this.changeTab
@@ -19,7 +17,6 @@
     acceptProviderTerms=this.acceptProviderTerms
     navigateToReconnectProviderAccount=this.navigateToReconnectProviderAccount
     cancelSetup=this.cancelSetup
-    onCredentialsInput=this.onCredentialsInput
     createAuthorizedAccount=this.createAuthorizedAccount
     oauthFlowRefocus=this.oauthFlowRefocus
     connectAccount=this.connectAccount

--- a/mirage/views/addons.ts
+++ b/mirage/views/addons.ts
@@ -431,7 +431,7 @@ export function updateAuthorizedComputingAccount(this: HandlerContext, schema: S
 function prepareAuthorizedAccountAttrs(
     attrs: NormalizedRequestAttrs<AllAuthorizedAccountTypes>, externalService: ModelInstance<AllProviderTypes>,
 ) {
-    const authorized = fakeCheckCredentials(attrs.credentials!, externalService.credentialsFormat);
+    const authorized = fakeCheckCredentials(attrs, externalService.credentialsFormat);
     attrs.credentials = undefined;
     // @ts-ignore: authUrl is set by the backend
     attrs.authUrl = !authorized && attrs.initiateOauth ? 'https://www.fake.com' : '';
@@ -440,10 +440,13 @@ function prepareAuthorizedAccountAttrs(
     return attrs;
 }
 
-function fakeCheckCredentials(credentials: AddonCredentialFields, credentialsFormat: CredentialsFormat) {
+function fakeCheckCredentials(
+    attrs: NormalizedRequestAttrs<AllAuthorizedAccountTypes>, credentialsFormat: CredentialsFormat,
+) {
+    const credentials = attrs.credentials as AddonCredentialFields;
     switch (credentialsFormat) {
     case CredentialsFormat.REPO_TOKEN:
-        if (!credentials.token || !credentials.repo) {
+        if (!credentials.token || !attrs.apiBaseUrl) {
             throw new Error('Token and repo is required');
         }
         break;
@@ -458,10 +461,10 @@ function fakeCheckCredentials(credentials: AddonCredentialFields, credentialsFor
         }
         break;
     case CredentialsFormat.URL_USERNAME_PASSWORD:
-        if (!credentials.url || !credentials.username || !credentials.password) {
+        if (!attrs.apiBaseUrl || !credentials.username || !credentials.password) {
             throw new Error('URL, username, and password are required');
         }
-        if (credentials.url.indexOf('http') < 0) {
+        if (attrs.apiBaseUrl.indexOf('http') < 0) {
             throw new Error('Invalid URL');
         }
         break;

--- a/tests/acceptance/guid-node/addons-test.ts
+++ b/tests/acceptance/guid-node/addons-test.ts
@@ -1,7 +1,7 @@
 import { click as untrackedClick, fillIn } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { percySnapshot } from 'ember-percy';
-import { module, skip, test } from 'qunit';
+import { module, test } from 'qunit';
 
 import { click, currentURL, setupOSFApplicationTest, visit } from 'ember-osf-web/tests/helpers';
 import { Permission } from 'ember-osf-web/models/osf-model';
@@ -234,8 +234,7 @@ module('Acceptance | guid-node/addons', hooks => {
             .exists({ count: 1 }, 'One remove button is present after removing one');
     });
 
-    // Skip until issue with added account not showing up is resolved
-    skip('Adding new configured addons', async function(assert) {
+    test('Adding new configured addons', async function(assert) {
         const store = this.owner.lookup('service:store');
         const mirageUser = server.create('user', 'loggedIn');
         const mirageNode = server.create('node', { id: 'add0n', currentUserPermissions: [Permission.Admin] });

--- a/tests/acceptance/settings/addons-test.ts
+++ b/tests/acceptance/settings/addons-test.ts
@@ -13,7 +13,7 @@ module('Acceptance | settings | addons', hooks => {
 
     hooks.beforeEach(function(this: TestContext) {
         const currentUser = server.create('user', 'loggedIn');
-        server.create('user-reference', { id: currentUser.id });
+        const currentUserReference = server.create('user-reference', { id: currentUser.id });
         const boxAddon = server.create('external-storage-service',
             {
                 id: 'box',
@@ -46,9 +46,9 @@ module('Acceptance | settings | addons', hooks => {
             });
         server.create('authorized-storage-account', {
             displayName: 'My Box Account',
-            scopes: ['write'],
+            authorizedCapabilities: ['write'],
             externalStorageService: boxAddon,
-            accountOwner: currentUser,
+            accountOwner: currentUserReference,
             credentialsAvailable: true,
         });
     });
@@ -100,7 +100,6 @@ module('Acceptance | settings | addons', hooks => {
                     TermsOfServiceCapabilities.REGISTERING,
                 ],
                 configurableApiRoot: true,
-                readOnly: false,
                 maxConcurrentDownloads: 1,
                 maxUploadMb: 5,
                 iconUrl: 'https://owncloud.com/favicon.ico',


### PR DESCRIPTION
-   Ticket: [ENG-5951]
-   Feature flag: n/a

## Purpose
- Address some bugs in the authorized-account creation process
  - Need to remove `AuthorizedAccount.credentials.url` and `AuthorizedAccount.credentials.repo` out and use `AuthorizedAccount.apiBaseUrl` instead
  - Should be able to rename accounts when reconnecting

## Summary of Changes
- Move `apiBaseUrl` to `AuthorizedAccount` superclass
- Move `configurableApiRoot` to `ExternalService` superclass
- Move some logic that was for account creation out of the manager component and into the addon-account-setup component
  - Moved `displayName`, `credentialsObject` and `connectAccountError`, and other methods
  - Change method args for account creation
- Allow users to change name on account reconnect
- Update Dataverse repo options to include "https://"
- Remove `AuthorizedAccount.credentials.repo` and `AuthorizedAccount.credentials.url` and have those fields go to `AuthorizedAccount.apiBaseUrl` property
- Add back skipped test that should have been done as part of [ENG-5950]

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-5951]: https://openscience.atlassian.net/browse/ENG-5951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-5950]: https://openscience.atlassian.net/browse/ENG-5950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ