### PR TITLE
[ENG-6459][ENG-6637][ENG-6638] Add Create new preprint version button

### DIFF
--- a/app/models/preprint.ts
+++ b/app/models/preprint.ts
@@ -41,6 +41,12 @@ export interface PreprintLicenseRecordModel {
     year: string;
 }
 
+const newVersionAllowedReviewsStates = [
+    ReviewsState.ACCEPTED,
+    ReviewsState.WITHDRAWAL_REJECTED,
+    ReviewsState.PENDING_WITHDRAWAL,
+];
+
 export default class PreprintModel extends AbstractNodeModel {
     @attr('fixstring') title!: string;
     @attr('date') dateCreated!: Date;
@@ -127,6 +133,17 @@ export default class PreprintModel extends AbstractNodeModel {
         return text
             .replace(/({{year}})/g, year)
             .replace(/({{copyrightHolders}})/g, copyright_holders.join(', '));
+    }
+
+    get currentUserIsAdmin(): boolean {
+        return this.currentUserPermissions.includes(Permission.Admin);
+    }
+
+    get canCreateNewVersion(): boolean {
+        const hasPermission = this.currentUserIsAdmin;
+        const isReviewStateValid = newVersionAllowedReviewsStates.includes(this.reviewsState);
+        const isVersionValid = this.isLatestVersion;
+        return hasPermission && isReviewStateValid && isVersionValid;
     }
 }
 

--- a/app/models/preprint.ts
+++ b/app/models/preprint.ts
@@ -41,12 +41,6 @@ export interface PreprintLicenseRecordModel {
     year: string;
 }
 
-const newVersionAllowedReviewsStates = [
-    ReviewsState.ACCEPTED,
-    ReviewsState.WITHDRAWAL_REJECTED,
-    ReviewsState.PENDING_WITHDRAWAL,
-];
-
 export default class PreprintModel extends AbstractNodeModel {
     @attr('fixstring') title!: string;
     @attr('date') dateCreated!: Date;
@@ -140,10 +134,7 @@ export default class PreprintModel extends AbstractNodeModel {
     }
 
     get canCreateNewVersion(): boolean {
-        const hasPermission = this.currentUserIsAdmin;
-        const isReviewStateValid = newVersionAllowedReviewsStates.includes(this.reviewsState);
-        const isVersionValid = this.isLatestVersion;
-        return hasPermission && isReviewStateValid && isVersionValid;
+        return this.currentUserIsAdmin && this.datePublished && this.isLatestVersion;
     }
 }
 

--- a/app/preprints/-components/preprint-tombstone/template.hbs
+++ b/app/preprints/-components/preprint-tombstone/template.hbs
@@ -8,7 +8,7 @@
         </div>
     {{/if}}
     <Preprints::-Components::PreprintAbstract @preprint={{@preprint}} />
-    <Preprints::-Components::PreprintDoi @preprint={{@preprint}} @provider={{@provider}} />
+    <Preprints::-Components::PreprintDoi @versions={{@versions}} @provider={{@provider}} />
     <Preprints::-Components::PreprintLicense @preprint={{@preprint}} />
     <Preprints::-Components::PreprintDiscipline @subjects={{@subjects}} />
     <Preprints::-Components::PreprintTag @preprint={{@preprint}} />

--- a/app/preprints/detail/controller.ts
+++ b/app/preprints/detail/controller.ts
@@ -71,10 +71,10 @@ export default class PrePrintsDetailController extends Controller {
     }
 
     get editButtonLabel(): string {
-        const editPreprint = 'preprints.detail.project_button.edit_preprint';
-        const editResubmitPreprint = 'preprints.detail.project_button.edit_resubmit_preprint';
+        const editPreprint = 'preprints.detail.edit_preprint';
+        const editResubmitPreprint = 'preprints.detail.edit_resubmit_preprint';
         const translation = this.model.provider.reviewsWorkflow === PreprintProviderReviewsWorkFlow.PRE_MODERATION
-            && this.model.preprint.reviewsState === ReviewsState.REJECTED && this.isAdmin()
+            && this.model.preprint.reviewsState === ReviewsState.REJECTED && this.model.preprint.currentUserIsAdmin
             ? editResubmitPreprint : editPreprint;
         return this.intl.t(translation, {
             documentType: this.model.provider.documentType.singular,
@@ -90,11 +90,6 @@ export default class PrePrintsDetailController extends Controller {
         return this.model.preprint.title;
     }
 
-    private isAdmin(): boolean {
-        // True if the current user has admin permissions for the node that contains the preprint
-        return (this.model.preprint.currentUserPermissions).includes(Permission.Admin);
-    }
-
     private hasReadWriteAccess(): boolean {
         // True if the current user has write permissions for the node that contains the preprint
         return (this.model.preprint.currentUserPermissions.includes(Permission.Write));
@@ -102,7 +97,7 @@ export default class PrePrintsDetailController extends Controller {
 
 
     get userIsContrib(): boolean {
-        if (this.isAdmin()) {
+        if (this.model.preprint.currentUserIsAdmin) {
             return true;
         } else if (this.model.contributors.length) {
             const authorIds = [] as string[];

--- a/app/preprints/detail/template.hbs
+++ b/app/preprints/detail/template.hbs
@@ -9,8 +9,8 @@
     <div local-class='header-container'>
         <div local-class='preprint-title-container'>
             <h1 data-test-preprint-title>{{this.displayTitle}}</h1>
-            {{#unless this.model.preprint.isWithdrawn}}
-                <div class='edit-preprint-button'>
+            <div>
+                {{#unless this.model.preprint.isWithdrawn}}
                     {{#if (and this.userIsContrib (not this.isPendingWithdrawal))}}
                         <OsfLink
                             data-test-edit-preprint-button
@@ -23,21 +23,20 @@
 
                         </OsfLink>
                     {{/if}}
-                    {{#if this.model.preprint.canCreateNewVersion}}
-                        <OsfLink
-                            data-test-create-new-version-button
-                            data-analytics-name='Create new version'
-                            local-class='btn btn-primary'
-                            {{!-- TODO: Update when new version route is implemented --}}
-                            @route='preprints.edit'
-                            @models={{array this.model.provider.id this.model.preprint.id}}
-                        >
-                            {{t 'preprints.detail.create_new_version'}}
-                        </OsfLink>
-                    {{/if}}
-                    <br>
-                </div>
-            {{/unless}}
+                {{/unless}}
+                {{#if this.model.preprint.canCreateNewVersion}}
+                    <OsfLink
+                        data-test-create-new-version-button
+                        data-analytics-name='Create new version'
+                        local-class='btn btn-primary'
+                        {{!-- TODO: Update when new version route is implemented --}}
+                        @route='preprints.edit'
+                        @models={{array this.model.provider.id this.model.preprint.id}}
+                    >
+                        {{t 'preprints.detail.create_new_version'}}
+                    </OsfLink>
+                {{/if}}
+            </div>
         </div>
         <div local-class='preprint-author-container'>
             <h5 local-class='view-authors'>

--- a/app/preprints/detail/template.hbs
+++ b/app/preprints/detail/template.hbs
@@ -63,6 +63,7 @@
         {{#if this.model.preprint.isWithdrawn}}
             <Preprints::-Components::PreprintTombstone
                 @preprint={{this.model.preprint}}
+                @versions={{this.model.versions}}
                 @provider={{this.model.provider}}
                 @subjects={{this.model.subjects}} />
         {{else}}

--- a/app/preprints/detail/template.hbs
+++ b/app/preprints/detail/template.hbs
@@ -23,6 +23,18 @@
 
                         </OsfLink>
                     {{/if}}
+                    {{#if this.model.preprint.canCreateNewVersion}}
+                        <OsfLink
+                            data-test-create-new-version-button
+                            data-analytics-name='Create new version'
+                            local-class='btn btn-primary'
+                            {{!-- TODO: Update when new version route is implemented --}}
+                            @route='preprints.edit'
+                            @models={{array this.model.provider.id this.model.preprint.id}}
+                        >
+                            {{t 'preprints.detail.create_new_version'}}
+                        </OsfLink>
+                    {{/if}}
                     <br>
                 </div>
             {{/unless}}

--- a/mirage/factories/preprint.ts
+++ b/mirage/factories/preprint.ts
@@ -251,6 +251,7 @@ export default Factory.extend<PreprintMirageModel & PreprintTraits>({
                     description: preprint.description,
                     provider: preprint.provider,
                     id: `${baseId}_v${version}`,
+                    reviewsState: preprint.reviewsState,
                     preprintVersion: version,
                     isLatestVersion: version === 3,
                 });

--- a/tests/acceptance/preprints/detail-test.ts
+++ b/tests/acceptance/preprints/detail-test.ts
@@ -1,0 +1,107 @@
+import { currentRouteName } from '@ember/test-helpers';
+import { ModelInstance } from 'ember-cli-mirage';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { TestContext } from 'ember-test-helpers';
+import { module, skip, test } from 'qunit';
+
+import { setupOSFApplicationTest, visit } from 'ember-osf-web/tests/helpers';
+import PreprintProviderModel from 'ember-osf-web/models/preprint-provider';
+import PreprintModel from 'ember-osf-web/models/preprint';
+import { PreprintProviderReviewsWorkFlow, ReviewsState } from 'ember-osf-web/models/provider';
+import { Permission } from 'ember-osf-web/models/osf-model';
+
+interface PreprintDetailTestContext extends TestContext {
+    provider: ModelInstance<PreprintProviderModel>;
+    preprint: ModelInstance<PreprintModel>;
+}
+
+module('Acceptance | preprints | detail', hooks => {
+    setupOSFApplicationTest(hooks);
+    setupMirage(hooks);
+
+    hooks.beforeEach(async function(this: PreprintDetailTestContext) {
+        server.loadFixtures('preprint-providers');
+        const provider = server.schema.preprintProviders.find('osf') as ModelInstance<PreprintProviderModel>;
+        provider.update({
+            reviewsWorkflow: PreprintProviderReviewsWorkFlow.PRE_MODERATION,
+            assertionsEnabled: true,
+        });
+
+        const preprint = server.create('preprint', {
+            id: 'test',
+            provider,
+            currentUserPermissions: Object.values(Permission),
+            title: 'Test Preprint',
+            description: 'This is a test preprint',
+        });
+        this.provider = provider;
+        this.preprint = preprint;
+    });
+
+    test('Accepted preprint detail page', async function(this: PreprintDetailTestContext, assert) {
+        this.preprint.update({
+            reviewsState: ReviewsState.ACCEPTED,
+        });
+        await visit('/preprints/osf/test');
+        assert.equal(currentRouteName(), 'preprints.detail', 'Current route is preprint detail');
+
+        // Check page title
+        const pageTitle = document.getElementsByTagName('title')[0].innerText;
+        assert.equal(pageTitle, 'OSF Preprints | Test Preprint', 'Page title is correct');
+
+        // Check preprint title
+        assert.dom('[data-test-preprint-title]').exists('Title is displayed');
+        assert.dom('[data-test-preprint-title]').hasText('Test Preprint', 'Title is correct');
+
+        // Check edit and new version buttons
+        assert.dom('[data-test-edit-preprint-button]').exists('Edit button is displayed');
+        assert.dom('[data-test-edit-preprint-button]').containsText('Edit', 'Edit button text is correct');
+        assert.dom('[data-test-create-new-version-button]').exists('New version button is displayed');
+
+        // Check preprint authors
+        assert.dom('[data-test-contributor-name]').exists('Authors are displayed');
+
+        // TODO: Check author assertions
+
+        // Check preprint status banner
+        assert.dom('[data-test-status]').exists('Status banner is displayed');
+        assert.dom('[data-test-status]').containsText('accepted', 'Status is correct');
+    });
+
+    test('Pre-mod: Rejected preprint detail page', async function(this: PreprintDetailTestContext, assert) {
+        this.provider.update({
+            reviewsWorkflow: PreprintProviderReviewsWorkFlow.PRE_MODERATION,
+        });
+        this.preprint.update({
+            reviewsState: ReviewsState.REJECTED,
+        });
+        await visit('/preprints/osf/test');
+        assert.equal(currentRouteName(), 'preprints.detail', 'Current route is preprint detail');
+
+        // Check page title. Should be same as accepted preprint
+        const pageTitle = document.getElementsByTagName('title')[0].innerText;
+        assert.equal(pageTitle, 'OSF Preprints | Test Preprint', 'Page title is correct');
+
+        // Check preprint title. Should be same as accepted preprint
+        assert.dom('[data-test-preprint-title]').exists('Title is displayed');
+        assert.dom('[data-test-preprint-title]').hasText('Test Preprint', 'Title is correct');
+
+        // Check edit and new version buttons
+        assert.dom('[data-test-edit-preprint-button]').exists('Edit button is displayed');
+        assert.dom('[data-test-edit-preprint-button]')
+            .hasText('Edit and resubmit', 'Edit button text indicates resubmission');
+        assert.dom('[data-test-create-new-version-button]').doesNotExist('New version button is not displayed');
+
+        // Check preprint authors
+        assert.dom('[data-test-contributor-name]').exists('Authors are displayed');
+
+        // Check preprint status banner
+        assert.dom('[data-test-status]').exists('Status banner is displayed');
+        assert.dom('[data-test-status]').containsText('rejected', 'Status is correct');
+    });
+
+
+    skip('Withdrawn preprint detail page', async function(this: PreprintDetailTestContext, _) {
+        // TODO: Implement test
+    });
+});

--- a/tests/acceptance/preprints/detail-test.ts
+++ b/tests/acceptance/preprints/detail-test.ts
@@ -21,6 +21,7 @@ module('Acceptance | preprints | detail', hooks => {
 
     hooks.beforeEach(async function(this: PreprintDetailTestContext) {
         server.loadFixtures('preprint-providers');
+        server.loadFixtures('citation-styles');
         const provider = server.schema.preprintProviders.find('osf') as ModelInstance<PreprintProviderModel>;
         provider.update({
             reviewsWorkflow: PreprintProviderReviewsWorkFlow.PRE_MODERATION,

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1437,9 +1437,9 @@ preprints:
         no_doi: 'No DOI'
         preprint_pending_doi_minted: 'DOIs are minted by a third party, and may take up to 24 hours to be registered.'
         private_preprint_warning: 'This {documentType} is private. Contact {supportEmail} if this is in error.'
-        project_button:
-            edit_preprint: 'Edit {documentType}'
-            edit_resubmit_preprint: 'Edit and resubmit'
+        edit_preprint: 'Edit {documentType}'
+        edit_resubmit_preprint: 'Edit and resubmit'
+        create_new_version: 'Create new version'
         see_less: 'See less'
         see_more: 'See more'
         share:


### PR DESCRIPTION
-   Ticket: [ENG-6459] [ENG-6637] [ENG-6638]
-   Feature flag: n/a

## Todo

- [x] Add Withdrawn preprint detail test

## Purpose
- Add a new "Create new version" button to the preprint detail page

## Summary of Changes
- Add a new `canCreateNewVersion` attr to preprint model
  - Only admins can create a new version
  - Only preprints that is the latest version can create a new version
  - Only preprints that are were published at some point (whether they are withdrawn or not, doesn't matter)
- Update tombstone page for preprint versions

## Screenshot(s)
- Accepted
![image](https://github.com/user-attachments/assets/75bc9360-91e3-4a2a-9c9c-b8970d66d4f6)

- Rejected (for pre-moderation providers)
![image](https://github.com/user-attachments/assets/68740894-321b-44a4-9e7c-f2d17425febb)

- Withdrawn
![image](https://github.com/user-attachments/assets/6f04d3e6-eab5-450c-a6b0-dd1a58438d5b)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6459]: https://openscience.atlassian.net/browse/ENG-6459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-6637]: https://openscience.atlassian.net/browse/ENG-6637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-6638]: https://openscience.atlassian.net/browse/ENG-6638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ