### PR TITLE
[ENG-6585] Move boolean filters into group

### DIFF
--- a/app/institutions/dashboard/-components/object-list/template.hbs
+++ b/app/institutions/dashboard/-components/object-list/template.hbs
@@ -240,6 +240,14 @@ as |list|>
                         @toggleFilter={{queue this.toggleFilter (perform list.searchObjectsTask)}}
                     />
                 {{/each}}
+                {{#if list.booleanFilters.length}}
+                    <SearchPage::BooleanFilters
+                        @cardSearchText={{this.cardSearchText}}
+                        @cardSearchFilter={{this.valueSearchQueryOptions}}
+                        @properties={{list.booleanFilters}}
+                        @toggleFilter={{queue this.toggleFilter (perform list.searchObjectsTask)}}
+                    />
+                {{/if}}
             </wrapper.right>
         {{/if}}
     </Institutions::Dashboard::-Components::InstitutionalDashboardWrapper>

--- a/lib/osf-components/addon/components/index-card-searcher/template.hbs
+++ b/lib/osf-components/addon/components/index-card-searcher/template.hbs
@@ -1,6 +1,7 @@
 {{yield (hash
     searchResults=this.searchResults
     relatedProperties=this.relatedProperties
+    booleanFilters=this.booleanFilters
     totalResultCount=this.totalResultCount
 
     debouceSearchObjectsTask=this.debouceSearchObjectsTask


### PR DESCRIPTION
-   Ticket: [ENG-6585]
-   Feature flag: n/a

## Purpose
- Combine boolean filters into one group to match filtering behavior of search page

## Summary of Changes
- Create a new boolean-filter group on institutional dashboard filter list

## Screenshot(s)
- Before (bug where some filter value names may be blank):
![image](https://github.com/user-attachments/assets/00d6006d-3670-44b9-b256-403696714f85)


- After:
![image](https://github.com/user-attachments/assets/cf8590f1-865c-4e7c-92f3-495bdb08e7c2)
 

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6585]: https://openscience.atlassian.net/browse/ENG-6585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ