### PR TITLE
[ENG-6015] Add User Preprint List Endpoint to Mirage Server

### DIFF
--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -46,6 +46,7 @@ import {
     claimUnregisteredUser,
     userNodeList,
     userRegistrationList,
+    userPreprintList,
 } from './views/user';
 import { updatePassword } from './views/user-password';
 import * as userSettings from './views/user-setting';
@@ -312,6 +313,7 @@ export default function(this: Server) {
     this.get('/users/:id/nodes', userNodeList);
     this.get('/sparse/users/:id/nodes', userNodeList);
     this.get('/users/:id/registrations', userRegistrationList);
+    this.get('/users/:id/preprints', userPreprintList);
     osfNestedResource(this, 'user', 'draftRegistrations', {
         only: ['index'],
     });

--- a/mirage/views/user.ts
+++ b/mirage/views/user.ts
@@ -30,6 +30,23 @@ export function userRegistrationList(this: HandlerContext, schema: Schema, reque
     return json;
 }
 
+export function userPreprintList(this: HandlerContext, schema: Schema, request: Request) {
+    const user = schema.users.find(request.params.id);
+    const preprints = [];
+    const { contributorIds } = user;
+
+    for (const contributorId of contributorIds as string[]) {
+        const contributor = schema.contributors.find(contributorId);
+        const preprint = contributor.preprint;
+        if (preprint && filter(preprint, request)) {
+            preprints.push(this.serialize(preprint).data);
+        }
+    }
+
+    const json = process(schema, request, this, preprints, { defaultSortKey: 'dateModified' });
+    return json;
+}
+
 export function claimUnregisteredUser(this: HandlerContext) {
     return new Response(204);
 }

--- a/mirage/views/user.ts
+++ b/mirage/views/user.ts
@@ -43,7 +43,7 @@ export function userPreprintList(this: HandlerContext, schema: Schema, request: 
         }
     }
 
-    const json = process(schema, request, this, preprints, { defaultSortKey: 'dateModified' });
+    const json = process(schema, request, this, preprints, { defaultSortKey: 'last_logged' });
     return json;
 }
 


### PR DESCRIPTION
-   Ticket: [[ENG-6015]](https://openscience.atlassian.net/browse/ENG-6015)
-   Feature flag: n/a

## Purpose

Added a new endpoint to Mirage to handle requests for fetching a list of preprints associated with a specific user.

## Summary of Changes

- Added `userPreprintList` function to `mirage/views/user.ts` to fetch and filter preprints associated with a user's contributors.
- Configured the new `/users/:id/preprints` endpoint in `mirage/config.ts` to use the `userPreprintList` function for retrieving preprint data.



[ENG-6015]: https://openscience.atlassian.net/browse/ENG-6015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ