### PR TITLE
[ENG-6346] Update logic to set initial folder id in file manager

### DIFF
--- a/app/models/addon-operation-invocation.ts
+++ b/app/models/addon-operation-invocation.ts
@@ -16,15 +16,28 @@ export enum ItemType {
     File = 'FILE',
 }
 
-export interface OperationResult{
+export type OperationResult = ListItemsResult | GetItemInfoResult;
+
+export interface ListItemsResult {
     items: Item[];
-    cursor?: string; // TODO: name??
+    thisSampleCursor?: string;
+    nextSampleCursor?: string;
+    prevSampleCursor?: string;
+    firstSampleCursor?: string;
+    totalCount?: number;
 }
+
+export interface GetItemInfoResult {
+    itemId: string;
+    itemName: string;
+    itemType: ItemType;
+}
+
 export interface Item {
     itemId: string;
     itemName: string;
     itemType: ItemType;
-    itemPath: string;
+    itemPath?: Item[];
 }
 
 export default class AddonOperationInvocationModel extends Model {

--- a/app/models/addon-operation-invocation.ts
+++ b/app/models/addon-operation-invocation.ts
@@ -16,7 +16,7 @@ export enum ItemType {
     File = 'FILE',
 }
 
-export type OperationResult = ListItemsResult | GetItemInfoResult;
+export type OperationResult = ListItemsResult | Item;
 
 export interface ListItemsResult {
     items: Item[];
@@ -25,12 +25,6 @@ export interface ListItemsResult {
     prevSampleCursor?: string;
     firstSampleCursor?: string;
     totalCount?: number;
-}
-
-export interface GetItemInfoResult {
-    itemId: string;
-    itemName: string;
-    itemType: ItemType;
 }
 
 export interface Item {

--- a/app/models/configured-storage-addon.ts
+++ b/app/models/configured-storage-addon.ts
@@ -71,7 +71,7 @@ export default class ConfiguredStorageAddonModel extends ConfiguredAddonModel {
     }
 
     get externalServiceId() {
-        return (this as ConfiguredStorageAddonModel).belongsTo('externalStorageService').id();
+        return this.get('baseAccount').get('externalStorageService').get('id');
     }
 }
 

--- a/app/models/configured-storage-addon.ts
+++ b/app/models/configured-storage-addon.ts
@@ -71,6 +71,7 @@ export default class ConfiguredStorageAddonModel extends ConfiguredAddonModel {
     }
 
     get externalServiceId() {
+        return (this as ConfiguredStorageAddonModel).belongsTo('externalStorageService').id();
         return this.get('baseAccount').get('externalStorageService').get('id');
     }
 }

--- a/app/models/configured-storage-addon.ts
+++ b/app/models/configured-storage-addon.ts
@@ -72,7 +72,6 @@ export default class ConfiguredStorageAddonModel extends ConfiguredAddonModel {
 
     get externalServiceId() {
         return (this as ConfiguredStorageAddonModel).belongsTo('externalStorageService').id();
-        return this.get('baseAccount').get('externalStorageService').get('id');
     }
 }
 

--- a/lib/osf-components/addon/components/addons-service/configured-addon-edit/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/configured-addon-edit/template.hbs
@@ -27,23 +27,27 @@
         as |fileManager|
     >
         <div local-class='current-path'>
-            {{#each fileManager.currentPath as |pathItem index|}}
-                <span>
-                    <Button
-                        data-test-folder-path-option='{{pathItem.itemName}}'
-                        data-analytics-name='Go to ancestor folder'
-                        @layout='fake-link'
-                        aria-label={{t 'addons.configure.go-to-folder' folderName=pathItem.itemName}}
-                        {{on 'click' (fn fileManager.goToFolder pathItem)}}
-                    >
-                        {{#if (eq index 0)}}
-                            <FaIcon @icon='home' />
-                        {{else}}
-                            <FaIcon @icon='chevron-right' />
-                        {{/if}}
-                        {{pathItem.itemName}}
-                    </Button>
-                </span>
+            <Button
+                data-test-go-to-root
+                data-analytics-name='Go to root folder'
+                @layout='fake-link'
+                aria-label={{t 'addons.configure.go-to-root'}}
+                {{on 'click' fileManager.goToRoot}}
+            >
+                <FaIcon @icon='home' />
+                {{t 'general.home'}}
+            </Button>
+            {{#each fileManager.currentPath as |pathItem|}}
+                <Button
+                    data-test-folder-path-option='{{pathItem.itemName}}'
+                    data-analytics-name='Go to ancestor folder'
+                    @layout='fake-link'
+                    aria-label={{t 'addons.configure.go-to-folder' folderName=pathItem.itemName}}
+                    {{on 'click' (fn fileManager.goToFolder pathItem)}}
+                >
+                    <FaIcon @icon='chevron-right' />
+                    {{pathItem.itemName}}
+                </Button>
             {{/each}}
         </div>
         <table local-class='file-tree-table'>

--- a/lib/osf-components/addon/components/addons-service/configured-addon-edit/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/configured-addon-edit/template.hbs
@@ -54,43 +54,59 @@
                 </tr>
             </thead>
             <tbody local-class='table-body'>
-                {{#each fileManager.currentItems as |folder|}}
-                    <tr>
-                        <td>
-                            <Button
-                                data-test-folder-link='{{folder.itemName}}'
-                                data-analytics-name='Go to folder'
-                                @layout='fake-link'
-                                aria-label={{t 'addons.configure.go-to-folder' folderName=folder.itemName}}
-                                {{on 'click' (fn fileManager.goToFolder folder)}}
-                            >
-                                <FaIcon @icon='folder' />
-                                {{folder.itemName}}
-                            </Button>
-                        </td>
-                        <td>
-                            <input
-                                data-test-root-folder-option='{{folder.itemName}}'
-                                data-analytics-name='Select folder'
-                                type='radio'
-                                name='folder'
-                                value={{folder.itemName}}
-                                aria-label={{t 'addons.configure.select-folder' folderName=folder.itemName}}
-                                {{on 'change'(fn this.selectFolder folder)}}
-                            >
-                        </td>
-                    </tr>
-                {{else if fileManager.isLoading}}
+                {{#if fileManager.isLoading}}
                     <LoadingIndicator @dark={{true}} />
                 {{else if fileManager.isError}}
                     <tr>
                         <td colspan='2'>{{t 'addons.configure.error-loading-items'}}</td>
                     </tr>
                 {{else}}
-                    <tr>
-                        <td colspan='2'>{{t 'addons.configure.no-folders'}}</td>
-                    </tr>
-                {{/each}}
+                    {{#each fileManager.currentItems as |folder|}}
+                        <tr>
+                            <td>
+                                <Button
+                                    data-test-folder-link='{{folder.itemName}}'
+                                    data-analytics-name='Go to folder'
+                                    @layout='fake-link'
+                                    aria-label={{t 'addons.configure.go-to-folder' folderName=folder.itemName}}
+                                    {{on 'click' (fn fileManager.goToFolder folder)}}
+                                >
+                                    <FaIcon @icon='folder' />
+                                    {{folder.itemName}}
+                                </Button>
+                            </td>
+                            <td>
+                                <input
+                                    data-test-root-folder-option='{{folder.itemName}}'
+                                    data-analytics-name='Select folder'
+                                    type='radio'
+                                    name='folder'
+                                    value={{folder.itemName}}
+                                    aria-label={{t 'addons.configure.select-folder' folderName=folder.itemName}}
+                                    {{on 'change'(fn this.selectFolder folder)}}
+                                >
+                            </td>
+                        </tr>
+                    {{else}}
+                        <tr>
+                            <td colspan='2'>{{t 'addons.configure.no-folders'}}</td>
+                        </tr>
+                    {{/each}}
+                    {{#if fileManager.hasMore}}
+                        <tr>
+                            <td colspan='2'>
+                                <Button
+                                    data-test-load-more-folders
+                                    data-analytics-name='Load more folders'
+                                    @layout='fake-link'
+                                    {{on 'click' fileManager.getMore}}
+                                >
+                                    {{t 'general.load_more'}}
+                                </Button>
+                            </td>
+                        </tr>
+                    {{/if}}
+                {{/if}}
             </tbody>
         </table>
         <div local-class='footer-buttons-wrapper'>

--- a/lib/osf-components/addon/components/addons-service/file-manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/file-manager/component.ts
@@ -18,13 +18,11 @@ interface Args {
     startingFolderId: string;
 }
 
-type PathItem = Item | { itemName: string };
-
 export default class FileManager extends Component<Args> {
     @service intl!: IntlService;
     @service toast!: Toast;
 
-    @tracked currentPath: PathItem[] = [];
+    @tracked currentPath: Item[] = [];
     @tracked currentItems: Item[] = [];
     @tracked currentFolderId?: string;
 
@@ -58,8 +56,8 @@ export default class FileManager extends Component<Args> {
     @action
     goToRoot() {
         this.cursor = undefined;
-        this.currentPath = this.currentPath.slice(0, 1);
-        this.currentFolderId = this.args.startingFolderId;
+        this.currentPath = this.currentPath = [];
+        this.currentFolderId = undefined;
         taskFor(this.getItems).perform();
     }
 
@@ -93,8 +91,6 @@ export default class FileManager extends Component<Args> {
                 const result = invocation.operationResult as Item;
                 this.currentFolderId = result.itemId;
                 this.currentPath = result.itemPath ? [...result.itemPath] : [];
-            } else {
-                this.currentPath = [{itemName: 'Root'}];
             }
         } catch (e) {
             captureException(e);

--- a/lib/osf-components/addon/components/addons-service/file-manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/file-manager/component.ts
@@ -76,7 +76,7 @@ export default class FileManager extends Component<Args> {
 
     @action
     getMore() {
-        this.cursor = this.lastInvocation?.operationResult.cursor;
+        this.cursor = this.lastInvocation?.operationResult.nextSampleCursor;
         taskFor(this.getItems).perform();
     }
 

--- a/lib/osf-components/addon/components/addons-service/file-manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/file-manager/component.ts
@@ -18,11 +18,13 @@ interface Args {
     startingFolderId: string;
 }
 
+type PathItem = Item | { itemName: string };
+
 export default class FileManager extends Component<Args> {
     @service intl!: IntlService;
     @service toast!: Toast;
 
-    @tracked currentPath: Item[] = [];
+    @tracked currentPath: PathItem[] = [];
     @tracked currentItems: Item[] = [];
     @tracked currentFolderId?: string;
 
@@ -92,7 +94,7 @@ export default class FileManager extends Component<Args> {
                 this.currentFolderId = result.itemId;
                 this.currentPath = result.itemPath ? [...result.itemPath] : [];
             } else {
-                this.currentPath = [];
+                this.currentPath = [{itemName: 'Root'}];
             }
         } catch (e) {
             captureException(e);

--- a/mirage/views/addons.ts
+++ b/mirage/views/addons.ts
@@ -260,19 +260,20 @@ export function createAddonOperationInvocation(this: HandlerContext, schema: Sch
     const invocation = schema.addonOperationInvocations.create(attrs) as ModelInstance<MirageAddonOperationInvocation>;
     let result: any = null;
     const folderId = kwargs.item_id || 'root';
+    const item_type = kwargs.item_type || ItemType.Folder;
     if (attrs.operationName === ConnectedOperationNames.GetItemInfo) {
         result = {
             item_id: folderId,
             item_name: `Item with ID ${folderId}`,
-            item_type: kwargs.item_type || ItemType.Folder,
+            item_type,
             item_path: folderId,
         };
     } else {
         result = {
             items: '12345'.split('').map(i => ({
                 item_id: `${folderId}-${i}`,
-                item_name: `${kwargs.item_type}${i} in ${folderId}`,
-                item_type: kwargs.item_type,
+                item_name: `${item_type}${i} in ${folderId}`,
+                item_type,
                 item_path: folderId,
             })),
         };

--- a/mirage/views/addons.ts
+++ b/mirage/views/addons.ts
@@ -261,12 +261,14 @@ export function createAddonOperationInvocation(this: HandlerContext, schema: Sch
     let result: any = null;
     const folderId = kwargs.item_id || 'root';
     const item_type = kwargs.item_type || ItemType.Folder;
+    const fakePath = folderId.split('-')
+        .map((folder: string) => ({ item_id: folder, item_name: folder, item_type: ItemType.Folder }));
     if (attrs.operationName === ConnectedOperationNames.GetItemInfo) {
         result = {
             item_id: folderId,
-            item_name: `Item with ID ${folderId}`,
+            item_name: `Folder with ID ${folderId}`,
             item_type,
-            item_path: folderId,
+            item_path: folderId === 'root' ? undefined : fakePath,
         };
     } else {
         result = {
@@ -274,7 +276,7 @@ export function createAddonOperationInvocation(this: HandlerContext, schema: Sch
                 item_id: `${folderId}-${i}`,
                 item_name: `${item_type}${i} in ${folderId}`,
                 item_type,
-                item_path: folderId,
+                item_path: folderId === 'root' ? undefined : fakePath,
             })),
         };
     }

--- a/tests/acceptance/guid-node/addons-test.ts
+++ b/tests/acceptance/guid-node/addons-test.ts
@@ -192,6 +192,7 @@ module('Acceptance | guid-node/addons', hooks => {
         assert.dom('[data-test-display-name-input]').exists('Name input is present');
         assert.dom('[data-test-display-name-input]')
             .hasValue(s3AccountsDisplayNamesAndRootFolders[0].displayName, 'Name input has correct value');
+        assert.dom('[data-test-go-to-root]').exists('Go to root button is present');
         assert.dom('[data-test-folder-path-option]').exists({ count: 1 }, 'Folder path shown');
         assert.dom('[data-test-root-folder-save]').isEnabled('Save button is enabled when name is present');
         assert.dom('[data-test-root-folder-cancel]').exists('Cancel button is present');

--- a/tests/acceptance/guid-node/addons-test.ts
+++ b/tests/acceptance/guid-node/addons-test.ts
@@ -223,7 +223,7 @@ module('Acceptance | guid-node/addons', hooks => {
         const firstRootFolder = document.querySelectorAll('[data-test-configured-addon-root-folder]')[0];
         assert.dom(firstDisplayName)
             .containsText('New S3 Account Display Name', 'Display name change is saved');
-        assert.dom(firstRootFolder).containsText('s3root-1-1', 'Root folder change is saved');
+        assert.dom(firstRootFolder).containsText('root-1-1', 'Root folder change is saved');
 
         // Remove other account
         await click('[data-test-remove-connected-location]:last-child');

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -352,6 +352,7 @@ addons:
     configure:
         heading: 'Configure {providerName}'
         display-name: 'Display name'
+        go-to-root: 'Go to root'
         go-to-folder: 'Go to folder {folderName}'
         select-folder: 'Select {folderName} as root folder'
         table-headings:

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -352,7 +352,7 @@ addons:
     configure:
         heading: 'Configure {providerName}'
         display-name: 'Display name'
-        go-to-root: 'Go to root'
+        go-to-root: 'Go to home folder'
         go-to-folder: 'Go to folder {folderName}'
         select-folder: 'Select {folderName} as root folder'
         table-headings:

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -64,6 +64,7 @@ general:
     hosted_on_the_osf: 'Hosted on OSF'
     last_modified: 'Last modified'
     loading: Loading...
+    load_more: 'Load more'
     md5: MD5
     modified: Modified
     more: more


### PR DESCRIPTION
-   Ticket: [ENG-6346]
-   Feature flag: n/a

## Purpose
- Address a bug where the root folder picker doesn't show the correct folder content when widget loads (shows root folder's parent, not root folder's contents). See video in ticket for better description

## Summary of Changes
- Update types
- Set currentFolder to be the explicit Id of the starting folder
- Always show Home option in breadcrumbs

## Screenshot(s)
- Prevents this bug where "All Files" is apparently the current folder content that you are viewing, and while also only showing the "All Files item"
![image](https://github.com/user-attachments/assets/cd11a634-ecd4-47a3-bbad-e68bd89d57e1)
- Should look like this if "All Files" is the selected root folder upon loading this page:
![image](https://github.com/user-attachments/assets/95b6eca2-892e-4a5c-a25b-effb838321ae)
- Should look like this if no root folder is selected
![image](https://github.com/user-attachments/assets/daa93401-3760-4bf8-b68f-888c969e5fa7)



## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6346]: https://openscience.atlassian.net/browse/ENG-6346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ