### PR TITLE
[ENG-5899][WIP] 2.1.1 FE: Make contributor widget read-only for read-write user

### DIFF
--- a/app/preprints/-components/submit/metadata/component.ts
+++ b/app/preprints/-components/submit/metadata/component.ts
@@ -79,7 +79,7 @@ const MetadataFormValidation: ValidationObject<MetadataForm> = {
 export default class Metadata extends Component<MetadataArgs>{
     @service store!: Store;
     metadataFormChangeset = buildChangeset(this.args.manager.preprint, MetadataFormValidation);
-    showAddContributorWidget = true;
+    showAddContributorWidget = this.args.manager.isAdmin();
     @tracked displayRequiredLicenseFields = false;
     @tracked licenses = [] as LicenseModel[];
     license!: LicenseModel;

--- a/lib/osf-components/addon/components/contributors/card/readonly/template.hbs
+++ b/lib/osf-components/addon/components/contributors/card/readonly/template.hbs
@@ -36,6 +36,9 @@
                 data-test-contributor-permission={{@contributor.id}}
                 local-class='permission-section'
             >
+                <EmberTooltip>
+                    {{t 'osf-components.contributors.permissionsNotEditable' }}
+                </EmberTooltip>
                 {{t (concat 'osf-components.contributors.permissions.' @contributor.permission)}}
             </div>
             <div local-class='action-section'>

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -2680,6 +2680,7 @@ osf-components:
                 button: 'Remove contributor'
             success: 'You have successfully removed {contributorName}.'
             errorHeading: 'Could not remove contributor. '
+        permissionsNotEditable: 'Only Admins may edit permissions.'
     reviewActionsList:
         failedToLoadActions: 'Failed to load moderation history'
         noActionsFound: 'No moderation history found'


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: https://openscience.atlassian.net/browse/ENG-5899
-   Feature flag: n/a

## Purpose

Hides Add contributor widget for non-admins and adds tooltips for the readonly contributor widget.

## Summary of Changes

- Makes `showAddContributorWidget` depend on admin status
- Adds `EmberTooltip` to readonly version of contributor widget

## Screenshot(s)
![Screenshot 2024-08-21 at 10 05 48 AM](https://github.com/user-attachments/assets/5ab2bcb2-267d-4ddb-97bf-86b586fafce4)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
