### PR TITLE
[ENG-6447] Update preprint model for versioning

### DIFF
--- a/app/models/preprint.ts
+++ b/app/models/preprint.ts
@@ -70,6 +70,8 @@ export default class PreprintModel extends AbstractNodeModel {
     @attr('string') whyNoData!: string | null;
     @attr('string') whyNoPrereg!: string | null;
     @attr('string') preregLinkInfo!: PreprintPreregLinkInfoEnum;
+    @attr('number') preprintVersion!: number;
+    @attr('boolean') isLatestVersion!: boolean;
 
     @belongsTo('node', { inverse: 'preprints' })
     node!: AsyncBelongsTo<NodeModel> & NodeModel;
@@ -106,6 +108,9 @@ export default class PreprintModel extends AbstractNodeModel {
 
     @hasMany('identifiers')
     identifiers!: AsyncHasMany<IdentifierModel>;
+
+    @hasMany('preprint', { inverse: null })
+    versions!: AsyncHasMany<PreprintModel>;
 
     @alias('links.doi') articleDoiUrl!: string | null;
     @alias('links.preprint_doi') preprintDoiUrl!: string;

--- a/app/preprints/detail/route.ts
+++ b/app/preprints/detail/route.ts
@@ -76,6 +76,7 @@ export default class PreprintsDetail extends Route {
             const license = await preprint?.get('license');
 
             const subjects = await preprint?.queryHasMany('subjects');
+            const versions = await preprint?.queryHasMany('versions');
 
             return {
                 preprint,
@@ -85,6 +86,7 @@ export default class PreprintsDetail extends Route {
                 primaryFile,
                 license,
                 subjects,
+                versions,
             };
 
         } catch (error) {

--- a/app/serializers/preprint.ts
+++ b/app/serializers/preprint.ts
@@ -1,6 +1,19 @@
+import Model from '@ember-data/model';
+import { Resource } from 'osf-api';
+
 import OsfSerializer from './osf-serializer';
 
 export default class PreprintSerializer extends OsfSerializer {
+    normalize(modelClass: Model, resourceHash: Resource) {
+        const result = super.normalize(modelClass, resourceHash);
+        // Insert a `versions` relationship to the model
+        result.data.relationships!.versions = {
+            links: {
+                related: resourceHash.links!.preprint_versions!,
+            },
+        };
+        return result;
+    }
 }
 
 declare module 'ember-data/types/registries/serializer' {

--- a/mirage/config.ts
+++ b/mirage/config.ts
@@ -51,7 +51,7 @@ import {
 import { updatePassword } from './views/user-password';
 import * as userSettings from './views/user-setting';
 import * as wb from './views/wb';
-import { createPreprint } from './views/preprint';
+import { createPreprint, getPreprintVersions } from './views/preprint';
 
 const { OSF: { apiUrl, shareBaseUrl, url: osfUrl } } = config;
 
@@ -354,6 +354,9 @@ export default function(this: Server) {
         const id = request.params.id;
         return schema.preprints.find(id);
     });
+
+    this.get('/preprints/:id/versions', getPreprintVersions);
+    // TODO: add post view
 
     osfNestedResource(this, 'preprint', 'contributors', {
         path: '/preprints/:parentID/contributors/',

--- a/mirage/factories/preprint.ts
+++ b/mirage/factories/preprint.ts
@@ -78,7 +78,7 @@ export default Factory.extend<PreprintMirageModel & PreprintTraits>({
     dateWithdrawn: null,
 
     doi: null,
-    preprintVersion: 0,
+    preprintVersion: 1,
     isLatestVersion: true,
 
     tags() {
@@ -245,7 +245,7 @@ export default Factory.extend<PreprintMirageModel & PreprintTraits>({
     withVersions: trait<PreprintModel>({
         afterCreate(preprint, server) {
             const baseId = preprint.id;
-            const versionedPreprints = [0, 1, 2, 3].map((version: number) => {
+            const versionedPreprints = [1, 2, 3].map((version: number) => {
                 server.create('preprint', {
                     title: preprint.title,
                     description: preprint.description,

--- a/mirage/factories/preprint.ts
+++ b/mirage/factories/preprint.ts
@@ -32,6 +32,7 @@ export interface PreprintTraits {
     rejectedWithdrawalNoComment: Trait;
     reviewAction: Trait;
     withAffiliatedInstitutions: Trait;
+    withVersions: Trait;
 }
 
 export default Factory.extend<PreprintMirageModel & PreprintTraits>({
@@ -77,6 +78,8 @@ export default Factory.extend<PreprintMirageModel & PreprintTraits>({
     dateWithdrawn: null,
 
     doi: null,
+    preprintVersion: 0,
+    isLatestVersion: true,
 
     tags() {
         return faker.lorem.words(5).split(' ');
@@ -236,6 +239,23 @@ export default Factory.extend<PreprintMirageModel & PreprintTraits>({
             institutions.models.push(osfInstitution);
             currentUser.update({institutions});
             preprint.update({ affiliatedInstitutions });
+        },
+    }),
+
+    withVersions: trait<PreprintModel>({
+        afterCreate(preprint, server) {
+            const baseId = preprint.id;
+            const versionedPreprints = [0, 1, 2, 3].map((version: number) => {
+                server.create('preprint', {
+                    title: preprint.title,
+                    description: preprint.description,
+                    provider: preprint.provider,
+                    id: `${baseId}_v${version}`,
+                    preprintVersion: version,
+                    isLatestVersion: version === 3,
+                });
+            });
+            preprint.provider.update({ preprints: versionedPreprints });
         },
     }),
 

--- a/mirage/scenarios/preprints.ts
+++ b/mirage/scenarios/preprints.ts
@@ -234,6 +234,15 @@ function buildOSF(
         hasPreregLinks: PreprintPreregLinksEnum.NOT_APPLICABLE,
     });
 
+    const versionedPreprint = server.create('preprint', {
+        provider: osf,
+        id: 'versioned-preprint',
+        title: 'Versioned Preprint',
+        currentUserPermissions: Object.values(Permission),
+        reviewsState: ReviewsState.ACCEPTED,
+        isPublished: true,
+    }, 'withVersions');
+
     const subjects = server.createList('subject', 7);
 
     osf.update({
@@ -264,6 +273,7 @@ function buildOSF(
             acceptedWithdrawalPreprintComment,
             notContributorPreprint,
             publicDoiPreprint,
+            versionedPreprint,
         ],
         description: 'This is the description for osf',
     });

--- a/mirage/serializers/preprint.ts
+++ b/mirage/serializers/preprint.ts
@@ -11,6 +11,7 @@ export default class PreprintSerializer extends ApplicationSerializer<PreprintMi
             self: `${apiUrl}/v2/preprints/${model.id}/`,
             doi: model.doi ?  `https://doi.org/${model.doi}` : null,
             preprint_doi: model.isPreprintDoi ? `https://doi.org/10.31219/osf.io/${model.id}` : null,
+            preprint_versions: `${apiUrl}/v2/preprints/${model.id}/versions/`,
         };
     }
 

--- a/mirage/views/preprint.ts
+++ b/mirage/views/preprint.ts
@@ -4,6 +4,7 @@ import PreprintModel from 'ember-osf-web/models/preprint';
 import faker from 'faker';
 
 import { guid } from '../factories/utils';
+import { process } from './utils';
 
 
 export function createPreprint(this: HandlerContext, schema: Schema) {
@@ -35,6 +36,8 @@ export function createPreprint(this: HandlerContext, schema: Schema) {
         subjects: [],
         tags: [] as string[] ,
         currentUserPermission: [Permission.Admin, Permission.Read, Permission.Write],
+        versionNumber: 0,
+        isLatestVersion: true,
     };
     const preprint = schema.preprints.create(attrs) as ModelInstance<PreprintModel>;
 
@@ -80,4 +83,13 @@ export function updatePreprint(this: HandlerContext, schema: Schema, request: Re
     }
     resource.update(attributes);
     return this.serialize(resource);
+}
+
+export function getPreprintVersions(this: HandlerContext, schema: Schema) {
+    const preprintId = this.request.params.id as string;
+    const baseId = preprintId.split('_v')[0]; // assumes preprint id is of the form <baseId>_v<versionNumber>
+    const preprints = schema.preprints.all().models
+        .filter((preprint: ModelInstance<PreprintModel>) => preprint.id !== baseId && preprint.id.includes(baseId));
+    return process(schema, this.request, this,
+        preprints.map((preprint: ModelInstance) => this.serialize(preprint).data));
 }

--- a/mirage/views/preprint.ts
+++ b/mirage/views/preprint.ts
@@ -36,7 +36,7 @@ export function createPreprint(this: HandlerContext, schema: Schema) {
         subjects: [],
         tags: [] as string[] ,
         currentUserPermission: [Permission.Admin, Permission.Read, Permission.Write],
-        versionNumber: 0,
+        versionNumber: 1,
         isLatestVersion: true,
     };
     const preprint = schema.preprints.create(attrs) as ModelInstance<PreprintModel>;

--- a/types/osf-api.d.ts
+++ b/types/osf-api.d.ts
@@ -96,5 +96,6 @@ export interface NormalLinks extends JSONAPI.Links {
     self?: JSONAPI.Link;
     html?: JSONAPI.Link;
     iri?: JSONAPI.Link;
+    preprint_versions?: JSONAPI.Link;
 }
 /* eslint-enable camelcase */


### PR DESCRIPTION
-   Ticket: [ENG-6447]
-   Feature flag: n/a

## Purpose
- Update the Preprint model to add new version-specific fields

## Summary of Changes
- Add new `preprintVersion` and `isLatestVersion` attrs to Preprint
- Add new `versions` relationship to Preprint
  - This won't be returned from the API, but the preprint response should have a `preprint_version` URL that can be used to get versions, hence the chicanery with the preprint-serializer
- Add new mirage view to handle fetching versions
- Add new trait to preprint factory to quickly create versions for a given preprint

## Screenshot(s)
- This is the mirage request/response made when accessing the detail page of a preprint with versions
![image](https://github.com/user-attachments/assets/b38fcc2a-87d3-4eaf-9583-0712c5710814)

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6447]: https://openscience.atlassian.net/browse/ENG-6447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ