### PR TITLE
Feature flag for SHARE download button

### DIFF
--- a/app/config/environment.d.ts
+++ b/app/config/environment.d.ts
@@ -196,6 +196,7 @@ declare const config: {
         registrationFilesPage: string;
         verifyEmailModals: string;
         egapAdmins: string;
+        shareDownload: string;
     };
     gReCaptcha: {
         siteKey: string;

--- a/app/institutions/dashboard/-components/object-list/component-test.ts
+++ b/app/institutions/dashboard/-components/object-list/component-test.ts
@@ -5,6 +5,10 @@ import { setupIntl } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 import { TestContext } from 'ember-test-helpers';
 import { module, test } from 'qunit';
+import Service from '@ember/service';
+const featuresStub = Service.extend({
+    isEnabled: () => true,
+});
 
 import { OsfLinkRouterStub } from 'ember-osf-web/tests/integration/helpers/osf-link-router-stub';
 
@@ -14,6 +18,7 @@ module('Integration | institutions | dashboard | -components | object-list', hoo
     setupIntl(hooks);
 
     hooks.beforeEach(function(this: TestContext) {
+        this.owner.register('service:features', featuresStub);
         this.owner.unregister('service:router');
         this.owner.register('service:router', OsfLinkRouterStub);
         const columns = [

--- a/app/institutions/dashboard/-components/object-list/component.ts
+++ b/app/institutions/dashboard/-components/object-list/component.ts
@@ -1,12 +1,17 @@
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import Features from 'ember-feature-flags/services/features';
 
 import IndexCardSearchModel from 'ember-osf-web/models/index-card-search';
 import InstitutionModel from 'ember-osf-web/models/institution';
 import { SuggestedFilterOperators } from 'ember-osf-web/models/related-property-path';
 import SearchResultModel from 'ember-osf-web/models/search-result';
 import { Filter } from 'osf-components/components/search-page/component';
+import config from 'ember-osf-web/config/environment';
+
+const shareDownloadFlag = config.featureFlagNames.shareDownload;
 
 interface Column {
     name: string;
@@ -37,6 +42,7 @@ interface InstitutionalObjectListArgs {
 }
 
 export default class InstitutionalObjectList extends Component<InstitutionalObjectListArgs> {
+    @service features!: Features;
     @tracked activeFilters: Filter[] = [];
     @tracked page = '';
     @tracked sort = '-dateModified';
@@ -72,6 +78,10 @@ export default class InstitutionalObjectList extends Component<InstitutionalObje
         return {
             ...this.queryOptions.cardSearchFilter,
         };
+    }
+
+    get showDownloadButtons() {
+        return this.features.isEnabled(shareDownloadFlag);
     }
 
     downloadUrl(cardSearch: IndexCardSearchModel, format: string) {

--- a/app/institutions/dashboard/-components/object-list/template.hbs
+++ b/app/institutions/dashboard/-components/object-list/template.hbs
@@ -86,47 +86,49 @@ as |list|>
                                     </OsfLink>
                                 </div>
                             {{/if}}
-                            <ResponsiveDropdown @renderInPlace={{true}} @buttonStyling={{true}} as |dd| >
-                                <dd.trigger
-                                    data-test-download-dropdown
-                                    aria-label={{t 'institutions.dashboard.download_dropdown_label'}}
-                                    local-class='download-dropdown-trigger'
-                                >
-                                    <FaIcon @icon='download' />
-                                </dd.trigger>
-                                <dd.content local-class='download-dropdown-content'>
-                                    <OsfLink
-                                        data-test-download-csv-link
-                                        data-analytics-name='Download CSV'
-                                        local-class='download-link'
-                                        {{on 'click' dd.close}}
-                                        @href={{call (fn (action this.downloadCsvUrl list.latestIndexCardSearch))}}
-                                        @target='_blank'
+                            {{#if this.showDownloadButtons}}
+                                <ResponsiveDropdown @renderInPlace={{true}} @buttonStyling={{true}} as |dd| >
+                                    <dd.trigger
+                                        data-test-download-dropdown
+                                        aria-label={{t 'institutions.dashboard.download_dropdown_label'}}
+                                        local-class='download-dropdown-trigger'
                                     >
-                                        {{t 'institutions.dashboard.format_labels.csv'}}
-                                    </OsfLink>
-                                    <OsfLink
-                                        data-test-download-tsv-link
-                                        data-analytics-name='Download TSV'
-                                        local-class='download-link'
-                                        {{on 'click' dd.close}}
-                                        @href={{call (fn (action this.downloadTsvUrl list.latestIndexCardSearch))}}
-                                        @target='_blank'
-                                    >
-                                        {{t 'institutions.dashboard.format_labels.tsv'}}
-                                    </OsfLink>
-                                    <OsfLink
-                                        data-test-download-json-link
-                                        data-analytics-name='Download JSON'
-                                        local-class='download-link'
-                                        {{on 'click' dd.close}}
-                                        @href={{call (fn (action this.downloadJsonUrl list.latestIndexCardSearch))}}
-                                        @target='_blank'
-                                    >
-                                        {{t 'institutions.dashboard.format_labels.json'}}
-                                    </OsfLink>
-                                </dd.content>
-                            </ResponsiveDropdown>
+                                        <FaIcon @icon='download' />
+                                    </dd.trigger>
+                                    <dd.content local-class='download-dropdown-content'>
+                                        <OsfLink
+                                            data-test-download-csv-link
+                                            data-analytics-name='Download CSV'
+                                            local-class='download-link'
+                                            {{on 'click' dd.close}}
+                                            @href={{call (fn (action this.downloadCsvUrl list.latestIndexCardSearch))}}
+                                            @target='_blank'
+                                        >
+                                            {{t 'institutions.dashboard.format_labels.csv'}}
+                                        </OsfLink>
+                                        <OsfLink
+                                            data-test-download-tsv-link
+                                            data-analytics-name='Download TSV'
+                                            local-class='download-link'
+                                            {{on 'click' dd.close}}
+                                            @href={{call (fn (action this.downloadTsvUrl list.latestIndexCardSearch))}}
+                                            @target='_blank'
+                                        >
+                                            {{t 'institutions.dashboard.format_labels.tsv'}}
+                                        </OsfLink>
+                                        <OsfLink
+                                            data-test-download-json-link
+                                            data-analytics-name='Download JSON'
+                                            local-class='download-link'
+                                            {{on 'click' dd.close}}
+                                            @href={{call (fn (action this.downloadJsonUrl list.latestIndexCardSearch))}}
+                                            @target='_blank'
+                                        >
+                                            {{t 'institutions.dashboard.format_labels.json'}}
+                                        </OsfLink>
+                                    </dd.content>
+                                </ResponsiveDropdown>
+                            {{/if}}
                         </div>
                     </div>
                 </div>

--- a/config/environment.js
+++ b/config/environment.js
@@ -315,6 +315,7 @@ module.exports = function(environment) {
             },
             registrationFilesPage: 'ember_registration_files_page',
             egapAdmins: 'egap_admins',
+            shareDownload: 'share_download',
         },
         gReCaptcha: {
             siteKey: RECAPTCHA_SITE_KEY,

--- a/mirage/factories/root.ts
+++ b/mirage/factories/root.ts
@@ -10,6 +10,7 @@ const {
         navigation,
         storageI18n,
         verifyEmailModals,
+        shareDownload,
     },
 } = config;
 
@@ -35,6 +36,7 @@ export const defaultRootAttrs = {
         ...Object.values(navigation),
         storageI18n,
         verifyEmailModals,
+        shareDownload,
     ])],
     message: 'Welcome to the OSF API.',
     version: '2.8',


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: `share_download`

## Purpose
- Move Institutional Dashboard Project/Registration/Preprint download button behind a feature flag

## Summary of Changes
- Add new flag `share_download`
- Show/hide download buttons on Institutional Dashboard based on this feature flag

## Screenshot(s)
- With flag turned on
![image](https://github.com/user-attachments/assets/1d215cf0-ae2f-4d30-a74e-036ac73adae4)

- With flag turned off
![image](https://github.com/user-attachments/assets/b953cc2b-7eac-4bb4-b4af-b8de2ed62c10)

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
