### PR TITLE
[ENG-6774] fix computing model / service names (and some citations, too!)

### DIFF
--- a/app/guid-node/addons/index/template.hbs
+++ b/app/guid-node/addons/index/template.hbs
@@ -194,16 +194,18 @@
                                         </Button>
                                     </span>
                                 </div>
-                                <div
-                                    data-test-configured-addon-root-folder
-                                    local-class='configured-addon-root-folder'
-                                >
-                                    {{#if configuredAddon.rootFolder}}
-                                        {{configuredAddon.rootFolder}}
-                                    {{else}}
-                                        {{t 'addons.list.root-folder-not-set'}}
-                                    {{/if}}
-                                </div>
+                                {{#if configuredAddon.hasRootFolder}}
+                                    <div
+                                        data-test-configured-addon-root-folder
+                                        local-class='configured-addon-root-folder'
+                                    >
+                                        {{#if configuredAddon.rootFolder}}
+                                            {{configuredAddon.rootFolder}}
+                                        {{else}}
+                                            {{t 'addons.list.root-folder-not-set'}}
+                                        {{/if}}
+                                    </div>
+                                {{/if}}
                                 <div local-class='configured-addon-connected-to'>
                                     {{t 'addons.list.connected-to-account'}} {{configuredAddon.baseAccount.displayName}}
                                 </div>

--- a/app/models/authorized-computing-account.ts
+++ b/app/models/authorized-computing-account.ts
@@ -1,19 +1,19 @@
 import { AsyncBelongsTo, belongsTo } from '@ember-data/model';
 
-import ExternalComputingService from './external-computing-service';
+import ExternalComputingServiceModel from './external-computing-service';
 import AuthorizedAccountModel from './authorized-account';
 import UserReferenceModel from './user-reference';
 
-export default class AuthorizedComputingAccount extends AuthorizedAccountModel {
+export default class AuthorizedComputingAccountModel extends AuthorizedAccountModel {
     @belongsTo('user-reference', { inverse: 'authorizedComputingAccounts' })
     accountOwner!: AsyncBelongsTo<UserReferenceModel> & UserReferenceModel;
 
     @belongsTo('external-computing-service')
-    computingService!: AsyncBelongsTo<ExternalComputingService> & ExternalComputingService;
+    externalComputingService!: AsyncBelongsTo<ExternalComputingServiceModel> & ExternalComputingServiceModel;
 }
 
 declare module 'ember-data/types/registries/model' {
     export default interface ModelRegistry {
-        'authorized-computing-account': AuthorizedComputingAccount;
+        'authorized-computing-account': AuthorizedComputingAccountModel;
     } // eslint-disable-line semi
 }

--- a/app/models/configured-addon.ts
+++ b/app/models/configured-addon.ts
@@ -37,4 +37,8 @@ export default class ConfiguredAddonModel extends Model {
         // To be implemented in child classes
         return;
     }
+
+    get hasRootFolder() {
+        return true;
+    }
 }

--- a/app/models/configured-computing-addon.ts
+++ b/app/models/configured-computing-addon.ts
@@ -1,16 +1,16 @@
 import { AsyncBelongsTo, belongsTo } from '@ember-data/model';
 
 import ResourceReferenceModel from 'ember-osf-web/models/resource-reference';
-import AuthorizedComputingAccount from './authorized-computing-account';
-import ExternalComputingService from './external-computing-service';
+import AuthorizedComputingAccountModel from './authorized-computing-account';
+import ExternalComputingServiceModel from './external-computing-service';
 import ConfiguredAddonModel from './configured-addon';
 
 export default class ConfiguredComputingAddonModel extends ConfiguredAddonModel {
     @belongsTo('external-computing-service', { inverse: null })
-    externalComputingService!: AsyncBelongsTo<ExternalComputingService> & ExternalComputingService;
+    externalComputingService!: AsyncBelongsTo<ExternalComputingServiceModel> & ExternalComputingServiceModel;
 
     @belongsTo('authorized-computing-account')
-    baseAccount!: AsyncBelongsTo<AuthorizedComputingAccount> & AuthorizedComputingAccount;
+    baseAccount!: AsyncBelongsTo<AuthorizedComputingAccountModel> & AuthorizedComputingAccountModel;
 
     @belongsTo('resource-reference', { inverse: 'configuredComputingAddons' })
     authorizedResource!: AsyncBelongsTo<ResourceReferenceModel> & ResourceReferenceModel;

--- a/app/models/configured-computing-addon.ts
+++ b/app/models/configured-computing-addon.ts
@@ -18,6 +18,11 @@ export default class ConfiguredComputingAddonModel extends ConfiguredAddonModel 
     get externalServiceId() {
         return (this as ConfiguredComputingAddonModel).belongsTo('externalComputingService').id();
     }
+
+    get hasRootFolder() {
+        return false;
+    }
+
 }
 
 declare module 'ember-data/types/registries/model' {

--- a/app/models/user-reference.ts
+++ b/app/models/user-reference.ts
@@ -2,7 +2,7 @@ import Model, { AsyncHasMany, attr, hasMany } from '@ember-data/model';
 
 import AuthorizedStorageAccountModel from './authorized-storage-account';
 import AuthorizedCitationAccountModel from './authorized-citation-account';
-import AuthorizedComputingAccount from './authorized-computing-account';
+import AuthorizedComputingAccountModel from './authorized-computing-account';
 import ResourceReferenceModel from './resource-reference';
 
 export default class UserReferenceModel extends Model {
@@ -16,8 +16,8 @@ export default class UserReferenceModel extends Model {
         AuthorizedCitationAccountModel[];
 
     @hasMany('authorized-computing-account', { inverse: 'accountOwner' })
-    authorizedComputingAccounts!: AsyncHasMany<AuthorizedComputingAccount>
-        & AuthorizedComputingAccount[];
+    authorizedComputingAccounts!: AsyncHasMany<AuthorizedComputingAccountModel>
+        & AuthorizedComputingAccountModel[];
 
     @hasMany('resource-reference')
     configuredResources!: AsyncHasMany<ResourceReferenceModel> & ResourceReferenceModel[];

--- a/app/models/user-reference.ts
+++ b/app/models/user-reference.ts
@@ -1,7 +1,7 @@
 import Model, { AsyncHasMany, attr, hasMany } from '@ember-data/model';
 
 import AuthorizedStorageAccountModel from './authorized-storage-account';
-import AuthorizedCitationAccount from './authorized-citation-account';
+import AuthorizedCitationAccountModel from './authorized-citation-account';
 import AuthorizedComputingAccount from './authorized-computing-account';
 import ResourceReferenceModel from './resource-reference';
 
@@ -12,8 +12,8 @@ export default class UserReferenceModel extends Model {
     authorizedStorageAccounts!: AsyncHasMany<AuthorizedStorageAccountModel> & AuthorizedStorageAccountModel[];
 
     @hasMany('authorized-citation-account', { inverse: 'accountOwner' })
-    authorizedCitationAccounts!: AsyncHasMany<AuthorizedCitationAccount> &
-        AuthorizedCitationAccount[];
+    authorizedCitationAccounts!: AsyncHasMany<AuthorizedCitationAccountModel> &
+        AuthorizedCitationAccountModel[];
 
     @hasMany('authorized-computing-account', { inverse: 'accountOwner' })
     authorizedComputingAccounts!: AsyncHasMany<AuthorizedComputingAccount>

--- a/app/packages/addons-service/provider.ts
+++ b/app/packages/addons-service/provider.ts
@@ -19,7 +19,7 @@ import ConfiguredComputingAddonModel from 'ember-osf-web/models/configured-compu
 import { AccountCreationArgs } from 'ember-osf-web/models/authorized-account';
 import AuthorizedStorageAccountModel from 'ember-osf-web/models/authorized-storage-account';
 import AuthorizedCitationAccountModel from 'ember-osf-web/models/authorized-citation-account';
-import AuthorizedComputingAccount from 'ember-osf-web/models/authorized-computing-account';
+import AuthorizedComputingAccountModel from 'ember-osf-web/models/authorized-computing-account';
 import ExternalStorageServiceModel from 'ember-osf-web/models/external-storage-service';
 import ExternalComputingServiceModel from 'ember-osf-web/models/external-computing-service';
 import ExternalCitationServiceModel from 'ember-osf-web/models/external-citation-service';
@@ -33,7 +33,7 @@ export type AllProviderTypes =
 export type AllAuthorizedAccountTypes =
     AuthorizedStorageAccountModel |
     AuthorizedCitationAccountModel |
-    AuthorizedComputingAccount;
+    AuthorizedComputingAccountModel;
 export type AllConfiguredAddonTypes =
     ConfiguredStorageAddonModel |
     ConfiguredCitationAddonModel |
@@ -208,7 +208,7 @@ export default class Provider {
     async getAuthorizedComputingAccounts() {
         const authorizedComputingAccounts = await this.userReference.authorizedComputingAccounts;
         this.authorizedAccounts = authorizedComputingAccounts
-            .filterBy('computingService.id', this.provider.id).toArray();
+            .filterBy('externalComputingService.id', this.provider.id).toArray();
     }
 
     @task
@@ -269,7 +269,7 @@ export default class Provider {
             initiateOauth,
             externalUserId: this.currentUser.user?.id,
             scopes: [],
-            computingService: this.provider,
+            externalComputingService: this.provider,
             accountOwner: this.userReference,
             displayName,
         });
@@ -325,13 +325,15 @@ export default class Provider {
 
     @task
     @waitFor
-    private async createConfiguredComputingAddon(account: AuthorizedComputingAccount) {
+    private async createConfiguredComputingAddon(account: AuthorizedComputingAccountModel) {
         const configuredComputingAddon = this.store.createRecord('configured-computing-addon', {
-            rootFolder: '',
-            computingService: this.provider,
+            // rootFolder: '',
+            externalComputingService: this.provider,
             accountOwner: this.userReference,
-            authorizedResource: this.serviceNode,
+            // authorizedResource: this.serviceNode,
+            authorizedResourceUri: this.node!.links.iri,
             baseAccount: account,
+            connectedCapabilities: ['ACCESS', 'UPDATE'],
         });
         return await configuredComputingAddon.save();
     }

--- a/app/packages/addons-service/provider.ts
+++ b/app/packages/addons-service/provider.ts
@@ -268,6 +268,7 @@ export default class Provider {
             apiBaseUrl,
             initiateOauth,
             externalUserId: this.currentUser.user?.id,
+            authorizedCapabilities: ['ACCESS', 'UPDATE'],
             scopes: [],
             externalComputingService: this.provider,
             accountOwner: this.userReference,

--- a/lib/osf-components/addon/components/addons-service/configured-addon-edit/component.ts
+++ b/lib/osf-components/addon/components/addons-service/configured-addon-edit/component.ts
@@ -33,7 +33,7 @@ export default class ConfiguredAddonEdit extends Component<Args> {
     }
 
     get disableSave() {
-        return this.hasRootFolder && (!this.selectedFolder || this.invalidDisplayName || this.args.onSave.isRunning);
+        return this.invalidDisplayName || this.args.onSave.isRunning || (this.hasRootFolder && !this.selectedFolder);
     }
 
     get onSaveArgs() {

--- a/lib/osf-components/addon/components/addons-service/configured-addon-edit/component.ts
+++ b/lib/osf-components/addon/components/addons-service/configured-addon-edit/component.ts
@@ -5,6 +5,7 @@ import { TaskInstance } from 'ember-concurrency';
 
 import { Item, ItemType } from 'ember-osf-web/models/addon-operation-invocation';
 import AuthorizedAccountModel from 'ember-osf-web/models/authorized-account';
+import AuthorizedComputingAccountModel from 'ember-osf-web/models/authorized-computing-account';
 import ConfiguredAddonModel from 'ember-osf-web/models/configured-addon';
 
 
@@ -23,12 +24,16 @@ export default class ConfiguredAddonEdit extends Component<Args> {
         itemType: ItemType.Folder,
     };
 
+    get hasRootFolder() {
+        return !(this.args.authorizedAccount instanceof AuthorizedComputingAccountModel);
+    }
+
     get invalidDisplayName() {
         return !this.displayName || this.displayName?.trim().length === 0;
     }
 
     get disableSave() {
-        return !this.selectedFolder || this.invalidDisplayName || this.args.onSave.isRunning;
+        return this.hasRootFolder && (!this.selectedFolder || this.invalidDisplayName || this.args.onSave.isRunning);
     }
 
     get onSaveArgs() {

--- a/lib/osf-components/addon/components/addons-service/configured-addon-edit/component.ts
+++ b/lib/osf-components/addon/components/addons-service/configured-addon-edit/component.ts
@@ -7,6 +7,7 @@ import { Item, ItemType } from 'ember-osf-web/models/addon-operation-invocation'
 import AuthorizedAccountModel from 'ember-osf-web/models/authorized-account';
 import AuthorizedComputingAccountModel from 'ember-osf-web/models/authorized-computing-account';
 import ConfiguredAddonModel from 'ember-osf-web/models/configured-addon';
+import ConfiguredComputingAddonModel from 'ember-osf-web/models/configured-computing-addon';
 
 
 interface Args {
@@ -25,7 +26,11 @@ export default class ConfiguredAddonEdit extends Component<Args> {
     };
 
     get hasRootFolder() {
-        return !(this.args.authorizedAccount instanceof AuthorizedComputingAccountModel);
+        return !(
+            this.args.authorizedAccount instanceof AuthorizedComputingAccountModel
+            ||
+            this.args.configuredAddon instanceof ConfiguredComputingAddonModel
+        );
     }
 
     get invalidDisplayName() {

--- a/lib/osf-components/addon/components/addons-service/configured-addon-edit/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/configured-addon-edit/template.hbs
@@ -21,14 +21,14 @@
             </span>
         {{/if}}
     </div>
-    <AddonsService::FileManager
-        @configuredAddon={{@configuredAddon}}
-        @authorizedAccount={{@authorizedAccount}}
-        @defaultKwargs={{this.defaultKwargs}}
-        @startingFolderId={{this.selectedFolder}}
-        as |fileManager|
-    >
-        {{#if this.hasRootFolder }}
+    {{#if this.hasRootFolder }}
+        <AddonsService::FileManager
+            @configuredAddon={{@configuredAddon}}
+            @authorizedAccount={{@authorizedAccount}}
+            @defaultKwargs={{this.defaultKwargs}}
+            @startingFolderId={{this.selectedFolder}}
+            as |fileManager|
+        >
             <div local-class='current-path'>
                 <Button
                     data-test-go-to-root
@@ -127,25 +127,25 @@
                     {{/if}}
                 </tbody>
             </table>
-        {{/if}}
-        <div local-class='footer-buttons-wrapper'>
-            <Button
-                data-test-root-folder-save
-                data-analytics-name='Save selected folder'
-                @type='primary'
-                disabled={{this.disableSave}}
-                {{on 'click' (fn @onSave this.onSaveArgs)}}
-            >
-                {{t 'general.save'}}
-            </Button>
-            <Button
-                data-test-root-folder-cancel
-                data-analytics-name='Cancel'
-                @type='secondary'
-                {{on 'click' @onCancel}}
-            >
-                {{t 'general.cancel'}}
-            </Button>
-        </div>
-    </AddonsService::FileManager>
+        </AddonsService::FileManager>
+    {{/if}}
+    <div local-class='footer-buttons-wrapper'>
+        <Button
+            data-test-root-folder-save
+            data-analytics-name='Save selected folder'
+            @type='primary'
+            disabled={{this.disableSave}}
+            {{on 'click' (fn @onSave this.onSaveArgs)}}
+        >
+            {{t 'general.save'}}
+        </Button>
+        <Button
+            data-test-root-folder-cancel
+            data-analytics-name='Cancel'
+            @type='secondary'
+            {{on 'click' @onCancel}}
+        >
+            {{t 'general.cancel'}}
+        </Button>
+    </div>
 </div>

--- a/lib/osf-components/addon/components/addons-service/configured-addon-edit/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/configured-addon-edit/template.hbs
@@ -28,104 +28,106 @@
         @startingFolderId={{this.selectedFolder}}
         as |fileManager|
     >
-        <div local-class='current-path'>
-            <Button
-                data-test-go-to-root
-                data-analytics-name='Go to root folder'
-                @layout='fake-link'
-                aria-label={{t 'addons.configure.go-to-root'}}
-                {{on 'click' fileManager.goToRoot}}
-            >
-                <FaIcon @icon='home' />
-                {{t 'general.home'}}
-            </Button>
-            {{#each fileManager.currentPath as |pathItem|}}
+        {{#if this.hasRootFolder }}
+            <div local-class='current-path'>
                 <Button
-                    data-test-folder-path-option='{{pathItem.itemName}}'
-                    data-analytics-name='Go to ancestor folder'
+                    data-test-go-to-root
+                    data-analytics-name='Go to root folder'
                     @layout='fake-link'
-                    aria-label={{t 'addons.configure.go-to-folder' folderName=pathItem.itemName}}
-                    {{on 'click' (fn fileManager.goToFolder pathItem)}}
+                    aria-label={{t 'addons.configure.go-to-root'}}
+                    {{on 'click' fileManager.goToRoot}}
                 >
-                    <FaIcon @icon='chevron-right' />
-                    {{pathItem.itemName}}
+                    <FaIcon @icon='home' />
+                    {{t 'general.home'}}
                 </Button>
-            {{/each}}
-        </div>
-        <table local-class='file-tree-table'>
-            <thead>
-                <tr>
-                    <th>{{t 'addons.configure.table-headings.folder-name'}}</th>
-                    <th>{{t 'addons.configure.table-headings.select'}}</th>
-                </tr>
-            </thead>
-            <tbody local-class='table-body'>
-                {{#if fileManager.isLoading}}
-                    <LoadingIndicator @dark={{true}} />
-                {{else if fileManager.isError}}
+                {{#each fileManager.currentPath as |pathItem|}}
+                    <Button
+                        data-test-folder-path-option='{{pathItem.itemName}}'
+                        data-analytics-name='Go to ancestor folder'
+                        @layout='fake-link'
+                        aria-label={{t 'addons.configure.go-to-folder' folderName=pathItem.itemName}}
+                        {{on 'click' (fn fileManager.goToFolder pathItem)}}
+                    >
+                        <FaIcon @icon='chevron-right' />
+                        {{pathItem.itemName}}
+                    </Button>
+                {{/each}}
+            </div>
+            <table local-class='file-tree-table'>
+                <thead>
                     <tr>
-                        <td colspan='2'>{{t 'addons.configure.error-loading-items'}}</td>
+                        <th>{{t 'addons.configure.table-headings.folder-name'}}</th>
+                        <th>{{t 'addons.configure.table-headings.select'}}</th>
                     </tr>
-                {{else}}
-                    {{#each fileManager.currentItems as |folder|}}
+                </thead>
+                <tbody local-class='table-body'>
+                    {{#if fileManager.isLoading}}
+                        <LoadingIndicator @dark={{true}} />
+                    {{else if fileManager.isError}}
                         <tr>
-                            <td>
-                                {{#if folder.mayContainRootCandidates}}
-                                    <Button
-                                        data-test-folder-link='{{folder.itemName}}'
-                                        data-analytics-name='Go to folder'
-                                        @layout='fake-link'
-                                        aria-label={{t 'addons.configure.go-to-folder' folderName=folder.itemName}}
-                                        {{on 'click' (fn fileManager.goToFolder folder)}}
-                                    >
+                            <td colspan='2'>{{t 'addons.configure.error-loading-items'}}</td>
+                        </tr>
+                    {{else}}
+                        {{#each fileManager.currentItems as |folder|}}
+                            <tr>
+                                <td>
+                                    {{#if folder.mayContainRootCandidates}}
+                                        <Button
+                                            data-test-folder-link='{{folder.itemName}}'
+                                            data-analytics-name='Go to folder'
+                                            @layout='fake-link'
+                                            aria-label={{t 'addons.configure.go-to-folder' folderName=folder.itemName}}
+                                            {{on 'click' (fn fileManager.goToFolder folder)}}
+                                        >
+                                            <span local-class='item-name'>
+                                                <FaIcon @icon='folder' />
+                                                {{folder.itemName}}
+                                            </span>
+                                        </Button>
+                                    {{else}}
                                         <span local-class='item-name'>
                                             <FaIcon @icon='folder' />
                                             {{folder.itemName}}
                                         </span>
-                                    </Button>
-                                {{else}}
-                                    <span local-class='item-name'>
-                                        <FaIcon @icon='folder' />
-                                        {{folder.itemName}}
-                                    </span>
-                                {{/if}}
-                            </td>
-                            <td>
-                                {{#if folder.canBeRoot}}
-                                    <input
-                                        data-test-root-folder-option='{{folder.itemName}}'
-                                        data-analytics-name='Select folder'
-                                        type='radio'
-                                        name='folder'
-                                        value={{folder.itemName}}
-                                        aria-label={{t 'addons.configure.select-folder' folderName=folder.itemName}}
-                                        {{on 'change'(fn this.selectFolder folder)}}
+                                    {{/if}}
+                                </td>
+                                <td>
+                                    {{#if folder.canBeRoot}}
+                                        <input
+                                            data-test-root-folder-option='{{folder.itemName}}'
+                                            data-analytics-name='Select folder'
+                                            type='radio'
+                                            name='folder'
+                                            value={{folder.itemName}}
+                                            aria-label={{t 'addons.configure.select-folder' folderName=folder.itemName}}
+                                            {{on 'change'(fn this.selectFolder folder)}}
+                                        >
+                                    {{/if}}
+                                </td>
+                            </tr>
+                        {{else}}
+                            <tr>
+                                <td colspan='2'>{{t 'addons.configure.no-folders'}}</td>
+                            </tr>
+                        {{/each}}
+                        {{#if fileManager.hasMore}}
+                            <tr>
+                                <td colspan='2'>
+                                    <Button
+                                        data-test-load-more-folders
+                                        data-analytics-name='Load more folders'
+                                        @layout='fake-link'
+                                        {{on 'click' fileManager.getMore}}
                                     >
-                                {{/if}}
-                            </td>
-                        </tr>
-                    {{else}}
-                        <tr>
-                            <td colspan='2'>{{t 'addons.configure.no-folders'}}</td>
-                        </tr>
-                    {{/each}}
-                    {{#if fileManager.hasMore}}
-                        <tr>
-                            <td colspan='2'>
-                                <Button
-                                    data-test-load-more-folders
-                                    data-analytics-name='Load more folders'
-                                    @layout='fake-link'
-                                    {{on 'click' fileManager.getMore}}
-                                >
-                                    {{t 'general.load_more'}}
-                                </Button>
-                            </td>
-                        </tr>
+                                        {{t 'general.load_more'}}
+                                    </Button>
+                                </td>
+                            </tr>
+                        {{/if}}
                     {{/if}}
-                {{/if}}
-            </tbody>
-        </table>
+                </tbody>
+            </table>
+        {{/if}}
         <div local-class='footer-buttons-wrapper'>
             <Button
                 data-test-root-folder-save

--- a/lib/osf-components/addon/components/addons-service/manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/manager/component.ts
@@ -347,10 +347,10 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
             activeFilterObject.configuredAddons = A(configuredAddons.toArray());
         }
 
-        const serviceCloudComputingProviders: Provider[] =
+        const serviceCitationProviders: Provider[] =
             await taskFor(this.getExternalProviders)
                 .perform(activeFilterObject.modelName, activeFilterObject.configuredAddons);
-        activeFilterObject.list = serviceCloudComputingProviders.sort(this.providerSorter);
+        activeFilterObject.list = serviceCitationProviders.sort(this.providerSorter);
     }
 
     providerSorter(a: Provider, b: Provider) {

--- a/lib/osf-components/addon/components/addons-service/manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/manager/component.ts
@@ -77,7 +77,7 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
         },
         [FilterTypes.CLOUD_COMPUTING]: {
             modelName: 'external-computing-service',
-            task: taskFor(this.getCloudComputingProviders),
+            task: taskFor(this.getComputingAddonProviders),
             list: A([]),
             configuredAddons: A([]),
         },
@@ -323,7 +323,7 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
 
     @task
     @waitFor
-    async getCloudComputingProviders() {
+    async getComputingAddonProviders() {
         const activeFilterObject = this.filterTypeMapper[FilterTypes.CLOUD_COMPUTING];
 
         if (this.addonServiceNode) {
@@ -331,10 +331,10 @@ export default class AddonsServiceManagerComponent extends Component<Args> {
             activeFilterObject.configuredAddons = A(configuredAddons.toArray());
         }
 
-        const cloudComputingProviders: Provider[] =
+        const serviceComputingProviders: Provider[] =
             await taskFor(this.getExternalProviders)
                 .perform(activeFilterObject.modelName, activeFilterObject.configuredAddons);
-        activeFilterObject.list = cloudComputingProviders.sort(this.providerSorter);
+        activeFilterObject.list = serviceComputingProviders.sort(this.providerSorter);
     }
 
     @task

--- a/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
@@ -276,9 +276,9 @@ export default class UserAddonManagerComponent extends Component<Args> {
     @waitFor
     async getCitationAddonProviders() {
         const activeFilterObject = this.filterTypeMapper[FilterTypes.CITATION_MANAGER];
-        const serviceCloudComputingProviders = await taskFor(this.getExternalProviders)
+        const serviceCitationProviders = await taskFor(this.getExternalProviders)
             .perform(activeFilterObject.modelName) as ExternalCitationServiceModel[];
-        activeFilterObject.list = serviceCloudComputingProviders.sort(this.providerSorter)
+        activeFilterObject.list = serviceCitationProviders.sort(this.providerSorter)
             .map(provider => new Provider(
                 provider,
                 this.currentUser,

--- a/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
@@ -16,7 +16,7 @@ import CurrentUserService from 'ember-osf-web/services/current-user';
 import AuthorizedAccountModel, { AccountCreationArgs } from 'ember-osf-web/models/authorized-account';
 import AuthorizedStorageAccountModel from 'ember-osf-web/models/authorized-storage-account';
 import AuthorizedCitationAccountModel from 'ember-osf-web/models/authorized-citation-account';
-import AuthorizedComputingAccount from 'ember-osf-web/models/authorized-computing-account';
+import AuthorizedComputingAccountModel from 'ember-osf-web/models/authorized-computing-account';
 import UserModel from 'ember-osf-web/models/user';
 
 import ExternalStorageServiceModel from 'ember-osf-web/models/external-storage-service';
@@ -67,10 +67,10 @@ export default class UserAddonManagerComponent extends Component<Args> {
         },
         [FilterTypes.CLOUD_COMPUTING]: {
             modelName: 'external-computing-service',
-            fetchProvidersTask: taskFor(this.getCloudComputingProviders),
+            fetchProvidersTask: taskFor(this.getComputingAddonProviders),
             list: A([]) as EmberArray<Provider>,
             getAuthorizedAccountsTask: taskFor(this.getAuthorizedComputingAccounts),
-            authorizedAccounts: [] as AuthorizedComputingAccount[],
+            authorizedAccounts: [] as AuthorizedComputingAccountModel[],
             authorizedServiceIds: [] as string[],
         },
     };
@@ -156,7 +156,7 @@ export default class UserAddonManagerComponent extends Component<Args> {
             providerId = (account as AuthorizedCitationAccountModel).externalCitationService.get('id');
             break;
         case 'authorized-computing-account':
-            providerId = (account as AuthorizedComputingAccount).computingService.get('id');
+            providerId = (account as AuthorizedComputingAccountModel).externalComputingService.get('id');
             break;
         default:
             break;
@@ -226,7 +226,7 @@ export default class UserAddonManagerComponent extends Component<Args> {
         const mappedObject = this.filterTypeMapper[FilterTypes.CLOUD_COMPUTING];
         const accounts = (await userReference.authorizedComputingAccounts).toArray();
         mappedObject.authorizedAccounts = accounts;
-        mappedObject.authorizedServiceIds = accounts.map(account => account.computingService.get('id'));
+        mappedObject.authorizedServiceIds = accounts.map(account => account.externalComputingService.get('id'));
         notifyPropertyChange(this, 'filterTypeMapper');
     }
 
@@ -257,11 +257,11 @@ export default class UserAddonManagerComponent extends Component<Args> {
 
     @task
     @waitFor
-    async getCloudComputingProviders() {
+    async getComputingAddonProviders() {
         const activeFilterObject = this.filterTypeMapper[FilterTypes.CLOUD_COMPUTING];
-        const cloudComputingProviders = await taskFor(this.getExternalProviders)
+        const serviceComputingProviders = await taskFor(this.getExternalProviders)
             .perform(activeFilterObject.modelName) as ExternalComputingServiceModel[];
-        activeFilterObject.list = cloudComputingProviders.sort(this.providerSorter)
+        activeFilterObject.list = serviceComputingProviders.sort(this.providerSorter)
             .map(provider => new Provider(
                 provider,
                 this.currentUser,

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -2350,7 +2350,7 @@ routes:
         institution: Institution
         email: Email
 osf-components:
-    addons-srvice:
+    addons-service:
         file-manager:
             get-item-error: 'Error fetching item'
             get-items-error: 'Error fetching items'


### PR DESCRIPTION
-   Ticket: [ENG-6774](https://openscience.atlassian.net/browse/ENG-6774)
-   Feature flag: n/a

## Purpose

The new Boa addon is trying to `POST` a relationship called `computing-service` rather than `external-computing-service`. After investigation, it looks like some of the naming conventions for computing have gone stale and need to be updated.

## Summary of Changes

* Update computing model names to be consistent with their storage and citation brethren, i.e. `AuthorizedComputingAccount` => `AuthorizedComputingAccountModel`
* Update relationship reference names from `computingService` to `externalComputingService` to match the gv API.
* Fix a few spots for citations with the same issues.
* fix a misspelling in the en_us key translations
* set the default capabilities for computing addons

## Screenshot(s)

nope

## Side Effects

still testing, will let you know!

## QA Notes

Don't think so.

## Ticket

[ENG-6774](https://openscience.atlassian.net/browse/ENG-6774)

[ENG-6774]: https://openscience.atlassian.net/browse/ENG-6774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-6774]: https://openscience.atlassian.net/browse/ENG-6774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ