### PR TITLE
Remove tooltip from summary kpi

### DIFF
--- a/app/institutions/dashboard/-components/total-count-kpi-wrapper/total-count-kpi/template.hbs
+++ b/app/institutions/dashboard/-components/total-count-kpi-wrapper/total-count-kpi/template.hbs
@@ -8,9 +8,6 @@
                 <div local-class='total-container'>
                     {{@data.total}}
                 </div>
-                <EmberTooltip>
-                    {{@data.title}} - {{@data.total}}
-                </EmberTooltip>
             {{else}}
                 {{t 'institutions.dashboard.empty'}}
             {{/if}}


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Remove hover tooltip from summary page KPIs as requested by product

## Summary of Changes
- Remove `EmberTooltip` from summary KPIs

## Screenshot(s)
- Prevents this visual issue
![image](https://github.com/user-attachments/assets/15a723f3-0095-4fc6-b898-a8a5e0a8321c)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
