### PR TITLE
[No ticket] Fix institutional dashboard index-value-search

### DIFF
--- a/app/institutions/dashboard/-components/object-list/component.ts
+++ b/app/institutions/dashboard/-components/object-list/component.ts
@@ -57,6 +57,13 @@ export default class InstitutionalObjectList extends Component<InstitutionalObje
         return fullQueryOptions;
     }
 
+    get valueSearchQueryOptions() {
+        const { defaultQueryOptions } = this.args;
+        return {
+            ...defaultQueryOptions.cardSearchFilter,
+        };
+    }
+
     @action
     updateVisibleColumns() {
         this.visibleColumns = [...this.dirtyVisibleColumns];

--- a/app/institutions/dashboard/-components/object-list/template.hbs
+++ b/app/institutions/dashboard/-components/object-list/template.hbs
@@ -196,7 +196,7 @@ as |list|>
                 {{#each list.relatedProperties as |property|}}
                     <SearchPage::FilterFacet
                         @cardSearchText={{this.cardSearchText}}
-                        @cardSearchFilter={{this.queryOptions}}
+                        @cardSearchFilter={{this.valueSearchQueryOptions}}
                         @property={{property}}
                         @toggleFilter={{queue this.toggleFilter (perform list.searchObjectsTask)}}
                     />


### PR DESCRIPTION
-   Ticket: [No ticket]
-   Feature flag: n/a

## Purpose
- Fix index-value-search query-params from institutional dashboard page

## Summary of Changes
- Add new `valueSearchQueryOptions` to use for index-value-search

## Screenshot(s)
- Prevents this issue:
<img width="609" alt="image" src="https://github.com/user-attachments/assets/7dfe4aef-75f4-4d6d-9f5f-a858914099d4">

- And should now look like:
![image](https://github.com/user-attachments/assets/e70fb59d-5415-4969-8393-3a5dd2e5d122)

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
