### PR TITLE
Fix broken contributor fields

### DIFF
--- a/app/institutions/dashboard/-components/object-list/contributors-field/component.ts
+++ b/app/institutions/dashboard/-components/object-list/contributors-field/component.ts
@@ -64,9 +64,14 @@ function hasInstitutionAffiliation(contributors: any[], attribution: any, instit
     }
 
     return attributedContributor.affiliation.some(
-        (affiliation: any) => affiliation.identifier.some(
-            (affiliationIdentifier: any) => institutionIris.includes(affiliationIdentifier['@value']),
-        ),
+        (affiliation: any) => {
+            if (affiliation.identifier) {
+                return affiliation.identifier.some(
+                    (affiliationIdentifier: any) => institutionIris.includes(affiliationIdentifier['@value']),
+                );
+            }
+            return institutionIris.includes(affiliation['@id']);
+        },
     );
 }
 


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Fix contributor fields that were broken on test

## Summary of Changes
- Account for some affiliations that do no have an `identifier` field and fall back to using the `@id` property  to check affiliation

## Screenshot(s)
- Example of two affiliations, one with the `identifier` attribute and the other with no `identifier` attribute (this second one would cause the page to break):
![image](https://github.com/user-attachments/assets/7fd7492e-eb1d-4094-b6ad-62cf89bfd096)

- Before:
![image](https://github.com/user-attachments/assets/fc54e6dd-4ade-41a9-959c-6959de68f90a)

- After:
![image](https://github.com/user-attachments/assets/98a57a5f-d55e-481e-9e20-21835e4aebc7)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
