### PR TITLE
[No ticket ]Right panel hidden

### DIFF
--- a/app/institutions/dashboard/-components/institutional-dashboard-wrapper/styles.scss
+++ b/app/institutions/dashboard/-components/institutional-dashboard-wrapper/styles.scss
@@ -2,20 +2,8 @@
 @import 'app/styles/components';
 
 .container {
-    display: flex;
-    flex-direction: row;
-    flex-grow: 1;
-
-    > div {
-        // override OsfLayout styles for forcing drawer mode
-        max-width: none;
-        position: inherit;
-    }
-
-    > :global(.media-mobile),
-    > :global(.media-tablet) {
-        // allow drawer to be hidden offscreen
-        position: relative;
+    > div { // override OsfLayout styles for forcing drawer mode
+        overflow-x: hidden;
     }
 }
 


### PR DESCRIPTION

-   Ticket: [No ticket]
-   Feature flag: n/a

## Purpose
- Properly hide right panel on desktop view

## Summary of Changes
- Update CSS to hide right-panel in desktop view
  - Currently it is off screen, but there is a horizontal scroll option that allows you to see the right-panel by scrolling over
- Remove unneeded CSS

## Screenshot(s)
- Before:
  - Closed (note the scrollbar at the bottom):
![image](https://github.com/user-attachments/assets/76322a4a-e158-4cc6-ab6e-b4a48dc6bc7e)
  - Right panel is "Closed", but you can just scroll over to see it
![image](https://github.com/user-attachments/assets/98653d7d-1c23-42e0-9c3b-f2eaefd02aee)

- After:
  - Closed:
![image](https://github.com/user-attachments/assets/1bbc4dbd-d84d-4c74-b029-5a41528ea27c)

  - Opened:
![image](https://github.com/user-attachments/assets/d6f04aa7-d29f-4352-8ae3-4ed1ad81382b)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
