### PR TITLE
[ENG-6436] Add new canBeRoot and mayContainRootCandidates flags

### DIFF
--- a/app/models/addon-operation-invocation.ts
+++ b/app/models/addon-operation-invocation.ts
@@ -30,6 +30,8 @@ export interface Item {
     itemId: string;
     itemName: string;
     itemType: ItemType;
+    canBeRoot: boolean;
+    mayContainRootCandidates: boolean;
     itemPath?: Item[];
 }
 

--- a/lib/osf-components/addon/components/addons-service/configured-addon-edit/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/configured-addon-edit/template.hbs
@@ -68,27 +68,36 @@
                     {{#each fileManager.currentItems as |folder|}}
                         <tr>
                             <td>
-                                <Button
-                                    data-test-folder-link='{{folder.itemName}}'
-                                    data-analytics-name='Go to folder'
-                                    @layout='fake-link'
-                                    aria-label={{t 'addons.configure.go-to-folder' folderName=folder.itemName}}
-                                    {{on 'click' (fn fileManager.goToFolder folder)}}
-                                >
-                                    <FaIcon @icon='folder' />
-                                    {{folder.itemName}}
-                                </Button>
+                                {{#if folder.mayContainRootCandidates}}
+                                    <Button
+                                        data-test-folder-link='{{folder.itemName}}'
+                                        data-analytics-name='Go to folder'
+                                        @layout='fake-link'
+                                        aria-label={{t 'addons.configure.go-to-folder' folderName=folder.itemName}}
+                                        {{on 'click' (fn fileManager.goToFolder folder)}}
+                                    >
+                                        <FaIcon @icon='folder' />
+                                        {{folder.itemName}}
+                                    </Button>
+                                {{else}}
+                                    <span>
+                                        <FaIcon @icon='folder' />
+                                        {{folder.itemName}}
+                                    </span>
+                                {{/if}}
                             </td>
                             <td>
-                                <input
-                                    data-test-root-folder-option='{{folder.itemName}}'
-                                    data-analytics-name='Select folder'
-                                    type='radio'
-                                    name='folder'
-                                    value={{folder.itemName}}
-                                    aria-label={{t 'addons.configure.select-folder' folderName=folder.itemName}}
-                                    {{on 'change'(fn this.selectFolder folder)}}
-                                >
+                                {{#if folder.canBeRoot}}
+                                    <input
+                                        data-test-root-folder-option='{{folder.itemName}}'
+                                        data-analytics-name='Select folder'
+                                        type='radio'
+                                        name='folder'
+                                        value={{folder.itemName}}
+                                        aria-label={{t 'addons.configure.select-folder' folderName=folder.itemName}}
+                                        {{on 'change'(fn this.selectFolder folder)}}
+                                    >
+                                {{/if}}
                             </td>
                         </tr>
                     {{else}}

--- a/mirage/views/addons.ts
+++ b/mirage/views/addons.ts
@@ -269,6 +269,8 @@ export function createAddonOperationInvocation(this: HandlerContext, schema: Sch
             item_name: `Folder with ID ${folderId}`,
             item_type,
             item_path: folderId === 'root' ? undefined : fakePath,
+            canBeRoot: item_type === ItemType.Folder,
+            mayContainRootCandidates: item_type === ItemType.Folder,
         };
     } else {
         result = {
@@ -277,6 +279,8 @@ export function createAddonOperationInvocation(this: HandlerContext, schema: Sch
                 item_name: `${item_type}${i} in ${folderId}`,
                 item_type,
                 item_path: folderId === 'root' ? undefined : fakePath,
+                canBeRoot: item_type === ItemType.Folder,
+                mayContainRootCandidates: item_type === ItemType.Folder,
             })),
         };
     }


### PR DESCRIPTION
-   Ticket: [ENG-6436]
-   Feature flag: n/a

## Purpose
- Add logic to prevent users from selecting or navigating into an inappropriate item when selecting a root folder

## Summary of Changes
- Add `canBeRoot` and `mayContainRootCandidates` flags to addon-operation-invocation item-results
- Use these flags to control whether a user can navigate into that item (`mayContainRootCandidates`), or select an item as a root folder (`canBeRoot`)
- Relevant GV PR https://github.com/CenterForOpenScience/gravyvalet/pull/139

## Screenshot(s)
- An example of items that can be roots or may contain roots for illustrative purposes. In practice, folders should be selectable as root folders and navigable to find root folder candidates
  - FOLDER1: `canBeRoot: true` and `mayContainRootCandidates: true`
  - FOLDER2: `canBeRoot: false` and `mayContainRootCandidates: true`
  - FOLDER3: `canBeRoot: true` and `mayContainRootCandidates: false`
![Screen Shot 2024-11-01 at 2 50 30 PM](https://github.com/user-attachments/assets/8875f981-a8dc-48b0-b683-17d735dc20c7)


## Side Effects

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6436]: https://openscience.atlassian.net/browse/ENG-6436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ