### PR TITLE
[ENG-6054] Add a cancel button to the preprint page.

### DIFF
--- a/app/preprints/-components/submit/preprint-state-machine/action-flow/styles.scss
+++ b/app/preprints/-components/submit/preprint-state-machine/action-flow/styles.scss
@@ -9,6 +9,10 @@
     justify-content: flex-start;
     border-bottom: 1px solid $color-border-gray-darker;
 
+    &.edit {
+        height: 240px;
+    }
+
     .btn {
         width: 145px;
         display: flex;

--- a/app/preprints/-components/submit/preprint-state-machine/action-flow/template.hbs
+++ b/app/preprints/-components/submit/preprint-state-machine/action-flow/template.hbs
@@ -1,4 +1,4 @@
-<div local-class='action-flow-container  {{if (is-mobile) 'mobile'}}'>
+<div local-class='action-flow-container  {{if (is-mobile) 'mobile'}} {{if @manager.isEditFlow 'edit'}}'>
     {{#if this.isSubmit}}
         {{#if (is-mobile)}}
             <div local-class='mobile-button-container'>
@@ -117,6 +117,37 @@
                 />
             </div>
         {{/if}}
+    {{/if}}
+    {{#if @manager.isEditFlow}}
+        {{#if (is-mobile)}}
+            <div local-class='mobile-button-container'>
+                <DeleteButton
+                    data-test-cancel-button
+                    @small={{true}}
+                    @icon='times'
+                    @noBackground={{true}}
+                    @delete={{perform @manager.onCancel}}
+                    @modalTitle={{t 'preprints.submit.action-flow.cancel-modal-title'}}
+                    @modalBody={{t 'preprints.submit.action-flow.cancel-modal-body'}}
+                />
+            </div>
+        {{else}}
+            <div local-class='desktop-button-container'>
+                <DeleteButton
+                    data-test-cancel-button
+                    class='btn-destroy'
+                    local-class='btn'
+                    @buttonLayout='large'
+                    @noBackground={{true}}
+                    @delete={{perform @manager.onCancel}}
+                    @modalTitle={{t 'preprints.submit.action-flow.cancel-modal-title'}}
+                    @modalBody={{t 'preprints.submit.action-flow.cancel-modal-body'}}
+                    @buttonLabel={{t 'preprints.submit.action-flow.cancel'}}
+                    @confirmButtonText={{t 'general.ok'}}
+                />
+            </div>
+        {{/if}}
+
     {{/if}}
     {{#if @manager.isWithdrawalButtonDisplayed}}
         <div local-class='{{if (is-mobile) 'mobile-button-container' 'desktop-button-container'}}'>

--- a/app/preprints/-components/submit/preprint-state-machine/component.ts
+++ b/app/preprints/-components/submit/preprint-state-machine/component.ts
@@ -130,6 +130,16 @@ export default class PreprintStateMachine extends Component<StateMachineArgs>{
      */
     @task
     @waitFor
+    public async onCancel(): Promise<void> {
+        await this.router.transitionTo('preprints.detail', this.provider.id, this.preprint.id);
+    }
+
+
+    /**
+     * Callback for the action-flow component
+     */
+    @task
+    @waitFor
     public async onWithdrawal(): Promise<void> {
         try {
             const preprintRequest = await this.store.createRecord('preprint-request', {

--- a/app/preprints/-components/submit/preprint-state-machine/template.hbs
+++ b/app/preprints/-components/submit/preprint-state-machine/template.hbs
@@ -6,6 +6,7 @@
     onNext=this.onNext
     onPrevious=this.onPrevious
     onSubmit=this.onSubmit
+    onCancel=this.onCancel
     preprint=this.preprint
     provider=this.provider
     isNextButtonDisabled=this.isNextButtonDisabled

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1289,6 +1289,9 @@ preprints:
             step-supplements: 'Supplements'
             step-review: 'Review'
         action-flow:
+            cancel: 'Cancel'
+            cancel-modal-body: 'Are you sure you want to cancel editing? The updates on this page will not be saved.'
+            cancel-modal-title: 'Cancel Edit'
             delete: 'Delete'
             delete-modal-body: 'Are you sure you want to delete the {singularPreprintWord}? This action CAN NOT be undone.'
             delete-modal-title: 'Delete {singularPreprintWord}'


### PR DESCRIPTION
-   Ticket: [ENG-6054]
-   Feature flag: n/a

## Purpose

Add the ability to cancel or leave the edit flow

## Summary of Changes

Added a button to the action component with logic in the manager component

## Screenshot(s)

![Screenshot 2024-08-20 at 1 02 55 PM](https://github.com/user-attachments/assets/ff219a71-2656-4a93-add0-13894e3750a8)


## Side Effects

None

## QA Notes

Done

[ENG-6054]: https://openscience.atlassian.net/browse/ENG-6054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ