### PR TITLE
[ENG-6428] Allow citation addons to pick root folder

### DIFF
--- a/app/guid-node/addons/index/template.hbs
+++ b/app/guid-node/addons/index/template.hbs
@@ -267,7 +267,7 @@
                         </OsfDialog>
                     {{else if (eq manager.pageMode 'configure')}}
                         <AddonsService::ConfiguredAddonEdit
-                            @configuredStorageAddon={{manager.selectedConfiguration}}
+                            @configuredAddon={{manager.selectedConfiguration}}
                             @onSave={{perform manager.saveConfiguration}}
                             @onCancel={{manager.cancelSetup}}
                         />

--- a/app/models/addon-operation-invocation.ts
+++ b/app/models/addon-operation-invocation.ts
@@ -1,9 +1,8 @@
 import Model, { AsyncBelongsTo, attr, belongsTo } from '@ember-data/model';
 
 import UserReferenceModel from 'ember-osf-web/models/user-reference';
-import ConfiguredAddonModel from 'ember-osf-web/models/configured-addon';
+import ConfiguredAddonModel, { ConnectedOperationNames } from 'ember-osf-web/models/configured-addon';
 import AuthorizedAccountModel from 'ember-osf-web/models/authorized-account';
-import { ConnectedOperationNames } from 'ember-osf-web/models/configured-storage-addon';
 
 export enum InvocationStatus {
     STARTING = 'STARTING',

--- a/app/models/configured-addon.ts
+++ b/app/models/configured-addon.ts
@@ -1,10 +1,33 @@
 import Model, { AsyncBelongsTo, attr, belongsTo } from '@ember-data/model';
+import { waitFor } from '@ember/test-waiters';
+import { task } from 'ember-concurrency';
 
+import { ItemType } from './addon-operation-invocation';
 import ResourceReferenceModel from './resource-reference';
 import UserReferenceModel from './user-reference';
 
+export enum ConnectedCapabilities {
+    Access = 'ACCESS',
+    Update = 'UPDATE',
+}
+
+export enum ConnectedOperationNames {
+    DownloadAsZip = 'download_as_zip',
+    CopyInto = 'copy_into',
+    HasRevisions = 'has_revisions',
+    ListRootItems = 'list_root_items',
+    ListChildItems = 'list_child_items',
+    GetItemInfo = 'get_item_info',
+}
+
+export interface OperationKwargs {
+    itemId?: string;
+    itemType?: ItemType;
+    pageCursor?: string;
+}
 export interface ConfiguredAddonEditableAttrs {
     displayName: string;
+    rootFolder: string;
 }
 
 export default class ConfiguredAddonModel extends Model {
@@ -15,10 +38,39 @@ export default class ConfiguredAddonModel extends Model {
     @attr('string') iconUrl!: string;
     @attr('string') authorizedResourceUri!: string;
 
+    @attr('array') connectedCapabilities!: ConnectedCapabilities[];
+    @attr('array') connectedOperationNames!: ConnectedOperationNames[];
+    @attr('fixstring') rootFolder!: string;
+
 
     @belongsTo('user-reference', { inverse: null })
     accountOwner!: AsyncBelongsTo<UserReferenceModel> & UserReferenceModel;
 
     @belongsTo('resource-reference', { inverse: 'configuredStorageAddons' })
     authorizedResource!: AsyncBelongsTo<ResourceReferenceModel> & ResourceReferenceModel;
+
+    @task
+    @waitFor
+    async getFolderItems(this: ConfiguredAddonModel, kwargs?: OperationKwargs) {
+        const operationKwargs = kwargs || {};
+        const operationName = operationKwargs.itemId ? ConnectedOperationNames.ListChildItems :
+            ConnectedOperationNames.ListRootItems;
+        const newInvocation = this.store.createRecord('addon-operation-invocation', {
+            operationName,
+            operationKwargs,
+            thruAddon: this,
+        });
+        return await newInvocation.save();
+    }
+
+    @task
+    @waitFor
+    async getItemInfo(this: ConfiguredAddonModel, itemId: string) {
+        const newInvocation = this.store.createRecord('addon-operation-invocation', {
+            operationName: ConnectedOperationNames.GetItemInfo,
+            operationKwargs: { itemId },
+            thruAddon: this,
+        });
+        return await newInvocation.save();
+    }
 }

--- a/app/models/configured-citation-addon.ts
+++ b/app/models/configured-citation-addon.ts
@@ -1,6 +1,5 @@
-import { AsyncBelongsTo, attr, belongsTo } from '@ember-data/model';
+import { AsyncBelongsTo, belongsTo } from '@ember-data/model';
 
-import { ConnectedCapabilities } from 'ember-osf-web/models/configured-storage-addon';
 import AuthorizedCitationAccountModel from './authorized-citation-account';
 import ExternalCitationServiceModel from './external-citation-service';
 import ConfiguredAddonModel from './configured-addon';
@@ -11,8 +10,6 @@ export default class ConfiguredCitationAddonModel extends ConfiguredAddonModel {
 
     @belongsTo('authorized-citation-account')
     baseAccount!: AsyncBelongsTo<AuthorizedCitationAccountModel> & AuthorizedCitationAccountModel;
-
-    @attr('array') connectedCapabilities!: ConnectedCapabilities[];
 
     get externalServiceId() {
         return (this as ConfiguredCitationAddonModel).belongsTo('externalCitationService').id();

--- a/app/models/configured-storage-addon.ts
+++ b/app/models/configured-storage-addon.ts
@@ -1,74 +1,18 @@
 import { AsyncBelongsTo, attr, belongsTo } from '@ember-data/model';
-import { waitFor } from '@ember/test-waiters';
-import { task } from 'ember-concurrency';
 
 import AuthorizedStorageAccountModel from './authorized-storage-account';
-import ConfiguredAddonModel, { ConfiguredAddonEditableAttrs } from './configured-addon';
+import ConfiguredAddonModel from './configured-addon';
 import ExternalStorageServiceModel from './external-storage-service';
-import { ItemType } from './addon-operation-invocation';
 
-export enum ConnectedCapabilities {
-    Access = 'ACCESS',
-    Update = 'UPDATE',
-}
-
-export enum ConnectedOperationNames {
-    DownloadAsZip = 'download_as_zip',
-    CopyInto = 'copy_into',
-    HasRevisions = 'has_revisions',
-    ListRootItems = 'list_root_items',
-    ListChildItems = 'list_child_items',
-    GetItemInfo = 'get_item_info',
-}
-
-export interface OperationKwargs {
-    itemId?: string;
-    itemType?: ItemType;
-    pageCursor?: string;
-}
-
-export interface ConfiguredStorageAddonEditableAttrs extends ConfiguredAddonEditableAttrs {
-    rootFolder: string;
-}
 
 export default class ConfiguredStorageAddonModel extends ConfiguredAddonModel {
-    // Move these to superclass?
-    @attr('array') connectedCapabilities!: ConnectedCapabilities[];
-    @attr('array') connectedOperationNames!: ConnectedOperationNames[];
-
     @attr('number') concurrentUploads!: number;
-    @attr('fixstring') rootFolder!: string;
 
     @belongsTo('external-storage-service', { inverse: null })
     externalStorageService!: AsyncBelongsTo<ExternalStorageServiceModel> & ExternalStorageServiceModel;
 
     @belongsTo('authorized-storage-account')
     baseAccount!: AsyncBelongsTo<AuthorizedStorageAccountModel> & AuthorizedStorageAccountModel;
-
-    @task
-    @waitFor
-    async getFolderItems(this: ConfiguredStorageAddonModel, kwargs?: OperationKwargs) {
-        const operationKwargs = kwargs || {};
-        const operationName = operationKwargs.itemId ? ConnectedOperationNames.ListChildItems :
-            ConnectedOperationNames.ListRootItems;
-        const newInvocation = this.store.createRecord('addon-operation-invocation', {
-            operationName,
-            operationKwargs,
-            thruAddon: this,
-        });
-        return await newInvocation.save();
-    }
-
-    @task
-    @waitFor
-    async getItemInfo(this: ConfiguredStorageAddonModel, itemId: string) {
-        const newInvocation = this.store.createRecord('addon-operation-invocation', {
-            operationName: ConnectedOperationNames.GetItemInfo,
-            operationKwargs: { itemId },
-            thruAddon: this,
-        });
-        return await newInvocation.save();
-    }
 
     get externalServiceId() {
         return (this as ConfiguredStorageAddonModel).belongsTo('externalStorageService').id();

--- a/lib/osf-components/addon/components/addons-service/configured-addon-edit/component.ts
+++ b/lib/osf-components/addon/components/addons-service/configured-addon-edit/component.ts
@@ -4,17 +4,17 @@ import { tracked } from '@glimmer/tracking';
 import { TaskInstance } from 'ember-concurrency';
 
 import { Item, ItemType } from 'ember-osf-web/models/addon-operation-invocation';
-import ConfiguredStorageAddonModel from 'ember-osf-web/models/configured-storage-addon';
+import ConfiguredAddonModel from 'ember-osf-web/models/configured-addon';
 
 
 interface Args {
-    configuredStorageAddon: ConfiguredStorageAddonModel;
+    configuredAddon: ConfiguredAddonModel;
     onSave: TaskInstance<void>;
 }
 
 export default class ConfiguredAddonEdit extends Component<Args> {
-    @tracked displayName = this.args.configuredStorageAddon.displayName;
-    @tracked selectedFolder = this.args.configuredStorageAddon.rootFolder;
+    @tracked displayName = this.args.configuredAddon.displayName;
+    @tracked selectedFolder = this.args.configuredAddon.rootFolder;
     @tracked currentItems: Item[] = [];
 
     defaultKwargs = {

--- a/lib/osf-components/addon/components/addons-service/configured-addon-edit/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/configured-addon-edit/template.hbs
@@ -21,7 +21,7 @@
         {{/if}}
     </div>
     <AddonsService::FileManager
-        @configuredStorageAddon={{@configuredStorageAddon}}
+        @configuredAddon={{@configuredAddon}}
         @defaultKwargs={{this.defaultKwargs}}
         @startingFolderId={{this.selectedFolder}}
         as |fileManager|

--- a/lib/osf-components/addon/components/addons-service/file-manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/file-manager/component.ts
@@ -8,12 +8,13 @@ import { taskFor } from 'ember-concurrency-ts';
 import IntlService from 'ember-intl/services/intl';
 import Toast from 'ember-toastr/services/toast';
 
+import { OperationKwargs } from 'ember-osf-web/models/configured-addon';
 import { Item, ListItemsResult } from 'ember-osf-web/models/addon-operation-invocation';
-import ConfiguredStorageAddonModel, { OperationKwargs } from 'ember-osf-web/models/configured-storage-addon';
+import ConfiguredAddonModel from 'ember-osf-web/models/configured-addon';
 import captureException, { getApiErrorMessage } from 'ember-osf-web/utils/capture-exception';
 
 interface Args {
-    configuredStorageAddon: ConfiguredStorageAddonModel;
+    configuredAddon: ConfiguredAddonModel;
     defaultKwargs?: OperationKwargs;
     startingFolderId: string;
 }
@@ -32,12 +33,12 @@ export default class FileManager extends Component<Args> {
     private lastInvocation: any = null;
 
     get isLoading() {
-        return taskFor(this.args.configuredStorageAddon.getFolderItems).isRunning ||
+        return taskFor(this.args.configuredAddon.getFolderItems).isRunning ||
             taskFor(this.getStartingFolder).isRunning;
     }
 
     get isError() {
-        return taskFor(this.args.configuredStorageAddon.getFolderItems).lastPerformed?.error ||
+        return taskFor(this.args.configuredAddon.getFolderItems).lastPerformed?.error ||
             taskFor(this.getStartingFolder).lastPerformed?.error;
     }
 
@@ -84,10 +85,10 @@ export default class FileManager extends Component<Args> {
     @task
     @waitFor
     async getStartingFolder() {
-        const { startingFolderId, configuredStorageAddon } = this.args;
+        const { startingFolderId, configuredAddon } = this.args;
         try {
             if (startingFolderId) {
-                const invocation = await taskFor(configuredStorageAddon.getItemInfo).perform(startingFolderId);
+                const invocation = await taskFor(configuredAddon.getItemInfo).perform(startingFolderId);
                 const result = invocation.operationResult as Item;
                 this.currentFolderId = result.itemId;
                 this.currentPath = result.itemPath ? [...result.itemPath] : [];
@@ -108,7 +109,7 @@ export default class FileManager extends Component<Args> {
         kwargs.pageCursor = this.cursor;
         try {
             const getFolderArgs = !this.currentFolderId ? {} : kwargs;
-            const invocation = await taskFor(this.args.configuredStorageAddon.getFolderItems).perform(getFolderArgs);
+            const invocation = await taskFor(this.args.configuredAddon.getFolderItems).perform(getFolderArgs);
             this.lastInvocation = invocation;
             const operationResult = invocation.operationResult as ListItemsResult;
             if (!this.currentFolderId) {

--- a/lib/osf-components/addon/components/addons-service/manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/manager/component.ts
@@ -18,8 +18,7 @@ import Provider, {
 } from 'ember-osf-web/packages/addons-service/provider';
 import CurrentUserService from 'ember-osf-web/services/current-user';
 import { ConfiguredAddonEditableAttrs } from 'ember-osf-web/models/configured-addon';
-import ConfiguredStorageAddonModel,
-{ ConfiguredStorageAddonEditableAttrs } from 'ember-osf-web/models/configured-storage-addon';
+import ConfiguredStorageAddonModel from 'ember-osf-web/models/configured-storage-addon';
 import { AccountCreationArgs} from 'ember-osf-web/models/authorized-account';
 import AuthorizedStorageAccountModel from 'ember-osf-web/models/authorized-storage-account';
 
@@ -238,7 +237,7 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
     async saveConfiguration(args: ConfiguredAddonEditableAttrs) {
         try {
             if (this.selectedConfiguration && this.selectedConfiguration instanceof ConfiguredStorageAddonModel) {
-                this.selectedConfiguration.rootFolder = (args as ConfiguredStorageAddonEditableAttrs).rootFolder;
+                this.selectedConfiguration.rootFolder = (args as ConfiguredAddonEditableAttrs).rootFolder;
                 this.selectedConfiguration.displayName = args.displayName;
                 await this.selectedConfiguration.save();
                 this.toast.success(this.intl.t('addons.configure.success', {

--- a/mirage/scenarios/dashboard.ts
+++ b/mirage/scenarios/dashboard.ts
@@ -7,7 +7,7 @@ import NodeModel from 'ember-osf-web/models/node';
 import { Permission } from 'ember-osf-web/models/osf-model';
 import ExternalStorageServiceModel from 'ember-osf-web/models/external-storage-service';
 import User from 'ember-osf-web/models/user';
-import { ConnectedOperationNames, ConnectedCapabilities } from 'ember-osf-web/models/configured-storage-addon';
+import { ConnectedOperationNames, ConnectedCapabilities } from 'ember-osf-web/models/configured-addon';
 
 const {
     dashboard: {

--- a/mirage/serializers/configured-citation-addon.ts
+++ b/mirage/serializers/configured-citation-addon.ts
@@ -40,12 +40,12 @@ export default class ConfiguredCitationAddonSerializer extends AddonServiceSeria
             baseAccount: {
                 links: {
                     related: {
-                        href: `${addonServiceAPIUrl}authorized-storage-accounts/${model.baseAccountId}/`,
+                        href: `${addonServiceAPIUrl}authorized-citation-accounts/${model.baseAccountId}/`,
                     },
                 },
                 data: {
                     id: model.baseAccountId,
-                    type: 'authorized-storage-accounts',
+                    type: 'authorized-citation-accounts',
                 },
             },
             externalCitationService: {

--- a/mirage/serializers/configured-computing-addon.ts
+++ b/mirage/serializers/configured-computing-addon.ts
@@ -40,12 +40,12 @@ export default class ConfiguredComputingAddonSerializer extends AddonServiceSeri
             baseAccount: {
                 links: {
                     related: {
-                        href: `${addonServiceAPIUrl}authorized-storage-accounts/${model.baseAccountId}/`,
+                        href: `${addonServiceAPIUrl}authorized-computing-accounts/${model.baseAccountId}/`,
                     },
                 },
                 data: {
                     id: model.baseAccountId,
-                    type: 'authorized-storage-accounts',
+                    type: 'authorized-computing-accounts',
                 },
             },
             externalComputingService: {

--- a/mirage/views/addons.ts
+++ b/mirage/views/addons.ts
@@ -6,7 +6,7 @@ import AuthorizedCitationAccountModel from 'ember-osf-web/models/authorized-cita
 import AuthorizedComputingAccountModel from 'ember-osf-web/models/authorized-computing-account';
 import { AddonCredentialFields} from 'ember-osf-web/models/authorized-account';
 import AuthorizedStorageAccountModel from 'ember-osf-web/models/authorized-storage-account';
-import { ConnectedOperationNames } from 'ember-osf-web/models/configured-storage-addon';
+import { ConnectedOperationNames } from 'ember-osf-web/models/configured-addon';
 import { CredentialsFormat } from 'ember-osf-web/models/external-service';
 import ExternalStorageServiceModel from 'ember-osf-web/models/external-storage-service';
 import ExternalCitationServiceModel from 'ember-osf-web/models/external-citation-service';

--- a/tests/integration/components/addons-service/configured-addon-edit/component-test.ts
+++ b/tests/integration/components/addons-service/configured-addon-edit/component-test.ts
@@ -50,7 +50,7 @@ module('Integration | Component | addons-service | configured-addon-edit', funct
         this.onCancel = sinon.fake();
         await render(hbs`
 <AddonsService::ConfiguredAddonEdit
-    @configuredStorageAddon={{this.configuredAddon}}
+    @configuredAddon={{this.configuredAddon}}
     @onSave={{this.onSave}}
     @onCancel={{this.onCancel}}
 />


### PR DESCRIPTION
-   Ticket: [ENG-6428]
-   Feature flag: n/a

## Purpose
- Allow root-folder to be chosen for configured-citation-addons

## Summary of Changes
- Move tasks for creating `addon-operation-invocations` to the `configured-addons` superclass
  - Update imports and such

## Screenshot(s)
For setting up Mendeley for example:
![image](https://github.com/user-attachments/assets/bda539e5-59e4-4c91-ba7c-c4d70eba0976)


## Side Effects


## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6428]: https://openscience.atlassian.net/browse/ENG-6428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ