### PR TITLE
[ENG-6011] Link My Preprints on nav bar to new page

### DIFF
--- a/lib/osf-components/addon/components/osf-navbar/preprint-links/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/preprint-links/template.hbs
@@ -1,6 +1,6 @@
 <li data-test-nav-my-preprints-link>
     <OsfLink
-        @href='/preprints/my-preprints'
+        @route='preprints.my-preprints'
         data-analytics-name='My preprints'
         {{on 'click' @onLinkClicked}}
     >

--- a/lib/osf-components/addon/components/osf-navbar/preprint-links/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/preprint-links/template.hbs
@@ -1,6 +1,6 @@
 <li data-test-nav-my-preprints-link>
     <OsfLink
-        @href='/myprojects/#preprints'
+        @href='/preprints/my-preprints'
         data-analytics-name='My preprints'
         {{on 'click' @onLinkClicked}}
     >


### PR DESCRIPTION
-   Ticket:[ [ENG-6011]](https://openscience.atlassian.net/browse/ENG-6011)
-   Feature flag: n/a

## Purpose

Link 'My Preprints' on navbar to new page

## Summary of Changes

Change the link of the My Preprints button on the preprints navbar to link to the new My Preprints page.


[ENG-6011]: https://openscience.atlassian.net/browse/ENG-6011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ