### PR TITLE
Fix issue when applying multiple filters of a kind

### DIFF
--- a/app/institutions/dashboard/-components/object-list/component.ts
+++ b/app/institutions/dashboard/-components/object-list/component.ts
@@ -53,7 +53,7 @@ export default class InstitutionalObjectList extends Component<InstitutionalObje
         const fullQueryOptions = this.activeFilters.reduce((acc, filter: Filter) => {
             const currentValue = acc.cardSearchFilter[filter.propertyPathKey];
             acc.cardSearchFilter[filter.propertyPathKey] =
-                currentValue ? [...currentValue, filter.value] : [filter.value];
+                currentValue ? currentValue.concat(filter.value) : [filter.value];
             return acc;
         }, options);
         return fullQueryOptions;


### PR DESCRIPTION
-   Ticket: [No ticket]
-   Feature flag: n/a

## Purpose
- Fix bug when applying multiple filter types of a given category

## Summary of Changes
- Update how filters are appended

## Screenshot(s)
- Issue was stemming from how existing filters were used leading to queries that looked like
![image](https://github.com/user-attachments/assets/76ca5d3b-546f-453b-81bd-33408551fc39)


- Should now look like
![image](https://github.com/user-attachments/assets/8d08396c-2783-4ea6-b0a8-16d77349640d)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
