### PR TITLE
Add remaining user search query-params to download

### DIFF
--- a/app/institutions/dashboard/-components/institutional-users-list/component.ts
+++ b/app/institutions/dashboard/-components/institutional-users-list/component.ts
@@ -191,6 +191,9 @@ export default class InstitutionalUsersList extends Component<InstitutionalUsers
         const userURL = new URL(usersLink!);
         userURL.searchParams.set('format', format);
         userURL.searchParams.set('page[size]', '10000');
+        Object.entries(this.queryUsers).forEach(([key, value]) => {
+            userURL.searchParams.set(key, value);
+        });
         return userURL.toString();
     }
 


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Add relevant user search query-params to the download links (follow up to this prior PR https://github.com/CenterForOpenScience/ember-osf-web/pull/2413)

## Summary of Changes
- Add the `queryUsers` object entries to the downloadUrl

## Screenshot(s)
- Behold, query-params in the anchor tag's href
![image](https://github.com/user-attachments/assets/c74d1b15-9f59-44bc-9290-c8c55cd6ca86)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
