### PR TITLE
[ENG-6242] Missed a field to reset on public preregistrations

### DIFF
--- a/app/preprints/-components/submit/author-assertions/public-preregistration/component.ts
+++ b/app/preprints/-components/submit/author-assertions/public-preregistration/component.ts
@@ -99,12 +99,14 @@ export default class PublicPreregistration extends Component<PublicPreregistrati
             this.args.changeSet.set('whyNoPrereg', null);
             this.isPublicPreregistrationWhyNoStatementDisabled = false || !this.args.manager.isAdmin();
         } else if (this.args.changeSet.get('hasPreregLinks') === PreprintPreregLinksEnum.NO) {
+            this.args.changeSet.set('preregLinkInfo', null);
             this.args.changeSet.set('preregLinks', []);
             this.args.changeSet.set('whyNoPrereg', null);
             this.isPublicPreregistrationWhyNoStatementDisabled = false || !this.args.manager.isAdmin();
             this.placeholder = this.intl.t('preprints.submit.step-assertions.public-preregistration-no-placeholder');
         } else {
             this.isPublicPreregistrationWhyNoStatementDisabled = true;
+            this.args.changeSet.set('preregLinkInfo', null);
             this.args.changeSet.set('preregLinks', []);
             this.args.changeSet.set('whyNoPrereg',
                 this.intl.t('preprints.submit.step-assertions.public-preregistration-na-placeholder',


### PR DESCRIPTION
-   Ticket: [ENG-6242]
-   Feature flag: n/a

## Purpose

A field was not reset on the changeSet and an error was occuring.

## Summary of Changes

Reset the field when the user clicked "No" or "Not Applicable"



[ENG-6242]: https://openscience.atlassian.net/browse/ENG-6242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ