### PR TITLE
[ENG-6181] Update search mirage view

### DIFF
--- a/app/adapters/share-adapter.ts
+++ b/app/adapters/share-adapter.ts
@@ -5,7 +5,7 @@ const osfUrl = config.OSF.url;
 
 export default class ShareAdapter extends JSONAPIAdapter {
     host = config.OSF.shareBaseUrl.replace(/\/$/, ''); // Remove trailing slash to avoid // in URLs
-    namespace = 'api/v3';
+    namespace = 'trove';
 
     queryRecord(store: any, type: any, query: any) {
         // check if we aren't serving locally, otherwise add accessService query param to card/value searches

--- a/app/models/index-card.ts
+++ b/app/models/index-card.ts
@@ -16,7 +16,7 @@ export interface LanguageText {
     '@value': string;
 }
 
-export enum ShareResourceTypes {
+export enum OsfmapResourceTypes {
     Project = 'Project',
     ProjectComponent = 'ProjectComponent',
     Registration = 'Registration',
@@ -51,8 +51,8 @@ export default class IndexCardModel extends Model {
     }
 
     get osfModelType() {
-        const types: ShareResourceTypes = this.resourceMetadata.resourceType
-            .map((item: Record<'@id', ShareResourceTypes>) => item['@id']);
+        const types: OsfmapResourceTypes = this.resourceMetadata.resourceType
+            .map((item: Record<'@id', OsfmapResourceTypes>) => item['@id']);
         if (types.includes('Project') || types.includes('ProjectComponent')) {
             return 'node';
         } else if (types.includes('Registration') || types.includes('RegistrationComponent')) {

--- a/app/models/index-card.ts
+++ b/app/models/index-card.ts
@@ -16,6 +16,21 @@ export interface LanguageText {
     '@value': string;
 }
 
+export enum ShareResourceTypes {
+    Project = 'Project',
+    ProjectComponent = 'ProjectComponent',
+    Registration = 'Registration',
+    RegistrationComponent = 'RegistrationComponent',
+    Preprint = 'Preprint',
+    File = 'File',
+    Person = 'Person',
+    Agent = 'Agent',
+    Organization = 'Organization',
+    Concept = 'Concept',
+    ConceptScheme = 'Concept:Scheme',
+}
+
+
 export default class IndexCardModel extends Model {
     @service intl!: IntlService;
 
@@ -36,7 +51,8 @@ export default class IndexCardModel extends Model {
     }
 
     get osfModelType() {
-        const types = this.resourceMetadata.resourceType.map( (item: any) => item['@id']);
+        const types: ShareResourceTypes = this.resourceMetadata.resourceType
+            .map((item: Record<'@id', ShareResourceTypes>) => item['@id']);
         if (types.includes('Project') || types.includes('ProjectComponent')) {
             return 'node';
         } else if (types.includes('Registration') || types.includes('RegistrationComponent')) {
@@ -74,7 +90,7 @@ export default class IndexCardModel extends Model {
     async getOsfModel(options?: object) {
         const identifier = this.resourceIdentifier;
         if (identifier && this.osfModelType) {
-            const guid = this.guidFromIdentifierList(identifier);
+            const guid = this.guidFromIdentifierList();
             if (guid) {
                 const osfModel = await this.store.findRecord(this.osfModelType, guid, options);
                 this.osfModel = osfModel;

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -65,12 +65,9 @@ export default function(this: Server) {
 
     // SHARE-powered search endpoints
     this.urlPrefix = shareBaseUrl;
-    this.namespace = '/api/v3/';
+    this.namespace = '/trove/'; // /api/v3/ works as well, but /trove/ is the preferred URL
     this.get('/index-card-search', cardSearch);
     this.get('/index-value-search', valueSearch);
-    this.namespace = '/trove/';  // share's /api/v3/ is the same as /trove/
-    this.get('/index-card-searches', cardSearch);
-    this.get('/index-value-searches', valueSearch);
 
     this.urlPrefix = osfUrl;
     this.namespace = '/api/v1/';

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -68,10 +68,9 @@ export default function(this: Server) {
     this.namespace = '/api/v3/';
     this.get('/index-card-search', cardSearch);
     this.get('/index-value-search', valueSearch);
-    // this.get('/index-card/:id', Detail);
+    this.namespace = '/trove/';  // share's /api/v3/ is the same as /trove/
     this.get('/index-card-searches', cardSearch);
     this.get('/index-value-searches', valueSearch);
-    // this.get('/index-cards/:id', Detail);
 
     this.urlPrefix = osfUrl;
     this.namespace = '/api/v1/';

--- a/mirage/utils.ts
+++ b/mirage/utils.ts
@@ -1,7 +1,7 @@
 import faker from 'faker';
 
 export function placekitten(width: number, height: number, n = 12) {
-    return `https://placekitten.com/${width}/${height}?image=${n % 17}`;
+    return `https://placecats.com/${width}/${height}?image=${n % 17}`;
 }
 
 export function randomGravatar(size?: number) {

--- a/mirage/views/search.ts
+++ b/mirage/views/search.ts
@@ -2,10 +2,10 @@ import { Request, Schema } from 'ember-cli-mirage';
 import faker from 'faker';
 import { PaginationLinks } from 'jsonapi-typescript';
 
-import { ShareResourceTypes } from 'ember-osf-web/models/index-card';
+import { OsfmapResourceTypes } from 'ember-osf-web/models/index-card';
 
 const rdfString = 'https://www.w3.org/1999/02/22-rdf-syntax-ns#string';
-const resourceMetadataByType: Partial<Record<ShareResourceTypes, any>> = {
+const resourceMetadataByType: Partial<Record<OsfmapResourceTypes, any>> = {
     Registration: () => ({
         '@id': faker.random.uuid(),
         // accessService: [{}],
@@ -141,7 +141,7 @@ const resourceMetadataByType: Partial<Record<ShareResourceTypes, any>> = {
             '@value': faker.name.findName(),
             '@type': rdfString,
         }],
-        resourceType: [{ '@id': ShareResourceTypes.Person }, { '@id': ShareResourceTypes.Agent }],
+        resourceType: [{ '@id': OsfmapResourceTypes.Person }, { '@id': OsfmapResourceTypes.Agent }],
         sameAs: [{ '@id': 'https://orcid.org/0000-0000-0000-0000' }], // some ORCID
     }),
 };
@@ -218,9 +218,9 @@ export function cardSearch(_: Schema, request: Request) {
     const pageSize = queryParams['page[size]'] ? parseInt(queryParams['page[size]'], 10) : 10;
 
     // cardSearchFilter[resourceType] is a comma-separated list (e.g. 'Project,ProjectComponent') or undefined
-    let requestedResourceTypes = queryParams['cardSearchFilter[resourceType]']?.split(',') as ShareResourceTypes[];
+    let requestedResourceTypes = queryParams['cardSearchFilter[resourceType]']?.split(',') as OsfmapResourceTypes[];
     if (!requestedResourceTypes) {
-        requestedResourceTypes = Object.keys(resourceMetadataByType) as ShareResourceTypes[];
+        requestedResourceTypes = Object.keys(resourceMetadataByType) as OsfmapResourceTypes[];
     }
 
     const indexCardSearch = {
@@ -429,7 +429,7 @@ export function cardSearch(_: Schema, request: Request) {
             },
         });
         // pick a random resource type among the possible ones requested
-        const requestedResourceType: ShareResourceTypes
+        const requestedResourceType: OsfmapResourceTypes
             = requestedResourceTypes[Math.floor(Math.random() * requestedResourceTypes.length)];
         const resourceTypeMetadata = resourceMetadataByType[requestedResourceType];
         includedIndexCard.push({
@@ -584,7 +584,7 @@ function _sharePersonField() {
     const fakeIdentifier = faker.internet.url();
     return {
         '@id': fakeIdentifier,
-        resourceType: [{ '@id': ShareResourceTypes.Person }, { '@id': ShareResourceTypes.Agent }],
+        resourceType: [{ '@id': OsfmapResourceTypes.Person }, { '@id': OsfmapResourceTypes.Agent }],
         identifier: [{
             '@value': 'https://orcid.org/0000-0000-0000-0000', // hard-coded as search-result looks for orcid URL
             '@type': rdfString,
@@ -602,7 +602,7 @@ function _shareOrganizationField() {
     const fakeIdentifier = faker.internet.url();
     return {
         '@id': fakeIdentifier,
-        resourceType: [{ '@id': ShareResourceTypes.Organization }, { '@id': ShareResourceTypes.Agent }],
+        resourceType: [{ '@id': OsfmapResourceTypes.Organization }, { '@id': OsfmapResourceTypes.Agent }],
         identifier: [_shareIdentifierField(fakeIdentifier)],
         name: [{
             '@value': faker.company.companyName(),
@@ -643,10 +643,10 @@ function _shareLicneseField() {
 function _shareSubjectField() {
     return {
         '@id': 'https://api.osf.io/v2/subjects/584240da54be81056cecac48',
-        resourceType: [{ '@id': ShareResourceTypes.Concept }],
+        resourceType: [{ '@id': OsfmapResourceTypes.Concept }],
         inScheme: [{
             '@id': 'https://api.osf.io/v2/schemas/subjects/',
-            resourceType: [{ '@id': ShareResourceTypes.ConceptScheme }],
+            resourceType: [{ '@id': OsfmapResourceTypes.ConceptScheme }],
             title: [{
                 '@value': 'bepress Digital Commons Three-Tiered Taxonomy',
                 '@type': rdfString,

--- a/mirage/views/search.ts
+++ b/mirage/views/search.ts
@@ -265,7 +265,7 @@ export function cardSearch(_: Schema, request: Request) {
                     ],
                     links: {
                         next: {
-                            href: 'https://staging-share.osf.io/api/v3/index-card-search?page%5Bcursor%5D=lmnop',
+                            href: 'https://staging-share.osf.io/trove/index-card-search?page%5Bcursor%5D=lmnop',
                         },
                     },
                 },
@@ -503,7 +503,7 @@ export function valueSearch(_: Schema, __: Request) {
                     ],
                     links: {
                         next: {
-                            href: 'https://staging-share.osf.io/api/v3/index-value-search?page%5Bcursor%5D=lmnop',
+                            href: 'https://staging-share.osf.io/trove/index-value-search?page%5Bcursor%5D=lmnop',
                         },
                     },
                 },

--- a/mirage/views/search.ts
+++ b/mirage/views/search.ts
@@ -17,73 +17,24 @@ const resourceMetadataByType: Partial<Record<ShareResourceTypes, any>> = {
                 '@type': rdfString,
             }],
         }],
-        creator: [{
-            '@id': faker.internet.url(),
-            resourceType: [{ '@id': ShareResourceTypes.Person }, { '@id': ShareResourceTypes.Agent }],
-            identifier: [{
-                '@value': 'https://orcid.org/0000-0000-0000-0000',
-                '@type': rdfString,
-            }],
-            name: [{
-                '@value': faker.name.findName(),
-                '@type': rdfString,
-            }],
-        }],
-        dateAvailable: [{
-            '@value': _randomPastYearMonthDay(),
-            '@type': rdfString,
-        }],
-        dateCopyrighted: [{
-            '@value': _randomPastYearMonthDay(),
-            '@type': rdfString,
-        }],
-        dateCreated: [{
-            '@value': _randomPastYearMonthDay(),
-            '@type': rdfString,
-        }],
-        dateModified: [{
-            '@value': _randomPastYearMonthDay(),
-            '@type': rdfString,
-        }],
+        creator: [_sharePersonField()],
+        dateAvailable: [_shareDateField()],
+        dateCopyrighted: [_shareDateField()],
+        dateCreated: [_shareDateField()],
+        dateModified: [_shareDateField()],
         description: [{
             '@value': faker.lorem.sentence(),
             '@type': rdfString,
         }],
         hasPart: [{}], // RegistrationComponent
-        hostingInstition: [{
-            '@id': faker.internet.url(),
-            resourceType: [{ '@id': ShareResourceTypes.Agent }, { '@id': ShareResourceTypes.Organization }],
-            identifier: [{
-                '@value': faker.internet.url(),
-                '@type': rdfString,
-            }],
-            name: [{
-                '@value': faker.company.companyName(),
-                '@type': rdfString,
-            }],
-            // sameAs: [{}], // some ROR
-        }],
-        identifier: [{
-            '@value': faker.internet.url(),
-            '@type': rdfString,
-        }],
+        hostingInstition: [_shareOrganizationField()],
+        identifier: [_shareIdentifierField()],
         isVersionOf: [{}], // if this is from a project
         keyword: [{ // tags
             '@value': faker.random.word(),
             '@type': rdfString,
         }],
-        publisher: [{ // Registration Provider
-            '@id': faker.internet.url(),
-            resourceType: [{ '@id': ShareResourceTypes.Organization }, { '@id': ShareResourceTypes.Agent }],
-            identifier: [{
-                '@value': faker.internet.url(),
-                '@type': rdfString,
-            }],
-            name: [{
-                '@value': faker.company.companyName(),
-                '@type': rdfString,
-            }],
-        }],
+        publisher: [_shareOrganizationField()], // Registration Provider
         resourceNature: [{ // Registration Category
             '@id': 'https://schema.datacite.org/meta/kernel-4/#StudyRegistration',
             displayLabel: [{
@@ -92,34 +43,9 @@ const resourceMetadataByType: Partial<Record<ShareResourceTypes, any>> = {
             }],
         }],
         resourceType: [{ '@id': 'Registration' }],
-        rights: [{ // License
-            '@id': 'http://creativecommons.org/licenses/by/4.0/',
-            identifier: [{
-                '@value': 'http://creativecommons.org/licenses/by/4.0/',
-                '@type': rdfString,
-            }],
-            name: [{
-                '@value': 'CC-BY-4.0',
-                '@type': rdfString,
-            }],
-        }],
+        rights: [_shareLicneseField()],
         sameAs: [{}], // some DOI
-        subject: [{
-            '@id': 'https://api.osf.io/v2/subjects/584240da54be81056cecac48',
-            resourceType: [{ '@id': ShareResourceTypes.Concept }],
-            inScheme: [{
-                '@id': 'https://api.osf.io/v2/schemas/subjects/',
-                resourceType: [{ '@id': ShareResourceTypes.ConceptScheme }],
-                title: [{
-                    '@value': 'bepress Digital Commons Three-Tiered Taxonomy',
-                    '@type': rdfString,
-                }],
-            }],
-            prefLabel: [{
-                '@value': 'Social and Behavioral Sciences',
-                '@type': rdfString,
-            }],
-        }],
+        subject: [_shareSubjectField()],
         title: [{
             '@value': faker.lorem.words(3),
             '@type': rdfString,
@@ -128,97 +54,26 @@ const resourceMetadataByType: Partial<Record<ShareResourceTypes, any>> = {
     Project: () => ({
         '@id': faker.internet.url(),
         // accessService: [{}],
-        creator: [{
-            '@id': faker.internet.url(),
-            resourceType: [{ '@id': ShareResourceTypes.Person }, { '@id': ShareResourceTypes.Agent }],
-            identifier: [{
-                '@value': 'https://orcid.org/0000-0000-0000-0000',
-                '@type': rdfString,
-            }],
-            name: [{
-                '@value': faker.name.findName(),
-                '@type': rdfString,
-            }],
-        }],
-        dateCopyrighted: [{
-            '@value': _randomPastYearMonthDay(),
-            '@type': rdfString,
-        }],
-        dateCreated: [{
-            '@value': _randomPastYearMonthDay(),
-            '@type': rdfString,
-        }],
-        dateModified: [{
-            '@value': _randomPastYearMonthDay(),
-            '@type': rdfString,
-        }],
+        creator: [_sharePersonField()],
+        dateCopyrighted: [_shareDateField()],
+        dateCreated: [_shareDateField()],
+        dateModified: [_shareDateField()],
         description: [{
             '@value': faker.lorem.sentence(),
             '@type': rdfString,
         }],
         hasPart: [{}], // ProjectComponent
-        hostingInstition: [{
-            '@id': faker.internet.url(),
-            resourceType: [{ '@id': ShareResourceTypes.Agent }, { '@id': ShareResourceTypes.Organization }],
-            identifier: [{
-                '@value': faker.internet.url(),
-                '@type': rdfString,
-            }],
-            name: [{
-                '@value': faker.company.companyName(),
-                '@type': rdfString,
-            }],
-            // sameAs: [{}], // some ROR
-        }],
-        identifier: [{
-            '@value': faker.internet.url(),
-            '@type': rdfString,
-        }],
+        hostingInstition: [_shareOrganizationField()],
+        identifier: [_shareIdentifierField()],
         keyword: [{ // tags
             '@value': faker.random.word(),
             '@type': rdfString,
         }],
-        publisher: [{ // Project Provider
-            '@id': faker.internet.url(),
-            resourceType: [{ '@id': ShareResourceTypes.Organization }, { '@id': ShareResourceTypes.Agent }],
-            identifier: [{
-                '@value': faker.internet.url(),
-                '@type': rdfString,
-            }],
-            name: [{
-                '@value': faker.company.companyName(),
-                '@type': rdfString,
-            }],
-        }],
+        publisher: [_shareOrganizationField()],
         resourceType: [{ '@id': 'Project' }],
-        rights: [{ // License
-            '@id': 'http://creativecommons.org/licenses/by/4.0/',
-            identifier: [{
-                '@value': 'http://creativecommons.org/licenses/by/4.0/',
-                '@type': rdfString,
-            }],
-            name: [{
-                '@value': 'CC-BY-4.0',
-                '@type': rdfString,
-            }],
-        }],
+        rights: [_shareLicneseField()],
         sameAs: [{}], // some DOI
-        subject: [{
-            '@id': 'https://api.osf.io/v2/subjects/584240da54be81056cecac48',
-            resourceType: [{ '@id': ShareResourceTypes.Concept }],
-            inScheme: [{
-                '@id': 'https://api.osf.io/v2/schemas/subjects/',
-                resourceType: [{ '@id': ShareResourceTypes.ConceptScheme }],
-                title: [{
-                    '@value': 'bepress Digital Commons Three-Tiered Taxonomy',
-                    '@type': rdfString,
-                }],
-            }],
-            prefLabel: [{
-                '@value': 'Social and Behavioral Sciences',
-                '@type': rdfString,
-            }],
-        }],
+        subject: [_shareSubjectField()],
         title: [{
             '@value': faker.lorem.words(3),
             '@type': rdfString,
@@ -227,60 +82,19 @@ const resourceMetadataByType: Partial<Record<ShareResourceTypes, any>> = {
     Preprint: () => ({
         '@id': faker.internet.url(),
         // accessService: [{}],
-        creator: [{
-            '@id': faker.internet.url(),
-            resourceType: [{ '@id': ShareResourceTypes.Person }, { '@id': ShareResourceTypes.Agent }],
-            identifier: [{
-                '@value': 'https://orcid.org/0000-0000-0000-0000',
-                '@type': rdfString,
-            }],
-            name: [{
-                '@value': faker.name.findName(),
-                '@type': rdfString,
-            }],
-        }],
-        dateAccepted: [{
-            '@value': _randomPastYearMonthDay(),
-            '@type': rdfString,
-        }],
-        dateCopyrighted: [{
-            '@value': _randomPastYearMonthDay(),
-            '@type': rdfString,
-        }],
-        dateCreated: [{
-            '@value': _randomPastYearMonthDay(),
-            '@type': rdfString,
-        }],
-        dateSubmitted: [{
-            '@value': _randomPastYearMonthDay(),
-            '@type': rdfString,
-        }],
-        dateModified: [{
-            '@value': _randomPastYearMonthDay(),
-            '@type': rdfString,
-        }],
+        creator: [_sharePersonField()],
+        dateAccepted: [_shareDateField()],
+        dateCopyrighted: [_shareDateField()],
+        dateCreated: [_shareDateField()],
+        dateSubmitted: [_shareDateField()],
+        dateModified: [_shareDateField()],
         description: [{
             '@value': faker.lorem.sentence(),
             '@type': rdfString,
         }],
         hasPart: [{}], // File
-        hostingInstition: [{
-            '@id': faker.internet.url(),
-            resourceType: [{ '@id': ShareResourceTypes.Agent }, { '@id': ShareResourceTypes.Organization }],
-            identifier: [{
-                '@value': faker.internet.url(),
-                '@type': rdfString,
-            }],
-            name: [{
-                '@value': faker.company.companyName(),
-                '@type': rdfString,
-            }],
-            // sameAs: [{}], // some ROR
-        }],
-        identifier: [{
-            '@value': faker.internet.url(),
-            '@type': rdfString,
-        }],
+        hostingInstition: [_shareOrganizationField()],
+        identifier: [_shareIdentifierField()],
         // isSupplementedBy: [{}], // if this links a project
         keyword: [{ // tags
             '@value': faker.random.word(),
@@ -292,18 +106,7 @@ const resourceMetadataByType: Partial<Record<ShareResourceTypes, any>> = {
                 { '@id': 'hasPreregisteredAnalysisPlan' },
             ],
         }],
-        publisher: [{ // Preprint Provider
-            '@id': faker.internet.url(),
-            resourceType: [{ '@id': ShareResourceTypes.Organization }, { '@id': ShareResourceTypes.Agent }],
-            identifier: [{
-                '@value': faker.internet.url(),
-                '@type': rdfString,
-            }],
-            name: [{
-                '@value': faker.company.companyName(),
-                '@type': rdfString,
-            }],
-        }],
+        publisher: [_shareOrganizationField()], // Preprint Provider
         resourceNature: [{
             '@id': 'https://schema.datacite.org/meta/kernel-4/#Preprint',
             displayLabel: [{
@@ -312,94 +115,12 @@ const resourceMetadataByType: Partial<Record<ShareResourceTypes, any>> = {
             }],
         }],
         resourceType: [{ '@id': 'Preprint' }],
-        rights: [{ // License
-            '@id': 'http://creativecommons.org/licenses/by/4.0/',
-            identifier: [{
-                '@value': 'http://creativecommons.org/licenses/by/4.0/',
-                '@type': rdfString,
-            }],
-            name: [{
-                '@value': 'CC-BY-4.0',
-                '@type': rdfString,
-            }],
-        }],
+        rights: [_shareLicneseField()],
         sameAs: [{}], // some DOI
         statedConflictOfInterest: [{
             '@id': 'no-confict-of-interest',
         }],
-        subject: [{
-            '@id': 'https://api.osf.io/v2/subjects/584240da54be81056cecac48',
-            resourceType: [{ '@id': ShareResourceTypes.Concept }],
-            inScheme: [{
-                '@id': 'https://api.osf.io/v2/schemas/subjects/',
-                resourceType: [{ '@id': ShareResourceTypes.ConceptScheme }],
-                title: [{
-                    '@value': 'bepress Digital Commons Three-Tiered Taxonomy',
-                    '@type': rdfString,
-                }],
-            }],
-            prefLabel: [{
-                '@value': 'Social and Behavioral Sciences',
-                '@type': rdfString,
-            }],
-        }],
-        title: [{
-            '@value': faker.lorem.words(3),
-            '@type': rdfString,
-        }],
-    }),
-    File: () => ({
-        '@id': faker.internet.url(),
-        // accessService: [{}],
-        dateCreated: [{
-            '@value': _randomPastYearMonthDay(),
-            '@type': rdfString,
-        }],
-        dateModified: [{
-            '@value': _randomPastYearMonthDay(),
-            '@type': rdfString,
-        }],
-        description: [{
-            '@value': faker.lorem.sentence(),
-            '@type': rdfString,
-        }],
-        fileName: [{
-            '@value': faker.system.fileName(),
-            '@type': rdfString,
-        }],
-        filePath: [{
-            '@value': faker.system.filePath(),
-            '@type': rdfString,
-        }],
-        identifier: [{
-            '@value': faker.internet.url(),
-            '@type': rdfString,
-        }],
-        isContainedBy: [{ // Parent Project
-            '@id': faker.internet.url(),
-            resourceType: [{ '@id': ShareResourceTypes.Project }],
-            identifier: [{
-                '@value': faker.internet.url(),
-                '@type': rdfString,
-            }],
-            title: [{
-                '@value': faker.lorem.words(3),
-                '@type': rdfString,
-            }],
-        }],
-        language: [{
-            '@value': 'eng',
-            '@type': rdfString,
-        }],
-        // 'osf:hasFileVersion': [{}], // FileVersion
-        resourceNature: [{
-            '@id': 'https://schema.datacite.org/meta/kernel-4/#Dataset',
-            displayLabel: [{
-                '@value': 'Dataset',
-                '@language': 'en',
-            }],
-        }],
-        resourceType: [{ '@id': 'File' }],
+        subject: [_shareSubjectField()],
         title: [{
             '@value': faker.lorem.words(3),
             '@type': rdfString,
@@ -408,24 +129,9 @@ const resourceMetadataByType: Partial<Record<ShareResourceTypes, any>> = {
     Agent: () => ({
         '@id': faker.internet.url(),
         // accessService: [{}],
-        affiliation: [{
-            '@id': faker.internet.url(),
-            resourceType: [{ '@id': ShareResourceTypes.Organization }, { '@id': ShareResourceTypes.Agent }],
-            identifier: [{
-                '@value': faker.internet.url(),
-                '@type': rdfString,
-            }],
-            name: [{
-                '@value': faker.company.companyName(),
-                '@type': rdfString,
-            }],
-            // sameAs: [{}], // some ROR
-        }],
+        affiliation: [_shareOrganizationField()],
         identifier: [
-            {
-                '@value': faker.internet.url(),
-                '@type': rdfString,
-            },
+            _shareIdentifierField(),
             {
                 '@value': 'https://orcid.org/0000-0000-0000-0000',
                 '@type': rdfString,
@@ -461,6 +167,47 @@ resourceMetadataByType.RegistrationComponent = function() {
         }],
         hasRoot: [{ // Root Registration
             ...resourceMetadataByType.Registration(),
+        }],
+    };
+};
+resourceMetadataByType.File = function() {
+    return {
+        '@id': faker.internet.url(),
+        // accessService: [{}],
+        dateCreated: [_shareDateField()],
+        dateModified: [_shareDateField()],
+        description: [{
+            '@value': faker.lorem.sentence(),
+            '@type': rdfString,
+        }],
+        fileName: [{
+            '@value': faker.system.fileName(),
+            '@type': rdfString,
+        }],
+        filePath: [{
+            '@value': faker.system.filePath(),
+            '@type': rdfString,
+        }],
+        identifier: [_shareIdentifierField()],
+        isContainedBy: [{ // Parent Project
+            ...resourceMetadataByType.Project(),
+        }],
+        language: [{
+            '@value': 'eng',
+            '@type': rdfString,
+        }],
+        // 'osf:hasFileVersion': [{}], // FileVersion
+        resourceNature: [{
+            '@id': 'https://schema.datacite.org/meta/kernel-4/#Dataset',
+            displayLabel: [{
+                '@value': 'Dataset',
+                '@language': 'en',
+            }],
+        }],
+        resourceType: [{ '@id': 'File' }],
+        title: [{
+            '@value': faker.lorem.words(3),
+            '@type': rdfString,
         }],
     };
 };
@@ -830,6 +577,85 @@ export function valueSearch(_: Schema, __: Request) {
                 },
             },
         ],
+    };
+}
+
+function _sharePersonField() {
+    const fakeIdentifier = faker.internet.url();
+    return {
+        '@id': fakeIdentifier,
+        resourceType: [{ '@id': ShareResourceTypes.Person }, { '@id': ShareResourceTypes.Agent }],
+        identifier: [{
+            '@value': 'https://orcid.org/0000-0000-0000-0000', // hard-coded as search-result looks for orcid URL
+            '@type': rdfString,
+        },
+        _shareIdentifierField(fakeIdentifier),
+        ],
+        name: [{
+            '@value': faker.name.findName(),
+            '@type': rdfString,
+        }],
+    };
+}
+
+function _shareOrganizationField() {
+    const fakeIdentifier = faker.internet.url();
+    return {
+        '@id': fakeIdentifier,
+        resourceType: [{ '@id': ShareResourceTypes.Organization }, { '@id': ShareResourceTypes.Agent }],
+        identifier: [_shareIdentifierField(fakeIdentifier)],
+        name: [{
+            '@value': faker.company.companyName(),
+            '@type': rdfString,
+        }],
+        // sameAs: [{}], // some ROR
+    };
+}
+
+function _shareIdentifierField(idValue?: string) {
+    return {
+        '@value': idValue || faker.internet.url(),
+        '@type': rdfString,
+    };
+}
+
+function _shareDateField() {
+    return {
+        '@value': _randomPastYearMonthDay(),
+        '@type': rdfString,
+    };
+}
+
+function _shareLicneseField() {
+    return {
+        '@id': 'http://creativecommons.org/licenses/by/4.0/',
+        identifier: [{
+            '@value': 'http://creativecommons.org/licenses/by/4.0/',
+            '@type': rdfString,
+        }],
+        name: [{
+            '@value': 'CC-BY-4.0',
+            '@type': rdfString,
+        }],
+    };
+}
+
+function _shareSubjectField() {
+    return {
+        '@id': 'https://api.osf.io/v2/subjects/584240da54be81056cecac48',
+        resourceType: [{ '@id': ShareResourceTypes.Concept }],
+        inScheme: [{
+            '@id': 'https://api.osf.io/v2/schemas/subjects/',
+            resourceType: [{ '@id': ShareResourceTypes.ConceptScheme }],
+            title: [{
+                '@value': 'bepress Digital Commons Three-Tiered Taxonomy',
+                '@type': rdfString,
+            }],
+        }],
+        prefLabel: [{
+            '@value': 'Social and Behavioral Sciences',
+            '@type': rdfString,
+        }],
     };
 }
 

--- a/mirage/views/search.ts
+++ b/mirage/views/search.ts
@@ -1,13 +1,486 @@
 import { Request, Schema } from 'ember-cli-mirage';
 import faker from 'faker';
+import { PaginationLinks } from 'jsonapi-typescript';
 
-export function cardSearch(_: Schema, __: Request) {
-    // TODO: replace with a real index-card-search and use request to populate attrs
+import { ShareResourceTypes } from 'ember-osf-web/models/index-card';
+
+const rdfString = 'https://www.w3.org/1999/02/22-rdf-syntax-ns#string';
+const resourceMetadataByType: Partial<Record<ShareResourceTypes, any>> = {
+    Registration: () => ({
+        '@id': faker.random.uuid(),
+        // accessService: [{}],
+        archivedAt: [{}], // archive.org URL
+        conformsTo: [{ // Registration Schema
+            '@id': 'https://api.osf.io/v2/schemas/registrations/564d31db8c5e4a7c9694b2be/',
+            title: [{
+                '@value': 'Open-Ended Registration',
+                '@type': rdfString,
+            }],
+        }],
+        creator: [{
+            '@id': faker.internet.url(),
+            resourceType: [{ '@id': ShareResourceTypes.Person }, { '@id': ShareResourceTypes.Agent }],
+            identifier: [{
+                '@value': 'https://orcid.org/0000-0000-0000-0000',
+                '@type': rdfString,
+            }],
+            name: [{
+                '@value': faker.name.findName(),
+                '@type': rdfString,
+            }],
+        }],
+        dateAvailable: [{
+            '@value': _randomPastYearMonthDay(),
+            '@type': rdfString,
+        }],
+        dateCopyrighted: [{
+            '@value': _randomPastYearMonthDay(),
+            '@type': rdfString,
+        }],
+        dateCreated: [{
+            '@value': _randomPastYearMonthDay(),
+            '@type': rdfString,
+        }],
+        dateModified: [{
+            '@value': _randomPastYearMonthDay(),
+            '@type': rdfString,
+        }],
+        description: [{
+            '@value': faker.lorem.sentence(),
+            '@type': rdfString,
+        }],
+        hasPart: [{}], // RegistrationComponent
+        hostingInstition: [{
+            '@id': faker.internet.url(),
+            resourceType: [{ '@id': ShareResourceTypes.Agent }, { '@id': ShareResourceTypes.Organization }],
+            identifier: [{
+                '@value': faker.internet.url(),
+                '@type': rdfString,
+            }],
+            name: [{
+                '@value': faker.company.companyName(),
+                '@type': rdfString,
+            }],
+            // sameAs: [{}], // some ROR
+        }],
+        identifier: [{
+            '@value': faker.internet.url(),
+            '@type': rdfString,
+        }],
+        isVersionOf: [{}], // if this is from a project
+        keyword: [{ // tags
+            '@value': faker.random.word(),
+            '@type': rdfString,
+        }],
+        publisher: [{ // Registration Provider
+            '@id': faker.internet.url(),
+            resourceType: [{ '@id': ShareResourceTypes.Organization }, { '@id': ShareResourceTypes.Agent }],
+            identifier: [{
+                '@value': faker.internet.url(),
+                '@type': rdfString,
+            }],
+            name: [{
+                '@value': faker.company.companyName(),
+                '@type': rdfString,
+            }],
+        }],
+        resourceNature: [{ // Registration Category
+            '@id': 'https://schema.datacite.org/meta/kernel-4/#StudyRegistration',
+            displayLabel: [{
+                '@value': 'StudyRegistration',
+                '@language': 'en',
+            }],
+        }],
+        resourceType: [{ '@id': 'Registration' }],
+        rights: [{ // License
+            '@id': 'http://creativecommons.org/licenses/by/4.0/',
+            identifier: [{
+                '@value': 'http://creativecommons.org/licenses/by/4.0/',
+                '@type': rdfString,
+            }],
+            name: [{
+                '@value': 'CC-BY-4.0',
+                '@type': rdfString,
+            }],
+        }],
+        sameAs: [{}], // some DOI
+        subject: [{
+            '@id': 'https://api.osf.io/v2/subjects/584240da54be81056cecac48',
+            resourceType: [{ '@id': ShareResourceTypes.Concept }],
+            inScheme: [{
+                '@id': 'https://api.osf.io/v2/schemas/subjects/',
+                resourceType: [{ '@id': ShareResourceTypes.ConceptScheme }],
+                title: [{
+                    '@value': 'bepress Digital Commons Three-Tiered Taxonomy',
+                    '@type': rdfString,
+                }],
+            }],
+            prefLabel: [{
+                '@value': 'Social and Behavioral Sciences',
+                '@type': rdfString,
+            }],
+        }],
+        title: [{
+            '@value': faker.lorem.words(3),
+            '@type': rdfString,
+        }],
+    }),
+    Project: () => ({
+        '@id': faker.internet.url(),
+        // accessService: [{}],
+        creator: [{
+            '@id': faker.internet.url(),
+            resourceType: [{ '@id': ShareResourceTypes.Person }, { '@id': ShareResourceTypes.Agent }],
+            identifier: [{
+                '@value': 'https://orcid.org/0000-0000-0000-0000',
+                '@type': rdfString,
+            }],
+            name: [{
+                '@value': faker.name.findName(),
+                '@type': rdfString,
+            }],
+        }],
+        dateCopyrighted: [{
+            '@value': _randomPastYearMonthDay(),
+            '@type': rdfString,
+        }],
+        dateCreated: [{
+            '@value': _randomPastYearMonthDay(),
+            '@type': rdfString,
+        }],
+        dateModified: [{
+            '@value': _randomPastYearMonthDay(),
+            '@type': rdfString,
+        }],
+        description: [{
+            '@value': faker.lorem.sentence(),
+            '@type': rdfString,
+        }],
+        hasPart: [{}], // ProjectComponent
+        hostingInstition: [{
+            '@id': faker.internet.url(),
+            resourceType: [{ '@id': ShareResourceTypes.Agent }, { '@id': ShareResourceTypes.Organization }],
+            identifier: [{
+                '@value': faker.internet.url(),
+                '@type': rdfString,
+            }],
+            name: [{
+                '@value': faker.company.companyName(),
+                '@type': rdfString,
+            }],
+            // sameAs: [{}], // some ROR
+        }],
+        identifier: [{
+            '@value': faker.internet.url(),
+            '@type': rdfString,
+        }],
+        keyword: [{ // tags
+            '@value': faker.random.word(),
+            '@type': rdfString,
+        }],
+        publisher: [{ // Project Provider
+            '@id': faker.internet.url(),
+            resourceType: [{ '@id': ShareResourceTypes.Organization }, { '@id': ShareResourceTypes.Agent }],
+            identifier: [{
+                '@value': faker.internet.url(),
+                '@type': rdfString,
+            }],
+            name: [{
+                '@value': faker.company.companyName(),
+                '@type': rdfString,
+            }],
+        }],
+        resourceType: [{ '@id': 'Project' }],
+        rights: [{ // License
+            '@id': 'http://creativecommons.org/licenses/by/4.0/',
+            identifier: [{
+                '@value': 'http://creativecommons.org/licenses/by/4.0/',
+                '@type': rdfString,
+            }],
+            name: [{
+                '@value': 'CC-BY-4.0',
+                '@type': rdfString,
+            }],
+        }],
+        sameAs: [{}], // some DOI
+        subject: [{
+            '@id': 'https://api.osf.io/v2/subjects/584240da54be81056cecac48',
+            resourceType: [{ '@id': ShareResourceTypes.Concept }],
+            inScheme: [{
+                '@id': 'https://api.osf.io/v2/schemas/subjects/',
+                resourceType: [{ '@id': ShareResourceTypes.ConceptScheme }],
+                title: [{
+                    '@value': 'bepress Digital Commons Three-Tiered Taxonomy',
+                    '@type': rdfString,
+                }],
+            }],
+            prefLabel: [{
+                '@value': 'Social and Behavioral Sciences',
+                '@type': rdfString,
+            }],
+        }],
+        title: [{
+            '@value': faker.lorem.words(3),
+            '@type': rdfString,
+        }],
+    }),
+    Preprint: () => ({
+        '@id': faker.internet.url(),
+        // accessService: [{}],
+        creator: [{
+            '@id': faker.internet.url(),
+            resourceType: [{ '@id': ShareResourceTypes.Person }, { '@id': ShareResourceTypes.Agent }],
+            identifier: [{
+                '@value': 'https://orcid.org/0000-0000-0000-0000',
+                '@type': rdfString,
+            }],
+            name: [{
+                '@value': faker.name.findName(),
+                '@type': rdfString,
+            }],
+        }],
+        dateAccepted: [{
+            '@value': _randomPastYearMonthDay(),
+            '@type': rdfString,
+        }],
+        dateCopyrighted: [{
+            '@value': _randomPastYearMonthDay(),
+            '@type': rdfString,
+        }],
+        dateCreated: [{
+            '@value': _randomPastYearMonthDay(),
+            '@type': rdfString,
+        }],
+        dateSubmitted: [{
+            '@value': _randomPastYearMonthDay(),
+            '@type': rdfString,
+        }],
+        dateModified: [{
+            '@value': _randomPastYearMonthDay(),
+            '@type': rdfString,
+        }],
+        description: [{
+            '@value': faker.lorem.sentence(),
+            '@type': rdfString,
+        }],
+        hasPart: [{}], // File
+        hostingInstition: [{
+            '@id': faker.internet.url(),
+            resourceType: [{ '@id': ShareResourceTypes.Agent }, { '@id': ShareResourceTypes.Organization }],
+            identifier: [{
+                '@value': faker.internet.url(),
+                '@type': rdfString,
+            }],
+            name: [{
+                '@value': faker.company.companyName(),
+                '@type': rdfString,
+            }],
+            // sameAs: [{}], // some ROR
+        }],
+        identifier: [{
+            '@value': faker.internet.url(),
+            '@type': rdfString,
+        }],
+        // isSupplementedBy: [{}], // if this links a project
+        keyword: [{ // tags
+            '@value': faker.random.word(),
+            '@type': rdfString,
+        }],
+        omits: [{
+            ommittedMetadataProperty: [
+                { '@id': 'hasPreregisteredStudyDesign' },
+                { '@id': 'hasPreregisteredAnalysisPlan' },
+            ],
+        }],
+        publisher: [{ // Preprint Provider
+            '@id': faker.internet.url(),
+            resourceType: [{ '@id': ShareResourceTypes.Organization }, { '@id': ShareResourceTypes.Agent }],
+            identifier: [{
+                '@value': faker.internet.url(),
+                '@type': rdfString,
+            }],
+            name: [{
+                '@value': faker.company.companyName(),
+                '@type': rdfString,
+            }],
+        }],
+        resourceNature: [{
+            '@id': 'https://schema.datacite.org/meta/kernel-4/#Preprint',
+            displayLabel: [{
+                '@value': 'Preprint',
+                '@language': 'en',
+            }],
+        }],
+        resourceType: [{ '@id': 'Preprint' }],
+        rights: [{ // License
+            '@id': 'http://creativecommons.org/licenses/by/4.0/',
+            identifier: [{
+                '@value': 'http://creativecommons.org/licenses/by/4.0/',
+                '@type': rdfString,
+            }],
+            name: [{
+                '@value': 'CC-BY-4.0',
+                '@type': rdfString,
+            }],
+        }],
+        sameAs: [{}], // some DOI
+        statedConflictOfInterest: [{
+            '@id': 'no-confict-of-interest',
+        }],
+        subject: [{
+            '@id': 'https://api.osf.io/v2/subjects/584240da54be81056cecac48',
+            resourceType: [{ '@id': ShareResourceTypes.Concept }],
+            inScheme: [{
+                '@id': 'https://api.osf.io/v2/schemas/subjects/',
+                resourceType: [{ '@id': ShareResourceTypes.ConceptScheme }],
+                title: [{
+                    '@value': 'bepress Digital Commons Three-Tiered Taxonomy',
+                    '@type': rdfString,
+                }],
+            }],
+            prefLabel: [{
+                '@value': 'Social and Behavioral Sciences',
+                '@type': rdfString,
+            }],
+        }],
+        title: [{
+            '@value': faker.lorem.words(3),
+            '@type': rdfString,
+        }],
+    }),
+    File: () => ({
+        '@id': faker.internet.url(),
+        // accessService: [{}],
+        dateCreated: [{
+            '@value': _randomPastYearMonthDay(),
+            '@type': rdfString,
+        }],
+        dateModified: [{
+            '@value': _randomPastYearMonthDay(),
+            '@type': rdfString,
+        }],
+        description: [{
+            '@value': faker.lorem.sentence(),
+            '@type': rdfString,
+        }],
+        fileName: [{
+            '@value': faker.system.fileName(),
+            '@type': rdfString,
+        }],
+        filePath: [{
+            '@value': faker.system.filePath(),
+            '@type': rdfString,
+        }],
+        identifier: [{
+            '@value': faker.internet.url(),
+            '@type': rdfString,
+        }],
+        isContainedBy: [{ // Parent Project
+            '@id': faker.internet.url(),
+            resourceType: [{ '@id': ShareResourceTypes.Project }],
+            identifier: [{
+                '@value': faker.internet.url(),
+                '@type': rdfString,
+            }],
+            title: [{
+                '@value': faker.lorem.words(3),
+                '@type': rdfString,
+            }],
+        }],
+        language: [{
+            '@value': 'eng',
+            '@type': rdfString,
+        }],
+        // 'osf:hasFileVersion': [{}], // FileVersion
+        resourceNature: [{
+            '@id': 'https://schema.datacite.org/meta/kernel-4/#Dataset',
+            displayLabel: [{
+                '@value': 'Dataset',
+                '@language': 'en',
+            }],
+        }],
+        resourceType: [{ '@id': 'File' }],
+        title: [{
+            '@value': faker.lorem.words(3),
+            '@type': rdfString,
+        }],
+    }),
+    Agent: () => ({
+        '@id': faker.internet.url(),
+        // accessService: [{}],
+        affiliation: [{
+            '@id': faker.internet.url(),
+            resourceType: [{ '@id': ShareResourceTypes.Organization }, { '@id': ShareResourceTypes.Agent }],
+            identifier: [{
+                '@value': faker.internet.url(),
+                '@type': rdfString,
+            }],
+            name: [{
+                '@value': faker.company.companyName(),
+                '@type': rdfString,
+            }],
+            // sameAs: [{}], // some ROR
+        }],
+        identifier: [
+            {
+                '@value': faker.internet.url(),
+                '@type': rdfString,
+            },
+            {
+                '@value': 'https://orcid.org/0000-0000-0000-0000',
+                '@type': rdfString,
+            },
+        ],
+        name: [{
+            '@value': faker.name.findName(),
+            '@type': rdfString,
+        }],
+        resourceType: [{ '@id': ShareResourceTypes.Person }, { '@id': ShareResourceTypes.Agent }],
+        sameAs: [{ '@id': 'https://orcid.org/0000-0000-0000-0000' }], // some ORCID
+    }),
+};
+
+resourceMetadataByType.ProjectComponent = function() {
     return {
+        ...resourceMetadataByType.Project(),
+        resourceType: [{ '@id': 'ProjectComponent' }],
+        isPartOf: [{ // Parent Project
+            ...resourceMetadataByType.Project(),
+        }],
+        hasRoot: [{ // Root Project
+            ...resourceMetadataByType.Project(),
+        }],
+    };
+};
+resourceMetadataByType.RegistrationComponent = function() {
+    return {
+        ...resourceMetadataByType.Registration(),
+        resourceType: [{ '@id': 'RegistrationComponent' }],
+        isPartOf: [{ // Parent Registration
+            ...resourceMetadataByType.Registration(),
+        }],
+        hasRoot: [{ // Root Registration
+            ...resourceMetadataByType.Registration(),
+        }],
+    };
+};
+
+export function cardSearch(_: Schema, request: Request) {
+    const {queryParams} = request;
+    const pageCursor = queryParams['page[cursor]'];
+    const pageSize = queryParams['page[size]'] ? parseInt(queryParams['page[size]'], 10) : 10;
+
+    // cardSearchFilter[resourceType] is a comma-separated list (e.g. 'Project,ProjectComponent') or undefined
+    let requestedResourceTypes = queryParams['cardSearchFilter[resourceType]']?.split(',') as ShareResourceTypes[];
+    if (!requestedResourceTypes) {
+        requestedResourceTypes = Object.keys(resourceMetadataByType) as ShareResourceTypes[];
+    }
+
+    const indexCardSearch = {
         data: {
             type: 'index-card-search',
-            id: 'zzzzzz',
-            attributes:{
+            id: faker.random.uuid(),
+            attributes: {
                 cardSearchText: 'hello',
                 cardSearchFilter: [
                     {
@@ -28,27 +501,6 @@ export function cardSearch(_: Schema, __: Request) {
                 totalResultCount: 3,
             },
             relationships: {
-                searchResultPage: {
-                    data: [
-                        {
-                            type: 'search-result',
-                            id: 'abc',
-                        },
-                        {
-                            type: 'search-result',
-                            id: 'def',
-                        },
-                        {
-                            type: 'search-result',
-                            id: 'ghi',
-                        },
-                    ],
-                    links: {
-                        next: {
-                            href: 'https://staging-share.osf.io/api/v3/index-card-search?page%5Bcursor%5D=lmnop',
-                        },
-                    },
-                },
                 relatedProperties: {
                     data: [
                         {
@@ -70,234 +522,10 @@ export function cardSearch(_: Schema, __: Request) {
                         },
                     },
                 },
+                searchResultPage: {},
             },
         },
         included: [
-            {
-                type: 'search-result',
-                id: 'abc',
-                attributes: {
-                    matchEvidence: [
-                        {
-                            '@type': ['https://share.osf.io/vocab/2023/trove/TextMatchEvidence'],
-                            osfmapPropertyPath: 'description',
-                            matchingHighlight: '... say <em>hello</em>!',
-                        },
-                        {
-                            '@type': ['https://share.osf.io/vocab/2023/trove/TextMatchEvidence'],
-                            osfmapPropertyPath: 'title',
-                            matchingHighlight: '... shout <em>hello</em>!',
-                        },
-                    ],
-                },
-                relationships: {
-                    indexCard: {
-                        data: {
-                            type: 'index-card',
-                            id: 'abc',
-                        },
-                        links: {
-                            related: 'https://share.osf.io/api/v2/index-card/abc',
-                        },
-                    },
-                },
-            },
-            {
-                type: 'search-result',
-                id: 'def',
-                attributes: {
-                    matchEvidence: [
-                        {
-                            '@type': ['https://share.osf.io/vocab/2023/trove/TextMatchEvidence'],
-                            osfmapPropertyPath: 'description',
-                            matchingHighlight: '... computer said <em>hello</em> world!',
-                        },
-                    ],
-                },
-                relationships: {
-                    indexCard: {
-                        data: {
-                            type: 'index-card',
-                            id: 'def',
-                        },
-                        links: {
-                            related: 'https://share.osf.io/api/v2/index-card/def',
-                        },
-                    },
-                },
-            },
-            {
-                type: 'search-result',
-                id: 'ghi',
-                attributes: {
-                    matchEvidence: [
-                        {
-                            '@type': ['https://share.osf.io/vocab/2023/trove/TextMatchEvidence'],
-                            osfmapPropertyPath: 'title',
-                            matchingHighlight: '... you said <em>hello</em>!',
-                        },
-                    ],
-                },
-                relationships: {
-                    indexCard: {
-                        data: {
-                            type: 'index-card',
-                            id: 'ghi',
-                        },
-                        links: {
-                            related: 'https://share.osf.io/api/v2/index-card/abc',
-                        },
-                    },
-                },
-            },
-            {
-                type: 'index-card',
-                id: 'abc',
-                attributes: {
-                    resourceIdentifier: [
-                        'https://osf.example/abcfoo',
-                        'https://doi.org/10.0000/osf.example/abcfoo',
-                    ],
-                    resourceMetadata: {
-                        resourceType: [
-                            'osf:Registration',
-                            'dcterms:Dataset',
-                        ],
-                        '@id': 'https://osf.example/abcfoo',
-                        '@type': 'osf:Registration',
-                        title: [
-                            {
-                                '@value': 'I shout hello!',
-                                '@language': 'en',
-                            },
-                        ],
-                        description: [
-                            {
-                                '@value': 'I say hello!',
-                                '@language': 'en',
-                            },
-                        ],
-                        isPartOf: [
-                            {
-                                '@id': 'https://osf.example/xyzfoo',
-                                '@type': 'osf:Registration',
-                                title: [
-                                    {
-                                        '@value': 'a parent!',
-                                        '@language': 'en',
-                                    },
-                                ],
-                            },
-                        ],
-                        hasPart: [
-                            {
-                                '@id': 'https://osf.example/deffoo',
-                                '@type': 'osf:Registration',
-                                title: [
-                                    {
-                                        '@value': 'a child!',
-                                        '@language': 'en',
-                                    },
-                                ],
-                            },
-                            {
-                                '@id': 'https://osf.example/ghifoo',
-                                '@type': 'osf:Registration',
-                                title: [
-                                    {
-                                        '@value': 'another child!',
-                                        '@language': 'en',
-                                    },
-                                ],
-                            },
-                        ],
-                        subject: [
-                            {
-                                '@id': 'https://subjects.org/subjectId',
-                                '@type': 'dcterms:Subject',
-                                label: [
-                                    {
-                                        '@value': 'wibbleplop',
-                                        '@language': 'wi-bl',
-                                    },
-                                ],
-                            },
-                        ],
-                        creator: [{
-                            '@id': 'https://osf.example/person',
-                            '@type': 'dcterms:Agent',
-                            specificType: 'foaf:Person',
-                            name: 'person person, prsn',
-                        }],
-                    },
-                },
-                links: {
-                    self: 'https://share.osf.io/api/v2/index-card/abc',
-                    resource: 'https://osf.example/abcfoo',
-                },
-            },
-            {
-                type: 'index-card',
-                id: 'def',
-                attributes: {
-                    resourceIdentifier: [
-                        'https://osf.example/abcfoo',
-                        'https://doi.org/10.0000/osf.example/abcfoo',
-                    ],
-                    resourceMetadata: {
-                        resourceType: [
-                            'osf:Registration',
-                            'dcterms:Dataset',
-                        ],
-                        '@id': 'https://osf.example/abcfoo',
-                        '@type': 'osf:Registration',
-                        title: [
-                            {
-                                '@value': 'Hi!',
-                                '@language': 'en',
-                            },
-                        ],
-                    },
-                },
-                links: {
-                    self: 'https://share.osf.io/api/v2/index-card/ghi',
-                    resource: 'https://osf.example/abcfoo',
-                },
-            },
-            {
-                type: 'index-card',
-                id: 'ghi',
-                attributes: {
-                    resourceIdentifier: [
-                        'https://osf.example/abcfoo',
-                        'https://doi.org/10.0000/osf.example/abcfoo',
-                    ],
-                    resourceMetadata: {
-                        resourceType: [
-                            'osf:Registration',
-                            'dcterms:Dataset',
-                        ],
-                        '@id': 'https://osf.example/abcfoo',
-                        '@type': 'osf:Registration',
-                        title: [
-                            {
-                                '@value': 'Ahoj! That\'s hello in Czech!',
-                                '@language': 'en',
-                            },
-                        ],
-                        description: [
-                            {
-                                '@value': 'Some description',
-                                '@language': 'en',
-                            },
-                        ],
-                    },
-                },
-                links: {
-                    self: 'https://share.osf.io/api/v2/index-card/ghi',
-                    resource: 'https://osf.example/abcfoo',
-                },
-            },
             // Related properties
             {
                 type: 'related-property-path',
@@ -415,6 +643,83 @@ export function cardSearch(_: Schema, __: Request) {
             },
         ],
     };
+
+    const searchResultPageRelationship = { data: [] as any[], links: {} as PaginationLinks};
+    const includedSearchResultPage: any[] = [];
+    const includedIndexCard: any[] = [];
+    Array.from({ length: pageSize }).forEach(() => {
+        const searchResultId = faker.random.uuid();
+        const indexCardId = faker.random.uuid();
+        const indexCardURL = `https://share.osf.io/api/v2/index-card/${indexCardId}`;
+        searchResultPageRelationship.data.push({
+            type: 'search-result',
+            id: searchResultId,
+        });
+        includedSearchResultPage.push({
+            type: 'search-result',
+            id: searchResultId,
+            attributes: {
+                matchEvidence: [
+                    {
+                        '@type': ['https://share.osf.io/vocab/2023/trove/TextMatchEvidence'],
+                        evidenceCardIdentifier: indexCardURL,
+                        matchingHighlight: [`...<em>${faker.lorem.word()}</em>...`],
+                        osfmapPropertyPath: ['description'],
+                        propertyPathKey: 'description',
+                    },
+                ],
+            },
+            relationships: {
+                indexCard: {
+                    data: {
+                        type: 'index-card',
+                        id: indexCardId,
+                    },
+                    links: {
+                        related: indexCardURL,
+                    },
+                },
+            },
+        });
+        // pick a random resource type among the possible ones requested
+        const requestedResourceType: ShareResourceTypes
+            = requestedResourceTypes[Math.floor(Math.random() * requestedResourceTypes.length)];
+        const resourceTypeMetadata = resourceMetadataByType[requestedResourceType];
+        includedIndexCard.push({
+            type: 'index-card',
+            id: indexCardId,
+            attributes: {
+                resourceIdentifier: [
+                    indexCardURL,
+                    `https://doi.org/10.0000/osf.example/${indexCardId}`,
+                ],
+                resourceMetadata: resourceTypeMetadata(),
+            },
+            links: {
+                self: indexCardURL,
+                resource: `https://osf.example/${indexCardId}`,
+            },
+        });
+    });
+
+    const cursorizedUrl = new URL(request.url);
+    cursorizedUrl.searchParams.set('page[cursor]', faker.random.uuid());
+    searchResultPageRelationship.links = {
+        next: {
+            href: cursorizedUrl.toString(),
+        },
+    };
+    if (pageCursor) {
+        searchResultPageRelationship.links.prev = {
+            href: cursorizedUrl.toString(),
+        };
+        searchResultPageRelationship.links.first = {
+            href: cursorizedUrl.toString(),
+        };
+    }
+    indexCardSearch.data.relationships.searchResultPage = searchResultPageRelationship;
+    indexCardSearch.included.push(...includedSearchResultPage, ...includedIndexCard);
+    return indexCardSearch;
 }
 
 export function valueSearch(_: Schema, __: Request) {
@@ -526,4 +831,8 @@ export function valueSearch(_: Schema, __: Request) {
             },
         ],
     };
+}
+
+function _randomPastYearMonthDay(): string {
+    return faker.date.past().toISOString().split('T')[0];
 }


### PR DESCRIPTION
-   Ticket: [ENG-6181]
-   Feature flag: n/a

## Purpose
- Update mirage view for trove index-card-search to return some more realistic results

## Summary of Changes
- Replace placekittens with placecats
- Remove hard-coded return object in mirage/views/search.ts
  - add a new factory-type object that creates resourceMetadata for index-cards of a given type

## Screenshot(s)
- search page with richer metadata fields!
Projects:
![image](https://github.com/user-attachments/assets/e518bb3e-c9ef-4eaf-92bc-9f2e392405de)

Registrations:
![image](https://github.com/user-attachments/assets/305386a2-377e-4460-9340-5da5add0ce3d)

Preprints:
![image](https://github.com/user-attachments/assets/02df90ae-9531-41a0-b343-9b3b35adcf6d)

Files:
![image](https://github.com/user-attachments/assets/aac1e70e-a309-4980-a9bd-748f7905a80f)

Users:
![image](https://github.com/user-attachments/assets/8138cd9c-9052-42b4-a20f-27b00655edf1)


## Side Effects
- None, really. The search page and search-result-card component should be a bit better testable now, but I don't know if I want to blow up the scope of this ticket just yet...

## QA Notes
- This is to update the info returned in mirage (our fake backend), so this should have no testable bit from QA team


[ENG-6181]: https://openscience.atlassian.net/browse/ENG-6181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ