### PR TITLE
Fix value-search bugs

### DIFF
--- a/app/institutions/dashboard/-components/object-list/component.ts
+++ b/app/institutions/dashboard/-components/object-list/component.ts
@@ -60,9 +60,8 @@ export default class InstitutionalObjectList extends Component<InstitutionalObje
     }
 
     get valueSearchQueryOptions() {
-        const { defaultQueryOptions } = this.args;
         return {
-            ...defaultQueryOptions.cardSearchFilter,
+            ...this.queryOptions.cardSearchFilter,
         };
     }
 

--- a/app/institutions/dashboard/preprints/controller.ts
+++ b/app/institutions/dashboard/preprints/controller.ts
@@ -65,7 +65,7 @@ export default class InstitutionDashboardPreprints extends Controller {
         const identifiers = this.model.institution.iris.join(',');
         return {
             cardSearchFilter: {
-                affiliation: identifiers,
+                affiliation: [identifiers],
                 resourceType: ResourceTypeFilterValue.Preprints,
             },
         };

--- a/app/institutions/dashboard/projects/controller.ts
+++ b/app/institutions/dashboard/projects/controller.ts
@@ -96,7 +96,7 @@ export default class InstitutionDashboardProjects extends Controller {
         const identifiers = this.model.institution.iris.join(',');
         return {
             cardSearchFilter: {
-                affiliation: identifiers,
+                affiliation: [identifiers],
                 resourceType: ResourceTypeFilterValue.Projects,
             },
         };

--- a/app/institutions/dashboard/registrations/controller.ts
+++ b/app/institutions/dashboard/registrations/controller.ts
@@ -91,7 +91,7 @@ export default class InstitutionDashboardRegistrations extends Controller {
         const identifiers = this.model.institution.iris.join(',');
         return {
             cardSearchFilter: {
-                affiliation: identifiers,
+                affiliation: [identifiers],
                 resourceType: ResourceTypeFilterValue.Registrations,
             },
         };


### PR DESCRIPTION
-   Ticket: [No ticket]
-   Feature flag: n/a

## Purpose
- Fix an issue where the value-searches for a given filterable property were not being queried with any applied filters
- Fix an issue where adding more affiliation filters was breaking

## Summary of Changes
- Pass all applied filters to value-searches
- Update `cardSearchFilter[affiliation]` query-param to be an array, instead of a string

## Screenshot(s)
- `defaultQueryParams.cardSearchFilter.affiliation` not being an array lead to this misformatted request param (array.concat vs. string.concat)
![image](https://github.com/user-attachments/assets/786d789e-b12a-49ef-b036-e073c388a12f)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
