### PR TITLE
[ENG-6665] Add user messaging modal to user's tab on institutional dashboard

### DIFF
--- a/app/adapters/user-message.ts
+++ b/app/adapters/user-message.ts
@@ -1,0 +1,13 @@
+// app/adapters/user-message.js
+import { inject as service } from '@ember/service';
+import config from 'ember-osf-web/config/environment';
+const { OSF: { apiUrl } } = config;
+import OsfAdapter from './osf-adapter';
+
+export default class UserMessageAdapter extends OsfAdapter {
+    @service session;
+    urlForCreateRecord(modelName, snapshot) {
+        const userId = snapshot.record.user;
+        return `${apiUrl}/v2/users/${userId}/messages/`;
+    }
+}

--- a/app/institutions/dashboard/-components/institutional-users-list/component.ts
+++ b/app/institutions/dashboard/-components/institutional-users-list/component.ts
@@ -260,10 +260,12 @@ export default class InstitutionalUsersList extends Component<InstitutionalUsers
         }
     }
 
+    @action
     resetModalFields() {
         this.messageText = '';
         this.cc = false;
         this.replyTo = false;
+        this.selectedUserId = null;
     }
 
     @action
@@ -300,9 +302,9 @@ export default class InstitutionalUsersList extends Component<InstitutionalUsers
             });
 
             await userMessage.save();
-            this.toast.success(this.intl.t('success.message_sent'));
+            this.toast.success(this.intl.t('institutions.dashboard.send_message_modal.message_sent_success'));
         } catch (error) {
-            this.toast.error(this.intl.t('error.message_failed'));
+            this.toast.error(this.intl.t('institutions.dashboard.send_message_modal.message_sent_failed'));
         } finally {
             this.messageModalShown = false;
         }

--- a/app/institutions/dashboard/-components/institutional-users-list/component.ts
+++ b/app/institutions/dashboard/-components/institutional-users-list/component.ts
@@ -1,3 +1,4 @@
+import { task } from 'ember-concurrency';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
@@ -255,7 +256,8 @@ export default class InstitutionalUsersList extends Component<InstitutionalUsers
         this.messageText = (event.target as HTMLTextAreaElement).value;
     }
 
-    @action
+    @task
+    @waitFor
     async sendMessage() {
         if (!this.selectedUserId || !this.messageText.trim()) {
             return;

--- a/app/institutions/dashboard/-components/institutional-users-list/component.ts
+++ b/app/institutions/dashboard/-components/institutional-users-list/component.ts
@@ -252,14 +252,40 @@ export default class InstitutionalUsersList extends Component<InstitutionalUsers
     }
 
     @action
+    toggleMessageModal(userId: string | null = null) {
+        this.messageModalShown = !this.messageModalShown;
+        this.selectedUserId = userId;
+        if (!this.messageModalShown) {
+            this.resetModalFields();
+        }
+    }
+
+    resetModalFields() {
+        this.messageText = '';
+        this.cc = false;
+        this.replyTo = false;
+    }
+
+    @action
     updateMessageText(event: Event) {
         this.messageText = (event.target as HTMLTextAreaElement).value;
+    }
+
+    @action
+    toggleCc() {
+        this.cc = !this.cc;
+    }
+
+    @action
+    toggleReplyTo() {
+        this.replyTo = !this.replyTo;
     }
 
     @task
     @waitFor
     async sendMessage() {
-        if (!this.selectedUserId || !this.messageText.trim()) {
+        if (!this.messageText.trim()) {
+            this.toast.error(this.intl.t('error.empty_message'));
             return;
         }
 
@@ -267,16 +293,18 @@ export default class InstitutionalUsersList extends Component<InstitutionalUsers
             const userMessage = this.store.createRecord('user-message', {
                 messageText: this.messageText.trim(),
                 messageType: 'institutional_request',
+                cc: this.cc,
+                replyTo: this.replyTo,
                 institution: this.args.institution,
                 user: this.selectedUserId,
             });
+
             await userMessage.save();
-            this.toast.success(this.intl.t('institutions.dashboard.send_message_modal.message_sent_success'));
+            this.toast.success(this.intl.t('success.message_sent'));
         } catch (error) {
-            this.toast.error(this.intl.t('institutions.dashboard.send_message_modal.message_sent_failed'));
+            this.toast.error(this.intl.t('error.message_failed'));
         } finally {
             this.messageModalShown = false;
-            this.messageText = '';
         }
     }
 }

--- a/app/institutions/dashboard/-components/institutional-users-list/component.ts
+++ b/app/institutions/dashboard/-components/institutional-users-list/component.ts
@@ -11,6 +11,7 @@ import InstitutionModel from 'ember-osf-web/models/institution';
 import InstitutionDepartmentsModel from 'ember-osf-web/models/institution-department';
 import Analytics from 'ember-osf-web/services/analytics';
 import { RelationshipWithLinks } from 'osf-api';
+import {MessageTypeChoices} from 'ember-osf-web/models/user-message';
 
 interface Column {
     key: string;
@@ -319,7 +320,7 @@ export default class InstitutionalUsersList extends Component<InstitutionalUsers
         try {
             const userMessage = this.store.createRecord('user-message', {
                 messageText: this.messageText.trim(),
-                messageType: 'institutional_request',
+                messageType: MessageTypeChoices.InstitutionalRequest,
                 cc: this.cc,
                 replyTo: this.replyTo,
                 institution: this.args.institution,

--- a/app/institutions/dashboard/-components/institutional-users-list/component.ts
+++ b/app/institutions/dashboard/-components/institutional-users-list/component.ts
@@ -43,6 +43,8 @@ export default class InstitutionalUsersList extends Component<InstitutionalUsers
     @tracked filteredUsers = [];
     @tracked messageModalShown = false;
     @tracked messageText = '';
+    @tracked bcc_sender = false;
+    @tracked replyTo = false;
     @tracked selectedUserId = null;
     @service toast!: Toast;
 
@@ -289,24 +291,9 @@ export default class InstitutionalUsersList extends Component<InstitutionalUsers
     @action
     resetModalFields() {
         this.messageText = '';
-        this.cc = false;
+        this.bcc_sender = false;
         this.replyTo = false;
         this.selectedUserId = null;
-    }
-
-    @action
-    updateMessageText(event: Event) {
-        this.messageText = (event.target as HTMLTextAreaElement).value;
-    }
-
-    @action
-    toggleCc() {
-        this.cc = !this.cc;
-    }
-
-    @action
-    toggleReplyTo() {
-        this.replyTo = !this.replyTo;
     }
 
     @task
@@ -321,7 +308,7 @@ export default class InstitutionalUsersList extends Component<InstitutionalUsers
             const userMessage = this.store.createRecord('user-message', {
                 messageText: this.messageText.trim(),
                 messageType: MessageTypeChoices.InstitutionalRequest,
-                cc: this.cc,
+                bcc_sender: this.bcc_sender,
                 replyTo: this.replyTo,
                 institution: this.args.institution,
                 user: this.selectedUserId,

--- a/app/institutions/dashboard/-components/institutional-users-list/styles.scss
+++ b/app/institutions/dashboard/-components/institutional-users-list/styles.scss
@@ -330,3 +330,17 @@ input:checked + .slider::before {
 .message-label {
     display: block;
 }
+
+.checkbox-container {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 10px;
+}
+
+.checkbox-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+}

--- a/app/institutions/dashboard/-components/institutional-users-list/styles.scss
+++ b/app/institutions/dashboard/-components/institutional-users-list/styles.scss
@@ -326,3 +326,7 @@ input:checked + .slider::before {
     min-width: 450px;
     min-height: 280px;
 }
+
+.message-label {
+    display: block;
+}

--- a/app/institutions/dashboard/-components/institutional-users-list/styles.scss
+++ b/app/institutions/dashboard/-components/institutional-users-list/styles.scss
@@ -306,3 +306,23 @@ input:checked + .slider::before {
     justify-content: flex-end;
     margin-right: 15px;
 }
+
+
+.icon-message {
+    opacity: 0;
+    color: $color-text-blue-dark;
+    /* !important used to override ember Button border scripting  */
+    background-color: inherit !important;
+    border: 0 !important;
+    box-shadow: 0 !important;
+}
+
+.icon-message:hover {
+    opacity: 1;
+    background-color: inherit !important;
+}
+
+.message-textarea {
+    min-width: 450px;
+    min-height: 280px;
+}

--- a/app/institutions/dashboard/-components/institutional-users-list/template.hbs
+++ b/app/institutions/dashboard/-components/institutional-users-list/template.hbs
@@ -206,12 +206,12 @@
                 <label for='message-text' local-class='message-label'>
                     {{t 'institutions.dashboard.send_message_modal.opening_message_label'}}
                 </label>
-                <textarea
+                <Textarea
                     id='message-text'
                     local-class='message-textarea'
-                    value={{this.messageText}}
-                    {{on 'input' this.updateMessageText}}
-                ></textarea>
+                    @value={{this.messageText}}
+                >
+                </Textarea>
                 <div>
                     {{t 'institutions.dashboard.send_message_modal.closing_message_label' adminName=this.currentUser.user.fullName}}
                 </div>

--- a/app/institutions/dashboard/-components/institutional-users-list/template.hbs
+++ b/app/institutions/dashboard/-components/institutional-users-list/template.hbs
@@ -203,9 +203,9 @@
         </dialog.heading>
         <dialog.main>
             <div >
-                <div for='message-text'>
+                <label for='message-text' local-class="message-label">
                     {{t 'institutions.dashboard.send_message_modal.opening_message_label'}}
-                </div>
+                </label>
                 <textarea
                     id='message-text'
                     local-class='message-textarea'

--- a/app/institutions/dashboard/-components/institutional-users-list/template.hbs
+++ b/app/institutions/dashboard/-components/institutional-users-list/template.hbs
@@ -156,6 +156,12 @@
                             <OsfLink @href={{concat '/' institutionalUser.userGuid '/'}}>
                                 {{institutionalUser.userName}}
                             </OsfLink>
+                            <Button
+                                local-class='icon-message'
+                                {{on 'click' (fn this.openMessageModal institutionalUser.userGuid)}}
+                            >
+                                <FaIcon @icon='comment' />
+                            </Button>
                         {{else if (eq column.type 'osf_link')}}
                             <OsfLink @href={{concat '/' institutionalUser.userGuid '/'}}>
                                 {{institutionalUser.userGuid}}
@@ -185,4 +191,44 @@
             {{t 'institutions.dashboard.users_list.empty'}}
         </list.empty>
     </PaginatedList::HasMany>
+    <OsfDialog
+        @isOpen={{this.messageModalShown}}
+        @onClose={{fn (mut this.messageModalShown) false}}
+        as |dialog|
+    >
+        <dialog.heading>
+            {{t 'institutions.dashboard.send_message_modal.title'}}
+        </dialog.heading>
+        <dialog.main>
+            <div >
+                <div for='message-text'>
+                    {{t 'institutions.dashboard.send_message_modal.opening_message_label'}}
+                </div>
+                <textarea
+                    id='message-text'
+                    local-class='message-textarea'
+                    value={{this.messageText}}
+                    {{on 'input' this.updateMessageText}}
+                ></textarea>
+                <div>
+                    {{t 'institutions.dashboard.send_message_modal.closing_message_label' adminName=this.currentUser.user.fullName}}
+                </div>
+            </div>
+        </dialog.main>
+        <dialog.footer>
+            <Button
+                @type='secondary'
+                {{on 'click' (fn (mut this.messageModalShown) false)}}
+            >
+                {{t 'general.cancel'}}
+            </Button>
+            <Button
+                @type='primary'
+                @disabled={{not this.messageText}}
+                {{on 'click' (queue this.sendMessage dialog.close)}}
+            >
+                {{t 'institutions.dashboard.send_message_modal.send'}}
+            </Button>
+        </dialog.footer>
+    </OsfDialog>
 {{/if}}

--- a/app/institutions/dashboard/-components/institutional-users-list/template.hbs
+++ b/app/institutions/dashboard/-components/institutional-users-list/template.hbs
@@ -207,6 +207,9 @@
                   local-class='message-textarea'
                   @value={{this.messageText}}
                 />
+                <div>
+                    {{t 'institutions.dashboard.send_message_modal.closing_message_label' adminName=this.currentUser.user.fullName htmlSafe=true}}
+                </div>
                 <div local-class='checkbox-container'>
                     <label local-class='checkbox-item'>
                         <input type='checkbox' checked={{this.cc}} {{on 'change' this.toggleCc}} />
@@ -216,9 +219,6 @@
                         <input type='checkbox' checked={{this.replyTo}} {{on 'change' this.toggleReplyTo}} />
                         {{t 'institutions.dashboard.send_message_modal.reply_to_label'}}
                     </label>
-                </div>
-                <div>
-                    {{t 'institutions.dashboard.send_message_modal.closing_message_label' adminName=this.currentUser.user.fullName}}
                 </div>
             </div>
         </dialog.main>

--- a/app/institutions/dashboard/-components/institutional-users-list/template.hbs
+++ b/app/institutions/dashboard/-components/institutional-users-list/template.hbs
@@ -193,25 +193,30 @@
             {{t 'institutions.dashboard.users_list.empty'}}
         </list.empty>
     </PaginatedList::HasMany>
-    <OsfDialog
-        @isOpen={{this.messageModalShown}}
-        @onClose={{fn (mut this.messageModalShown) false}}
-        as |dialog|
-    >
+    <OsfDialog @isOpen={{this.messageModalShown}} @onClose={{this.toggleMessageModal}} as |dialog|>
         <dialog.heading>
             {{t 'institutions.dashboard.send_message_modal.title'}}
         </dialog.heading>
         <dialog.main>
-            <div >
+            <div>
                 <label for='message-text' local-class='message-label'>
                     {{t 'institutions.dashboard.send_message_modal.opening_message_label'}}
                 </label>
                 <Textarea
-                    id='message-text'
-                    local-class='message-textarea'
-                    @value={{this.messageText}}
-                >
-                </Textarea>
+                  id='message-text'
+                  local-class='message-textarea'
+                  @value={{this.messageText}}
+                />
+                <div local-class='checkbox-container'>
+                    <label local-class='checkbox-item'>
+                        <input type='checkbox' checked={{this.cc}} {{on 'change' this.toggleCc}} />
+                        {{t 'institutions.dashboard.send_message_modal.cc_label'}}
+                    </label>
+                    <label local-class='checkbox-item'>
+                        <input type='checkbox' checked={{this.replyTo}} {{on 'change' this.toggleReplyTo}} />
+                        {{t 'institutions.dashboard.send_message_modal.reply_to_label'}}
+                    </label>
+                </div>
                 <div>
                     {{t 'institutions.dashboard.send_message_modal.closing_message_label' adminName=this.currentUser.user.fullName}}
                 </div>
@@ -219,16 +224,14 @@
         </dialog.main>
         <dialog.footer>
             <Button
-                aria-label={{t 'institutions.dashboard.send_message_modal.close_aira_label'}}
                 @type='secondary'
-                {{on 'click' (fn (mut this.messageModalShown) false)}}
+                {{on 'click' this.toggleMessageModal}}
             >
                 {{t 'general.cancel'}}
             </Button>
             <Button
-                aria-label={{t 'institutions.dashboard.send_message_modal.send_aira_label'}}
                 @type='primary'
-                @disabled={{not this.messageText}}
+                @disabled={{not this.messageText.trim}}
                 {{on 'click' (queue (perform this.sendMessage) dialog.close)}}
             >
                 {{t 'institutions.dashboard.send_message_modal.send'}}

--- a/app/institutions/dashboard/-components/institutional-users-list/template.hbs
+++ b/app/institutions/dashboard/-components/institutional-users-list/template.hbs
@@ -203,7 +203,7 @@
         </dialog.heading>
         <dialog.main>
             <div >
-                <label for='message-text' local-class="message-label">
+                <label for='message-text' local-class='message-label'>
                     {{t 'institutions.dashboard.send_message_modal.opening_message_label'}}
                 </label>
                 <textarea
@@ -229,7 +229,7 @@
                 aria-label={{t 'institutions.dashboard.send_message_modal.send_aira_label'}}
                 @type='primary'
                 @disabled={{not this.messageText}}
-                {{on 'click' (queue this.sendMessage dialog.close)}}
+                {{on 'click' (queue (perform this.sendMessage) dialog.close)}}
             >
                 {{t 'institutions.dashboard.send_message_modal.send'}}
             </Button>

--- a/app/institutions/dashboard/-components/institutional-users-list/template.hbs
+++ b/app/institutions/dashboard/-components/institutional-users-list/template.hbs
@@ -231,11 +231,11 @@
                 </div>
                 <div local-class='checkbox-container'>
                     <label local-class='checkbox-item'>
-                        <input type='checkbox' checked={{this.cc}} {{on 'change' this.toggleCc}} />
+                        <Input @type='checkbox' @checked={{this.bcc_sender}} />
                         {{t 'institutions.dashboard.send_message_modal.cc_label'}}
                     </label>
                     <label local-class='checkbox-item'>
-                        <input type='checkbox' checked={{this.replyTo}} {{on 'change' this.toggleReplyTo}} />
+                        <Input @type='checkbox' @checked={{this.replyTo}} />
                         {{t 'institutions.dashboard.send_message_modal.reply_to_label'}}
                     </label>
                 </div>
@@ -252,7 +252,6 @@
                 @type='primary'
                 @disabled={{not this.messageText.trim}}
                 {{on 'click' (queue (perform this.sendMessage))}}
-                {{on 'click' this.toggleMessageModal}}
 
             >
                 {{t 'institutions.dashboard.send_message_modal.send'}}

--- a/app/institutions/dashboard/-components/institutional-users-list/template.hbs
+++ b/app/institutions/dashboard/-components/institutional-users-list/template.hbs
@@ -232,7 +232,9 @@
             <Button
                 @type='primary'
                 @disabled={{not this.messageText.trim}}
-                {{on 'click' (queue (perform this.sendMessage) dialog.close)}}
+                {{on 'click' (queue (perform this.sendMessage))}}
+                {{on 'click' this.toggleMessageModal}}
+
             >
                 {{t 'institutions.dashboard.send_message_modal.send'}}
             </Button>

--- a/app/institutions/dashboard/-components/institutional-users-list/template.hbs
+++ b/app/institutions/dashboard/-components/institutional-users-list/template.hbs
@@ -158,6 +158,8 @@
                             </OsfLink>
                             <Button
                                 local-class='icon-message'
+                                aria-label={{t 'institutions.dashboard.send_message_modal.open_aira_label'}}
+
                                 {{on 'click' (fn this.openMessageModal institutionalUser.userGuid)}}
                             >
                                 <FaIcon @icon='comment' />
@@ -217,12 +219,14 @@
         </dialog.main>
         <dialog.footer>
             <Button
+                aria-label={{t 'institutions.dashboard.send_message_modal.close_aira_label'}}
                 @type='secondary'
                 {{on 'click' (fn (mut this.messageModalShown) false)}}
             >
                 {{t 'general.cancel'}}
             </Button>
             <Button
+                aria-label={{t 'institutions.dashboard.send_message_modal.send_aira_label'}}
                 @type='primary'
                 @disabled={{not this.messageText}}
                 {{on 'click' (queue this.sendMessage dialog.close)}}

--- a/app/models/user-message.ts
+++ b/app/models/user-message.ts
@@ -4,5 +4,5 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 export default class UserMessageModel extends Model {
     @attr('string') messageText;
     @attr('string') messageType;
-    @belongsTo('institution') institution;
+    @belongsTo('institution') institution: AsyncBelongsTo<InstitutionModel> & InstitutionModel;
 }

--- a/app/models/user-message.ts
+++ b/app/models/user-message.ts
@@ -1,0 +1,8 @@
+// app/models/user-message.js
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class UserMessageModel extends Model {
+    @attr('string') messageText;
+    @attr('string') messageType;
+    @belongsTo('institution') institution;
+}

--- a/app/models/user-message.ts
+++ b/app/models/user-message.ts
@@ -9,7 +9,7 @@ export enum MessageTypeChoices {
 export default class UserMessageModel extends Model {
   @attr('string') messageText;
   @attr('string') messageType: MessageTypeChoices;
-  @attr('boolean') cc;
+  @attr('boolean') bcc_sender;
   @attr('boolean') replyTo;
   @belongsTo('institution') institution;
 }

--- a/app/models/user-message.ts
+++ b/app/models/user-message.ts
@@ -2,7 +2,9 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class UserMessageModel extends Model {
-    @attr('string') messageText;
-    @attr('string') messageType;
-    @belongsTo('institution') institution: AsyncBelongsTo<InstitutionModel> & InstitutionModel;
+  @attr('string') messageText;
+  @attr('string') messageType;
+  @attr('boolean') cc;
+  @attr('boolean') replyTo;
+  @belongsTo('institution') institution;
 }

--- a/app/models/user-message.ts
+++ b/app/models/user-message.ts
@@ -1,9 +1,14 @@
 // app/models/user-message.js
 import Model, { attr, belongsTo } from '@ember-data/model';
 
+export enum MessageTypeChoices {
+    InstitutionalRequest = 'institutional_request',
+}
+
+
 export default class UserMessageModel extends Model {
   @attr('string') messageText;
-  @attr('string') messageType;
+  @attr('string') messageType: MessageTypeChoices;
   @attr('boolean') cc;
   @attr('boolean') replyTo;
   @belongsTo('institution') institution;

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -809,6 +809,8 @@ institutions:
           message_sent_success: 'Message has been sent'
           message_sent_failed: 'Message has failed to send. If the issue persists contact your administrator'
           send: 'Send'
+          cc_label: 'CC sender?'
+          reply_to_label: 'allow reply to sender address?'
         tabs:
             summary: Summary
             users: Users

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -800,6 +800,9 @@ institutions:
     load_more: 'Load more institutions'
     dashboard:
         send_message_modal:
+          open_aira_label: 'Open User Message Modal Button'
+          close_aira_label: 'Close User Message Modal Button'
+          send_aira_label: 'Send User Message Button'
           title: 'Send Email'
           opening_message_label: 'Comments:'
           closing_message_label: 'Sincerely Yours, {adminName}'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -805,12 +805,12 @@ institutions:
           send_aira_label: 'Send User Message Button'
           title: 'Send Email'
           opening_message_label: 'Comments:'
-          closing_message_label: 'Sincerely Yours, {adminName}'
+          closing_message_label: 'Sincerely Yours,<br> {adminName}'
           message_sent_success: 'Message has been sent'
           message_sent_failed: 'Message has failed to send. If the issue persists contact your administrator'
           send: 'Send'
-          cc_label: 'CC sender?'
-          reply_to_label: 'allow reply to sender address?'
+          cc_label: 'CC sender'
+          reply_to_label: 'Allow reply to sender address'
         tabs:
             summary: Summary
             users: Users

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -804,7 +804,7 @@ institutions:
           opening_message_label: 'Comments:'
           closing_message_label: 'Sincerely Yours, {adminName}'
           message_sent_success: 'Message has been sent'
-          message_sent_failed: 'Message has failed to send of the issue persists contact your administrator'
+          message_sent_failed: 'Message has failed to send. If the issue persists contact your administrator'
           send: 'Send'
         tabs:
             summary: Summary

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -799,6 +799,13 @@ institutions:
     search_placeholder: 'Search institutions'
     load_more: 'Load more institutions'
     dashboard:
+        send_message_modal:
+          title: 'Send Email'
+          opening_message_label: 'Comments:'
+          closing_message_label: 'Sincerely Yours, {adminName}'
+          message_sent_success: 'Message has been sent'
+          message_sent_failed: 'Message has failed to send of the issue persists contact your administrator'
+          send: 'Send'
         tabs:
             summary: Summary
             users: Users


### PR DESCRIPTION
⚠️ Needs https://github.com/CenterForOpenScience/osf.io/pull/10824 for API usaage.
## Purpose

Adds a modal that allows an institutional admin to send a message through a text input as part of an email template.

## Summary of Changes

- add user-message modal
- modifies component to allow for model logic
- Add modal to template with styling


## Screenshot(s)

<!-- Attach screenshots if applicable. -->
![Screenshot 2024-12-05 at 8 02 44 AM](https://github.com/user-attachments/assets/2c589fbe-cc53-4cd0-a0c8-ce4e88562870)
![Screenshot 2024-12-11 at 2 15 25 PM](https://github.com/user-attachments/assets/ac2ad2a4-5814-4e82-a9da-1a5c1ac948ec)
![Screenshot 2024-12-05 at 8 02 00 AM](https://github.com/user-attachments/assets/febdf3e8-92b5-4d6d-91e2-8a9ff4d688cd)

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
