### PR TITLE
[ENG-6617][ENG-6559] Integrate user download functionality

### DIFF
--- a/app/institutions/dashboard/-components/institutional-users-list/component.ts
+++ b/app/institutions/dashboard/-components/institutional-users-list/component.ts
@@ -203,7 +203,7 @@ export default class InstitutionalUsersList extends Component<InstitutionalUsers
     }
 
     get downloadJsonUrl() {
-        return this.downloadUrl('json');
+        return this.downloadUrl('json_report');
     }
 
     @restartableTask

--- a/app/institutions/dashboard/-components/institutional-users-list/component.ts
+++ b/app/institutions/dashboard/-components/institutional-users-list/component.ts
@@ -9,6 +9,7 @@ import Intl from 'ember-intl/services/intl';
 import InstitutionModel from 'ember-osf-web/models/institution';
 import InstitutionDepartmentsModel from 'ember-osf-web/models/institution-department';
 import Analytics from 'ember-osf-web/services/analytics';
+import { RelationshipWithLinks } from 'osf-api';
 
 interface Column {
     key: string;
@@ -184,6 +185,27 @@ export default class InstitutionalUsersList extends Component<InstitutionalUsers
         return query;
     }
 
+    downloadUrl(format: string) {
+        const institutionRelationships = this.args.institution.links.relationships;
+        const usersLink = (institutionRelationships!.user_metrics as RelationshipWithLinks).links.related.href;
+        const userURL = new URL(usersLink!);
+        userURL.searchParams.set('format', format);
+        userURL.searchParams.set('page[size]', '10000');
+        return userURL.toString();
+    }
+
+    get downloadCsvUrl() {
+        return this.downloadUrl('csv');
+    }
+
+    get downloadTsvUrl() {
+        return this.downloadUrl('tsv');
+    }
+
+    get downloadJsonUrl() {
+        return this.downloadUrl('json');
+    }
+
     @restartableTask
     @waitFor
     async searchDepartment(name: string) {
@@ -237,5 +259,4 @@ export default class InstitutionalUsersList extends Component<InstitutionalUsers
     clickToggleOrcidFilter(hasOrcid: boolean) {
         this.hasOrcid = !hasOrcid;
     }
-
 }

--- a/app/institutions/dashboard/-components/institutional-users-list/styles.scss
+++ b/app/institutions/dashboard/-components/institutional-users-list/styles.scss
@@ -9,6 +9,10 @@
 .download-dropdown-content {
     display: flex;
     flex-direction: column;
+    align-items: flex-start;
+    border: 1px solid $color-border-gray;
+    padding: 8px;
+    width: max-content;
 }
 
 .table {

--- a/app/institutions/dashboard/-components/institutional-users-list/styles.scss
+++ b/app/institutions/dashboard/-components/institutional-users-list/styles.scss
@@ -6,6 +6,11 @@
     color: $color-select;
 }
 
+.download-dropdown-content {
+    display: flex;
+    flex-direction: column;
+}
+
 .table {
     margin-bottom: 45px;
 

--- a/app/institutions/dashboard/-components/institutional-users-list/styles.scss
+++ b/app/institutions/dashboard/-components/institutional-users-list/styles.scss
@@ -11,8 +11,11 @@
     flex-direction: column;
     align-items: flex-start;
     border: 1px solid $color-border-gray;
-    padding: 8px;
     width: max-content;
+}
+
+.downlaod-link {
+    padding: 4px 8px;
 }
 
 .table {

--- a/app/institutions/dashboard/-components/institutional-users-list/template.hbs
+++ b/app/institutions/dashboard/-components/institutional-users-list/template.hbs
@@ -95,6 +95,8 @@
                             </dd.trigger>
                             <dd.content local-class='download-dropdown-content'>
                                 <OsfLink
+                                    data-test-csv-download-button
+                                    data-analytics-name='Download CSV'
                                     {{on 'click' dd.close}}
                                     @target='_blank'
                                     @href={{this.downloadCsvUrl}}
@@ -102,6 +104,8 @@
                                     {{t 'institutions.dashboard.format_labels.csv'}}
                                 </OsfLink>
                                 <OsfLink
+                                    data-test-tsv-download-button
+                                    data-analytics-name='Download TSV'
                                     {{on 'click' dd.close}}
                                     @target='_blank'
                                     @href={{this.downloadTsvUrl}}
@@ -109,6 +113,8 @@
                                     {{t 'institutions.dashboard.format_labels.tsv'}}
                                 </OsfLink>
                                 <OsfLink
+                                    data-test-json-download-button
+                                    data-analytics-name='Download JSON'
                                     {{on 'click' dd.close}}
                                     @target='_blank'
                                     @href={{this.downloadJsonUrl}}

--- a/app/institutions/dashboard/-components/institutional-users-list/template.hbs
+++ b/app/institutions/dashboard/-components/institutional-users-list/template.hbs
@@ -98,6 +98,7 @@
                                 <OsfLink
                                     data-test-csv-download-button
                                     data-analytics-name='Download CSV'
+                                    local-class='downlaod-link'
                                     {{on 'click' dd.close}}
                                     @target='_blank'
                                     @href={{this.downloadCsvUrl}}
@@ -107,6 +108,7 @@
                                 <OsfLink
                                     data-test-tsv-download-button
                                     data-analytics-name='Download TSV'
+                                    local-class='downlaod-link'
                                     {{on 'click' dd.close}}
                                     @target='_blank'
                                     @href={{this.downloadTsvUrl}}
@@ -116,6 +118,7 @@
                                 <OsfLink
                                     data-test-json-download-button
                                     data-analytics-name='Download JSON'
+                                    local-class='downlaod-link'
                                     {{on 'click' dd.close}}
                                     @target='_blank'
                                     @href={{this.downloadJsonUrl}}

--- a/app/institutions/dashboard/-components/institutional-users-list/template.hbs
+++ b/app/institutions/dashboard/-components/institutional-users-list/template.hbs
@@ -94,18 +94,27 @@
                                 <FaIcon @icon='download' />
                             </dd.trigger>
                             <dd.content local-class='download-dropdown-content'>
-                                <Button local-class='download-option' {{on 'click' (queue this.downloadCsv dd.close)}}>
+                                <OsfLink
+                                    {{on 'click' dd.close}}
+                                    @target='_blank'
+                                    @href={{this.downloadCsvUrl}}
+                                >
                                     {{t 'institutions.dashboard.format_labels.csv'}}
-                                </Button>
-                                <Button local-class='download-option' {{on 'click' (queue this.downloadTsv dd.close)}}>
+                                </OsfLink>
+                                <OsfLink
+                                    {{on 'click' dd.close}}
+                                    @target='_blank'
+                                    @href={{this.downloadTsvUrl}}
+                                >
                                     {{t 'institutions.dashboard.format_labels.tsv'}}
-                                </Button>
-                                <Button local-class='download-option' {{on 'click' (queue this.downloadJsonTable dd.close)}}>
-                                    {{t 'institutions.dashboard.format_labels.json_table'}}
-                                </Button>
-                                <Button local-class='download-option' {{on 'click' (queue this.downloadJsonDirect dd.close)}}>
-                                    {{t 'institutions.dashboard.format_labels.json_direct'}}
-                                </Button>
+                                </OsfLink>
+                                <OsfLink
+                                    {{on 'click' dd.close}}
+                                    @target='_blank'
+                                    @href={{this.downloadJsonUrl}}
+                                >
+                                    {{t 'institutions.dashboard.format_labels.json'}}
+                                </OsfLink>
                             </dd.content>
                         </ResponsiveDropdown>
                     </div>

--- a/app/institutions/dashboard/-components/institutional-users-list/template.hbs
+++ b/app/institutions/dashboard/-components/institutional-users-list/template.hbs
@@ -88,6 +88,7 @@
                         <ResponsiveDropdown @renderInPlace={{true}} @buttonStyling={{true}} as |dd| >
                             <dd.trigger
                                 data-test-download-dropdown
+                                data-analytics-name='Download Dropdown'
                                 aria-label={{t 'institutions.dashboard.download_dropdown_label'}}
                                 local-class='download-dropdown-trigger'
                             >

--- a/tests/integration/routes/institutions/dashboard/-components/institutional-users-list/component-test.ts
+++ b/tests/integration/routes/institutions/dashboard/-components/institutional-users-list/component-test.ts
@@ -72,9 +72,9 @@ module('Integration | routes | institutions | dashboard | -components | institut
             .exists({ count: 5 }, '5 in the list with private projects');
 
         // Test download buttons
-        assert.dom('[data-test-download-csv]').exists('CSV download button');
-        assert.dom('[data-test-download-tsv]').exists('TSV download button');
-        assert.dom('[data-test-download-json]').exists('JSON download button');
+        assert.dom('[data-test-csv-download-button]').exists('CSV download button');
+        assert.dom('[data-test-tsv-download-button]').exists('TSV download button');
+        assert.dom('[data-test-json-download-button]').exists('JSON download button');
     });
 
     test('it sorts', async function(assert) {

--- a/tests/integration/routes/institutions/dashboard/-components/institutional-users-list/component-test.ts
+++ b/tests/integration/routes/institutions/dashboard/-components/institutional-users-list/component-test.ts
@@ -72,6 +72,7 @@ module('Integration | routes | institutions | dashboard | -components | institut
             .exists({ count: 5 }, '5 in the list with private projects');
 
         // Test download buttons
+        await click('[data-test-download-dropdown]');
         assert.dom('[data-test-csv-download-button]').exists('CSV download button');
         assert.dom('[data-test-tsv-download-button]').exists('TSV download button');
         assert.dom('[data-test-json-download-button]').exists('JSON download button');

--- a/tests/integration/routes/institutions/dashboard/-components/institutional-users-list/component-test.ts
+++ b/tests/integration/routes/institutions/dashboard/-components/institutional-users-list/component-test.ts
@@ -35,10 +35,10 @@ module('Integration | routes | institutions | dashboard | -components | institut
 
         this.set('model', model);
         await render(hbs`
-            <Institutions::Dashboard::-Components::InstitutionalUsersList
-                @modelTaskInstance={{this.model.taskInstance}}
-                @institution={{this.model.taskInstance.institution}}
-            />
+<Institutions::Dashboard::-Components::InstitutionalUsersList
+    @modelTaskInstance={{this.model.taskInstance}}
+    @institution={{this.model.taskInstance.institution}}
+/>
         `);
         assert.dom('[data-test-header]')
             .exists({ count: 9 }, '9 default headers');
@@ -70,6 +70,11 @@ module('Integration | routes | institutions | dashboard | -components | institut
             .exists({ count: 5 }, '5 in the list with public project');
         assert.dom('[data-test-item="privateProjects"]')
             .exists({ count: 5 }, '5 in the list with private projects');
+
+        // Test download buttons
+        assert.dom('[data-test-download-csv]').exists('CSV download button');
+        assert.dom('[data-test-download-tsv]').exists('TSV download button');
+        assert.dom('[data-test-download-json]').exists('JSON download button');
     });
 
     test('it sorts', async function(assert) {
@@ -105,10 +110,10 @@ module('Integration | routes | institutions | dashboard | -components | institut
 
         this.set('model', model);
         await render(hbs`
-            <Institutions::Dashboard::-Components::InstitutionalUsersList
-                @modelTaskInstance={{this.model.taskInstance}}
-                @institution={{this.model.taskInstance.institution}}
-            />
+<Institutions::Dashboard::-Components::InstitutionalUsersList
+    @modelTaskInstance={{this.model.taskInstance}}
+    @institution={{this.model.taskInstance.institution}}
+/>
         `);
         assert.dom('[data-test-item="user_name"]')
             .exists({ count: 3 }, '3 users');

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -819,8 +819,6 @@ institutions:
             csv: '.csv'
             tsv: '.tsv'
             json: 'JSON'
-            json_table: 'JSON (table)'
-            json_direct: 'JSON (direct)'
         download: 'Download'
         select_default: 'All Departments'
         users_list:

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -818,6 +818,7 @@ institutions:
         format_labels:
             csv: '.csv'
             tsv: '.tsv'
+            json: 'JSON'
             json_table: 'JSON (table)'
             json_direct: 'JSON (direct)'
         download: 'Download'


### PR DESCRIPTION
-   Ticket: [ENG-6559] [ENG-6617]
-   Feature flag: n/a

## Purpose
- Integrate download functionality for users tab (Projects, Registrations, and Preprints will be in a subsequent PR)

## Summary of Changes
- Add functionality to the download buttons on the FE
- Turn the buttons into links

## Screenshot(s)
![image](https://github.com/user-attachments/assets/6eed0ea5-604c-4c69-87e7-3a08f28ea661)



## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6559]: https://openscience.atlassian.net/browse/ENG-6559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ENG-6617]: https://openscience.atlassian.net/browse/ENG-6617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ