### PR TITLE
[ENG-5974] Add try-catch when getting addons

### DIFF
--- a/app/models/node.ts
+++ b/app/models/node.ts
@@ -13,6 +13,7 @@ import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 
 import getRelatedHref from 'ember-osf-web/utils/get-related-href';
+import captureException from 'ember-osf-web/utils/capture-exception';
 
 import AbstractNodeModel from 'ember-osf-web/models/abstract-node';
 import CitationModel from './citation';
@@ -331,20 +332,24 @@ export default class NodeModel extends AbstractNodeModel.extend(Validations, Col
     @task
     @waitFor
     async getEnabledAddons() {
-        const endpoint = `${apiUrl}/${apiNamespace}/nodes/${this.id}/addons/`;
-        const response = await this.currentUser.authenticatedAJAX({
-            url: endpoint,
-            type: 'GET',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            xhrFields: { withCredentials: true },
-        });
-        if (response.data) {
-            const addonList = response.data
-                .filter((addon: any) => addon.attributes.node_has_auth)
-                .map((addon: any) => addon.id);
-            this.set('addonsEnabled', addonList);
+        try {
+            const endpoint = `${apiUrl}/${apiNamespace}/nodes/${this.id}/addons/`;
+            const response = await this.currentUser.authenticatedAJAX({
+                url: endpoint,
+                type: 'GET',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                xhrFields: { withCredentials: true },
+            });
+            if (response.data) {
+                const addonList = response.data
+                    .filter((addon: any) => addon.attributes.node_has_auth)
+                    .map((addon: any) => addon.id);
+                this.set('addonsEnabled', addonList);
+            }
+        } catch (e) {
+            captureException(e);
         }
     }
 }


### PR DESCRIPTION
-   Ticket: [ENG-5974]
-   Feature flag: n/a

## Purpose
- Make files page a bit more robust with waffle flag `gravy_waffle`

## Summary of Changes
- Add try-catch around getting node addons, so page load doesn't break

## Screenshot(s)
- NA

## Side Effects

## QA Notes
- Ideally the files page won't break as things change with how we get addons

[ENG-5974]: https://openscience.atlassian.net/browse/ENG-5974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ