### PR TITLE
[ENG-6345] Failed OAuth workflow

### DIFF
--- a/lib/osf-components/addon/components/addons-service/addon-account-setup/component.ts
+++ b/lib/osf-components/addon/components/addons-service/addon-account-setup/component.ts
@@ -231,11 +231,22 @@ export default class AddonAccountSetupComponent extends Component<Args> {
     @action
     onVisibilityChange() {
         if (document.visibilityState === 'visible') {
-            taskFor(this.args.manager.oauthFlowRefocus).perform(this.newAccount!);
-            this.pendingOauth = false;
-            document.removeEventListener('visibilitychange', this.onVisibilityChange);
+            taskFor(this.checkOauthSuccess).perform();
         }
     }
+
+    @task
+    @waitFor
+    async checkOauthSuccess() {
+        const oauthSuccesful = await taskFor(this.args.manager.oauthFlowRefocus).perform(this.newAccount!);
+        if (oauthSuccesful) {
+            this.pendingOauth = false;
+            document.removeEventListener('visibilitychange', this.onVisibilityChange);
+        } else {
+            this.connectAccountError = true;
+        }
+    }
+
     @task
     @waitFor
     async startOauthFlow() {

--- a/lib/osf-components/addon/components/addons-service/addon-account-setup/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/addon-account-setup/template.hbs
@@ -16,6 +16,11 @@
                 >
                     {{t 'addons.accountCreate.oauth-start'}}
                 </OsfLink>
+                {{#if this.connectAccountError}}
+                    <p local-class='connect-error'>
+                        {{t 'addons.accountCreate.oauth-error' htmlSafe=true}}
+                    </p>
+                {{/if}}
             {{else}}
                 <div local-class='oauth-wrapper'>
                     {{t 'addons.accountCreate.oauth-description' providerName=@provider.name}}

--- a/lib/osf-components/addon/components/addons-service/manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/manager/component.ts
@@ -207,11 +207,15 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
 
     @task
     @waitFor
-    async oauthFlowRefocus(newAccount: AllAuthorizedAccountTypes) {
+    async oauthFlowRefocus(newAccount: AllAuthorizedAccountTypes): Promise<boolean> {
         await newAccount.reload();
-        await taskFor(this.selectedProvider!.getAuthorizedAccounts).perform();
-        this.selectedAccount = undefined;
-        this.chooseExistingAccount();
+        if (newAccount.credentialsAvailable) {
+            await taskFor(this.selectedProvider!.getAuthorizedAccounts).perform();
+            this.selectedAccount = undefined;
+            this.chooseExistingAccount();
+            return true;
+        }
+        return false;
     }
 
     @task

--- a/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
@@ -319,10 +319,15 @@ export default class UserAddonManagerComponent extends Component<Args> {
 
     @task
     @waitFor
-    async oauthFlowRefocus() {
-        this.cancelSetup();
-        this.changeTab(1);
-        await taskFor(this.getAuthorizedAccounts).perform();
+    async oauthFlowRefocus(newAccount: AllAuthorizedAccountTypes): Promise<boolean> {
+        await newAccount.reload();
+        if (newAccount.credentialsAvailable) {
+            this.cancelSetup();
+            this.changeTab(1);
+            await taskFor(this.getAuthorizedAccounts).perform();
+            return true;
+        }
+        return false;
     }
 
     @task

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -336,6 +336,7 @@ addons:
         oauth-pending: 'Complete the OAuth process in the new window before returning to this page.'
         oauth-pending-secondary: 'If you do not see a new window, please click the <b>Start Oauth</b> link below.'
         oauth-start: 'Start OAuth'
+        oauth-error: 'Error connecting account. Please try again.'
         oauth-reconnect-error: 'Error reconnecting account'
         oauth-description: 'Use OAuth to connect your {providerName} account'
         error: 'Error creating account'


### PR DESCRIPTION
-   Ticket: [ENG-6345]
-   Feature flag: n/a

## Purpose
- Add logic to prevent moving forward in account creation if OAuth flow fails

## Summary of Changes
- check `credentialsAvailable` flag in oauthRefocus callback and proceed or don't based on this flag
- Add some message to show that OAuth failed

## Screenshot(s)
![image](https://github.com/user-attachments/assets/b8f43b71-0962-4c0d-b224-6083d2613f66)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6345]: https://openscience.atlassian.net/browse/ENG-6345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ