### PR TITLE
[ENG-5879] Hide Categories Section for Draft Registrations

### DIFF
--- a/lib/osf-components/addon/components/node-card/template.hbs
+++ b/lib/osf-components/addon/components/node-card/template.hbs
@@ -80,7 +80,9 @@
                         {{/if}}
                     {{/if}}
 
-                    {{node-card/node-icon category=@node.category}}
+                    {{#unless @node.isRegistration}}
+                        {{node-card/node-icon category=@node.category}}
+                    {{/unless}}
                     <OsfLink
                         local-class='osf-link {{if this.isMobile 'mobile'}}'
                         data-analytics-name='Title'

--- a/lib/registries/addon/drafts/draft/metadata/controller.ts
+++ b/lib/registries/addon/drafts/draft/metadata/controller.ts
@@ -19,6 +19,8 @@ export default class RegistriesDraftMetadata extends Controller {
     categoryOptions = Object.values(NodeCategory);
     showAddContributorWidget = false;
 
+    hideCategories = true;
+
     @not('media.isDesktop') showMobileView!: boolean;
     osfUrl = config.OSF.url;
 

--- a/lib/registries/addon/drafts/draft/metadata/template.hbs
+++ b/lib/registries/addon/drafts/draft/metadata/template.hbs
@@ -83,12 +83,14 @@
                         />
                     {{/if}}
                 {{/let}}
-                <form.select data-test-metadata-category local-class='SchemaBlockDropdown' id='category'
-                    @label={{t 'registries.registration_metadata.category'}} @valuePath='category'
-                    @options={{this.categoryOptions}} @onchange={{perform this.draftManager.onMetadataInput}} as
-                    |option|>
-                    <NodeCategory @category={{option}} />
-                </form.select>
+                {{#unless this.hideCategories}}
+                    <form.select data-test-metadata-category local-class='SchemaBlockDropdown' id='category'
+                        @label={{t 'registries.registration_metadata.category'}} @valuePath='category'
+                        @options={{this.categoryOptions}} @onchange={{perform this.draftManager.onMetadataInput}} as
+                        |option|>
+                        <NodeCategory @category={{option}} />
+                    </form.select>
+                {{/unless}}
                 <fieldset id='affiliated_institutions'>
                     <legend>
                         {{t 'registries.registration_metadata.affiliated_institutions'}}

--- a/tests/engines/registries/acceptance/branded/new-test.ts
+++ b/tests/engines/registries/acceptance/branded/new-test.ts
@@ -114,6 +114,5 @@ module('Registries | Acceptance | branded.new', hooks => {
         assert.dom('[data-test-contributor-link]').exists({ count: 1 }, 'Only one contributor');
         assert.dom('[data-test-contributor-permission]').containsText('Administrator', 'user is admin');
         assert.dom('[data-test-contributor-citation]').containsText('Yes', 'user is bibliographic');
-        assert.dom('[data-test-option="uncategorized"]').exists('Category is uncategorized by default');
     });
 });

--- a/tests/engines/registries/acceptance/draft/draft-test.ts
+++ b/tests/engines/registries/acceptance/draft/draft-test.ts
@@ -945,16 +945,6 @@ module('Registries | Acceptance | draft form', hooks => {
         assert.dom('[data-test-validation-errors="description"]')
             .exists('error in description appears after removing valid string to blank string');
 
-        // Choose category and add a tag
-        await click('[data-test-metadata-category] > div');
-        await percySnapshot('Registries | Acceptance | draft form | metadata editing | metadata: categories opened');
-        assert.dom('[data-option-index="1"]').containsText('Other');
-        await click('[data-option-index="1"]');
-
-        await click('[data-test-metadata-tags]');
-        await fillIn('[data-test-metadata-tags] input', 'ragtagbag');
-        await triggerKeyEvent('[data-test-metadata-tags] input', 'keydown', 'Enter');
-
         // No errors for nodelicense fields
         assert.dom('[data-test-validation-errors="subjects"]')
             .doesNotExist('no error for required fields that user has yet to change: subjects');
@@ -969,12 +959,6 @@ module('Registries | Acceptance | draft form', hooks => {
         assert.dom('[data-test-goto-register]').isDisabled();
         assert.dom('[data-test-validation-errors="subjects"]');
         assert.dom('[data-test-validation-errors="license"]');
-
-        // Category and tag added appear on review page
-        assert.dom('[data-test-review-response="category"]')
-            .containsText('Other', 'category that was selected in metadata page shows up in review');
-        assert.dom('[data-test-tags-widget-tag="ragtagbag"]')
-            .exists('tag added in metadata shows up in review page');
 
         // Return to Metadata page and address errors for subjects and license
         await click('[data-test-link="metadata"]');


### PR DESCRIPTION

-   Ticket: [https://openscience.atlassian.net/browse/ENG-5879]
-   Feature flag: n/a

## Purpose

 Hide Categories Section for Draft Registrations

## Summary of Changes

- Added hideCategories Flag
- Added Conditional Category Display for draft registrations
