### PR TITLE
Limit institution banner image size

### DIFF
--- a/app/institutions/dashboard/-components/institutional-dashboard-wrapper/styles.scss
+++ b/app/institutions/dashboard/-components/institutional-dashboard-wrapper/styles.scss
@@ -19,6 +19,11 @@
     justify-content: space-between;
 }
 
+.institution-banner {
+    max-width: 100%;
+    max-height: 300px;
+}
+
 .tab-list {
     @include clamp-width;
     @include tab-list;

--- a/app/institutions/dashboard/-components/institutional-dashboard-wrapper/template.hbs
+++ b/app/institutions/dashboard/-components/institutional-dashboard-wrapper/template.hbs
@@ -7,7 +7,7 @@
         local-class='heading-wrapper'
     >
         <div local-class='banner'>
-            <img src='{{@institution.bannerUrl}}' alt='{{@institution.name}}'>
+            <img local-class='institution-banner' src='{{@institution.bannerUrl}}' alt='{{@institution.name}}'>
         </div>
         <ul
             data-analytics-scope='Dashboard tabs'


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- See title

## Summary of Changes
- Add `max-width` and `max-height` to institution banner image
## Screenshot(s)
- Prevents anything silly like this:
![image](https://github.com/user-attachments/assets/d24586f4-510a-4fae-a5b9-1efe261e001a)
- and now looks like
![image](https://github.com/user-attachments/assets/0b30404b-257c-4f1d-a549-7873b6718b70)

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
