### PR TITLE
[ENG-6590] Allow users to sort by view and download count

### DIFF
--- a/app/institutions/dashboard/preprints/controller.ts
+++ b/app/institutions/dashboard/preprints/controller.ts
@@ -50,6 +50,8 @@ export default class InstitutionDashboardPreprints extends Controller {
                 const metrics = searchResult.usageMetrics;
                 return metrics ? metrics.viewCount : this.missingItemPlaceholder;
             },
+            sortKey: 'usage.viewCount',
+            sortParam: 'integer-value',
         },
         { // Download count
             name: this.intl.t('institutions.dashboard.object-list.table-headers.download_count'),
@@ -57,6 +59,8 @@ export default class InstitutionDashboardPreprints extends Controller {
                 const metrics = searchResult.usageMetrics;
                 return metrics ? metrics.downloadCount : this.missingItemPlaceholder;
             },
+            sortKey: 'usage.downloadCount',
+            sortParam: 'integer-value',
         },
     ];
 

--- a/app/institutions/dashboard/projects/controller.ts
+++ b/app/institutions/dashboard/projects/controller.ts
@@ -59,6 +59,8 @@ export default class InstitutionDashboardProjects extends Controller {
                 const metrics = searchResult.usageMetrics;
                 return metrics ? metrics.viewCount : this.missingItemPlaceholder;
             },
+            sortKey: 'usage.viewCount',
+            sortParam: 'integer-value',
         },
         { // Resource type
             name: this.intl.t('institutions.dashboard.object-list.table-headers.resource_nature'),

--- a/app/institutions/dashboard/registrations/controller.ts
+++ b/app/institutions/dashboard/registrations/controller.ts
@@ -58,6 +58,8 @@ export default class InstitutionDashboardRegistrations extends Controller {
                 const metrics = searchResult.usageMetrics;
                 return metrics ? metrics.viewCount : this.missingItemPlaceholder;
             },
+            sortKey: 'usage.viewCount',
+            sortParam: 'integer-value',
         },
         { // Resource type
             name: this.intl.t('institutions.dashboard.object-list.table-headers.resource_nature'),


### PR DESCRIPTION
-   Ticket: [ENG-6590]
-   Feature flag: n/a

## Purpose
- Allow users to sort projects and registrations by view count
- Allow users to sort preprints by view and download counts

## Summary of Changes
- Add sort params to projects, registrations and preprint page controllers

## Screenshot(s)
- Before:
![image](https://github.com/user-attachments/assets/2b9e744a-3d3e-4c9b-8a6e-41625fba5ccb)


- After:
![image](https://github.com/user-attachments/assets/c6b03a15-9629-4eb1-b463-5b324d9f5882)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6590]: https://openscience.atlassian.net/browse/ENG-6590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ