### PR TITLE
Comment out button to add new configured addon for a given provider

### DIFF
--- a/app/guid-node/addons/index/template.hbs
+++ b/app/guid-node/addons/index/template.hbs
@@ -207,7 +207,8 @@
                                 </div>
                             {{/each}}
                         </div>
-                        <div local-class='float-right'>
+                        {{!-- Remove ability to add a new configured addon for now --}}
+                        {{!-- <div local-class='float-right'>
                             <Button
                                 data-test-add-another-location-button
                                 data-analytics-name='Add another location'
@@ -219,7 +220,7 @@
                             >
                                 {{t 'addons.list.add-another-location'}}
                             </Button>
-                        </div>
+                        </div> --}}
                         <OsfDialog
                             @isOpen={{manager.confirmRemoveConnectedLocation}}
                             @onClose={{action (mut manager.confirmRemoveConnectedLocation) false}}


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Disallow configuring multiple accounts for a given external-storage-services

## Summary of Changes
- Comment out button that allows users to connect another account for a given external-storage-service

## Screenshot(s)
- Removes this button on the "Configure provider" screen:
![Screen Shot 2024-09-13 at 5 22 24 PM](https://github.com/user-attachments/assets/485cf00a-1f4a-4a5f-95a2-76061b5098fe)


## Side Effects
- Not really a side-effect, but removes ability to add a second account to a node from the same service (e.g. can't connect a second Box account for a given storage provider), as this is no longer part of the project requirement

## QA Notes
