### PR TITLE
[ENG-6559] Download feature for SHARE data

### DIFF
--- a/app/institutions/dashboard/-components/object-list/component-test.ts
+++ b/app/institutions/dashboard/-components/object-list/component-test.ts
@@ -81,6 +81,11 @@ module('Integration | institutions | dashboard | -components | object-list', hoo
 
         // The table data is not blatantly incorrect
         assert.dom('[data-test-object-table-body-row]').exists({ count: 10 }, 'There are 10 rows');
+
+        // Download buttons are present
+        await click('[data-test-download-dropdown]');
+        assert.dom('[data-test-download-csv-link]').exists('CSV download link exists');
+        assert.dom('[data-test-download-tsv-link]').exists('TSV download link exists');
     });
 
     test('the table supports filtering', async function(assert) {

--- a/app/institutions/dashboard/-components/object-list/component-test.ts
+++ b/app/institutions/dashboard/-components/object-list/component-test.ts
@@ -86,6 +86,7 @@ module('Integration | institutions | dashboard | -components | object-list', hoo
         await click('[data-test-download-dropdown]');
         assert.dom('[data-test-download-csv-link]').exists('CSV download link exists');
         assert.dom('[data-test-download-tsv-link]').exists('TSV download link exists');
+        assert.dom('[data-test-download-json-link]').exists('JSON download link exists');
     });
 
     test('the table supports filtering', async function(assert) {

--- a/app/institutions/dashboard/-components/object-list/component.ts
+++ b/app/institutions/dashboard/-components/object-list/component.ts
@@ -74,27 +74,27 @@ export default class InstitutionalObjectList extends Component<InstitutionalObje
         };
     }
 
-    downloadUrl(cardSearch: IndexCardSearchModel, format: string, extension: string) {
+    downloadUrl(cardSearch: IndexCardSearchModel, format: string) {
         if (!cardSearch.links.self) {
             return '';
         }
         const cardSearchUrl = new URL((cardSearch.links.self as string));
         cardSearchUrl.searchParams.set('page[size]', '10000');
         cardSearchUrl.searchParams.set('acceptMediatype', format);
-        cardSearchUrl.searchParams.set('withFileName', `${this.args.objectType}-search-results.${extension}`);
+        cardSearchUrl.searchParams.set('withFileName', `${this.args.objectType}-search-results`);
         return cardSearchUrl.toString();
     }
 
     downloadCsvUrl(cardSearch: IndexCardSearchModel) {
-        return this.downloadUrl(cardSearch, 'text/csv', 'csv');
+        return this.downloadUrl(cardSearch, 'text/csv');
     }
 
     downloadTsvUrl(cardSearch: IndexCardSearchModel) {
-        return this.downloadUrl(cardSearch, 'text/tab-separated-values', 'tsv');
+        return this.downloadUrl(cardSearch, 'text/tab-separated-values');
     }
 
     downloadJsonUrl(cardSearch: IndexCardSearchModel) {
-        return this.downloadUrl(cardSearch, 'application/json', 'json');
+        return this.downloadUrl(cardSearch, 'application/json');
     }
 
     @action

--- a/app/institutions/dashboard/-components/object-list/component.ts
+++ b/app/institutions/dashboard/-components/object-list/component.ts
@@ -86,6 +86,16 @@ export default class InstitutionalObjectList extends Component<InstitutionalObje
             if (key === 'cardSearchFilter') {
                 Object.entries(value).forEach(([filterKey, filterValue]) => {
                     const cardSearchFilterKey = `cardSearchFilter[${filterKey}]`;
+                    // check if filterValue is an object, for boolean filters
+                    if (typeof filterValue === 'object' && !Array.isArray(filterValue)) {
+                        Object.entries(filterValue).forEach(([nestedFilterKey, nestedFilterValue]) => {
+                            searchUrl.searchParams.append(
+                                `${cardSearchFilterKey}[${nestedFilterKey}]`,
+                                (nestedFilterValue as boolean).toString(),
+                            );
+                        });
+                        return;
+                    }
                     searchUrl.searchParams.set(cardSearchFilterKey, filterValue.toString());
                 });
             } else {

--- a/app/institutions/dashboard/-components/object-list/component.ts
+++ b/app/institutions/dashboard/-components/object-list/component.ts
@@ -74,14 +74,23 @@ export default class InstitutionalObjectList extends Component<InstitutionalObje
     }
 
     downloadUrl(format: string) {
-        return format; // TODO: implement
+        const searchUrl = new URL('test');
+        searchUrl.searchParams.append('acceptMediatype', format);
+        const fileName = `${this.args.institution.name}-${this.args.objectType}-search-results`; // Extension?
+        searchUrl.searchParams.append('withFileName', fileName);
+        return searchUrl.toString();
     }
+
     get downloadCsvUrl() {
-        return this.downloadUrl('csv');
+        return this.downloadUrl('text/csv');
     }
 
     get downloadTsvUrl() {
-        return this.downloadUrl('tsv');
+        return this.downloadUrl('text/tab-separated-values');
+    }
+
+    get downloadJsonUrl() {
+        return this.downloadUrl('application/json');
     }
 
     @action

--- a/app/institutions/dashboard/-components/object-list/component.ts
+++ b/app/institutions/dashboard/-components/object-list/component.ts
@@ -73,6 +73,17 @@ export default class InstitutionalObjectList extends Component<InstitutionalObje
         };
     }
 
+    downloadUrl(format: string) {
+        return format; // TODO: implement
+    }
+    get downloadCsvUrl() {
+        return this.downloadUrl('csv');
+    }
+
+    get downloadTsvUrl() {
+        return this.downloadUrl('tsv');
+    }
+
     @action
     updateVisibleColumns() {
         this.visibleColumns = [...this.dirtyVisibleColumns];

--- a/app/institutions/dashboard/-components/object-list/styles.scss
+++ b/app/institutions/dashboard/-components/object-list/styles.scss
@@ -128,3 +128,12 @@
     display: inline-flex;
     padding-left: 10px;
 }
+
+.download-dropdown-content {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    border: 1px solid $color-border-gray;
+    padding: 8px;
+    width: max-content;
+}

--- a/app/institutions/dashboard/-components/object-list/styles.scss
+++ b/app/institutions/dashboard/-components/object-list/styles.scss
@@ -134,6 +134,9 @@
     flex-direction: column;
     align-items: flex-start;
     border: 1px solid $color-border-gray;
-    padding: 8px;
     width: max-content;
+}
+
+.download-link {
+    padding: 4px 8px;
 }

--- a/app/institutions/dashboard/-components/object-list/template.hbs
+++ b/app/institutions/dashboard/-components/object-list/template.hbs
@@ -98,6 +98,7 @@ as |list|>
                                     <OsfLink
                                         data-test-download-csv-link
                                         data-analytics-name='Download CSV'
+                                        local-class='download-link'
                                         {{on 'click' dd.close}}
                                         @href={{this.downloadCsvUrl}}
                                         @target='_blank'
@@ -107,11 +108,22 @@ as |list|>
                                     <OsfLink
                                         data-test-download-tsv-link
                                         data-analytics-name='Download TSV'
+                                        local-class='download-link'
                                         {{on 'click' dd.close}}
                                         @href={{this.downloadTsvUrl}}
                                         @target='_blank'
                                     >
                                         {{t 'institutions.dashboard.format_labels.tsv'}}
+                                    </OsfLink>
+                                    <OsfLink
+                                        data-test-download-json-link
+                                        data-analytics-name='Download JSON'
+                                        local-class='download-link'
+                                        {{on 'click' dd.close}}
+                                        @href={{this.downloadJsonUrl}}
+                                        @target='_blank'
+                                    >
+                                        {{t 'institutions.dashboard.format_labels.json'}}
                                     </OsfLink>
                                 </dd.content>
                             </ResponsiveDropdown>

--- a/app/institutions/dashboard/-components/object-list/template.hbs
+++ b/app/institutions/dashboard/-components/object-list/template.hbs
@@ -95,18 +95,22 @@ as |list|>
                                     <FaIcon @icon='download' />
                                 </dd.trigger>
                                 <dd.content local-class='download-dropdown-content'>
-                                    <Button
-                                        local-class='download-option'
-                                        {{on 'click' (queue this.downloadCsv dd.close)}}
+                                    <OsfLink
+                                        data-test-download-csv-link
+                                        data-analytics-name='Download CSV'
+                                        @href={{this.downloadCsvUrl}}
+                                        @target='_blank'
                                     >
                                         {{t 'institutions.dashboard.format_labels.csv'}}
-                                    </Button>
-                                    <Button
-                                        local-class='download-option'
-                                        {{on 'click' (queue this.downloadTsv dd.close)}}
+                                    </OsfLink>
+                                    <OsfLink
+                                        data-test-download-tsv-link
+                                        data-analytics-name='Download TSV'
+                                        @href={{this.downloadTsvUrl}}
+                                        @target='_blank'
                                     >
                                         {{t 'institutions.dashboard.format_labels.tsv'}}
-                                    </Button>
+                                    </OsfLink>
                                 </dd.content>
                             </ResponsiveDropdown>
                         </div>

--- a/app/institutions/dashboard/-components/object-list/template.hbs
+++ b/app/institutions/dashboard/-components/object-list/template.hbs
@@ -100,7 +100,7 @@ as |list|>
                                         data-analytics-name='Download CSV'
                                         local-class='download-link'
                                         {{on 'click' dd.close}}
-                                        @href={{this.downloadCsvUrl}}
+                                        @href={{call (fn (action this.downloadCsvUrl list.latestIndexCardSearch))}}
                                         @target='_blank'
                                     >
                                         {{t 'institutions.dashboard.format_labels.csv'}}
@@ -110,7 +110,7 @@ as |list|>
                                         data-analytics-name='Download TSV'
                                         local-class='download-link'
                                         {{on 'click' dd.close}}
-                                        @href={{this.downloadTsvUrl}}
+                                        @href={{call (fn (action this.downloadTsvUrl list.latestIndexCardSearch))}}
                                         @target='_blank'
                                     >
                                         {{t 'institutions.dashboard.format_labels.tsv'}}
@@ -120,7 +120,7 @@ as |list|>
                                         data-analytics-name='Download JSON'
                                         local-class='download-link'
                                         {{on 'click' dd.close}}
-                                        @href={{this.downloadJsonUrl}}
+                                        @href={{call (fn (action this.downloadJsonUrl list.latestIndexCardSearch))}}
                                         @target='_blank'
                                     >
                                         {{t 'institutions.dashboard.format_labels.json'}}

--- a/app/institutions/dashboard/-components/object-list/template.hbs
+++ b/app/institutions/dashboard/-components/object-list/template.hbs
@@ -98,6 +98,7 @@ as |list|>
                                     <OsfLink
                                         data-test-download-csv-link
                                         data-analytics-name='Download CSV'
+                                        {{on 'click' dd.close}}
                                         @href={{this.downloadCsvUrl}}
                                         @target='_blank'
                                     >
@@ -106,6 +107,7 @@ as |list|>
                                     <OsfLink
                                         data-test-download-tsv-link
                                         data-analytics-name='Download TSV'
+                                        {{on 'click' dd.close}}
                                         @href={{this.downloadTsvUrl}}
                                         @target='_blank'
                                     >

--- a/app/models/index-card-search.ts
+++ b/app/models/index-card-search.ts
@@ -1,4 +1,5 @@
 import Model, { AsyncHasMany, attr, hasMany } from '@ember-data/model';
+import {Links} from 'jsonapi-typescript';
 
 import RelatedPropertyPathModel from './related-property-path';
 import SearchResultModel from './search-result';
@@ -15,6 +16,7 @@ export default class IndexCardSearchModel extends Model {
     @attr('string') cardSearchText!: string;
     @attr('array') cardSearchFilters!: SearchFilter[];
     @attr('string') totalResultCount!: number | typeof ShareMoreThanTenThousand;
+    @attr('object') links!: Links;
 
     @hasMany('search-result', { inverse: null })
     searchResultPage!: AsyncHasMany<SearchResultModel> & SearchResultModel[];

--- a/app/serializers/index-card-search.ts
+++ b/app/serializers/index-card-search.ts
@@ -1,6 +1,20 @@
+import * as JSONAPI from 'jsonapi-typescript';
+
 import ShareSerializer from './share-serializer';
 
 export default class IndexCardSearchSerializer extends ShareSerializer {
+    // Taken from osf-serializer.ts
+    _mergeLinks(resourceHash: JSONAPI.ResourceObject): Partial<JSONAPI.ResourceObject> {
+        const links = { ...(resourceHash.links || {}) };
+        return {
+            attributes: { ...resourceHash.attributes, links: (links as any) },
+        };
+    }
+
+    extractAttributes(modelClass: any, resourceHash: JSONAPI.ResourceObject) {
+        const attributeHash = this._mergeLinks(resourceHash);
+        return super.extractAttributes(modelClass, attributeHash);
+    }
 }
 
 declare module 'ember-data/types/registries/serializer' {

--- a/lib/osf-components/addon/components/index-card-searcher/component.ts
+++ b/lib/osf-components/addon/components/index-card-searcher/component.ts
@@ -9,6 +9,7 @@ import Toast from 'ember-toastr/services/toast';
 import SearchResultModel from 'ember-osf-web/models/search-result';
 import { taskFor } from 'ember-concurrency-ts';
 import RelatedPropertyPathModel, { SuggestedFilterOperators } from 'ember-osf-web/models/related-property-path';
+import IndexCardSearchModel from 'ember-osf-web/models/index-card-search';
 
 interface IndexCardSearcherArgs {
     queryOptions: Record<string, any>;
@@ -27,6 +28,7 @@ export default class IndexCardSearcher extends Component<IndexCardSearcherArgs> 
     @tracked relatedProperties?: RelatedPropertyPathModel[] = [];
     @tracked booleanFilters?: RelatedPropertyPathModel[] = [];
 
+    @tracked latestIndexCardSearch?: IndexCardSearchModel;
     @tracked firstPageCursor?: string;
     @tracked nextPageCursor?: string;
     @tracked prevPageCursor?: string;
@@ -64,6 +66,7 @@ export default class IndexCardSearcher extends Component<IndexCardSearcherArgs> 
                 (property: RelatedPropertyPathModel) =>
                     property.suggestedFilterOperator !== SuggestedFilterOperators.IsPresent, // AnyOf or AtDate
             );
+            this.latestIndexCardSearch = searchResult;
             this.firstPageCursor = searchResult.firstPageCursor;
             this.nextPageCursor = searchResult.nextPageCursor;
             this.prevPageCursor = searchResult.prevPageCursor;

--- a/lib/osf-components/addon/components/index-card-searcher/template.hbs
+++ b/lib/osf-components/addon/components/index-card-searcher/template.hbs
@@ -7,6 +7,7 @@
     debouceSearchObjectsTask=this.debouceSearchObjectsTask
     searchObjectsTask=this.searchObjectsTask
 
+    latestIndexCardSearch=this.latestIndexCardSearch
     firstPageCursor=this.firstPageCursor
     nextPageCursor=this.nextPageCursor
     prevPageCursor=this.prevPageCursor

--- a/mirage/views/search.ts
+++ b/mirage/views/search.ts
@@ -277,10 +277,11 @@ export function cardSearch(_: Schema, request: Request) {
         requestedResourceTypes = Object.keys(resourceMetadataByType) as OsfmapResourceTypes[];
     }
 
+    const indexCardSearchId = faker.random.uuid();
     const indexCardSearch = {
         data: {
             type: 'index-card-search',
-            id: faker.random.uuid(),
+            id:indexCardSearchId,
             attributes: {
                 cardSearchText: 'hello',
                 cardSearchFilter: [
@@ -324,6 +325,9 @@ export function cardSearch(_: Schema, request: Request) {
                     },
                 },
                 searchResultPage: {},
+            },
+            links: {
+                self: `https://share.osf.io/api/v2/index-card-search/${indexCardSearchId}`,
             },
         },
         included: [


### PR DESCRIPTION
-   Ticket: [ENG-6559]
-   Feature flag: n/a

## Purpose
- Allow users to download projects/registrations/preprints info in institutional dashboard

## Summary of Changes
- Add functionality to download from SHARE using the `acceptMediatype` and `withFileName` query-params

## Screenshot(s)
- For this filter set (where license is a boolean filter)...
![image](https://github.com/user-attachments/assets/51c0db38-c038-4b4a-a7f5-04c355970408)
... the CSV download link would look like 

```
https://staging-share.osf.io/trove/index-card-search
?acceptMediatype=text/csv
&withFileName=projects-search-results
&cardSearchFilter[affiliation]=http://ror.org/has-users
&cardSearchFilter[resourceType]=Project
&cardSearchFilter[rights][is-present]=true
&cardSearchFilter[funder]=http://dx.doi.org/10.10000/505000005050,https://doi.org/10.10000/100000001
&page[cursor]=&page[size]=10000&sort=-dateModified
```

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6559]: https://openscience.atlassian.net/browse/ENG-6559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ