### PR TITLE
[ENG-6203] Added logic to fix a bug on preprint edit flow with affiliated institutions

### DIFF
--- a/app/preprints/-components/preprint-institutions/institution-manager/component-test.ts
+++ b/app/preprints/-components/preprint-institutions/institution-manager/component-test.ts
@@ -100,6 +100,7 @@ module('Integration | Preprint | Component | Institution Manager', hooks => {
 
     test('it renders with 4 user institutions and 0 affiliated preprint institution - create flow',
         async function(assert) {
+            // Given the mock is instantiated
             const managerMock = this.get('managerMock');
 
             // And retrieve the preprint from the store
@@ -111,6 +112,7 @@ module('Integration | Preprint | Component | Institution Manager', hooks => {
             managerMock.preprint.affiliatedInstitutions = [];
             await managerMock.preprint.save();
 
+            // When the component is rendered
             await render(hbs`
 <Preprints::-Components::PreprintInstitutions::InstitutionManager
         @manager={{this.managerMock}} as |manager|>
@@ -127,11 +129,14 @@ module('Integration | Preprint | Component | Institution Manager', hooks => {
             assert.dom('[data-test-institution-input="2"]').isChecked();
             assert.dom('[data-test-institution-input="3"]').isChecked();
             assert.dom('[data-test-institution-input="4"]').doesNotExist();
+
+            // Finally the affiliatedInstitutions on the manager is verified
+            assert.equal(this.get('affiliatedInstitutions').length, 4);
         });
 
     test('it renders with 4 user institutions and 1 affiliated preprint institution - edit flow',
         async function(assert) {
-            // When the component is rendered
+            // Given the mock is instantiated
             const managerMock = this.get('managerMock');
 
             const affiliatedInstitutions = [] as any[];
@@ -141,6 +146,7 @@ module('Integration | Preprint | Component | Institution Manager', hooks => {
                 }
             });
 
+            // When the component is rendered
             managerMock.preprint.affiliatedInstitutions = affiliatedInstitutions;
             this.set('managerMock', managerMock);
             await render(hbs`
@@ -159,6 +165,9 @@ module('Integration | Preprint | Component | Institution Manager', hooks => {
             assert.dom('[data-test-institution-input="2"]').isNotChecked();
             assert.dom('[data-test-institution-input="3"]').isNotChecked();
             assert.dom('[data-test-institution-input="4"]').doesNotExist();
+
+            // Finally the affiliatedInstitutions on the manager is verified
+            assert.equal(this.get('affiliatedInstitutions').length, 1);
         });
 
     test('it removes affiliated preprint institution',
@@ -189,6 +198,9 @@ module('Integration | Preprint | Component | Institution Manager', hooks => {
             affiliatedInstitutions.forEach((institution: InstitutionModel) => {
                 assert.notEqual(institution.id, 'osf', 'The osf institution is found.');
             });
+
+            // Finally the affiliatedInstitutions on the manager is verified
+            assert.equal(this.get('affiliatedInstitutions').length, 0);
         });
 
     test('it adds affiliated preprint institution',
@@ -229,10 +241,14 @@ module('Integration | Preprint | Component | Institution Manager', hooks => {
             });
 
             assert.true(isInstitutionAffiliatedFound, 'The second institution is now affiliated');
+
+            // Finally the affiliatedInstitutions on the manager is verified
+            assert.equal(this.get('affiliatedInstitutions').length, 2);
         });
 
     test('it renders with the institutions enabled for write users',
         async function(assert) {
+            // Given the mock is instantiated
             const managerMock = this.get('managerMock');
             managerMock.preprint.currentUserPermissions = [Permission.Write, Permission.Read];
             this.set('managerMock', managerMock);
@@ -258,10 +274,14 @@ module('Integration | Preprint | Component | Institution Manager', hooks => {
             assert.dom('[data-test-institution-input="3"]').isNotChecked();
             assert.dom('[data-test-institution-input="3"]').isEnabled();
             assert.dom('[data-test-institution-input="4"]').doesNotExist();
+
+            // Finally the affiliatedInstitutions on the manager is verified
+            assert.equal(this.get('affiliatedInstitutions').length, 1);
         });
 
     test('it renders with the institutions as disabled for read users',
         async function(assert) {
+            // Given the mock is instantiated
             const managerMock = this.get('managerMock');
             managerMock.preprint.currentUserPermissions = [Permission.Read];
             this.set('managerMock', managerMock);
@@ -287,5 +307,8 @@ module('Integration | Preprint | Component | Institution Manager', hooks => {
             assert.dom('[data-test-institution-input="3"]').isNotChecked();
             assert.dom('[data-test-institution-input="3"]').isDisabled();
             assert.dom('[data-test-institution-input="4"]').doesNotExist();
+
+            // Finally the affiliatedInstitutions on the manager is verified
+            assert.equal(this.get('affiliatedInstitutions').length, 1);
         });
 });

--- a/app/preprints/-components/preprint-institutions/institution-manager/component.ts
+++ b/app/preprints/-components/preprint-institutions/institution-manager/component.ts
@@ -55,28 +55,39 @@ export default class InstitutionsManagerComponent extends Component<InstitutionA
 
                 await this.manager.preprint.affiliatedInstitutions;
 
+                userInstitutions.map((institution: PreprintInstitutionModel) => {
+                    this.institutions.push(institution);
+                });
+
                 /**
                  * The affiliated institutions of a preprint is in
                  * "edit" mode if there are institutions on the
-                 * preprint model. Since the affiliated institutions
+                 * preprint model or the flow is in edit mode.
+                 * Since the affiliated institutions
                  * are persisted by clicking the next button, the
                  * affiliated institutions can be in "Edit mode" even
                  * when the manager is not in edit mode.
                  */
-                let isEditMode = false;
+                let isEditMode = this.manager.isEditFlow;
                 this.manager.preprint.affiliatedInstitutions.map((institution: PreprintInstitutionModel) => {
                     isEditMode = true;
-                    institution.isSelected = true;
-                    this.manager.updateAffiliatedInstitution(institution);
-                });
-
-                userInstitutions.forEach((institution: PreprintInstitutionModel) => {
-                    if (!isEditMode) {
+                    if(this.isAffiliatedInstitutionOwnerByUser(institution.id)) {
                         institution.isSelected = true;
                         this.manager.updateAffiliatedInstitution(institution);
                     }
-                    this.institutions.push(institution);
                 });
+
+                /**
+                 * The business rule is during the create flow or
+                 * "non-edit-flow" all of the institutions should be
+                 * checked by default
+                 */
+                if (!isEditMode) {
+                    userInstitutions.map((institution: PreprintInstitutionModel) => {
+                        institution.isSelected = true;
+                        this.manager.updateAffiliatedInstitution(institution);
+                    });
+                }
 
                 notifyPropertyChange(this, 'institutions');
 
@@ -87,6 +98,12 @@ export default class InstitutionsManagerComponent extends Component<InstitutionA
                 throw e;
             }
         }
+    }
+
+    private isAffiliatedInstitutionOwnerByUser(id: string): boolean {
+        return this.institutions.find(
+            institution => institution.id === id,
+        ) !== undefined;
     }
 
     @action

--- a/app/preprints/edit/route.ts
+++ b/app/preprints/edit/route.ts
@@ -13,6 +13,7 @@ import PreprintEdit from 'ember-osf-web/preprints/edit/controller';
 import Intl from 'ember-intl/services/intl';
 import Transition from '@ember/routing/-private/transition';
 import { Permission } from 'ember-osf-web/models/osf-model';
+import Toast from 'ember-toastr/services/toast';
 
 @requireAuth()
 export default class PreprintEditRoute extends Route.extend(ConfirmationMixin, {}) {
@@ -21,6 +22,7 @@ export default class PreprintEditRoute extends Route.extend(ConfirmationMixin, {
     @service router!: RouterService;
     @service intl!: Intl;
     @service metaTags!: MetaTags;
+    @service toast!: Toast;
     headTags?: HeadTagDef[];
 
     // This does NOT work on chrome and I'm going to leave it just in case
@@ -46,9 +48,13 @@ export default class PreprintEditRoute extends Route.extend(ConfirmationMixin, {
                 !preprint.currentUserPermissions.includes(Permission.Write) ||
                 preprint.isWithdrawn
             ) {
-                throw new Error('User does not have permission to edit this preprint');
+                const errorMessage = this.intl.t('preprints.submit.edit-permission-error',
+                    {
+                        singularPreprintWord: provider.documentType.singular,
+                    });
+                this.toast.error(errorMessage);
+                throw new Error(errorMessage);
             }
-
 
             return {
                 provider,

--- a/mirage/scenarios/default.ts
+++ b/mirage/scenarios/default.ts
@@ -15,6 +15,7 @@ import { settingsScenario } from './settings';
 import { registrationsLiteScenario } from './registrations.lite';
 import { registrationsManyProjectsScenario} from './registrations.many-projects';
 import { userScenario } from './user';
+import { preprintsAffiliatedInstitutionsScenario } from './preprints.affiliated-institutions';
 
 const {
     mirageScenarios,
@@ -76,7 +77,9 @@ export default function(server: Server) {
     if (mirageScenarios.includes('preprints')) {
         preprintsScenario(server, currentUser);
     }
-
+    if (mirageScenarios.includes('preprints::affiliated-institutions')) {
+        preprintsAffiliatedInstitutionsScenario(server, currentUser);
+    }
     if (mirageScenarios.includes('cedar')) {
         cedarMetadataRecordsScenario(server);
     }

--- a/mirage/scenarios/preprints.affiliated-institutions.ts
+++ b/mirage/scenarios/preprints.affiliated-institutions.ts
@@ -1,0 +1,104 @@
+import { ModelInstance, Server } from 'ember-cli-mirage';
+import { Permission } from 'ember-osf-web/models/osf-model';
+import {
+    PreprintDataLinksEnum,
+    PreprintPreregLinksEnum,
+} from 'ember-osf-web/models/preprint';
+
+import PreprintProvider from 'ember-osf-web/models/preprint-provider';
+import { ReviewsState } from 'ember-osf-web/models/provider';
+import User from 'ember-osf-web/models/user';
+import faker from 'faker';
+
+export function preprintsAffiliatedInstitutionsScenario(
+    server: Server,
+    currentUser: ModelInstance<User>,
+) {
+    buildOSF(server, currentUser);
+    // }, 'withAffiliatedInstitutions');
+}
+
+function buildOSF(
+    server: Server,
+    currentUser: ModelInstance<User>,
+) {
+    const osf = server.schema.preprintProviders.find('osf') as ModelInstance<PreprintProvider>;
+
+    const brand = server.create('brand', {
+        primaryColor: '#286090',
+        secondaryColor: '#fff',
+        heroLogoImage: 'images/default-brand/osf-preprints-white.png',
+        heroBackgroundImage: 'images/default-brand/bg-dark.jpg',
+    });
+
+    const currentUserModerator = server.create('moderator',
+        { id: currentUser.id, user: currentUser, provider: osf }, 'asAdmin');
+
+    const noAffiliatedInstitutionsPreprint = server.create('preprint', {
+        provider: osf,
+        id: 'osf-no-affiliated-institutions',
+        title: 'Preprint RWF: Pre-moderation, Admin and Approved',
+        currentUserPermissions: [Permission.Admin,Permission.Write,Permission.Read],
+        reviewsState: ReviewsState.ACCEPTED,
+        description: `${faker.lorem.sentence(200)}\n${faker.lorem.sentence(100)}`,
+        doi: '10.30822/artk.v1i1.79',
+        originalPublicationDate: new Date('2016-11-30T16:00:00.000000Z'),
+        preprintDoiCreated: new Date('2016-11-30T16:00:00.000000Z'),
+        customPublicationCitation: 'This is the publication Citation',
+        hasCoi: true,
+        conflictOfInterestStatement: 'This is the conflict of interest statement',
+        hasDataLinks: PreprintDataLinksEnum.NOT_APPLICABLE,
+        dataLinks: [
+            'http://www.datalink.com/1',
+            'http://www.datalink.com/2',
+            'http://www.datalink.com/3',
+        ],
+        hasPreregLinks: PreprintPreregLinksEnum.NOT_APPLICABLE,
+    });
+
+    const osfApprovedAdminIdentifier = server.create('identifier');
+
+    noAffiliatedInstitutionsPreprint.update({ identifiers: [osfApprovedAdminIdentifier] });
+
+    const affiliatedInstitutionsPreprint = server.create('preprint', {
+        provider: osf,
+        id: 'osf-no-affiliated-institutions',
+        title: 'Preprint RWF: Pre-moderation, Admin and Approved',
+        currentUserPermissions: [Permission.Admin,Permission.Write,Permission.Read],
+        reviewsState: ReviewsState.ACCEPTED,
+        description: `${faker.lorem.sentence(200)}\n${faker.lorem.sentence(100)}`,
+        doi: '10.30822/artk.v1i1.79',
+        originalPublicationDate: new Date('2016-11-30T16:00:00.000000Z'),
+        preprintDoiCreated: new Date('2016-11-30T16:00:00.000000Z'),
+        customPublicationCitation: 'This is the publication Citation',
+        hasCoi: true,
+        conflictOfInterestStatement: 'This is the conflict of interest statement',
+        hasDataLinks: PreprintDataLinksEnum.NOT_APPLICABLE,
+        dataLinks: [
+            'http://www.datalink.com/1',
+            'http://www.datalink.com/2',
+            'http://www.datalink.com/3',
+        ],
+        hasPreregLinks: PreprintPreregLinksEnum.NOT_APPLICABLE,
+    });
+
+    const subjects = server.createList('subject', 7);
+
+    osf.update({
+        allowSubmissions: true,
+        highlightedSubjects: subjects,
+        subjects,
+        licensesAcceptable: server.schema.licenses.all(),
+        // currentUser,
+        // eslint-disable-next-line max-len
+        advisory_board: '<div class=\'preprint-advisory-header\'>\n<h2>Advisory Group</h2>\n<p>Our advisory group includes leaders in preprints and scholarly communication\n</p></div>\n<div class=\'preprint-advisory-list\'><div class=\'preprint-advisory-list-column\'>\n<ul>\n<li><strong>Devin Berg</strong> : engrXiv, University of Wisconsin-Stout</li>\n<li><strong>Pete Binfield</strong> : PeerJ PrePrints</li>\n<li><strong>Benjamin Brown</strong> : PsyArXiv, Georgia Gwinnett College</li>\n<li><strong>Philip Cohen</strong> : SocArXiv, University of Maryland</li>\n<li><strong>Kathleen Fitzpatrick</strong> : Modern Language Association</li>\n</ul>\n</div>\n<div class=\'preprint-advisory-list-column\'>\n<ul>\n<li><strong>John Inglis</strong> : bioRxiv, Cold Spring Harbor Laboratory Press</li>\n<li><strong>Rebecca Kennison</strong> : K | N Consultants</li>\n<li><strong>Kristen Ratan</strong> : CoKo Foundation</li>\n<li><strong>Oya Riege</strong>r : Ithaka S+R</li>\n<li><strong>Judy Ruttenberg</strong> : SHARE, Association of Research Libraries</li>\n</ul>\n</div>\n</div>',
+        footer_links: '',
+        brand,
+        moderators: [currentUserModerator],
+        preprints: [
+            noAffiliatedInstitutionsPreprint,
+            affiliatedInstitutionsPreprint,
+        ],
+        description: 'This is the description for osf',
+    });
+}

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1179,6 +1179,7 @@ preprints:
         paragraph: 'A preprint is a version of a scholarly or scientific paper that is posted online before it has undergone formal peer review and published in a scientific journal. <a href={link}>Learn More</a>.'
         create_button: 'Create Preprint'
     submit:
+        edit-permission-error: 'User does not have permission to edit this {singularPreprintWord}'
         title-submit: 'New {documentType}'
         title-edit: 'Edit {documentType}'
         step-title:


### PR DESCRIPTION

-   Ticket: [ENG-6203]
-   Feature flag: n/a

## Purpose

There was a bug submitting affiliated institutions that were not owned by the current user.

## Summary of Changes

Reworked the logic to only persist affiliated institutions owned by the current user
Added a toast message because it was confusing without it
Added to the tests
Augmented mirage scenarios (still need some help from Futa on Monday)

## Screenshot(s)

N.A

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6203]: https://openscience.atlassian.net/browse/ENG-6203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ