### PR TITLE
[No ticket] Actually remove filters when removing them in the UI

### DIFF
--- a/app/institutions/dashboard/-components/object-list/component.ts
+++ b/app/institutions/dashboard/-components/object-list/component.ts
@@ -42,7 +42,9 @@ export default class InstitutionalObjectList extends Component<InstitutionalObje
 
     get queryOptions() {
         const options = {
-            ... this.args.defaultQueryOptions,
+            cardSearchFilter: {
+                ...this.args.defaultQueryOptions.cardSearchFilter,
+            },
             'page[cursor]': this.page,
             'page[size]': 10,
             sort: this.sort,


### PR DESCRIPTION
-   Ticket: [No ticket]
-   Feature flag: n/a

## Purpose
- Fix bug where removed filters were "remembered"

## Summary of Changes
- Change how we use the `args.defaultQueryOptions` param when building request query options
  -  Previous method of initializing `options` was allowing us to directly add entries to `defaultQueryOptions` in line 53 (now line 55) when doing `acc.cardSearchFilter[filter.propertyPathKey] = ...`
  - New way of initializing `options` should no longer allow us to add new entries to `defaultQueryOptions`
  - Shallow copies are a doozy

## Screenshot(s)
- Before the fix: `args.defaultQueryOptions` object before and after this showing the newly added `rights` entry
![image](https://github.com/user-attachments/assets/352674e6-f7d8-49d4-b56f-692cdd1263ba)
- After the fix: `args..defaultQueryOptions` object remains the same
![image](https://github.com/user-attachments/assets/b67eab39-4bdb-478f-a325-e7e8efcfddef)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
