### PR TITLE
[ENG-6471] Add status labels to version dropdowns

### DIFF
--- a/app/models/preprint.ts
+++ b/app/models/preprint.ts
@@ -36,6 +36,12 @@ export enum PreprintPreregLinkInfoEnum {
     PREREG_BOTH = 'prereg_both',
 }
 
+export const VersionStatusSimpleLabelKey = {
+    [ReviewsState.PENDING]: 'preprints.detail.version_status.pending',
+    [ReviewsState.REJECTED]: 'preprints.detail.version_status.rejected',
+    [ReviewsState.WITHDRAWN]: 'preprints.detail.version_status.withdrawn',
+};
+
 export interface PreprintLicenseRecordModel {
     copyright_holders: string[];
     year: string;

--- a/app/preprints/-components/preprint-doi/component.ts
+++ b/app/preprints/-components/preprint-doi/component.ts
@@ -1,7 +1,10 @@
+import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import PreprintModel from 'ember-osf-web/models/preprint';
+import Intl from 'ember-intl/services/intl';
+
+import PreprintModel, { VersionStatusSimpleLabelKey } from 'ember-osf-web/models/preprint';
 import PreprintProviderModel from 'ember-osf-web/models/preprint-provider';
 
 interface InputArgs {
@@ -10,10 +13,14 @@ interface InputArgs {
 }
 
 export default class PreprintAbstract extends Component<InputArgs> {
+    @service intl!: Intl;
+
     provider = this.args.provider;
     documentType = this.provider.documentType.singularCapitalized;
 
     @tracked selectedVersion = this.args.versions[0];
+
+    reviewStateLabelKeyMap = VersionStatusSimpleLabelKey;
 
     @action
     selectVersion(version: PreprintModel) {

--- a/app/preprints/-components/preprint-doi/styles.scss
+++ b/app/preprints/-components/preprint-doi/styles.scss
@@ -1,4 +1,4 @@
 .version-dropdown {
     margin-bottom: 12px;
-    width: 120px;
+    width: 200px;
 }

--- a/app/preprints/-components/preprint-doi/template.hbs
+++ b/app/preprints/-components/preprint-doi/template.hbs
@@ -14,7 +14,12 @@
             <span
                 data-test-preprint-version={{version.version}}
             >
-                {{t 'preprints.detail.version_doi_title' number=version.version}}
+                {{#let (get this.reviewStateLabelKeyMap version.reviewsState) as |reviewStateLabelKey|}}
+                    {{t 'preprints.detail.version_doi_title' number=version.version}}
+                    {{#if reviewStateLabelKey}}
+                        {{t (get this.reviewStateLabelKeyMap version.reviewsState)}}
+                    {{/if}}
+                {{/let}}
             </span>
         </PowerSelect>
     {{else}}

--- a/app/preprints/detail/controller.ts
+++ b/app/preprints/detail/controller.ts
@@ -1,19 +1,21 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import config from 'ember-osf-web/config/environment';
-import Theme from 'ember-osf-web/services/theme';
-import CurrentUserService from 'ember-osf-web/services/current-user';
-import Features from 'ember-feature-flags';
-import ContributorModel from 'ember-osf-web/models/contributor';
-import Intl from 'ember-intl/services/intl';
-import { Permission } from 'ember-osf-web/models/osf-model';
-import { ReviewsState, PreprintProviderReviewsWorkFlow } from 'ember-osf-web/models/provider';
+import { waitFor } from '@ember/test-waiters';
 import { tracked } from '@glimmer/tracking';
+import { task } from 'ember-concurrency';
+import Features from 'ember-feature-flags';
+import Intl from 'ember-intl/services/intl';
 import Media from 'ember-responsive';
 import Toast from 'ember-toastr/services/toast';
-import { task } from 'ember-concurrency';
-import { waitFor } from '@ember/test-waiters';
+
+import config from 'ember-osf-web/config/environment';
+import ContributorModel from 'ember-osf-web/models/contributor';
+import { Permission } from 'ember-osf-web/models/osf-model';
+import { VersionStatusSimpleLabelKey } from 'ember-osf-web/models/preprint';
+import { PreprintProviderReviewsWorkFlow, ReviewsState } from 'ember-osf-web/models/provider';
+import CurrentUserService from 'ember-osf-web/services/current-user';
+import Theme from 'ember-osf-web/services/theme';
 
 
 /**
@@ -53,6 +55,7 @@ export default class PrePrintsDetailController extends Controller {
     @tracked plauditIsReady = false;
 
     metricsStartDate = config.OSF.metricsStartDate;
+    reviewStateLabelKeyMap = VersionStatusSimpleLabelKey;
 
     get hyperlink(): string {
         return window.location.href;

--- a/app/preprints/detail/styles.scss
+++ b/app/preprints/detail/styles.scss
@@ -265,6 +265,7 @@
 }
 
 .version-picker-list {
+    width: max-content;
     list-style: none;
     margin: 0;
     padding-inline-start: 0;

--- a/app/preprints/detail/template.hbs
+++ b/app/preprints/detail/template.hbs
@@ -36,7 +36,12 @@
                                             @route='preprints.detail'
                                             @models={{array this.model.provider.id version.id}}
                                         >
-                                            {{t 'preprints.detail.preprint_version_number' number=version.version}}
+                                            {{#let (get this.reviewStateLabelKeyMap version.reviewsState) as |reviewStateLabelKey|}}
+                                                {{t 'preprints.detail.preprint_version_number' number=version.version}}
+                                                {{#if reviewStateLabelKey}}
+                                                    {{t (get this.reviewStateLabelKeyMap version.reviewsState)}}
+                                                {{/if}}
+                                            {{/let}}
                                         </OsfLink>
                                     </li>
                                 {{else}}

--- a/tests/acceptance/preprints/detail-test.ts
+++ b/tests/acceptance/preprints/detail-test.ts
@@ -148,6 +148,7 @@ module('Acceptance | preprints | detail', hooks => {
             dateWithdrawn: new Date(),
             currentUserPermissions: Object.values(Permission),
             title: 'Test Preprint',
+            reviewsState: ReviewsState.WITHDRAWN,
             description: 'This is a test preprint',
         }, 'withVersions');
         this.preprint.update({

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1445,6 +1445,10 @@ preprints:
         orphan_preprint: 'The user has removed this file.'
         preprint_doi: '{documentType} DOI'
         version_doi_title: 'Version {number}'
+        version_status:
+            pending: '(Pending)'
+            rejected: '(Rejected)'
+            withdrawn: '(Withdrawn)'
         preprint_pending_doi: 'DOI created after {documentType} is made public'
         preprint_pending_doi_moderation: 'DOI created after moderator approval'
         no_doi: 'No DOI'


### PR DESCRIPTION
-   Ticket: [ENG-6471]
-   Feature flag: n/a

## Purpose
- Add version statuses for pending, rejected, and withdrawn versions

## Summary of Changes
- Add version status to Version DOI selector
- Add version status to Withdrawn page's version selector dropdown

## Screenshot(s)
- Version DOI selector dropdown:
![image](https://github.com/user-attachments/assets/ddd4d125-460a-4724-b38a-3ce8e4398964)

- Withdrawn version selector dropdown:
![image](https://github.com/user-attachments/assets/74ee0748-441f-45ab-ad50-9b614a618c6c)

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6471]: https://openscience.atlassian.net/browse/ENG-6471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ