### PR TITLE
[ENG-6744] FE: Contributors can "configure" others' addons

### DIFF
--- a/app/guid-node/addons/index/template.hbs
+++ b/app/guid-node/addons/index/template.hbs
@@ -169,15 +169,17 @@
                                 >
                                     {{configuredAddon.displayName}}
                                     <span local-class='float-right'>
-                                        <Button
-                                            data-test-edit-connected-location={{configuredAddon.displayName}}
-                                            data-analytics-name='Edit connected location'
-                                            local-class='edit-connected-button'
-                                            aria-label={{t 'addons.list.edit-location' displayName=configuredAddon.displayName}}
-                                            {{on 'click' (fn manager.configureProvider manager.selectedProvider configuredAddon)}}
-                                        >
-                                            <FaIcon @icon='pencil-alt' />
-                                        </Button>
+                                        {{#if configuredAddon.currentUserIsOwner}}
+                                            <Button
+                                                data-test-edit-connected-location={{configuredAddon.displayName}}
+                                                data-analytics-name='Edit connected location'
+                                                local-class='edit-connected-button'
+                                                aria-label={{t 'addons.list.edit-location' displayName=configuredAddon.displayName}}
+                                                {{on 'click' (fn manager.configureProvider manager.selectedProvider configuredAddon)}}
+                                            >
+                                                <FaIcon @icon='pencil-alt' />
+                                            </Button>
+                                        {{/if}}
                                         <Button
                                             data-test-remove-connected-location={{configuredAddon.displayName}}
                                             data-analytics-name='Remove connected location'

--- a/app/models/configured-addon.ts
+++ b/app/models/configured-addon.ts
@@ -1,5 +1,6 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { AsyncBelongsTo, attr, belongsTo } from '@ember-data/model';
 
+import UserReferenceModel from 'ember-osf-web/models/user-reference';
 import { ConnectedStorageOperationNames, OperationKwargs } from './addon-operation-invocation';
 import AuthorizedAccountModel, { ConnectedCapabilities } from './authorized-account';
 
@@ -19,6 +20,9 @@ export default class ConfiguredAddonModel extends Model {
     @attr('array') connectedCapabilities!: ConnectedCapabilities[];
     @attr('array') connectedOperationNames!: ConnectedStorageOperationNames[];
     @attr('fixstring') rootFolder!: string;
+
+    @belongsTo('user-reference', { inverse: null })
+    accountOwner!: AsyncBelongsTo<UserReferenceModel> & UserReferenceModel;
 
     @attr('boolean')
     currentUserIsOwner!: boolean;

--- a/app/models/configured-addon.ts
+++ b/app/models/configured-addon.ts
@@ -1,7 +1,6 @@
-import Model, { AsyncBelongsTo, attr, belongsTo } from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 
 import { ConnectedStorageOperationNames, OperationKwargs } from './addon-operation-invocation';
-import UserReferenceModel from './user-reference';
 import AuthorizedAccountModel, { ConnectedCapabilities } from './authorized-account';
 
 export interface ConfiguredAddonEditableAttrs {
@@ -21,9 +20,8 @@ export default class ConfiguredAddonModel extends Model {
     @attr('array') connectedOperationNames!: ConnectedStorageOperationNames[];
     @attr('fixstring') rootFolder!: string;
 
-
-    @belongsTo('user-reference', { inverse: null })
-    accountOwner!: AsyncBelongsTo<UserReferenceModel> & UserReferenceModel;
+    @attr('boolean')
+    currentUserIsOwner!: boolean;
 
     async getFolderItems(this: AuthorizedAccountModel, _kwargs?: OperationKwargs) : Promise<any> {
         // To be implemented in child classes

--- a/app/packages/addons-service/provider.ts
+++ b/app/packages/addons-service/provider.ts
@@ -99,7 +99,7 @@ export default class Provider {
         if (this.node?.userHasAdminPermission) {
             return true;
         }
-        if (!this.configuredAddons) {
+        if (!this.configuredAddons || this.configuredAddons.length === 0) {
             return true;
         }
         if (!this.userReference) {

--- a/app/packages/addons-service/provider.ts
+++ b/app/packages/addons-service/provider.ts
@@ -95,17 +95,38 @@ export default class Provider {
         return Boolean(this.configuredAddons?.length);
     }
 
+    get isOwned() {
+        if (this.node?.userHasAdminPermission) {
+            return true;
+        }
+        if (!this.configuredAddons) {
+            return true;
+        }
+        if (!this.userReference) {
+            return false;
+        }
+        return this.configuredAddons?.any(
+            addon => addon.currentUserIsOwner,
+        );
+    }
+
     constructor(
         provider: any,
         currentUser: CurrentUserService,
         node?: NodeModel,
         allConfiguredAddons?: EmberArray<AllConfiguredAddonTypes>,
+        resourceReference?: ResourceReferenceModel,
+        userReference?: UserReferenceModel,
     ) {
         setOwner(this, getOwner(provider));
         this.node = node;
         this.currentUser = currentUser;
         this.provider = provider;
         this.configuredAddons = allConfiguredAddons?.filter(addon => addon.externalServiceId === this.provider.id);
+        this.serviceNode = resourceReference;
+        if (userReference) {
+            this.userReference = userReference;
+        }
 
         if (provider instanceof ExternalStorageServiceModel) {
             this.providerMap = this.providerTypeMapper.externalStorageService;
@@ -144,6 +165,9 @@ export default class Provider {
     @task
     @waitFor
     async getUserReference() {
+        if (this.userReference){
+            return;
+        }
         const { user } = this.currentUser;
         const userReferences = await this.store.query('user-reference', {
             filter: {user_uri: user?.links.iri?.toString()},
@@ -155,7 +179,7 @@ export default class Provider {
     @task
     @waitFor
     async getResourceReference() {
-        if (this.node) {
+        if (this.node && !this.serviceNode) {
             const resourceRefs = await this.store.query('resource-reference', {
                 filter: {resource_uri: this.node.links.iri?.toString()},
             });

--- a/lib/osf-components/addon/components/addon-card/component.ts
+++ b/lib/osf-components/addon/components/addon-card/component.ts
@@ -17,4 +17,8 @@ export default class AddonsCardComponent extends Component<Args> {
     get addonIsConfigured() {
         return this.args.addon.isConfigured;
     }
+
+    get addonIsOwned() {
+        return this.args.addon.isOwned;
+    }
 }

--- a/lib/osf-components/addon/components/addon-card/template.hbs
+++ b/lib/osf-components/addon/components/addon-card/template.hbs
@@ -15,25 +15,26 @@
     >
         {{@addon.provider.displayName}}
     </div>
-    
-    <div local-class='buttons-wrapper'>
-        {{#if this.addonIsConfigured}}
-            <Button
-                data-test-addon-card-configure
-                data-analytics-name='Configure'
-                {{on 'click' (fn @manager.listProviderConfigurations @addon)}}
-            >
-                {{t 'osf-components.addon-card.configure'}}
-            </Button>
-        {{else}}
-            <Button
-                data-test-addon-card-connect
-                data-analytics-name='Connect'
-                {{on 'click' (fn @manager.beginAccountSetup @addon)}}
-            >
-                {{t 'osf-components.addon-card.connect'}}
-            </Button>
-        {{/if}}
-    </div>
+    {{#if this.addonIsOwned}}
+        <div local-class='buttons-wrapper'>
+            {{#if this.addonIsConfigured}}
+                <Button
+                    data-test-addon-card-configure
+                    data-analytics-name='Configure'
+                    {{on 'click' (fn @manager.listProviderConfigurations @addon)}}
+                >
+                    {{t 'osf-components.addon-card.configure'}}
+                </Button>
+            {{else}}
+                <Button
+                    data-test-addon-card-connect
+                    data-analytics-name='Connect'
+                    {{on 'click' (fn @manager.beginAccountSetup @addon)}}
+                >
+                    {{t 'osf-components.addon-card.connect'}}
+                </Button>
+            {{/if}}
+        </div>
+    {{/if}}
 </div>
 

--- a/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
+++ b/lib/osf-components/addon/components/addons-service/user-addons-manager/component.ts
@@ -244,7 +244,14 @@ export default class UserAddonManagerComponent extends Component<Args> {
         const serviceStorageProviders = await taskFor(this.getExternalProviders)
             .perform(activeFilterObject.modelName) as ExternalStorageServiceModel[];
         const list = serviceStorageProviders.sort(this.providerSorter)
-            .map(provider => new Provider(provider, this.currentUser));
+            .map(provider => new Provider(
+                provider,
+                this.currentUser,
+                undefined,
+                undefined,
+                undefined,
+                this.userReference,
+            ));
         activeFilterObject.list = list;
     }
 
@@ -255,7 +262,14 @@ export default class UserAddonManagerComponent extends Component<Args> {
         const cloudComputingProviders = await taskFor(this.getExternalProviders)
             .perform(activeFilterObject.modelName) as ExternalComputingServiceModel[];
         activeFilterObject.list = cloudComputingProviders.sort(this.providerSorter)
-            .map(provider => new Provider(provider, this.currentUser));
+            .map(provider => new Provider(
+                provider,
+                this.currentUser,
+                undefined,
+                undefined,
+                undefined,
+                this.userReference,
+            ));
     }
 
     @task
@@ -265,7 +279,14 @@ export default class UserAddonManagerComponent extends Component<Args> {
         const serviceCloudComputingProviders = await taskFor(this.getExternalProviders)
             .perform(activeFilterObject.modelName) as ExternalCitationServiceModel[];
         activeFilterObject.list = serviceCloudComputingProviders.sort(this.providerSorter)
-            .map(provider => new Provider(provider, this.currentUser));
+            .map(provider => new Provider(
+                provider,
+                this.currentUser,
+                undefined,
+                undefined,
+                undefined,
+                this.userReference,
+            ));
     }
 
     @task

--- a/tests/acceptance/guid-node/addons-test.ts
+++ b/tests/acceptance/guid-node/addons-test.ts
@@ -124,6 +124,7 @@ module('Acceptance | guid-node/addons', hooks => {
             externalStorageService: box,
             accountOwner: userRef,
             authorizedResource: nodeRef,
+            currentUserIsOwner: true,
         });
         const s3AccountsDisplayNamesAndRootFolders = [{
             displayName: 'My Box Account',
@@ -139,6 +140,7 @@ module('Acceptance | guid-node/addons', hooks => {
             externalStorageService: s3,
             accountOwner: userRef,
             authorizedResource: nodeRef,
+            currentUserIsOwner: true,
         });
         server.create('configured-storage-addon', {
             displayName: s3AccountsDisplayNamesAndRootFolders[1].displayName,
@@ -147,6 +149,7 @@ module('Acceptance | guid-node/addons', hooks => {
             externalStorageService: s3,
             accountOwner: userRef,
             authorizedResource: nodeRef,
+            currentUserIsOwner: true,
         });
 
         const url = `/${node.id}/addons`;

--- a/tests/integration/components/addon-card/component-test.ts
+++ b/tests/integration/components/addon-card/component-test.ts
@@ -35,10 +35,10 @@ module('Integration | Component | addon-card', hooks => {
                 id: 'box',
                 displayName: 'Test Addon',
                 iconUrl: 'https://some.url/from/addons/service/box.png',
-                isOwned: true,
             },
             disableProjectAddon: sinon.stub(),
             nodeAddon: { configured: false },
+            isOwned: true,
         };
         this.manager ={
             node: { id: 'testnode' },

--- a/tests/integration/components/addon-card/component-test.ts
+++ b/tests/integration/components/addon-card/component-test.ts
@@ -35,6 +35,7 @@ module('Integration | Component | addon-card', hooks => {
                 id: 'box',
                 displayName: 'Test Addon',
                 iconUrl: 'https://some.url/from/addons/service/box.png',
+                isOwned: true,
             },
             disableProjectAddon: sinon.stub(),
             nodeAddon: { configured: false },
@@ -78,6 +79,7 @@ module('Integration | Component | addon-card', hooks => {
             disableProjectAddon: { perform: sinon.stub() },
             nodeAddon: { configured: true },
             isConfigured: true,
+            isOwned: true,
         };
         this.addon = addonObj;
         this.manager = {


### PR DESCRIPTION
… 
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-6744]
-   Feature flag: gravy_waffle

## Purpose


## Summary of Changes

- fixed configure button displayed when user won't be able to configure addon
- fixed user and resource reference reuest swarm

## Screenshot(s)
![image](https://github.com/user-attachments/assets/b7f05242-6bf6-4f0a-af5a-3b282247ee3a)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6744]: https://openscience.atlassian.net/browse/ENG-6744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ