### PR TITLE
[ENG-6448] Update preprint-doi component to handle versions

### DIFF
--- a/app/preprints/-components/preprint-doi/component.ts
+++ b/app/preprints/-components/preprint-doi/component.ts
@@ -1,14 +1,22 @@
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import PreprintModel from 'ember-osf-web/models/preprint';
 import PreprintProviderModel from 'ember-osf-web/models/preprint-provider';
 
 interface InputArgs {
-    preprint: PreprintModel;
+    versions: PreprintModel[];
     provider: PreprintProviderModel;
 }
 
 export default class PreprintAbstract extends Component<InputArgs> {
     provider = this.args.provider;
+    documentType = this.provider.documentType.singularCapitalized;
 
-    documentType = this.provider.documentType.singular;
+    @tracked selectedVersion = this.args.versions[0];
+
+    @action
+    selectVersion(version: PreprintModel) {
+        this.selectedVersion = version;
+    }
 }

--- a/app/preprints/-components/preprint-doi/styles.scss
+++ b/app/preprints/-components/preprint-doi/styles.scss
@@ -1,0 +1,4 @@
+.version-dropdown {
+    margin-bottom: 12px;
+    width: 120px;
+}

--- a/app/preprints/-components/preprint-doi/template.hbs
+++ b/app/preprints/-components/preprint-doi/template.hbs
@@ -1,23 +1,48 @@
 <div>
-    <h4>{{t 'preprints.detail.preprint_doi' documentType=this.documentType}}</h4>
-    {{#if @preprint.preprintDoiUrl}}
-        {{#if @preprint.preprintDoiCreated}}
-            <OsfLink
-                data-test-article-doi
-                data-analytics-name='preprint doi'
-                @href={{@preprint.preprintDoiUrl}} 
+    <h4 data-test-preprint-doi-heading>
+        {{t 'preprints.detail.preprint_doi' documentType=this.documentType}}
+    </h4>
+    {{#if @versions}}
+        <PowerSelect
+            data-test-version-select-dropdown
+            @options={{@versions}}
+            @selected={{this.selectedVersion}}
+            @onChange={{this.selectVersion}}
+            as |version|
+        >
+            <span
+                data-test-preprint-version={{version.preprintVersion}}
             >
-                {{@preprint.preprintDoiUrl}}
-            </OsfLink>
-        {{else}}
-            <p> {{@preprint.preprintDoiUrl}} </p>
-            <p> {{t 'preprints.detail.preprint_pending_doi_minted'}} </p>
-        {{/if}}
+                {{t 'preprints.detail.version_doi_title' number=version.preprintVersion}}
+            </span>
+        </PowerSelect>
     {{else}}
-        {{#if (not @preprint.public)}}
-            {{t 'preprints.detail.preprint_pending_doi' documentType=this.documentType}}
-        {{else if (and this.provider.reviewsWorkflow (not this.preprint.isPublished))}}
-            {{t 'preprints.detail.preprint_pending_doi_moderation'}}
+        <p>{{t 'preprints.detail.no_versions'}}</p>
+    {{/if}}
+    {{#if this.selectedVersion}}
+        {{#if this.selectedVersion.preprintDoiUrl}}
+            {{#if this.selectedVersion.preprintDoiCreated}}
+                <OsfLink
+                    data-test-linked-doi-url
+                    data-analytics-name='preprint doi'
+                    @href={{this.selectedVersion.preprintDoiUrl}}
+                >
+                    {{this.selectedVersion.preprintDoiUrl}}
+                </OsfLink>
+            {{else}}
+                <p data-test-unlinked-doi-url> {{this.selectedVersion.preprintDoiUrl}} </p>
+                <p data-test-unlinked-doi-description> {{t 'preprints.detail.preprint_pending_doi_minted'}} </p>
+            {{/if}}
+        {{else}}
+            <p data-test-no-doi-text>
+                {{#if (not this.selectedVersion.public)}}
+                    {{t 'preprints.detail.preprint_pending_doi' documentType=this.documentType}}
+                {{else if (and this.provider.reviewsWorkflow (not this.preprint.isPublished))}}
+                    {{t 'preprints.detail.preprint_pending_doi_moderation'}}
+                {{else}}
+                    {{t 'preprints.detail.no_doi'}}
+                {{/if}}
+            </p>
         {{/if}}
     {{/if}}
 </div>

--- a/app/preprints/-components/preprint-doi/template.hbs
+++ b/app/preprints/-components/preprint-doi/template.hbs
@@ -5,6 +5,7 @@
     {{#if @versions}}
         <PowerSelect
             data-test-version-select-dropdown
+            local-class='version-dropdown'
             @options={{@versions}}
             @selected={{this.selectedVersion}}
             @onChange={{this.selectVersion}}

--- a/app/preprints/detail/template.hbs
+++ b/app/preprints/detail/template.hbs
@@ -181,7 +181,10 @@
                             </OsfLink>
                         </div>
                     {{/if}}
-                    <Preprints::-Components::PreprintDoi @preprint={{this.model.preprint}} @provider={{this.model.provider}} />
+                    <Preprints::-Components::PreprintDoi
+                        @versions={{this.model.versions}}
+                        @provider={{this.model.provider}}
+                    />
                     {{#if this.model.preprint.articleDoiUrl}}
                         <div>
                             <h4>{{t 'preprints.detail.article_doi'}}</h4>

--- a/mirage/factories/preprint.ts
+++ b/mirage/factories/preprint.ts
@@ -255,7 +255,9 @@ export default Factory.extend<PreprintMirageModel & PreprintTraits>({
                     isLatestVersion: version === 3,
                 });
             });
-            preprint.provider.update({ preprints: versionedPreprints });
+            if (preprint.provider) {
+                preprint.provider.update({ preprints: versionedPreprints });
+            }
         },
     }),
 

--- a/mirage/views/preprint.ts
+++ b/mirage/views/preprint.ts
@@ -90,6 +90,7 @@ export function getPreprintVersions(this: HandlerContext, schema: Schema) {
     const baseId = preprintId.split('_v')[0]; // assumes preprint id is of the form <baseId>_v<versionNumber>
     const preprints = schema.preprints.all().models
         .filter((preprint: ModelInstance<PreprintModel>) => preprint.id !== baseId && preprint.id.includes(baseId));
+    const versions = preprints.sortBy('versionNumber').reverse();
     return process(schema, this.request, this,
-        preprints.map((preprint: ModelInstance) => this.serialize(preprint).data));
+        versions.map((version: ModelInstance) => this.serialize(version).data));
 }

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1431,8 +1431,10 @@ preprints:
         original_publication_date: 'Original Publication Date'
         orphan_preprint: 'The user has removed this file.'
         preprint_doi: '{documentType} DOI'
+        version_doi_title: 'Version {number}'
         preprint_pending_doi: 'DOI created after {documentType} is made public'
         preprint_pending_doi_moderation: 'DOI created after moderator approval'
+        no_doi: 'No DOI'
         preprint_pending_doi_minted: 'DOIs are minted by a third party, and may take up to 24 hours to be registered.'
         private_preprint_warning: 'This {documentType} is private. Contact {supportEmail} if this is in error.'
         project_button:


### PR DESCRIPTION
-   Ticket: [ENG-6448]
-   Feature flag: n/a

## Purpose
- Update preprint-doi component to handle versions

## Summary of Changes
- Update Preprints::PreprintDoi component 
  - Takes an array of versions, rather than a single preprint
  - Add dropdown to select a specific version
  - Tests

## Screenshot(s)
- Example of a preprint with a fully minted DOI (from tests, so that's why the background is weird):
![image](https://github.com/user-attachments/assets/e244a073-812b-472e-9e17-03958aa9a247)


- Example of a preprint that has a DOI, but it is pending:
![image](https://github.com/user-attachments/assets/41cd5eac-d30c-4cb9-b098-dcad6be0f9d6)
- Example of preprint with no DOI due to it pending moderation (from tests, so that's why the background is weird)

![image](https://github.com/user-attachments/assets/2bfba19f-601b-4302-98c5-39c0f7a4f441)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6448]: https://openscience.atlassian.net/browse/ENG-6448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ