### PR TITLE
[ENG-5900] Added the ability to make the assertion page read-only for non-admins

### DIFF
--- a/app/preprints/-components/preprint-institutions/institution-manager/component-test.ts
+++ b/app/preprints/-components/preprint-institutions/institution-manager/component-test.ts
@@ -52,10 +52,12 @@ module('Integration | Preprint | Component | Institution Manager', hooks => {
                     singular: 'Test Preprint Word',
                 },
             },
-            isEditFlow: true,
             preprint,
             resetAffiliatedInstitutions: (): void => {
                 this.set('affiliatedInstitutions', []);
+            },
+            isElementDisabled(): boolean {
+                return !(this.preprint.currentUserPermissions).includes(Permission.Admin);
             },
             updateAffiliatedInstitution: (affiliatedIinstitution: InstitutionModel): void => {
                 const affiliatedInstitutions = this.get('affiliatedInstitutions');
@@ -128,7 +130,6 @@ module('Integration | Preprint | Component | Institution Manager', hooks => {
         async function(assert) {
             // When the component is rendered
             const managerMock = this.get('managerMock');
-            managerMock.isEditFlow = true;
 
             const affiliatedInstitutions = [] as any[];
             managerMock.preprint.affiliatedInstitutions.map((institution: InstitutionModel) => {
@@ -231,7 +232,6 @@ module('Integration | Preprint | Component | Institution Manager', hooks => {
         async function(assert) {
             const managerMock = this.get('managerMock');
             managerMock.preprint.currentUserPermissions = [Permission.Write, Permission.Read];
-            managerMock.isEditFlow = false;
             this.set('managerMock', managerMock);
 
             // When the component is rendered

--- a/app/preprints/-components/preprint-institutions/institution-manager/component.ts
+++ b/app/preprints/-components/preprint-institutions/institution-manager/component.ts
@@ -13,7 +13,6 @@ import Store from '@ember-data/store';
 import CurrentUser from 'ember-osf-web/services/current-user';
 import InstitutionModel from 'ember-osf-web/models/institution';
 import PreprintStateMachine from 'ember-osf-web/preprints/-components/submit/preprint-state-machine/component';
-import { Permission } from 'ember-osf-web/models/osf-model';
 
 
 interface PreprintInstitutionModel extends InstitutionModel {
@@ -95,7 +94,7 @@ export default class InstitutionsManagerComponent extends Component<InstitutionA
         this.manager.updateAffiliatedInstitution(institution);
     }
 
-    public get disableWriteAccess(): boolean {
-        return !(this.manager.preprint.currentUserPermissions).includes(Permission.Admin);
+    public get isElementDisabled(): boolean {
+        return this.manager.isElementDisabled();
     }
 }

--- a/app/preprints/-components/preprint-institutions/institution-manager/template.hbs
+++ b/app/preprints/-components/preprint-institutions/institution-manager/template.hbs
@@ -2,5 +2,5 @@
     institutions=this.institutions
     toggleInstitution=this.toggleInstitution
     preprintWord=this.preprintWord
-    disableWriteAccess=this.disableWriteAccess
+    isElementDisabled=this.isElementDisabled
 )}}

--- a/app/preprints/-components/preprint-institutions/institution-select-list/template.hbs
+++ b/app/preprints/-components/preprint-institutions/institution-select-list/template.hbs
@@ -13,7 +13,7 @@
                     <Input
                         data-test-institution-input={{index}}
                         @type='checkbox'
-                        @disabled={{@manager.disableWriteAccess}}
+                        @disabled={{@manager.isElementDisabled}}
                         @checked={{institution.isSelected}}
                         {{on 'change' (fn @manager.toggleInstitution institution)}}
                     />

--- a/app/preprints/-components/submit/author-assertions/component.ts
+++ b/app/preprints/-components/submit/author-assertions/component.ts
@@ -132,7 +132,6 @@ const AuthorAssertionsFormValidation: ValidationObject<AuthorAssertionsForm> = {
 export default class PublicData extends Component<AuthorAssertionsArgs>{
     @service intl!: Intl;
     @tracked isConflictOfInterestStatementDisabled = true;
-    @tracked isPublicDataStatementDisabled = true;
     authorAssertionFormChangeset = buildChangeset(
         this.args.manager.preprint,
         AuthorAssertionsFormValidation,
@@ -169,7 +168,7 @@ export default class PublicData extends Component<AuthorAssertionsArgs>{
                 this.intl.t('preprints.submit.step-assertions.conflict-of-interest-none'));
             this.isConflictOfInterestStatementDisabled = true;
         } else {
-            this.isConflictOfInterestStatementDisabled = false;
+            this.isConflictOfInterestStatementDisabled = false || !this.args.manager.isAdmin();
         }
     }
 
@@ -177,7 +176,7 @@ export default class PublicData extends Component<AuthorAssertionsArgs>{
     public updateCoi(): void {
         if (this.authorAssertionFormChangeset.get('hasCoi')) {
             this.authorAssertionFormChangeset.set('conflictOfInterestStatement', null);
-            this.isConflictOfInterestStatementDisabled = false;
+            this.isConflictOfInterestStatementDisabled = false || !this.args.manager.isAdmin();
         } else {
             this.authorAssertionFormChangeset.set('conflictOfInterestStatement',
                 this.intl.t('preprints.submit.step-assertions.conflict-of-interest-none'));
@@ -197,5 +196,9 @@ export default class PublicData extends Component<AuthorAssertionsArgs>{
         }
         this.authorAssertionFormChangeset.execute();
         this.args.manager.validateAuthorAssertions(true);
+    }
+
+    public get isElementDisabled(): boolean {
+        return this.args.manager.isElementDisabled();
     }
 }

--- a/app/preprints/-components/submit/author-assertions/link-widget/component.ts
+++ b/app/preprints/-components/submit/author-assertions/link-widget/component.ts
@@ -10,6 +10,7 @@ import { tracked } from '@glimmer/tracking';
  */
 interface LinkWidgetArgs {
     update: (_: string[]) => {};
+    disabled: boolean;
     links: string[];
 }
 

--- a/app/preprints/-components/submit/author-assertions/link-widget/link/component.ts
+++ b/app/preprints/-components/submit/author-assertions/link-widget/link/component.ts
@@ -15,6 +15,7 @@ import { tracked } from '@glimmer/tracking';
 interface LinkArgs {
     remove: (__:number) => {};
     update: (_: string, __:number) => {};
+    disabled: boolean;
     value: string;
     placeholder: string;
     index: number;

--- a/app/preprints/-components/submit/author-assertions/link-widget/link/template.hbs
+++ b/app/preprints/-components/submit/author-assertions/link-widget/link/template.hbs
@@ -12,6 +12,7 @@
                 <form.text
                     data-test-link-input
                     @isRequired={{true}}
+                    @disabled={{@disabled}}
                     {{on 'change' this.onUpdate}}
                     @placeholder={{ @placeholder }}
                     @valuePath={{'value'}}
@@ -20,17 +21,19 @@
 
             </div>
             <div local-class='delete-container'>
-                <Button
-                    data-test-remove-link
-                    aria-label={{t 'preprints.submit.step-assertions.public-link-remove-button'}}
-                    @layout='fake-link'
-                    {{on 'click' this.removeLink}}
-                >
-                    <FaIcon @icon='times' local-class='delete' />
-                    <EmberTooltip>
-                        {{t 'preprints.submit.step-assertions.public-link-remove-button'}}
-                    </EmberTooltip>
-                </Button>
+                {{#unless @disabled}}
+                    <Button
+                        data-test-remove-link
+                        aria-label={{t 'preprints.submit.step-assertions.public-link-remove-button'}}
+                        @layout='fake-link'
+                        {{on 'click' this.removeLink}}
+                    >
+                        <FaIcon @icon='times' local-class='delete' />
+                        <EmberTooltip>
+                            {{t 'preprints.submit.step-assertions.public-link-remove-button'}}
+                        </EmberTooltip>
+                    </Button>
+                {{/unless}}
             </div>
         </FormControls>
     {{/if}}

--- a/app/preprints/-components/submit/author-assertions/link-widget/template.hbs
+++ b/app/preprints/-components/submit/author-assertions/link-widget/template.hbs
@@ -7,18 +7,21 @@
                 @value={{link}}
                 @index={{index}}
                 @placeholder={{@placeholder}}
+                @disabled={{@disabled}}
             />
         </div>
     {{/each}}
 
-    <Button
-        data-test-add-another-link
-        aria-label={{t 'preprints.submit.step-assertions.public-link-add-button'}}
-        local-class='add-another-link'
-        @layout='fake-link'
-        {{on 'click' this.addLink}}
-    >
-        <FaIcon @icon='plus' local-class='plus-icon' />
-        {{t 'preprints.submit.step-assertions.public-link-add-button'}}
-    </Button>
+    {{#unless @disabled}}
+        <Button
+            data-test-add-another-link
+            aria-label={{t 'preprints.submit.step-assertions.public-link-add-button'}}
+            local-class='add-another-link'
+            @layout='fake-link'
+            {{on 'click' this.addLink}}
+        >
+            <FaIcon @icon='plus' local-class='plus-icon' />
+            {{t 'preprints.submit.step-assertions.public-link-add-button'}}
+        </Button>
+    {{/unless}}
 </div>

--- a/app/preprints/-components/submit/author-assertions/public-data/component.ts
+++ b/app/preprints/-components/submit/author-assertions/public-data/component.ts
@@ -16,6 +16,7 @@ interface PublicDataArgs {
     manager: PreprintStateMachine;
     changeSet: BufferedChangeset;
     preprintWord: string;
+    disabled: boolean;
     validate: () => {};
 }
 
@@ -64,11 +65,11 @@ export default class PublicData extends Component<PublicDataArgs>{
     public updatePublicDataOptions(): void {
         if (this.args.changeSet.get('hasDataLinks') === PreprintDataLinksEnum.AVAILABLE) {
             this.args.changeSet.set('whyNoData', null);
-            this.isPublicDataWhyNoStatementDisabled = false;
+            this.isPublicDataWhyNoStatementDisabled = false || !this.args.manager.isAdmin();
         } else if (this.args.changeSet.get('hasDataLinks') === PreprintDataLinksEnum.NO) {
             this.args.changeSet.set('dataLinks', []);
             this.args.changeSet.set('whyNoData', null);
-            this.isPublicDataWhyNoStatementDisabled = false;
+            this.isPublicDataWhyNoStatementDisabled = false || !this.args.manager.isAdmin();
             this.placeholder = this.intl.t('preprints.submit.step-assertions.public-data-no-placeholder');
         } else {
             this.args.changeSet.set('dataLinks', []);

--- a/app/preprints/-components/submit/author-assertions/public-data/template.hbs
+++ b/app/preprints/-components/submit/author-assertions/public-data/template.hbs
@@ -20,6 +20,7 @@
                 @valuePath={{'hasDataLinks'}}
                 @class='radio-group {{if (is-mobile) 'mobile'}}'
                 @isRequired={{true}}
+                @disabled={{@disabled}}
                 @options={{this.publicDataOptions}}
                 @onchange={{this.updatePublicDataOptions}}
                 as |radioGroup|
@@ -33,6 +34,7 @@
                 <Preprints::-Components::Submit::AuthorAssertions::LinkWidget
                 @update={{this.updatePublicDataLinks}}
                 @placeholder={{t 'preprints.submit.step-assertions.public-data-link-placeholder'}}
+                @disabled={{@disabled}}
                 @links={{@manager.preprint.dataLinks}}
             />
             </div>

--- a/app/preprints/-components/submit/author-assertions/public-preregistration/component.ts
+++ b/app/preprints/-components/submit/author-assertions/public-preregistration/component.ts
@@ -16,6 +16,7 @@ interface PublicPreregistrationArgs {
     manager: PreprintStateMachine;
     changeSet: BufferedChangeset;
     preprintWord: string;
+    disabled: boolean;
     validate: () => {};
 }
 
@@ -96,11 +97,11 @@ export default class PublicPreregistration extends Component<PublicPreregistrati
     public updatePublicPreregistrationOptions(): void {
         if (this.args.changeSet.get('hasPreregLinks') === PreprintPreregLinksEnum.AVAILABLE) {
             this.args.changeSet.set('whyNoPrereg', null);
-            this.isPublicPreregistrationWhyNoStatementDisabled = false;
+            this.isPublicPreregistrationWhyNoStatementDisabled = false || !this.args.manager.isAdmin();
         } else if (this.args.changeSet.get('hasPreregLinks') === PreprintPreregLinksEnum.NO) {
             this.args.changeSet.set('preregLinks', []);
             this.args.changeSet.set('whyNoPrereg', null);
-            this.isPublicPreregistrationWhyNoStatementDisabled = false;
+            this.isPublicPreregistrationWhyNoStatementDisabled = false || !this.args.manager.isAdmin();
             this.placeholder = this.intl.t('preprints.submit.step-assertions.public-preregistration-no-placeholder');
         } else {
             this.isPublicPreregistrationWhyNoStatementDisabled = true;

--- a/app/preprints/-components/submit/author-assertions/public-preregistration/template.hbs
+++ b/app/preprints/-components/submit/author-assertions/public-preregistration/template.hbs
@@ -20,6 +20,7 @@
                 @valuePath={{'hasPreregLinks'}}
                 @class='radio-group {{if (is-mobile) 'mobile'}}'
                 @isRequired={{true}}
+                @disabled={{@disabled}}
                 @options={{this.publicPreregistrationOptions}}
                 @onchange={{this.updatePublicPreregistrationOptions}}
                 as |radioGroup|
@@ -33,6 +34,7 @@
                 <select
                     onchange={{action 'updatePreregistrationLinkInfo' value='target.value'}}
                     local-class='select'
+                    disabled={{@disabled}}
                     class='form-control'
                 >
                     {{#each this.publicPreregLinkInfoOptions as |infoOption|}}
@@ -54,6 +56,7 @@
             <div local-class='input-container'>
                 <Preprints::-Components::Submit::AuthorAssertions::LinkWidget
                 @update={{this.updatePublicPreregistrationLinks}}
+                @disabled={{@disabled}}
                 @placeholder={{t 'preprints.submit.step-assertions.public-preregistration-link-placeholder'}}
                 @links={{@manager.preprint.preregLinks}}
             />

--- a/app/preprints/-components/submit/author-assertions/template.hbs
+++ b/app/preprints/-components/submit/author-assertions/template.hbs
@@ -29,6 +29,7 @@
                         @class='radio-group {{if (is-mobile) 'mobile'}}'
                         @isRequired={{true}}
                         @options={{this.coiOptions}}
+                        @disabled={{this.isElementDisabled}}
                         @onchange={{this.updateCoi}}
                         as |radioGroup|
                     >
@@ -52,6 +53,7 @@
                     @changeSet={{this.authorAssertionFormChangeset}}
                     @preprintWord={{@manager.provider.documentType.singular}}
                     @validate={{this.validate}}
+                    @disabled={{this.isElementDisabled}}
                     @manager={{@manager}}
                 />
             </div>
@@ -61,6 +63,7 @@
                     @changeSet={{this.authorAssertionFormChangeset}}
                     @preprintWord={{@manager.provider.documentType.singular}}
                     @validate={{this.validate}}
+                    @disabled={{this.isElementDisabled}}
                     @manager={{@manager}}
                 />
             </div>

--- a/app/preprints/-components/submit/metadata/component.ts
+++ b/app/preprints/-components/submit/metadata/component.ts
@@ -167,4 +167,8 @@ export default class Metadata extends Component<MetadataArgs>{
         this.metadataFormChangeset.execute();
         this.args.manager.validateMetadata(true);
     }
+
+    public get widgetMode(): string {
+        return this.args.manager.isAdmin() ? 'editable' : 'readonly';
+    }
 }

--- a/app/preprints/-components/submit/metadata/template.hbs
+++ b/app/preprints/-components/submit/metadata/template.hbs
@@ -16,7 +16,7 @@
                     @preprint={{@manager.preprint}}
                     @shouldShowAdd={{this.showAddContributorWidget}}
                     @toggleAddContributorWidget={{this.toggleAddContributorWidget}}
-                    @widgetMode={{'editable'}}
+                    @widgetMode={{this.widgetMode}}
                     @displayPermissionWarning={{this.displayPermissionWarning}}
                 />
             </div>

--- a/app/preprints/-components/submit/preprint-state-machine/template.hbs
+++ b/app/preprints/-components/submit/preprint-state-machine/template.hbs
@@ -41,4 +41,7 @@
 
     updateAffiliatedInstitution=this.updateAffiliatedInstitution
     resetAffiliatedInstitutions=this.resetAffiliatedInstitutions
+
+    isElementDisabled=this.isElementDisabled
+    isAdmin=this.isAdmin
 )}}


### PR DESCRIPTION
-   Ticket: [ENG-5900]
-   Feature flag: n/a

## Purpose

[ENG-5900] Added the ability to make the assertion page read-only for non-admins

## Summary of Changes

Passed an 'isElementDisabled' or 'isAdmin' attribute around to the components on the assertion page.

## Screenshot(s)

![Screenshot 2024-08-19 at 1 55 09 PM](https://github.com/user-attachments/assets/d65fbf61-3e84-40ee-af43-ffc9a4165a20)


## Side Effects

Likely many

## QA Notes

Test it


[ENG-5900]: https://openscience.atlassian.net/browse/ENG-5900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-5900]: https://openscience.atlassian.net/browse/ENG-5900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ