### PR TITLE
Update month data fields to be strings

### DIFF
--- a/app/models/institution-user.ts
+++ b/app/models/institution-user.ts
@@ -15,9 +15,9 @@ export default class InstitutionUserModel extends OsfModel {
     @attr('number') publicFileCount!: number;
     @attr('number') storageByteCount!: number;
     @attr('number') totalObjectCount!: number;
-    @attr('date') monthLastLogin!: Date;
-    @attr('date') monthLastActive!: Date;
-    @attr('date') accountCreationDate!: Date;
+    @attr('string') monthLastLogin!: string; // YYYY-MM
+    @attr('string') monthLastActive!: string; // YYYY-MM
+    @attr('string') accountCreationDate!: string; // YYYY-MM
     @attr('fixstring') orcidId?: string;
 
     @belongsTo('user', { async: true })


### PR DESCRIPTION
-   Ticket: [No ticket]
-   Feature flag: n/a

## Purpose
- Update institution-user date fields to be strings to avoid a bug where month data would be shown incorrectly

## Summary of Changes
- Don't use `date` transform for InstitutionUser model's `monthLastLogin`, `monthLastActive`, and `accountCreationDate`
  - Use of this transform was causing problems with the display of these fields as the API would return `account_creation_date: "2024-10"`, but the `date` [transform would convert](https://github.com/emberjs/data/blob/v3.28.8/packages/serializer/addon/-private/transforms/date.js#L40) that to `9/2024` depending on timezone
   (e.g. `new Date('2024-10') // Mon Sep 30 2024 20:00:00 GMT-0400 (Eastern Daylight Time) {}`)

## Screenshot(s)
- Prevents this issue (Note the date in the API response and the date displayed in the table):
![image](https://github.com/user-attachments/assets/05a4f836-4e4a-4bbf-9e3b-d07b7723c29c)


<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- Great find!