### PR TITLE
Fixed a missed translation on a cancel button for mobile

### DIFF
--- a/app/preprints/-components/submit/preprint-state-machine/action-flow/template.hbs
+++ b/app/preprints/-components/submit/preprint-state-machine/action-flow/template.hbs
@@ -129,6 +129,8 @@
                     @delete={{perform @manager.onCancel}}
                     @modalTitle={{t 'preprints.submit.action-flow.cancel-modal-title'}}
                     @modalBody={{t 'preprints.submit.action-flow.cancel-modal-body'}}
+                    @buttonLabel={{t 'preprints.submit.action-flow.cancel'}}
+                    @confirmButtonText={{t 'general.ok'}}
                 />
             </div>
         {{else}}


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose

Wrong button on mobile flow

## Summary of Changes

Added code to update the buttons

## Screenshot(s)
![Screenshot 2024-08-23 at 9 15 41 AM](https://github.com/user-attachments/assets/5b6aa996-3716-4367-b196-4dc483629bb2)



## Side Effects

None

## QA Notes

Done
