### PR TITLE
[No ticket] Prevent 400 when POSTing configured-citation-addon

### DIFF
--- a/app/packages/addons-service/provider.ts
+++ b/app/packages/addons-service/provider.ts
@@ -289,6 +289,7 @@ export default class Provider {
     @waitFor
     private async createConfiguredCitationAddon(account: AuthorizedCitationAccountModel) {
         const configuredCitationAddon = this.store.createRecord('configured-citation-addon', {
+            rootFolder: '',
             externalCitationService: this.provider,
             accountOwner: this.userReference,
             authorizedResourceUri: this.node!.links.iri,
@@ -302,6 +303,7 @@ export default class Provider {
     @waitFor
     private async createConfiguredComputingAddon(account: AuthorizedComputingAccount) {
         const configuredComputingAddon = this.store.createRecord('configured-computing-addon', {
+            rootFolder: '',
             computingService: this.provider,
             accountOwner: this.userReference,
             authorizedResource: this.serviceNode,


### PR DESCRIPTION
-   Ticket: [No ticket]
-   Feature flag: n/a

## Purpose
- Prevent GV from responding with a 400 error when POSTing a new `configured-citation-addon`

## Summary of Changes
- Include `rootFolder: ''` when creating a new `configured-citation-addon` and `configured-computing-addon`

## Screenshot(s)
- Prevents this error
![image](https://github.com/user-attachments/assets/2af0fa43-7d2c-45cf-9faf-2722358b45bc)
![image](https://github.com/user-attachments/assets/7792e723-4259-4c7f-a46c-d1c11441020d)

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
