### PR TITLE
[ENG-6567][ENG-6598] Fix dropdown placement for mobile

### DIFF
--- a/app/institutions/dashboard/-components/institutional-users-list/styles.scss
+++ b/app/institutions/dashboard/-components/institutional-users-list/styles.scss
@@ -139,7 +139,6 @@
 
     &.mobile {
         max-width: none;
-        right: 100%;
     }
 }
 

--- a/lib/osf-components/addon/components/adjustable-paginator/template.hbs
+++ b/lib/osf-components/addon/components/adjustable-paginator/template.hbs
@@ -1,12 +1,15 @@
 <span local-class='paginator__control'>
     <div local-class='paginator__select-wrapper'>
-        <select title={{t 'paginator.itemsPerPage'}} local-class='paginator__select' onchange={{action this.onPageSizeChange value='target.value'}}>
-            {{#each this.pageSizeOptions as |page_size_option|}}
-                <option value={{page_size_option}} selected={{eq page_size_option this.selectedPageSize}}>
-                    {{t 'paginator.itemsPerPage'}} {{page_size_option}}
-                </option>
-            {{/each}}
-        </select>
+        <label>
+            {{t 'paginator.itemsPerPage'}}
+            <select local-class='paginator__select' onchange={{action this.onPageSizeChange value='target.value'}}>
+                {{#each this.pageSizeOptions as |page_size_option|}}
+                    <option value={{page_size_option}} selected={{eq page_size_option this.selectedPageSize}}>
+                        {{page_size_option}}
+                    </option>
+                {{/each}}
+            </select>
+        </label>
     </div>
 </span>
 


### PR DESCRIPTION
-   Ticket: [ENG-6567] [ENG-6598]
-   Feature flag: n/a

## Purpose
- Fix dropdown placement for mobile view
- Fix a11y best practice issue where dropdown isn't properly labeled

## Summary of Changes
- Remove unneeded CSS property
- Use an explicit `<label>` element for "Items per page" dropdown

## Screenshot(s)
- Before:
![image](https://github.com/user-attachments/assets/9d7c0c91-729f-4511-81dc-4faeaa8f065f)
![image](https://github.com/user-attachments/assets/c90d960c-5247-4fdb-b37d-722424f0edcb)

- After:
![image](https://github.com/user-attachments/assets/84175dbd-25f9-47ea-9437-abdf80db7512)
![image](https://github.com/user-attachments/assets/42540793-629a-4658-9f88-31601fbe634a)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6567]: https://openscience.atlassian.net/browse/ENG-6567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ENG-6598]: https://openscience.atlassian.net/browse/ENG-6598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ