### PR TITLE
[ENG-5994] Fix Preprint Resubmission Workflow to Ensure Proper Moderation Handling

### DIFF
--- a/app/models/abstract-node.ts
+++ b/app/models/abstract-node.ts
@@ -1,9 +1,9 @@
 import { hasMany, AsyncHasMany, attr } from '@ember-data/model';
-
+import { PromiseManyArray } from '@ember-data/store/-private';
 import BaseFileItem from 'ember-osf-web/models/base-file-item';
 import DraftRegistrationModel from 'ember-osf-web/models/draft-registration';
 import FileProviderModel from 'ember-osf-web/models/file-provider';
-
+import ReviewActionModel from 'ember-osf-web/models/review-action';
 import { Permission } from './osf-model';
 
 export default class AbstractNodeModel extends BaseFileItem {
@@ -14,6 +14,9 @@ export default class AbstractNodeModel extends BaseFileItem {
     draftRegistrations!: AsyncHasMany<DraftRegistrationModel> & DraftRegistrationModel[];
 
     @attr('array') currentUserPermissions!: Permission[];
+
+    @hasMany('review-action', { inverse: 'target' })
+    reviewActions!: PromiseManyArray<ReviewActionModel>;
 
 }
 

--- a/app/models/preprint.ts
+++ b/app/models/preprint.ts
@@ -5,7 +5,6 @@ import AbstractNodeModel from 'ember-osf-web/models/abstract-node';
 import CitationModel from 'ember-osf-web/models/citation';
 import PreprintRequestModel from 'ember-osf-web/models/preprint-request';
 import { ReviewsState } from 'ember-osf-web/models/provider';
-import ReviewActionModel from 'ember-osf-web/models/review-action';
 
 import ContributorModel from './contributor';
 import FileModel from './file';
@@ -81,9 +80,6 @@ export default class PreprintModel extends AbstractNodeModel {
 
     @belongsTo('preprint-provider', { inverse: 'preprints' })
     provider!: AsyncBelongsTo<PreprintProviderModel> & PreprintProviderModel;
-
-    @hasMany('review-action')
-    reviewActions!: AsyncHasMany<ReviewActionModel>;
 
     @hasMany('contributors', { inverse: 'preprint'})
     contributors!: AsyncHasMany<ContributorModel> & ContributorModel;

--- a/app/models/registration.ts
+++ b/app/models/registration.ts
@@ -3,7 +3,7 @@ import { buildValidations, validator } from 'ember-cp-validations';
 
 import DraftRegistrationModel from 'ember-osf-web/models/draft-registration';
 import ResourceModel from 'ember-osf-web/models/resource';
-import ReviewActionModel, { ReviewActionTrigger } from 'ember-osf-web/models/review-action';
+import { ReviewActionTrigger } from 'ember-osf-web/models/review-action';
 import SchemaResponseModel, { RevisionReviewStates } from 'ember-osf-web/models/schema-response';
 import { RegistrationResponse } from 'ember-osf-web/packages/registration-schema';
 
@@ -148,9 +148,6 @@ export default class RegistrationModel extends NodeModel.extend(Validations) {
 
     @hasMany('institution', { inverse: 'registrations' })
     affiliatedInstitutions!: AsyncHasMany<InstitutionModel> | InstitutionModel[];
-
-    @hasMany('review-action', { inverse: 'target' })
-    reviewActions!: AsyncHasMany<ReviewActionModel> | ReviewActionModel[];
 
     @hasMany('schema-response', { inverse: 'registration' })
     schemaResponses!: AsyncHasMany<SchemaResponseModel> | SchemaResponseModel[];

--- a/app/models/review-action.ts
+++ b/app/models/review-action.ts
@@ -63,7 +63,7 @@ export default class ReviewActionModel extends Action {
     @attr('string') fromState!: RegistrationReviewStates;
     @attr('string') toState!: RegistrationReviewStates;
 
-    @belongsTo('registration', { inverse: 'reviewActions', polymorphic: true })
+    @belongsTo('abstract-node', { inverse: 'reviewActions', polymorphic: true })
     target!: (AsyncBelongsTo<RegistrationModel> & RegistrationModel
         ) | (AsyncBelongsTo<PreprintModel> & PreprintModel);
 

--- a/app/preprints/-components/submit/preprint-state-machine/component.ts
+++ b/app/preprints/-components/submit/preprint-state-machine/component.ts
@@ -201,18 +201,18 @@ export default class PreprintStateMachine extends Component<StateMachineArgs>{
     @waitFor
     public async onSubmit(): Promise<void> {
         this.args.resetPageDirty();
-        if (!this.isEditFlow) {
-            if (this.provider.reviewsWorkflow) {
-                const reviewAction = this.store.createRecord('review-action', {
-                    actionTrigger: 'submit',
-                    target: this.preprint,
-                });
-                await reviewAction.save();
-            } else {
-                this.preprint.isPublished = true;
-                await this.preprint.save();
-            }
+        if (this.provider.reviewsWorkflow) {
+            const reviewAction = this.store.createRecord('review-action', {
+                actionTrigger: 'submit',
+                target: this.preprint,
+            });
+            await reviewAction.save();
+        } else {
+            this.preprint.isPublished = true;
+            await this.preprint.save();
         }
+
+        await this.preprint.reload();
 
         await this.router.transitionTo('preprints.detail', this.provider.id, this.preprint.id);
     }

--- a/tests/unit/models/review-action-test.ts
+++ b/tests/unit/models/review-action-test.ts
@@ -27,7 +27,7 @@ module('Unit | Model | review-action', hooks => {
         const relationship = get(model, 'relationshipsByName').get('target');
 
         assert.equal(relationship.key, 'target');
-        assert.equal(relationship.type, 'registration');
+        assert.equal(relationship.type, 'abstract-node');
         assert.equal(relationship.kind, 'belongsTo');
     });
 


### PR DESCRIPTION
-   Ticket: [https://openscience.atlassian.net/browse/ENG-5994]
-   Feature flag: n/a

## Purpose

Fix Preprint Resubmission Workflow to Ensure Proper Moderation Handling

## Summary of Changes

- Added a hasMany relationship to review-action with the inverse set to target.
- Changed the belongsTo relationship from registration to abstract-node with the inverse set to reviewActions.
- Removed the conditional check for isEditFlow to ensure the review action is correctly triggered during both initial submission and edits.


