### PR TITLE
[ENG-6345] Prevent users from using unauthorized accounts to make a configured-addon

### DIFF
--- a/app/guid-node/addons/index/template.hbs
+++ b/app/guid-node/addons/index/template.hbs
@@ -82,8 +82,8 @@
                                         />
                                         {{#if account.displayName}}
                                             {{account.displayName}}
-                                        {{else if (not account.credentialsAvailable)}}
-                                            {{t 'addons.accountSelect.unauthenticated-account'}}
+                                        {{else}}
+                                            {{t 'addons.accountSelect.unnamed-account'}}
                                         {{/if}}
                                     </label>
                                 </div>
@@ -128,6 +128,7 @@
                         <AddonsService::AddonAccountSetup
                             @provider={{provider.provider}}
                             @manager={{manager}}
+                            @account={{manager.selectedAccount}}
                             @onConnect={{manager.connectAccount}}
                         />
                     {{else if (eq manager.pageMode 'confirm')}}

--- a/lib/osf-components/addon/components/addons-service/addon-account-setup/component.ts
+++ b/lib/osf-components/addon/components/addons-service/addon-account-setup/component.ts
@@ -132,20 +132,20 @@ export default class AddonAccountSetupComponent extends Component<Args> {
             return [
                 {
                     name: 'access_token',
-                    labelText: t('addons.accountCreate.api-token-label') ,
+                    labelText: t('addons.accountCreate.api-token-label'),
                     inputType: 'text',
-                    inputPlaceholder:  t('addons.accountCreate.api-token-placeholder'),
+                    inputPlaceholder: t('addons.accountCreate.api-token-placeholder'),
                     inputValue: credentials.access_token,
                 },
             ];
         }
-        case CredentialsFormat.DATAVERSE_API_TOKEN:{
+        case CredentialsFormat.DATAVERSE_API_TOKEN: {
             return [
                 {
                     name: 'access_token',
                     labelText: t('addons.accountCreate.personal-access-token-label'),
                     inputType: 'text',
-                    inputPlaceholder:  t('addons.accountCreate.personal-access-token-placeholder'),
+                    inputPlaceholder: t('addons.accountCreate.personal-access-token-placeholder'),
                     inputValue: credentials.access_token,
                 },
             ];
@@ -281,6 +281,13 @@ export default class AddonAccountSetupComponent extends Component<Args> {
             } else {
                 this.toast.error(this.intl.t('addons.accountCreate.oauth-reconnect-error'));
             }
+        }
+    }
+
+    willDestroy() {
+        if (!this.args.account && this.newAccount && !this.newAccount.credentialsAvailable) {
+            this.newAccount.deleteRecord();
+            this.newAccount.save();
         }
     }
 }

--- a/lib/osf-components/addon/components/addons-service/addon-account-setup/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/addon-account-setup/template.hbs
@@ -12,7 +12,7 @@
                     data-test-start-oauth-button
                     data-analytics-name='Start OAuth'
                     @target='_blank'
-                    @href={{this.newAccount.authUrl}}
+                    @href={{if @account @account.authUrl this.newAccount.authUrl}}
                 >
                     {{t 'addons.accountCreate.oauth-start'}}
                 </OsfLink>

--- a/lib/osf-components/addon/components/addons-service/manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/manager/component.ts
@@ -171,7 +171,11 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
 
     @action
     authorizeSelectedAccount() {
-        this.pageMode = PageMode.CONFIRM;
+        if (this.selectedAccount && this.selectedAccount.credentialsAvailable) {
+            this.pageMode = PageMode.CONFIRM;
+        } else {
+            this.pageMode = PageMode.ACCOUNT_CREATE;
+        }
     }
 
     @task

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -306,7 +306,7 @@ addons:
         new-account: 'Setup new account'
         reconnect-account: 'Reconnect account'
         existing-account: 'Choose existing account'
-        unauthenticated-account: 'Unconnected account'
+        unnamed-account: 'Unnamed account'
     accountCreate:
         display-name-label: 'Display name'
         display-name-placeholder: 'Account name'


### PR DESCRIPTION
-   Ticket: [ENG-6345]
-   Feature flag: n/a

## Purpose
- Prevent users from creating a new unauthorized account and then selecting it later as an "Existing account"
- Send users to the "Connect acccount" page if a user selects an unauthorized account
  - Fix issues `addon-account-setup` component's reconnect workflow
- Follow-up to this prior PR https://github.com/CenterForOpenScience/ember-osf-web/pull/2372

## Summary of Changes
- Delete newly created account if the auth workflow hasn't succeeded and the user cancels out of the account creation process
  - Will not delete account if it is a "Reconnect"/Reauthorize workflow (checks if `account` is passed into `addon-account-setup` component
- Miscellaneous whitespace changes

## Screenshot(s)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6345]: https://openscience.atlassian.net/browse/ENG-6345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ