### PR TITLE
[No ticket] Fix reroute to not-found

### DIFF
--- a/app/institutions/dashboard/route.ts
+++ b/app/institutions/dashboard/route.ts
@@ -8,6 +8,7 @@ import InstitutionDepartmentModel from 'ember-osf-web/models/institution-departm
 import InstitutionSummaryMetricModel from 'ember-osf-web/models/institution-summary-metric';
 import { QueryHasManyResult } from 'ember-osf-web/models/osf-model';
 import captureException from 'ember-osf-web/utils/capture-exception';
+import { notFoundURL } from 'ember-osf-web/utils/clean-url';
 
 export interface InstitutionsDashboardModel {
     institution: InstitutionModel;
@@ -42,7 +43,7 @@ export default class InstitutionsDashboardRoute extends Route {
             };
         } catch (error) {
             captureException(error);
-            this.transitionTo('not-found', this.router.get('currentURL').slice(1));
+            this.transitionTo('not-found', notFoundURL(window.location.pathname));
             return undefined;
         }
     }


### PR DESCRIPTION
-   Ticket: [No ticket]
-   Feature flag: n/a

## Purpose
- Fix when users are rerouted from the dashboard to the `not-found` page for whatever reason

## Summary of Changes
- use `window.location.pathname` for `not-found` param as `this.router.get('currentURL')` would often times be `undefined` leading to an error and a blank screen

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
