### PR TITLE
[ENG-6368] Share summary graphs

### DIFF
--- a/app/institutions/dashboard/-components/chart-kpi-wrapper/chart-kpi/component.ts
+++ b/app/institutions/dashboard/-components/chart-kpi-wrapper/chart-kpi/component.ts
@@ -31,7 +31,7 @@ export default class ChartKpi extends Component<KPIChartWrapperArgs> {
      * @returns a ChartOptions model which is custom to COS
      */
     get chartOptions(): ChartOptions {
-        return {
+        const options = {
             aspectRatio: 1,
             legend: {
                 display: false,
@@ -42,9 +42,14 @@ export default class ChartKpi extends Component<KPIChartWrapperArgs> {
                 }],
                 yAxes: [{
                     display: false,
+                    ticks: { min: 0 },
                 }],
             },
         };
+        if (this.args.data.chartType === 'bar') {
+            options.scales.yAxes[0].display = true;
+        }
+        return options;
     }
 
     /**

--- a/app/institutions/dashboard/-components/chart-kpi-wrapper/chart-kpi/component.ts
+++ b/app/institutions/dashboard/-components/chart-kpi-wrapper/chart-kpi/component.ts
@@ -88,13 +88,9 @@ export default class ChartKpi extends Component<KPIChartWrapperArgs> {
         const labels = [] as string[];
         const { taskInstance, chartData } = this.args.data;
 
-        let rawData = chartData ? chartData : [];
-        if (taskInstance) {
-            if (taskInstance.value) {
-                rawData = taskInstance.value;
-            }
-        }
-        rawData.map((rawChartData: ChartDataModel, $index: number) => {
+        const rawData = taskInstance?.value || chartData || [];
+
+        rawData.forEach((rawChartData: ChartDataModel, $index: number) => {
             backgroundColors.push(this.getColor($index));
 
             data.push(rawChartData.total);

--- a/app/institutions/dashboard/-components/chart-kpi-wrapper/chart-kpi/component.ts
+++ b/app/institutions/dashboard/-components/chart-kpi-wrapper/chart-kpi/component.ts
@@ -85,21 +85,26 @@ export default class ChartKpi extends Component<KPIChartWrapperArgs> {
     get chartData(): ChartData {
         const backgroundColors = [] as string[];
         const data = [] as number[];
-        const labels =  [] as string[];
+        const labels = [] as string[];
+        const { taskInstance, chartData } = this.args.data;
 
-        this.args.data.chartData.map((chartData: ChartDataModel, $index: number) => {
+        let rawData = chartData ? chartData : [];
+        if (taskInstance) {
+            if (taskInstance.value) {
+                rawData = taskInstance.value;
+            }
+        }
+        rawData.map((rawChartData: ChartDataModel, $index: number) => {
             backgroundColors.push(this.getColor($index));
 
-            data.push(chartData.total);
-            labels.push(chartData.label);
-
+            data.push(rawChartData.total);
+            labels.push(rawChartData.label);
             this.expandedData.push({
-                name: chartData.label,
-                total: chartData.total,
+                name: rawChartData.label,
+                total: rawChartData.total,
                 color: this.getColor($index),
             });
         });
-
         return {
             labels,
             datasets: [{

--- a/app/institutions/dashboard/-components/chart-kpi-wrapper/chart-kpi/styles.scss
+++ b/app/institutions/dashboard/-components/chart-kpi-wrapper/chart-kpi/styles.scss
@@ -6,7 +6,7 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    align-items: flex-start;
+    text-align: center;
     width: 290px;
     min-height: 290px;
     height: fit-content;

--- a/app/institutions/dashboard/-components/chart-kpi-wrapper/chart-kpi/template.hbs
+++ b/app/institutions/dashboard/-components/chart-kpi-wrapper/chart-kpi/template.hbs
@@ -2,68 +2,74 @@
     local-class='chart-container {{if (is-mobile) 'mobile'}}'
     ...attributes 
 >
-    <div local-class='top-container'>
-        <div
-            data-test-chart
-            local-class='ember-chart'
-        >
-            <EmberChart
-                @type={{@data.chartType}}
-                @options={{this.chartOptions}}
-                @data={{this.chartData}}
-            />
-        </div>
-    </div>
-    <div local-class='bottom-container'>
-        {{#let (unique-id 'expanded-data') as |expandedDataId|}}
-            <div local-class='title-container'>
-                <div data-test-chart-title local-class='title'>{{@data.title}}</div>
-                <div local-class='button-container'>
-                    <Button
-                        data-analytics-name='Expand additional data'
-                        data-test-expand-additional-data
-                        @layout='fake-link'
-                        aria-controls={{expandedDataId}}
-                        aria-expanded={{this.expanded}}
-                        aria-label={{if this.expanded
-                        (t 'institutions.dashboard.kpi-chart.close-expanded-data')
-                        (t 'institutions.dashboard.kpi-chart.open-expanded-data')
-                        }}
-                        {{on 'click' this.toggleExpandedData}}
-                    >
-                        <FaIcon data-test-toggle-icon @icon={{if this.collapsed 'caret-down' 'caret-up'}} />
-                    </Button>
-                </div>
-            </div>
-            <div 
-                local-class='expanded-data-container {{if this.collapsed 'collapsed'}}'
-                data-test-expansion-data
-                id={{expandedDataId}}
+    {{#if @data.taskInstance.isRunning}}
+        <LoadingIndicator @dark={{true}} />
+    {{else if @data.taskInstance.isError}}
+        {{t 'institutions.dashboard.kpi-chart.error'}}
+    {{else}}
+        <div local-class='top-container'>
+            <div
+                data-test-chart
+                local-class='ember-chart'
             >
-                <ul local-class='data-list'>
-                    {{#each this.expandedData as |data index |}}
-                        <li
-                            local-class='data-container'
-                        >
-                            <div
-                                local-class='color'
-                                data-test-expanded-color='{{index}}'
-                                style={{html-safe (concat 'background-color:' data.color )}}>
-                            </div>
-                            <div local-class='name'
-                                data-test-expanded-name='{{index}}'
-                            >
-                                {{data.name}}
-                            </div>
-                            <div local-class='total'
-                                data-test-expanded-total='{{index}}'
-                            >
-                                {{data.total}}
-                            </div>
-                        </li>
-                    {{/each}}
-                </ul>
+                <EmberChart
+                    @type={{@data.chartType}}
+                    @options={{this.chartOptions}}
+                    @data={{this.chartData}}
+                />
             </div>
-        {{/let}}
-    </div>
+        </div>
+        <div local-class='bottom-container'>
+            {{#let (unique-id 'expanded-data') as |expandedDataId|}}
+                <div local-class='title-container'>
+                    <div data-test-chart-title local-class='title'>{{@data.title}}</div>
+                    <div local-class='button-container'>
+                        <Button
+                            data-analytics-name='Expand additional data'
+                            data-test-expand-additional-data
+                            @layout='fake-link'
+                            aria-controls={{expandedDataId}}
+                            aria-expanded={{this.expanded}}
+                            aria-label={{if this.expanded
+                            (t 'institutions.dashboard.kpi-chart.close-expanded-data')
+                            (t 'institutions.dashboard.kpi-chart.open-expanded-data')
+                            }}
+                            {{on 'click' this.toggleExpandedData}}
+                        >
+                            <FaIcon data-test-toggle-icon @icon={{if this.collapsed 'caret-down' 'caret-up'}} />
+                        </Button>
+                    </div>
+                </div>
+                <div 
+                    local-class='expanded-data-container {{if this.collapsed 'collapsed'}}'
+                    data-test-expansion-data
+                    id={{expandedDataId}}
+                >
+                    <ul local-class='data-list'>
+                        {{#each this.expandedData as |data index |}}
+                            <li
+                                local-class='data-container'
+                            >
+                                <div
+                                    local-class='color'
+                                    data-test-expanded-color='{{index}}'
+                                    style={{html-safe (concat 'background-color:' data.color )}}>
+                                </div>
+                                <div local-class='name'
+                                    data-test-expanded-name='{{index}}'
+                                >
+                                    {{data.name}}
+                                </div>
+                                <div local-class='total'
+                                    data-test-expanded-total='{{index}}'
+                                >
+                                    {{data.total}}
+                                </div>
+                            </li>
+                        {{/each}}
+                    </ul>
+                </div>
+            {{/let}}
+        </div>
+    {{/if}}
 </div>

--- a/app/institutions/dashboard/-components/chart-kpi-wrapper/component-test.ts
+++ b/app/institutions/dashboard/-components/chart-kpi-wrapper/component-test.ts
@@ -32,6 +32,9 @@ module('Integration | institutions | dashboard | -components | kpi-chart-wrapper
                     numberOfUsers: 37,
                 },
             ],
+            institution: {
+                iris: ['bleh'],
+            },
         });
 
         this.set('model', model);
@@ -225,22 +228,21 @@ module('Integration | institutions | dashboard | -components | kpi-chart-wrapper
 
         // And the expanded data position 0 name is verified
         assert.dom(`${parentDom} [data-test-expanded-name="0"]`)
-            .hasText('Math');
+            .exists();
 
         // And the expanded data position 0 total is verified
         assert.dom(`${parentDom} [data-test-expanded-total="0"]`)
-            .hasText('25');
+            .hasText('3');
 
         // And the expanded data position 1 name is verified
         assert.dom(`${parentDom} [data-test-expanded-name="1"]`)
-            .hasText('Science');
+            .exists();
 
         // And the expanded data position 1 total is verified
         assert.dom(`${parentDom} [data-test-expanded-total="1"]`)
-            .hasText('37');
+            .hasText('2');
 
-        // Finally there are only 2 expanded data points
-        assert.dom(`${parentDom} [data-test-expanded-name="2"]`)
+        assert.dom(`${parentDom} [data-test-expanded-total="2"]`)
             .doesNotExist();
     });
 
@@ -261,19 +263,19 @@ module('Integration | institutions | dashboard | -components | kpi-chart-wrapper
 
         // And the expanded data position 0 name is verified
         assert.dom(`${parentDom} [data-test-expanded-name="0"]`)
-            .hasText('Math');
+            .exists();
 
         // And the expanded data position 0 total is verified
         assert.dom(`${parentDom} [data-test-expanded-total="0"]`)
-            .hasText('25');
+            .hasText('3');
 
         // And the expanded data position 1 name is verified
         assert.dom(`${parentDom} [data-test-expanded-name="1"]`)
-            .hasText('Science');
+            .exists();
 
         // And the expanded data position 1 total is verified
         assert.dom(`${parentDom} [data-test-expanded-total="1"]`)
-            .hasText('37');
+            .hasText('2');
 
         // Finally there are only 2 expanded data points
         assert.dom(`${parentDom} [data-test-expanded-name="2"]`)
@@ -297,56 +299,19 @@ module('Integration | institutions | dashboard | -components | kpi-chart-wrapper
 
         // And the expanded data position 0 name is verified
         assert.dom(`${parentDom} [data-test-expanded-name="0"]`)
-            .hasText('Math');
+            .exists();
 
         // And the expanded data position 0 total is verified
         assert.dom(`${parentDom} [data-test-expanded-total="0"]`)
-            .hasText('25');
+            .hasText('3');
 
         // And the expanded data position 1 name is verified
         assert.dom(`${parentDom} [data-test-expanded-name="1"]`)
-            .hasText('Science');
+            .exists();
 
         // And the expanded data position 1 total is verified
         assert.dom(`${parentDom} [data-test-expanded-total="1"]`)
-            .hasText('37');
-
-        // Finally there are only 2 expanded data points
-        assert.dom(`${parentDom} [data-test-expanded-name="2"]`)
-            .doesNotExist();
-    });
-
-    test('it calculates the Public vs Private Data Storage data correctly', async function(assert) {
-        // Given the component is rendered
-        await render(hbs`
-<Institutions::Dashboard::-Components::ChartKpiWrapper
-@model={{this.model}}
-/>
-`);
-        const parentDom = '[data-test-kpi-chart="7"]';
-
-        // When I click the expanded icon
-        await click(`${parentDom} [data-test-expand-additional-data]`);
-
-        // And the title is verified
-        assert.dom(`${parentDom} [data-test-chart-title]`)
-            .hasText('Public vs Private Data Storage');
-
-        // And the expanded data position 0 name is verified
-        assert.dom(`${parentDom} [data-test-expanded-name="0"]`)
-            .hasText('Public Data Storage');
-
-        // And the expanded data position 0 total is verified
-        assert.dom(`${parentDom} [data-test-expanded-total="0"]`)
-            .hasText('2000');
-
-        // And the expanded data position 1 name is verified
-        assert.dom(`${parentDom} [data-test-expanded-name="1"]`)
-            .hasText('Private Data Storage');
-
-        // And the expanded data position 1 total is verified
-        assert.dom(`${parentDom} [data-test-expanded-total="1"]`)
-            .hasText('2100');
+            .hasText('2');
 
         // Finally there are only 2 expanded data points
         assert.dom(`${parentDom} [data-test-expanded-name="2"]`)

--- a/app/institutions/dashboard/-components/chart-kpi-wrapper/component-test.ts
+++ b/app/institutions/dashboard/-components/chart-kpi-wrapper/component-test.ts
@@ -19,7 +19,7 @@ module('Integration | institutions | dashboard | -components | kpi-chart-wrapper
                 publicProjectCount: 20,
                 publicRegistrationCount: 100,
                 embargoedRegistrationCount: 200,
-                preprintCount: 1000,
+                publishedPreprintCount: 1000,
                 storageByteCount: 2000,
             },
             departmentMetrics: [

--- a/app/institutions/dashboard/-components/chart-kpi-wrapper/component.ts
+++ b/app/institutions/dashboard/-components/chart-kpi-wrapper/component.ts
@@ -166,7 +166,7 @@ export default class ChartKpiWrapperComponent extends Component<TotalCountChartW
         let chartData = [
             {
                 label: this.intl.t('institutions.dashboard.kpi-chart.total-osf-objects.preprints'),
-                total: summaryMetrics.preprintCount,
+                total: summaryMetrics.publishedPreprintCount,
             } as ChartDataModel,
         ];
 
@@ -221,7 +221,6 @@ export default class ChartKpiWrapperComponent extends Component<TotalCountChartW
             cardSearchFilter: {
                 affiliation: this.args.model.institution.iris.join(','),
             },
-            sort: '-relevance',
             'page[size]': 10,
             valueSearchPropertyPath: propertyPath,
         });

--- a/app/institutions/dashboard/-components/chart-kpi-wrapper/component.ts
+++ b/app/institutions/dashboard/-components/chart-kpi-wrapper/component.ts
@@ -1,12 +1,16 @@
+import Store from '@ember-data/store';
+import { inject as service } from '@ember/service';
 import { waitFor } from '@ember/test-waiters';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { task } from 'ember-concurrency';
+import { task, TaskInstance } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 import Intl from 'ember-intl/services/intl';
-import { inject as service } from '@ember/service';
+
 import InstitutionDepartmentModel from 'ember-osf-web/models/institution-department';
 import InstitutionSummaryMetricModel from 'ember-osf-web/models/institution-summary-metric';
+import SearchResultModel from 'ember-osf-web/models/search-result';
+
 /*
 import InstitutionSummaryMetricModel from 'ember-osf-web/models/institution-summary-metric';
 */
@@ -24,10 +28,17 @@ export interface KpiChartModel {
     title: string;
     chartData: ChartDataModel[];
     chartType: string;
+    taskInstance?: TaskInstance<void>;
 }
+
+const licenseIndex = 4;
+const addonIndex = 5;
+const regionIndex = 6;
 
 export default class ChartKpiWrapperComponent extends Component<TotalCountChartWrapperArgs> {
     @service intl!: Intl;
+    @service store!: Store;
+
     @tracked model = this.args.model;
     @tracked kpiCharts = [] as KpiChartModel[];
     @tracked isLoading = true;
@@ -49,6 +60,11 @@ export default class ChartKpiWrapperComponent extends Component<TotalCountChartW
     @waitFor
     private async loadData(): Promise<void> {
         const metrics = await this.model;
+
+        const getLicenseTask = taskFor(this.getShareData).perform('rights', licenseIndex, 'licenses', 'bar');
+        const getAddonsTask = taskFor(this.getShareData).perform('hasOsfAddon', addonIndex, 'add-ons', 'bar');
+        const getRegionTask = taskFor(this.getShareData)
+            .perform('storageRegion', regionIndex, 'storage-regions', 'doughnut');
 
         this.kpiCharts.push(
             {
@@ -73,23 +89,21 @@ export default class ChartKpiWrapperComponent extends Component<TotalCountChartW
             },
             {
                 title: this.intl.t('institutions.dashboard.kpi-chart.licenses'),
-                chartData: this.calculateLicenses(metrics.departmentMetrics),
+                chartData: [],
                 chartType: 'bar',
+                taskInstance: getLicenseTask,
             },
             {
                 title: this.intl.t('institutions.dashboard.kpi-chart.add-ons'),
-                chartData: this.calculateAddons(metrics.departmentMetrics),
+                chartData: [],
                 chartType: 'bar',
+                taskInstance: getAddonsTask,
             },
             {
                 title: this.intl.t('institutions.dashboard.kpi-chart.storage-regions'),
-                chartData: this.calculateStorageRegions(metrics.departmentMetrics),
+                chartData: [],
                 chartType: 'doughnut',
-            },
-            {
-                title: this.intl.t('institutions.dashboard.kpi-chart.public-vs-private-data-storage.title'),
-                chartData: this.calculateDataStorage(metrics.summaryMetrics),
-                chartType: 'doughnut',
+                taskInstance: getRegionTask,
             },
         );
 
@@ -185,91 +199,59 @@ export default class ChartKpiWrapperComponent extends Component<TotalCountChartW
     }
 
     /**
-     * calculateLicenses
+     * getShareData
      *
-     * @description Abstracted method to build the ChartData model for licenses
-     * @param licenseMetrics The license metrics object
+     * @description Abstracted task to fetch data associated with the institution from SHARE
+     * @param propertyPath The property path to search for
+     * (e.g. propertyPathKey in the `related-property-path` of an index-card-search)
+     * @param dataPointerProperty The property on this component to store the data in
+     * @param index The index to store the data in the kpiCharts array
+     * @param translationKey The translation key to use for the title of the chart
      *
-     * @returns The licenses ChartData model
+     * @returns The total of private and public projects
      */
-    private calculateLicenses(licenseMetrics: InstitutionDepartmentModel[]): ChartDataModel[] {
-        const licenseData = [] as ChartDataModel[];
-
-        licenseMetrics.forEach((metric: InstitutionDepartmentModel ) => {
-            licenseData.push(
-                {
-                    label: metric.name,
-                    total: metric.numberOfUsers,
-                } as ChartDataModel,
-            );
+    @task
+    @waitFor
+    private async getShareData(
+        propertyPath: string,
+        index: number,
+        translationKey: string,
+        graphType?: string,
+    ) {
+        const valueSearch = await this.store.queryRecord('index-value-search', {
+            cardSearchFilter: {
+                affiliation: this.args.model.institution.iris.join(','),
+            },
+            sort: '-relevance',
+            'page[size]': 10,
+            valueSearchPropertyPath: propertyPath,
         });
-        return licenseData;
-    }
+        const resultPage = valueSearch.searchResultPage.toArray();
 
-    /**
-     * calculateAddons
-     *
-     * @description Abstracted method to build the ChartData model for add-ons
-     * @param addonMetrics The add-on metrics object
-     *
-     * @returns The add-ons ChartData model
-     */
-    private calculateAddons(addonMetrics: InstitutionDepartmentModel[]): ChartDataModel[] {
-        const addonData = [] as ChartDataModel[];
-
-        addonMetrics.forEach((metric: InstitutionDepartmentModel ) => {
-            addonData.push(
-                {
-                    label: metric.name,
-                    total: metric.numberOfUsers,
-                } as ChartDataModel,
-            );
+        let runningTotal = 0;
+        const chartData = resultPage.map((result: SearchResultModel) => {
+            runningTotal += result.cardSearchResultCount;
+            return {
+                label: result.indexCard.get('label'),
+                total: result.cardSearchResultCount,
+            };
         });
-        return addonData;
-    }
 
-    /**
-     * calculateStorageRegions
-     *
-     * @description Abstracted method to build the Storage Regions ChartData
-     * @param storageRegionsMetrics The storage regions metrics object
-     *
-     * @returns The storage regions ChartData model
-     */
-    private calculateStorageRegions(storageRegionsMetrics: InstitutionDepartmentModel[]): ChartDataModel[] {
-        const storageRegionsData = [] as ChartDataModel[];
+        if (runningTotal < valueSearch.totalResultCount) {
+            chartData.push({
+                label: this.intl.t('general.other'),
+                total: valueSearch.totalResultCount - runningTotal,
+            });
+        }
 
-        storageRegionsMetrics.forEach((metric: InstitutionDepartmentModel ) => {
-            storageRegionsData.push(
-                {
-                    label: metric.name,
-                    total: metric.numberOfUsers,
-                } as ChartDataModel,
-            );
-        });
-        return storageRegionsData;
-    }
+        const kpiChartObject = {
+            title: this.intl.t('institutions.dashboard.kpi-chart.' + translationKey),
+            chartData,
+            chartType: graphType ? graphType : 'bar',
 
-    /**
-     * calculateDataStorage
-     *
-     * @description Abstracted method to calculate the private and public data storage
-     * @param summaryMetrics The institutional summary metrics object
-     *
-     * @returns The total of private and public data storage
-     */
-    private calculateDataStorage(summaryMetrics: InstitutionSummaryMetricModel): ChartDataModel[] {
-        return [
-            {
-                label: this.intl.t('institutions.dashboard.kpi-chart.public-vs-private-data-storage.public'),
-                total: summaryMetrics.storageByteCount,
-            } as ChartDataModel,
-            {
-                label: this.intl.t('institutions.dashboard.kpi-chart.public-vs-private-data-storage.private'),
-                total: summaryMetrics.storageByteCount + 100,
-            } as ChartDataModel,
-        ];
+        };
+        this.kpiCharts[index] = kpiChartObject;
+
+        this.kpiCharts = [...this.kpiCharts]; // re-set the array to trigger a re-render
     }
 }
-
-

--- a/app/institutions/dashboard/-components/chart-kpi-wrapper/component.ts
+++ b/app/institutions/dashboard/-components/chart-kpi-wrapper/component.ts
@@ -207,8 +207,7 @@ export default class ChartKpiWrapperComponent extends Component<TotalCountChartW
      * @param dataPointerProperty The property on this component to store the data in
      * @param index The index to store the data in the kpiCharts array
      * @param translationKey The translation key to use for the title of the chart
-     *
-     * @returns The total of private and public projects
+     * @param graphType Optional: The type of graph to render
      */
     @task
     @waitFor

--- a/app/institutions/dashboard/-components/chart-kpi-wrapper/component.ts
+++ b/app/institutions/dashboard/-components/chart-kpi-wrapper/component.ts
@@ -29,7 +29,7 @@ export interface KpiChartModel {
     chartType: string;
     // Either chartData or taskInstance should be defined
     chartData?: ChartDataModel[];
-    taskInstance?: TaskInstance<void>;
+    taskInstance?: TaskInstance<ChartDataModel[]>;
 }
 
 export default class ChartKpiWrapperComponent extends Component<TotalCountChartWrapperArgs> {

--- a/app/institutions/dashboard/-components/chart-kpi-wrapper/component.ts
+++ b/app/institutions/dashboard/-components/chart-kpi-wrapper/component.ts
@@ -228,21 +228,10 @@ export default class ChartKpiWrapperComponent extends Component<TotalCountChartW
         });
         const resultPage = valueSearch.searchResultPage.toArray();
 
-        let runningTotal = 0;
-        const chartData = resultPage.map((result: SearchResultModel) => {
-            runningTotal += result.cardSearchResultCount;
-            return {
-                label: result.indexCard.get('label'),
-                total: result.cardSearchResultCount,
-            };
-        });
-
-        if (runningTotal < valueSearch.totalResultCount) {
-            chartData.push({
-                label: this.intl.t('general.other'),
-                total: valueSearch.totalResultCount - runningTotal,
-            });
-        }
+        const chartData = resultPage.map((result: SearchResultModel) => ({
+            total: result.cardSearchResultCount,
+            label: result.indexCard.get('label'),
+        }));
 
         const kpiChartObject = {
             title: this.intl.t('institutions.dashboard.kpi-chart.' + translationKey),

--- a/mirage/factories/institution-summary-metric.ts
+++ b/mirage/factories/institution-summary-metric.ts
@@ -19,7 +19,7 @@ export default Factory.extend<InstitutionSummaryMetricModel>({
     embargoedRegistrationCount() {
         return faker.random.number({ min: 0, max: 25});
     },
-    preprintCount() {
+    publishedPreprintCount() {
         return faker.random.number({ min: 15, max: 175});
     },
     storageByteCount() {

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -859,6 +859,7 @@ institutions:
                 title: 'Public vs Private Data Storage'
                 public: 'Public Data Storage' 
                 private: 'Private Data Storage' 
+            error: 'Error loading data'
         object-list:
             filter-button-label: 'Filter'
             filter-heading: 'Filter by:'

--- a/types/ember-cli-chart.d.ts
+++ b/types/ember-cli-chart.d.ts
@@ -20,14 +20,18 @@ declare module 'ember-cli-chart' {
             xAxes?: [
                 {
                     display?: boolean
+                    ticks?: {
+                        min?: number
+                    }
                 }
-
             ],
             yAxes?: [
                 {
                     display?: boolean
+                    ticks?: {
+                        min?: number
+                    }
                 }
-
             ]
         }
     }


### PR DESCRIPTION
-   Ticket: [ENG-6368]
-   Feature flag: n/a

## Purpose
- Hook up graphs for licenses, addon usage and storage locations to actual data

## Summary of Changes
- Add loading/error state to chart component
- Add task to fetch data from SHARE to chart-wrapper component

## Screenshot(s)
- Finished graphs:
![image](https://github.com/user-attachments/assets/b14ef126-c471-42b9-8c8b-4f6a2d966a01)

- Loading/error states:
![image](https://github.com/user-attachments/assets/28e938bd-3e83-4154-93c0-042732d7aef3)

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6368]: https://openscience.atlassian.net/browse/ENG-6368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ