### PR TITLE
[ENG-6434] Show/hide file upload page on preprint submit workflow

### DIFF
--- a/app/preprints/-components/preprint-provider-selection/template.hbs
+++ b/app/preprints/-components/preprint-provider-selection/template.hbs
@@ -28,6 +28,7 @@
     <div local-class='create-button-container'>
         <Button
             data-test-create-preprints
+            data-analytics-name='Create Preprint'
             local-class='create-button {{if this.isDisabled 'disabled'}}'
             disabled={{this.isDisabled}}
             @type='create'

--- a/app/preprints/-components/submit/preprint-state-machine/status-flow/status-flow-display/template.hbs
+++ b/app/preprints/-components/submit/preprint-state-machine/status-flow/status-flow-display/template.hbs
@@ -1,5 +1,7 @@
 {{#if this.shouldDisplayStatusType}}
-    <div local-class='status-container
+    <div
+        data-test-preprint-submission-step={{this.getStatusTitle}}
+        local-class='status-container
         {{if this.isSelected 'selected'}}
         {{if (is-mobile) 'mobile'}}'
     >

--- a/app/preprints/-components/submit/preprint-state-machine/template.hbs
+++ b/app/preprints/-components/submit/preprint-state-machine/template.hbs
@@ -12,6 +12,7 @@
     isNextButtonDisabled=this.isNextButtonDisabled
     isPreviousButtonDisabled=this.isPreviousButtonDisabled
     isEditFlow=this.isEditFlow
+    displayFileUploadStep=this.displayFileUploadStep
     isDeleteButtonDisplayed=this.isDeleteButtonDisplayed
     isWithdrawalButtonDisplayed=this.isWithdrawalButtonDisplayed
 

--- a/tests/acceptance/preprints/edit-test.ts
+++ b/tests/acceptance/preprints/edit-test.ts
@@ -1,0 +1,130 @@
+import { currentRouteName } from '@ember/test-helpers';
+import { ModelInstance } from 'ember-cli-mirage';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { TestContext } from 'ember-test-helpers';
+import { module, test } from 'qunit';
+
+import { setupOSFApplicationTest, visit } from 'ember-osf-web/tests/helpers';
+import PreprintProviderModel from 'ember-osf-web/models/preprint-provider';
+import PreprintModel from 'ember-osf-web/models/preprint';
+import { ReviewsState } from 'ember-osf-web/models/provider';
+import { Permission } from 'ember-osf-web/models/osf-model';
+
+interface PreprintEditTestContext extends TestContext {
+    provider: ModelInstance<PreprintProviderModel>;
+    miragePreprint: ModelInstance<PreprintModel>;
+}
+
+module('Acceptance | preprints | edit', hooks => {
+    setupOSFApplicationTest(hooks);
+    setupMirage(hooks);
+
+    hooks.beforeEach(async function(this: PreprintEditTestContext) {
+        server.loadFixtures('preprint-providers');
+        server.create('user', 'loggedIn');
+        const provider = server.schema.preprintProviders.find('osf') as ModelInstance<PreprintProviderModel>;
+        const miragePreprint = server.create('preprint', {
+            id: 'test',
+            provider,
+            currentUserPermissions: Object.values(Permission),
+        });
+
+        this.provider = provider;
+        this.miragePreprint = miragePreprint;
+    });
+
+    test('LeftNav for accepted preprint with author assertions', async function(this: PreprintEditTestContext, assert) {
+        this.provider.update({ assertionsEnabled: true });
+        this.miragePreprint.update({reviewsState: ReviewsState.ACCEPTED});
+        await visit('/preprints/osf/edit/test');
+        assert.equal(currentRouteName(), 'preprints.edit', 'Current route is preprint edit');
+
+        const pageTitle = document.getElementsByTagName('title')[0].innerText;
+        // TODO: Edit page title should have provider's preprintWord in title. Note the space after "Edit" in next line
+        assert.equal(pageTitle, 'OSF Preprints | Edit ', 'Page title is correct');
+
+        // Check leftnav for Title and Abstract, Metadata, Author Assertsions, Supplements and Review steps
+        // Should have no File step
+        assert.dom('[data-test-preprint-submission-step="Title and Abstract"]').exists();
+        assert.dom('[data-test-preprint-submission-step="Metadata"]').exists();
+        assert.dom('[data-test-preprint-submission-step="Author Assertions"]').exists();
+        assert.dom('[data-test-preprint-submission-step="Supplements"]').exists();
+        assert.dom('[data-test-preprint-submission-step="Review"]').exists();
+        assert.dom('[data-test-preprint-submission-step="File"]')
+            .doesNotExist('File step should not be present when editing an accepted preprint');
+    });
+
+    test('LeftNav for rejected preprint with author assertions', async function(this: PreprintEditTestContext, assert) {
+        this.provider.update({ assertionsEnabled: true });
+        this.miragePreprint.update({reviewsState: ReviewsState.REJECTED});
+
+        await visit('/preprints/osf/edit/test');
+        // Check leftnav for Title and Abstract, FILE, Metadata, Author Assertsions, Supplements and Review steps
+        assert.dom('[data-test-preprint-submission-step="Title and Abstract"]').exists();
+        assert.dom('[data-test-preprint-submission-step="File"]')
+            .exists('File upload step present when editing a rejected preprint');
+        assert.dom('[data-test-preprint-submission-step="Metadata"]').exists();
+        assert.dom('[data-test-preprint-submission-step="Author Assertions"]').exists();
+        assert.dom('[data-test-preprint-submission-step="Supplements"]').exists();
+        assert.dom('[data-test-preprint-submission-step="Review"]').exists();
+    });
+
+    // Same as above, but with assertions disabled
+    test('LeftNav for accepted preprint wihout assertions', async function(this: PreprintEditTestContext, assert) {
+        this.provider.update({ assertionsEnabled: false });
+        this.miragePreprint.update({reviewsState: ReviewsState.ACCEPTED});
+
+        await visit('/preprints/osf/edit/test');
+        // Check leftnav for Title and Abstract, Metadata, Supplements and Review steps
+        // Should have no File step, and no Author Assertions step
+        assert.dom('[data-test-preprint-submission-step="Title and Abstract"]').exists();
+        assert.dom('[data-test-preprint-submission-step="File"]')
+            .doesNotExist('File step should not be present when editing an accepted preprint');
+        assert.dom('[data-test-preprint-submission-step="Metadata"]').exists();
+        assert.dom('[data-test-preprint-submission-step="Author Assertions"]')
+            .doesNotExist('Author Assertions step should not be present when author assertions are disabled');
+        assert.dom('[data-test-preprint-submission-step="Supplements"]').exists();
+        assert.dom('[data-test-preprint-submission-step="Review"]').exists();
+    });
+
+    test('LeftNav for rejected preprint without assertions', async function(this: PreprintEditTestContext, assert) {
+        this.provider.update({ assertionsEnabled: false });
+        this.miragePreprint.update({reviewsState: ReviewsState.REJECTED});
+
+        await visit('/preprints/osf/edit/test');
+        // Check leftnav for Title and Abstract, FILE, Metadata, Supplements and Review steps
+        // Should have no Author Assertions step
+        assert.dom('[data-test-preprint-submission-step="Title and Abstract"]').exists();
+        assert.dom('[data-test-preprint-submission-step="File"]')
+            .exists('File upload step present when editing a rejected preprint');
+        assert.dom('[data-test-preprint-submission-step="Metadata"]').exists();
+        assert.dom('[data-test-preprint-submission-step="Author Assertions"]')
+            .doesNotExist('Author Assertions step should not be present when author assertions are disabled');
+        assert.dom('[data-test-preprint-submission-step="Supplements"]').exists();
+        assert.dom('[data-test-preprint-submission-step="Review"]').exists();
+    });
+
+    test('Edit workflow prepopulated with preprint info', async function(this: PreprintEditTestContext, assert) {
+        this.provider.update({ assertionsEnabled: true });
+        this.miragePreprint.update({
+            reviewsState: ReviewsState.ACCEPTED,
+            title: 'My preprint',
+            description: 'This is a my preprint',
+        });
+
+        await visit('/preprints/osf/edit/test');
+        // Check current step is Title and Abstract
+        assert.dom('[data-test-preprint-submission-step="Title and Abstract"] [data-test-icon]')
+            .hasClass('fa-dot-circle', 'Title and Abstract icon shows as active');
+
+        // check that the title and abstract are prepopulated
+        assert.dom('[data-test-title-input] input').hasValue('My preprint', 'Title input is prepopulated');
+        assert.dom('[data-test-abstract-input] textarea')
+            .hasValue('This is a my preprint', 'Abstract input is prepopulated');
+
+        // check rightnav validation status
+        assert.dom('[data-test-next-button]').exists('Next button present on Title and Abstract step');
+        assert.dom('[data-test-next-button]').isEnabled('Next button enabled on Title and Abstract step');
+        assert.dom('[data-test-submit-button]').doesNotExist('Submit button not present on Title and Abstract step');
+    });
+});

--- a/tests/acceptance/preprints/submit-test.ts
+++ b/tests/acceptance/preprints/submit-test.ts
@@ -44,9 +44,13 @@ module('Acceptance | preprints | submit', hooks => {
         // Create preprint workflow
         await click('[data-test-create-preprints]');
         assert.equal(currentRouteName(), 'preprints.submit', 'Current route is preprints submit page');
+    });
 
-        // Preprint submit page leftnav
+    test('Preprint submit page with assertions', async function(this: PreprintIndexTestContext, assert) {
+        await visit('/preprints/osf/submit');
         assert.equal(currentRouteName(), 'preprints.submit', 'Current route is preprints submit page');
+
+        // Check leftnav items
         assert.dom('[data-test-preprint-submission-step="Title and Abstract"]')
             .exists('Title and Abstract step is displayed');
         assert.dom('[data-test-preprint-submission-step="File"]').exists('File step is displayed');
@@ -55,6 +59,27 @@ module('Acceptance | preprints | submit', hooks => {
             .exists('Author Assertions step is displayed');
         assert.dom('[data-test-preprint-submission-step="Supplements"]').exists('Supplements step is displayed');
         assert.dom('[data-test-preprint-submission-step="Review"]').exists('Review step is displayed');
+    });
+
+    test('Preprint submit page with no assertions', async function(this: PreprintIndexTestContext, assert) {
+        const osfProvider = server.schema.preprintProviders.find('osf') as ModelInstance<PreprintProviderModel>;
+        osfProvider.update({ assertionsEnabled: false });
+        await visit('/preprints/osf/submit');
+        assert.equal(currentRouteName(), 'preprints.submit', 'Current route is preprints submit page');
+
+        // Check leftnav items
+        assert.dom('[data-test-preprint-submission-step="Title and Abstract"]')
+            .exists('Title and Abstract step is displayed');
+        assert.dom('[data-test-preprint-submission-step="File"]').exists('File step is displayed');
+        assert.dom('[data-test-preprint-submission-step="Metadata"]').exists('Metadata step is displayed');
+        assert.dom('[data-test-preprint-submission-step="Author Assertions"]')
+            .doesNotExist('Author Assertions step is NOT displayed');
+        assert.dom('[data-test-preprint-submission-step="Supplements"]').exists('Supplements step is displayed');
+        assert.dom('[data-test-preprint-submission-step="Review"]').exists('Review step is displayed');
+    });
+
+    test('Preprint submit page: Title and abstract', async function(this: PreprintIndexTestContext, assert) {
+        await visit('/preprints/osf/submit');
         assert.dom('[data-test-preprint-submission-step="Title and Abstract"] [data-test-icon]')
             .hasClass('fa-dot-circle', 'Title and Abstract step has selected icon');
         assert.dom('[data-test-preprint-submission-step="File"] [data-test-icon]')

--- a/tests/acceptance/preprints/submit-test.ts
+++ b/tests/acceptance/preprints/submit-test.ts
@@ -1,0 +1,76 @@
+import { currentRouteName } from '@ember/test-helpers';
+import { ModelInstance } from 'ember-cli-mirage';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { TestContext } from 'ember-test-helpers';
+import { module, test } from 'qunit';
+
+import { click, setupOSFApplicationTest, visit } from 'ember-osf-web/tests/helpers';
+import PreprintProviderModel from 'ember-osf-web/models/preprint-provider';
+
+interface PreprintIndexTestContext extends TestContext {
+    provider: ModelInstance<PreprintProviderModel>;
+}
+
+module('Acceptance | preprints | submit', hooks => {
+    setupOSFApplicationTest(hooks);
+    setupMirage(hooks);
+
+    hooks.beforeEach(async function(this: PreprintIndexTestContext) {
+        server.loadFixtures('preprint-providers');
+        server.create('user', 'loggedIn');
+    });
+
+    test('Select a provider workflow', async function(this: PreprintIndexTestContext, assert) {
+        await visit('/preprints');
+        assert.equal(currentRouteName(), 'preprints.index', 'Current route is preprints landing page');
+
+        // Preprint provider select page
+        await click('[data-test-add-a-preprint-osf-navbar]');
+        const pageTitle = document.getElementsByTagName('title')[0].innerText;
+        assert.equal(pageTitle, 'OSF Preprints | Select Providers', 'Provider select page title is correct');
+        assert.dom('[data-test-create-preprints]').isDisabled('Create preprint button is disabled by default');
+        assert.dom('[data-test-provider-id="osf"]').exists('OSF provider is displayed');
+        assert.dom('[data-test-provider-id="osf"] [data-test-select-button]').exists('OSF provider has select button');
+        assert.dom('[data-test-provider-id="osf"] [data-test-select-button]')
+            .hasText('Select', 'Select button has text when provider is not selected');
+
+        // Select OSF provider
+        await click('[data-test-provider-id="osf"] [data-test-select-button]');
+        assert.dom('[data-test-create-preprints]')
+            .isEnabled('Create preprint button is enabled after selecting provider');
+        assert.dom('[data-test-provider-id="osf"] [data-test-select-button]')
+            .hasText('Deselect', 'Select button language changes after selecting provider');
+
+        // Create preprint workflow
+        await click('[data-test-create-preprints]');
+        assert.equal(currentRouteName(), 'preprints.submit', 'Current route is preprints submit page');
+
+        // Preprint submit page leftnav
+        assert.equal(currentRouteName(), 'preprints.submit', 'Current route is preprints submit page');
+        assert.dom('[data-test-preprint-submission-step="Title and Abstract"]')
+            .exists('Title and Abstract step is displayed');
+        assert.dom('[data-test-preprint-submission-step="File"]').exists('File step is displayed');
+        assert.dom('[data-test-preprint-submission-step="Metadata"]').exists('Metadata step is displayed');
+        assert.dom('[data-test-preprint-submission-step="Author Assertions"]')
+            .exists('Author Assertions step is displayed');
+        assert.dom('[data-test-preprint-submission-step="Supplements"]').exists('Supplements step is displayed');
+        assert.dom('[data-test-preprint-submission-step="Review"]').exists('Review step is displayed');
+        assert.dom('[data-test-preprint-submission-step="Title and Abstract"] [data-test-icon]')
+            .hasClass('fa-dot-circle', 'Title and Abstract step has selected icon');
+        assert.dom('[data-test-preprint-submission-step="File"] [data-test-icon]')
+            .hasClass('fa-circle', 'File step has unselected icon');
+
+        // Preprint submit page rightnav
+        assert.dom('[data-test-next-button]').exists('Next button is displayed');
+        assert.dom('[data-test-next-button]').hasText('Next', 'Next button has text');
+        assert.dom('[data-test-next-button]').isDisabled('Next button is disabled upon creating new preprint');
+        assert.dom('[data-test-submit-button]').doesNotExist('Submit button is not displayed on first step');
+        assert.dom('[data-test-delete-button]').exists('Delete button is displayed');
+
+        // Preprint submit page main content
+        assert.dom('[data-test-title-label]').exists('Title label is displayed');
+        assert.dom('[data-test-title-input]').exists('Title input is displayed');
+        assert.dom('[data-test-abstract-label]').exists('Abstract label is displayed');
+        assert.dom('[data-test-abstract-input]').exists('Abstract input is displayed');
+    });
+});

--- a/tests/acceptance/preprints/submit-test.ts
+++ b/tests/acceptance/preprints/submit-test.ts
@@ -7,7 +7,7 @@ import { module, test } from 'qunit';
 import { click, setupOSFApplicationTest, visit } from 'ember-osf-web/tests/helpers';
 import PreprintProviderModel from 'ember-osf-web/models/preprint-provider';
 
-interface PreprintIndexTestContext extends TestContext {
+interface PreprintSubmitTestContext extends TestContext {
     provider: ModelInstance<PreprintProviderModel>;
 }
 
@@ -15,12 +15,12 @@ module('Acceptance | preprints | submit', hooks => {
     setupOSFApplicationTest(hooks);
     setupMirage(hooks);
 
-    hooks.beforeEach(async function(this: PreprintIndexTestContext) {
+    hooks.beforeEach(async function(this: PreprintSubmitTestContext) {
         server.loadFixtures('preprint-providers');
         server.create('user', 'loggedIn');
     });
 
-    test('Select a provider workflow', async function(this: PreprintIndexTestContext, assert) {
+    test('Select a provider workflow', async function(this: PreprintSubmitTestContext, assert) {
         await visit('/preprints');
         assert.equal(currentRouteName(), 'preprints.index', 'Current route is preprints landing page');
 
@@ -46,7 +46,7 @@ module('Acceptance | preprints | submit', hooks => {
         assert.equal(currentRouteName(), 'preprints.submit', 'Current route is preprints submit page');
     });
 
-    test('Preprint submit page with assertions', async function(this: PreprintIndexTestContext, assert) {
+    test('Preprint submit page with assertions', async function(this: PreprintSubmitTestContext, assert) {
         await visit('/preprints/osf/submit');
         assert.equal(currentRouteName(), 'preprints.submit', 'Current route is preprints submit page');
 
@@ -61,7 +61,7 @@ module('Acceptance | preprints | submit', hooks => {
         assert.dom('[data-test-preprint-submission-step="Review"]').exists('Review step is displayed');
     });
 
-    test('Preprint submit page with no assertions', async function(this: PreprintIndexTestContext, assert) {
+    test('Preprint submit page with no assertions', async function(this: PreprintSubmitTestContext, assert) {
         const osfProvider = server.schema.preprintProviders.find('osf') as ModelInstance<PreprintProviderModel>;
         osfProvider.update({ assertionsEnabled: false });
         await visit('/preprints/osf/submit');
@@ -78,8 +78,12 @@ module('Acceptance | preprints | submit', hooks => {
         assert.dom('[data-test-preprint-submission-step="Review"]').exists('Review step is displayed');
     });
 
-    test('Preprint submit page: Title and abstract', async function(this: PreprintIndexTestContext, assert) {
+    test('Preprint submit page: Title and abstract', async function(this: PreprintSubmitTestContext, assert) {
         await visit('/preprints/osf/submit');
+        const pageTitle = document.getElementsByTagName('title')[0].innerText;
+        // TODO: Submit page title should have provider's preprintWord in title. Note the space after "New" in next line
+        assert.equal(pageTitle, 'OSF Preprints | New ', 'Provider select page title is correct');
+
         assert.dom('[data-test-preprint-submission-step="Title and Abstract"] [data-test-icon]')
             .hasClass('fa-dot-circle', 'Title and Abstract step has selected icon');
         assert.dom('[data-test-preprint-submission-step="File"] [data-test-icon]')


### PR DESCRIPTION
-   Ticket: [ENG-6434]
-   Feature flag: n/a

## Todo

- [x] Add some sort of acceptance test so you can keep these workflows correct

## Purpose
- Add logic to show/hide the file upload step on the preprint submission/edit workflow

## Summary of Changes
- Add a new flag `displayFileUploadStep` that controls whether or not the file upload step is shown
  - Should be shown for initial preprint submission
  - Should be shown for rejected preprint re-submission

## Screenshot(s)
- Create new preprint workflow showing the file upload step
![Screen Shot 2024-12-05 at 9 39 59 AM](https://github.com/user-attachments/assets/0de3e366-163f-4e10-b77f-e09a5055c1e5)

- Edit and resubmit workflow showing the file upload step
![Screen Shot 2024-12-05 at 9 26 05 AM](https://github.com/user-attachments/assets/35c5947e-26c5-4b86-a5fb-aa32ac7657f0)

- Editing an existing preprint no longer showing the file upload step
![Screen Shot 2024-12-05 at 9 42 56 AM](https://github.com/user-attachments/assets/e0a442fe-d1f9-4abb-b92f-7ffd58616e33)


## Side Effects
- Editing an accepted preprint will now no longer show the option to upload a new file version

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6434]: https://openscience.atlassian.net/browse/ENG-6434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ