### PR TITLE
Add placeholder if user has no ORCID

### DIFF
--- a/app/institutions/dashboard/-components/institutional-users-list/template.hbs
+++ b/app/institutions/dashboard/-components/institutional-users-list/template.hbs
@@ -161,9 +161,13 @@
                                 {{institutionalUser.userGuid}}
                             </OsfLink>
                         {{else if (eq column.type 'orcid')}}
-                            <OsfLink @href={{concat this.orcidUrlPrefix institutionalUser.orcidId}}>
-                                {{institutionalUser.orcidId}}
-                            </OsfLink>
+                            {{#if institutionalUser.orcidId}}
+                                <OsfLink @href={{concat this.orcidUrlPrefix institutionalUser.orcidId}}>
+                                    {{institutionalUser.orcidId}}
+                                </OsfLink>
+                            {{else}}
+                                {{t 'institutions.dashboard.object-list.table-items.missing-info'}}
+                            {{/if}}
                         {{else if (eq column.type 'date_by_month')}}
                             {{#if (get institutionalUser column.key)}}
                                 {{moment-format (get institutionalUser column.key) 'MM/YYYY'}}


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Add a placeholder when user has no ORCID

## Summary of Changes
- Add a `-` if there is no orcid

## Screenshot(s)
- Before:
![image](https://github.com/user-attachments/assets/a4952e28-b397-4d8e-a2c7-cbe6a0375053)

- After:
![image](https://github.com/user-attachments/assets/4f163c56-cf63-4a99-9cc5-24d52405f84b)

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
