### PR TITLE
[No ticket] Prevent 400 errors when PATCHing configured addons

### DIFF
--- a/app/models/configured-addon.ts
+++ b/app/models/configured-addon.ts
@@ -36,7 +36,7 @@ export default class ConfiguredAddonModel extends Model {
     @attr('fixstring') externalUserDisplayName!: string;
 
     @attr('string') iconUrl!: string;
-    @attr('string') authorizedResourceUri!: string;
+    @attr('string') authorizedResourceUri?: string;
 
     @attr('array') connectedCapabilities!: ConnectedCapabilities[];
     @attr('array') connectedOperationNames!: ConnectedOperationNames[];

--- a/app/serializers/configured-addon.ts
+++ b/app/serializers/configured-addon.ts
@@ -1,0 +1,14 @@
+import DS from 'ember-data';
+import { SingleResourceDocument } from 'osf-api';
+
+import GravyValetSerializer from './gravy-valet-serializer';
+
+export default class ConfiguredAddonSerializer extends GravyValetSerializer {
+    serialize(snapshot: DS.Snapshot, options: {}) {
+        const serialized = super.serialize(snapshot, options) as SingleResourceDocument;
+        if (!serialized.data.attributes!.authorized_resource_uri) {
+            delete serialized.data.attributes!.authorized_resource_uri;
+        }
+        return serialized;
+    }
+}

--- a/app/serializers/configured-citation-addon.ts
+++ b/app/serializers/configured-citation-addon.ts
@@ -1,6 +1,16 @@
+import DS from 'ember-data';
+import { SingleResourceDocument } from 'osf-api';
+
 import GravyValetSerializer from './gravy-valet-serializer';
 
 export default class ConfiguredCitationAddonSerializer extends GravyValetSerializer {
+    serialize(snapshot: DS.Snapshot, options: {}) {
+        const serialized = super.serialize(snapshot, options) as SingleResourceDocument;
+        if (!serialized.data.attributes!.authorized_resource_uri) {
+            delete serialized.data.attributes!.authorized_resource_uri;
+        }
+        return serialized;
+    }
 }
 
 declare module 'ember-data/types/registries/serializer' {

--- a/app/serializers/configured-citation-addon.ts
+++ b/app/serializers/configured-citation-addon.ts
@@ -1,16 +1,6 @@
-import DS from 'ember-data';
-import { SingleResourceDocument } from 'osf-api';
+import ConfiguredAddonSerializer from './configured-addon';
 
-import GravyValetSerializer from './gravy-valet-serializer';
-
-export default class ConfiguredCitationAddonSerializer extends GravyValetSerializer {
-    serialize(snapshot: DS.Snapshot, options: {}) {
-        const serialized = super.serialize(snapshot, options) as SingleResourceDocument;
-        if (!serialized.data.attributes!.authorized_resource_uri) {
-            delete serialized.data.attributes!.authorized_resource_uri;
-        }
-        return serialized;
-    }
+export default class ConfiguredCitationAddonSerializer extends ConfiguredAddonSerializer {
 }
 
 declare module 'ember-data/types/registries/serializer' {

--- a/app/serializers/configured-computing-addon.ts
+++ b/app/serializers/configured-computing-addon.ts
@@ -1,16 +1,6 @@
-import DS from 'ember-data';
-import { SingleResourceDocument } from 'osf-api';
+import ConfiguredAddonSerializer from './configured-addon';
 
-import GravyValetSerializer from './gravy-valet-serializer';
-
-export default class ConfiguredComputingAddonSerializer extends GravyValetSerializer {
-    serialize(snapshot: DS.Snapshot, options: {}) {
-        const serialized = super.serialize(snapshot, options) as SingleResourceDocument;
-        if (!serialized.data.attributes!.authorized_resource_uri) {
-            delete serialized.data.attributes!.authorized_resource_uri;
-        }
-        return serialized;
-    }
+export default class ConfiguredComputingAddonSerializer extends ConfiguredAddonSerializer {
 }
 
 declare module 'ember-data/types/registries/serializer' {

--- a/app/serializers/configured-computing-addon.ts
+++ b/app/serializers/configured-computing-addon.ts
@@ -1,6 +1,16 @@
+import DS from 'ember-data';
+import { SingleResourceDocument } from 'osf-api';
+
 import GravyValetSerializer from './gravy-valet-serializer';
 
 export default class ConfiguredComputingAddonSerializer extends GravyValetSerializer {
+    serialize(snapshot: DS.Snapshot, options: {}) {
+        const serialized = super.serialize(snapshot, options) as SingleResourceDocument;
+        if (!serialized.data.attributes!.authorized_resource_uri) {
+            delete serialized.data.attributes!.authorized_resource_uri;
+        }
+        return serialized;
+    }
 }
 
 declare module 'ember-data/types/registries/serializer' {

--- a/app/serializers/configured-storage-addon.ts
+++ b/app/serializers/configured-storage-addon.ts
@@ -1,6 +1,16 @@
+import DS from 'ember-data';
+import { SingleResourceDocument } from 'osf-api';
+
 import GravyValetSerializer from './gravy-valet-serializer';
 
 export default class ConfiguredStorageAddonSerializer extends GravyValetSerializer {
+    serialize(snapshot: DS.Snapshot, options: {}) {
+        const serialized = super.serialize(snapshot, options) as SingleResourceDocument;
+        if (!serialized.data.attributes!.authorized_resource_uri) {
+            delete serialized.data.attributes!.authorized_resource_uri;
+        }
+        return serialized;
+    }
 }
 
 declare module 'ember-data/types/registries/serializer' {

--- a/app/serializers/configured-storage-addon.ts
+++ b/app/serializers/configured-storage-addon.ts
@@ -1,16 +1,6 @@
-import DS from 'ember-data';
-import { SingleResourceDocument } from 'osf-api';
+import ConfiguredAddonSerializer from './configured-addon';
 
-import GravyValetSerializer from './gravy-valet-serializer';
-
-export default class ConfiguredStorageAddonSerializer extends GravyValetSerializer {
-    serialize(snapshot: DS.Snapshot, options: {}) {
-        const serialized = super.serialize(snapshot, options) as SingleResourceDocument;
-        if (!serialized.data.attributes!.authorized_resource_uri) {
-            delete serialized.data.attributes!.authorized_resource_uri;
-        }
-        return serialized;
-    }
+export default class ConfiguredStorageAddonSerializer extends ConfiguredAddonSerializer {
 }
 
 declare module 'ember-data/types/registries/serializer' {


### PR DESCRIPTION
-   Ticket: [No ticket]
-   Feature flag: n/a

## Purpose
- Prevent 400 errors when PATCHing configured addons 

## Summary of Changes
- Remove the `authorizedResourceUri` attr in PATCH requests to configured-xyz-addons if `authorizedResourceUri` is `null`

## Screenshot(s)
- NA

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
