### PR TITLE
[ENG-6625] Add report date to Institutional Dashboard Summary and Users tab

### DIFF
--- a/app/institutions/dashboard/index/styles.scss
+++ b/app/institutions/dashboard/index/styles.scss
@@ -22,3 +22,9 @@
         }
     }
 }
+
+.updated-at {
+    align-self: flex-end;
+    margin-right: 12px;
+    margin-bottom: 12px;
+}

--- a/app/institutions/dashboard/index/template.hbs
+++ b/app/institutions/dashboard/index/template.hbs
@@ -1,7 +1,12 @@
-<Institutions::Dashboard::-Components::InstitutionalDashboardWrapper 
+<Institutions::Dashboard::-Components::InstitutionalDashboardWrapper
     @institution={{this.model.institution}} as |wrapper|
 >
     <wrapper.main local-class='main-container {{if (is-mobile) 'mobile'}}'>
+        {{#if this.model.summaryMetrics.reportYearmonth}}
+            <div local-class='updated-at'>
+                {{t 'institutions.dashboard.updated' date=this.model.summaryMetrics.reportYearmonth}}
+            </div>
+        {{/if}}
         <div local-class='kpi-container'>
             <Institutions::Dashboard::-Components::TotalCountKpiWrapper
                 @model={{this.model}}

--- a/app/institutions/dashboard/index/template.hbs
+++ b/app/institutions/dashboard/index/template.hbs
@@ -3,7 +3,10 @@
 >
     <wrapper.main local-class='main-container {{if (is-mobile) 'mobile'}}'>
         {{#if this.model.summaryMetrics.reportYearmonth}}
-            <div local-class='updated-at'>
+            <div
+                data-test-summary-report-year-month
+                local-class='updated-at'
+            >
                 {{t 'institutions.dashboard.updated' date=this.model.summaryMetrics.reportYearmonth}}
             </div>
         {{/if}}

--- a/app/institutions/dashboard/route.ts
+++ b/app/institutions/dashboard/route.ts
@@ -32,14 +32,15 @@ export default class InstitutionsDashboardRoute extends Route {
             const summaryMetrics = await institution.summaryMetrics;
             const userMetricInfo: QueryHasManyResult<never> = await institution.queryHasMany(
                 'userMetrics',
-                { size: 0 },
+                { size: 1 },
             );
+            const userMetric = userMetricInfo.toArray()[0];
 
             return {
                 institution,
                 departmentMetrics,
                 summaryMetrics,
-                totalUsers: userMetricInfo.meta.total,
+                userMetric,
             };
         } catch (error) {
             captureException(error);

--- a/app/institutions/dashboard/users/styles.scss
+++ b/app/institutions/dashboard/users/styles.scss
@@ -1,3 +1,8 @@
 .panel-wrapper {
     margin-top: 12px;
 }
+
+.updated-at {
+    float: right;
+    margin: 12px 12px 0 0;
+}

--- a/app/institutions/dashboard/users/template.hbs
+++ b/app/institutions/dashboard/users/template.hbs
@@ -1,7 +1,10 @@
 <Institutions::Dashboard::-Components::InstitutionalDashboardWrapper @institution={{this.model.institution}} as |wrapper|>
     <wrapper.main>
         {{#if this.model.userMetric.reportYearmonth}}
-            <div local-class='updated-at'>
+            <div
+                data-test-user-report-year-month
+                local-class='updated-at'
+            >
                 {{t 'institutions.dashboard.updated' date=this.model.userMetric.reportYearmonth}}
             </div>
         {{/if}}

--- a/app/institutions/dashboard/users/template.hbs
+++ b/app/institutions/dashboard/users/template.hbs
@@ -1,5 +1,10 @@
 <Institutions::Dashboard::-Components::InstitutionalDashboardWrapper @institution={{this.model.institution}} as |wrapper|>
     <wrapper.main>
+        {{#if this.model.userMetric.reportYearmonth}}
+            <div local-class='updated-at'>
+                {{t 'institutions.dashboard.updated' date=this.model.userMetric.reportYearmonth}}
+            </div>
+        {{/if}}
         <div local-class='panel-wrapper' data-analytics-scope='Users tab'>
             <Institutions::Dashboard::-Components::InstitutionalUsersList
                 @institution={{this.model.institution}}

--- a/app/models/institution-summary-metric.ts
+++ b/app/models/institution-summary-metric.ts
@@ -13,7 +13,7 @@ export default class InstitutionSummaryMetricModel extends OsfModel {
     @attr('number') publicFileCount!: number;
     @attr('number') monthlyLoggedInUserCount!: number;
     @attr('number') monthlyActiveUserCount!: number;
-
+    @attr('string') reportYearmonth!: string;
 
     get convertedStorageCount(): string {
         return humanFileSize(parseFloat(this.storageByteCount.toFixed(1)));

--- a/app/models/institution-user.ts
+++ b/app/models/institution-user.ts
@@ -18,6 +18,7 @@ export default class InstitutionUserModel extends OsfModel {
     @attr('string') monthLastLogin!: string; // YYYY-MM
     @attr('string') monthLastActive!: string; // YYYY-MM
     @attr('string') accountCreationDate!: string; // YYYY-MM
+    @attr('string') reportYearmonth!: string;
     @attr('fixstring') orcidId?: string;
 
     @belongsTo('user', { async: true })

--- a/mirage/factories/institution-summary-metric.ts
+++ b/mirage/factories/institution-summary-metric.ts
@@ -34,6 +34,9 @@ export default Factory.extend<InstitutionSummaryMetricModel>({
     monthlyLoggedInUserCount() {
         return faker.random.number({ min: 10, max: 100 * 100 });
     },
+    reportYearmonth() {
+        return faker.date.past(1).toISOString().slice(0, 7);
+    },
 });
 
 declare module 'ember-cli-mirage/types/registries/schema' {

--- a/mirage/factories/institution-user.ts
+++ b/mirage/factories/institution-user.ts
@@ -44,6 +44,9 @@ export default Factory.extend<InstitutionUser>({
     orcidId() {
         return faker.random.uuid(); // Simulate an ORCID ID
     },
+    reportYearmonth() {
+        return faker.date.past(1).toISOString().slice(0, 7);
+    },
     afterCreate(institutionUser, server) {
         if (!institutionUser.userName && !institutionUser.userGuid) {
             const user = server.create('user');

--- a/tests/acceptance/institutions/dashboard-test.ts
+++ b/tests/acceptance/institutions/dashboard-test.ts
@@ -31,6 +31,7 @@ module(moduleName, hooks => {
         // Summary tab
         await percySnapshot(`${moduleName} - summary`);
         assert.dom('[data-test-page-tab="summary"]').hasClass('active', 'Summary tab is active by default');
+        assert.dom('[data-test-summary-report-year-month]').exists('Report year month exists');
 
         // Users tab
         await click('[data-test-page-tab="users"]');
@@ -38,6 +39,7 @@ module(moduleName, hooks => {
         assert.dom('[data-test-page-tab="users"]').hasClass('active', 'Users tab is active');
         assert.dom('[data-test-link-to-reports-archive]').exists('Link to download prior reports exists');
         assert.dom('[data-test-download-dropdown]').exists('Link to download file formats');
+        assert.dom('[data-test-user-report-year-month]').exists('User report year month exists');
 
         // Projects tab
         await click('[data-test-page-tab="projects"]');

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -811,6 +811,7 @@ institutions:
             preprints: preprints
         content-placeholder: Content coming soon # Delete this eventually pls
         title: '{institutionName} Dashboard'
+        updated: 'Updated {date}'
         download_past_reports_label: 'Previous reports'
         download_dropdown_label: 'Download data'
         download_csv: 'Download CSV'


### PR DESCRIPTION
-   Ticket: [ENG-6625]
-   Feature flag: n/a

## Purpose
- Add report date to Institutional Dashboard Summary and Users tab

## Summary of Changes
- Add new `reportYearmonth` attribute to `institution-summary-metric` and `insitution-user` models
  - This attribute is a `string` to prevent an issue with the `@attr('date')` transform that would shift the month by one depending on your timezone
- Show this new attribute on the summary and users tab

## Screenshot(s)
- Desktop
![image](https://github.com/user-attachments/assets/e850d85d-f527-45ce-8096-9573bb9cbfbf)
![image](https://github.com/user-attachments/assets/2bced2a3-5c67-4201-8657-5f4194725f0b)
- Mobile
![image](https://github.com/user-attachments/assets/493e91bc-abcb-4a00-8859-b761785c407b)
![image](https://github.com/user-attachments/assets/9ac4aac5-5a29-4baf-9f15-d64c1ac2161f)


<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6625]: https://openscience.atlassian.net/browse/ENG-6625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ