### PR TITLE
[ENG-6320] Show link to start oauth

### DIFF
--- a/lib/osf-components/addon/components/addons-service/addon-account-setup/component.ts
+++ b/lib/osf-components/addon/components/addons-service/addon-account-setup/component.ts
@@ -245,13 +245,9 @@ export default class AddonAccountSetupComponent extends Component<Args> {
             apiBaseUrl: '',
         });
         if (this.newAccount) { // returned account should have authUrl
-            const oauthWindow = window.open(this.newAccount.authUrl, '_blank');
-            if (oauthWindow) {
-                document.addEventListener('visibilitychange', this.onVisibilityChange);
-                this.pendingOauth = true;
-            } else {
-                this.toast.error(this.intl.t('addons.accountCreate.oauth-window-blocked'));
-            }
+            this.pendingOauth = true;
+            window.open(this.newAccount.authUrl, '_blank');
+            document.addEventListener('visibilitychange', this.onVisibilityChange);
         }
     }
 

--- a/lib/osf-components/addon/components/addons-service/addon-account-setup/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/addon-account-setup/template.hbs
@@ -6,7 +6,16 @@
             {{#if this.pendingOauth}}
                 <p>
                     {{t 'addons.accountCreate.oauth-pending'}}
+                    {{t 'addons.accountCreate.oauth-pending-secondary' htmlSafe=true}}
                 </p>
+                <OsfLink
+                    data-test-start-oauth-button
+                    data-analytics-name='Start OAuth'
+                    @target='_blank'
+                    @href={{this.newAccount.authUrl}}
+                >
+                    {{t 'addons.accountCreate.oauth-start'}}
+                </OsfLink>
             {{else}}
                 <div local-class='oauth-wrapper'>
                     {{t 'addons.accountCreate.oauth-description' providerName=@provider.name}}

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -334,7 +334,8 @@ addons:
         secret-key-label: 'Secret Key'
         secret-key-placeholder: 'Secret Key'
         oauth-pending: 'Complete the OAuth process in the new window before returning to this page.'
-        oauth-window-blocked: "The OAuth window was blocked. Please disable adblock for this site or check your browser's security setting and try again."
+        oauth-pending-secondary: 'If you do not see a new window, please click the <b>Start Oauth</b> link below.'
+        oauth-start: 'Start OAuth'
         oauth-reconnect-error: 'Error reconnecting account'
         oauth-description: 'Use OAuth to connect your {providerName} account'
         error: 'Error creating account'


### PR DESCRIPTION
-   Ticket: [ENG-6320]
-   Feature flag: n/a

## Purpose
- Show a link to open the OAuth window in case the new window gets blocked

## Summary of Changes
- Add a new link when the page is pending OAuth
- Add some language letting folks know that there hould be an OAuth window opening

## Screenshot(s)
![image](https://github.com/user-attachments/assets/b3491af7-e275-47aa-8826-2b24a0c6a55b)

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6320]: https://openscience.atlassian.net/browse/ENG-6320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ