### PR TITLE
Link to reports updates

### DIFF
--- a/app/institutions/dashboard/-components/institutional-dashboard-wrapper/styles.scss
+++ b/app/institutions/dashboard/-components/institutional-dashboard-wrapper/styles.scss
@@ -19,20 +19,6 @@
     justify-content: space-between;
 }
 
-.download-button {
-    display: inline-block;
-    border: 1px solid $color-border-gray;
-    border-radius: 2px;
-    padding: 6px 12px;
-}
-
-.download-button:focus,
-.download-button:hover {
-    color: $color-text-black;
-    background-color: $color-shadow-dark;
-    border-color: $color-border-gray-darker;
-}
-
 .tab-list {
     @include clamp-width;
     @include tab-list;

--- a/app/institutions/dashboard/-components/institutional-dashboard-wrapper/template.hbs
+++ b/app/institutions/dashboard/-components/institutional-dashboard-wrapper/template.hbs
@@ -9,6 +9,7 @@
                     <OsfLink
                         data-test-link-to-reports-archive
                         data-analytics-name='Link to archived reports'
+                        @target='_blank'
                         @fakeButton={{true}}
                         @href={{@institution.linkToExternalReportsArchive}}
                     >

--- a/app/institutions/dashboard/-components/institutional-dashboard-wrapper/template.hbs
+++ b/app/institutions/dashboard/-components/institutional-dashboard-wrapper/template.hbs
@@ -9,7 +9,7 @@
                     <OsfLink
                         data-test-link-to-reports-archive
                         data-analytics-name='Link to archived reports'
-                        local-class='download-button'
+                        @fakeButton={{true}}
                         @href={{@institution.linkToExternalReportsArchive}}
                     >
                         <EmberTooltip @side='bottom'>

--- a/lib/osf-components/addon/components/osf-link/component.ts
+++ b/lib/osf-components/addon/components/osf-link/component.ts
@@ -35,6 +35,7 @@ export default class OsfLink extends Component {
     href?: string;
     queryParams?: Record<string, unknown>;
     fragment?: string;
+    fakeButton?: boolean;
 
     rel: AnchorRel = 'noopener noreferrer';
     target: AnchorTarget = '_self';

--- a/lib/osf-components/addon/components/osf-link/styles.scss
+++ b/lib/osf-components/addon/components/osf-link/styles.scss
@@ -6,3 +6,9 @@
         text-decoration: underline;
     }
 }
+
+.Button {
+    composes: Button from '../button/styles.scss';
+    composes: MediumButton from '../button/styles.scss';
+    composes: SecondaryButton from '../button/styles.scss';
+}

--- a/lib/osf-components/addon/components/osf-link/template.hbs
+++ b/lib/osf-components/addon/components/osf-link/template.hbs
@@ -3,7 +3,7 @@
     target={{this.target}}
     rel={{this.rel}}
     class='{{this.class}} {{if this.isActive 'active'}}'
-    local-class='OsfLink'
+    local-class='OsfLink {{if this.fakeButton 'Button'}}'
     onclick={{action this._onClick}}
     ...attributes
 >

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -800,7 +800,7 @@ institutions:
             preprints: Preprints
         content-placeholder: Content coming soon # Delete this eventually pls
         title: '{institutionName} Dashboard'
-        download_past_reports_label: 'View prior reports'
+        download_past_reports_label: 'Previous reports'
         download_csv: 'Download CSV'
         select_default: 'All Departments'
         users_list:

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -800,7 +800,7 @@ institutions:
             preprints: Preprints
         content-placeholder: Content coming soon # Delete this eventually pls
         title: '{institutionName} Dashboard'
-        download_past_reports_label: Reports
+        download_past_reports_label: 'View prior reports'
         download_csv: 'Download CSV'
         select_default: 'All Departments'
         users_list:


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Address some CR comments from prior PR https://github.com/CenterForOpenScience/ember-osf-web/pull/2296

## Summary of Changes
- Add a new arg `@fakeButton` to `OsfLink` to easily make a link look like a button (which maybe isn't a pattern we want to encourage, but at least now it's DRY when we do it 😬 )
- Update wording for hover text for reports
- Have link open in a new window

## Screenshot(s)
![image](https://github.com/user-attachments/assets/eb0f6445-05db-4007-8331-bb8ae74c05d0)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
