### PR TITLE
[ENG-5879] Hide Categories Section on Registrations

### DIFF
--- a/lib/registries/addon/components/registries-metadata/component.ts
+++ b/lib/registries/addon/components/registries-metadata/component.ts
@@ -27,6 +27,7 @@ export default class RegistriesMetadata extends Component {
     extendedFields?: boolean;
 
     @tracked provider?: RegistrationProviderModel;
+    hideCategories = true;
     // Private properties
     expandCitations = false;
 

--- a/lib/registries/addon/components/registries-metadata/template.hbs
+++ b/lib/registries/addon/components/registries-metadata/template.hbs
@@ -102,7 +102,7 @@
                             <ProviderMetadataDisplay @field={{metadataField}} @manager={{providerMetadataManager}} />
                         </field.display>
                     {{/each}}
-                    
+
                 </EditableField>
             </EditableField::ProviderMetadataManager>
         </div>
@@ -122,24 +122,26 @@
         </div>
     {{/if}}
 
-    <div local-class='Field'>
-        <EditableField::CategoryManager @node={{this.registration}} as |categoryManager|>
-            <EditableField
-                data-analytics-scope='Category'
-                @manager={{categoryManager}}
-                @title={{t 'registries.registration_metadata.category'}}
-                @name='category'
-                as |field|
-            >
-                <field.edit>
-                    <NodeCategoryPicker @manager={{categoryManager}} />
-                </field.edit>
-                <field.display>
-                    <NodeCategory @category={{categoryManager.category}} />
-                </field.display>
-            </EditableField>
-        </EditableField::CategoryManager>
-    </div>
+    {{#unless this.hideCategories}}
+        <div local-class='Field'>
+            <EditableField::CategoryManager @node={{this.registration}} as |categoryManager|>
+                <EditableField
+                    data-analytics-scope='Category'
+                    @manager={{categoryManager}}
+                    @title={{t 'registries.registration_metadata.category'}}
+                    @name='category'
+                    as |field|
+                >
+                    <field.edit>
+                        <NodeCategoryPicker @manager={{categoryManager}} />
+                    </field.edit>
+                    <field.display>
+                        <NodeCategory @category={{categoryManager.category}} />
+                    </field.display>
+                </EditableField>
+            </EditableField::CategoryManager>
+        </div>
+    {{/unless}}
 
     {{#if @extendedFields}}
         {{#unless this.registration.isAnonymous}}

--- a/tests/engines/registries/acceptance/overview/overview-test.ts
+++ b/tests/engines/registries/acceptance/overview/overview-test.ts
@@ -1,4 +1,3 @@
-import { capitalize } from '@ember/string';
 import { click as untrackedClick, fillIn, settled, triggerKeyEvent } from '@ember/test-helpers';
 import { ModelInstance } from 'ember-cli-mirage';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -322,7 +321,7 @@ module('Registries | Acceptance | overview.overview', hooks => {
         assert.dom('[data-test-edit-button="description"]').isNotVisible();
     });
 
-    test('editable registration category', async function(assert) {
+    test('categories section is hidden on registration page', async function(assert) {
         const reg = server.create('registration', {
             currentUserPermissions: Object.values(Permission),
             category: NodeCategory.Project,
@@ -330,30 +329,14 @@ module('Registries | Acceptance | overview.overview', hooks => {
 
         await visit(`/${reg.id}/`);
 
-        await click('[data-test-edit-button="category"]');
-        assert.dom('[data-test-select-category] div[class~="ember-power-select-trigger"]')
-            .hasText(capitalize(reg.category));
-
-        await untrackedClick('[data-test-select-category] div[class~="ember-power-select-trigger"]');
-        assert.dom('.ember-power-select-option').exists({ count: Object.values(NodeCategory).length - 1 });
-
-        await selectChoose('[data-test-select-category]', capitalize(NodeCategory.Instrumentation));
-        await click('[data-test-save-edits]');
-
-        reg.reload();
-        assert.equal(reg.category, NodeCategory.Instrumentation);
-
-        // Read user cannot edit
-        reg.update({ currentUserPermissions: [Permission.Read] });
-
-        await visit(`/${reg.id}/`);
         assert.dom('[data-test-edit-button="category"]').doesNotExist();
+        assert.dom('[data-test-select-category]').doesNotExist();
 
-        // Write user can edit
         reg.update({ currentUserPermissions: [Permission.Read, Permission.Write] });
 
         await visit(`/${reg.id}/`);
-        assert.dom('[data-test-edit-button="category"]').exists();
+        assert.dom('[data-test-edit-button="category"]').doesNotExist();
+        assert.dom('[data-test-select-category]').doesNotExist();
     });
 
     test('editable publication doi', async function(assert) {


### PR DESCRIPTION
-   Ticket: [https://openscience.atlassian.net/browse/ENG-5879]
-   Feature flag: n/a

## Purpose

Hide Categories Section on Registrations

## Summary of Changes

- Modified the registries-metadata component template to hide the categories field.
- Set a hideCategories flag in the component to control the visibility of the categories section.
