### PR TITLE
[ENG-6803] Preprint-doi select dropdown should have current version selected by default

### DIFF
--- a/app/preprints/-components/preprint-doi/component-test.ts
+++ b/app/preprints/-components/preprint-doi/component-test.ts
@@ -41,10 +41,12 @@ module('Integration | Component | preprint-doi', function(hooks) {
 
         const provider = await this.store.findRecord('preprint-provider', mirageProvider.id);
         this.set('versions', versions);
+        this.set('currentVersion', versions[1]);
         this.set('provider', provider);
 
         await render(hbs`
 <Preprints::-Components::PreprintDoi
+    @currentVersion={{this.currentVersion}}
     @versions={{this.versions}}
     @provider={{this.provider}}
 />
@@ -57,21 +59,23 @@ module('Integration | Component | preprint-doi', function(hooks) {
         // check dropdown exists
         assert.dom('[data-test-version-select-dropdown]').exists('Version select dropdown exists');
         assert.dom('[data-test-version-select-dropdown]')
-            .hasText('Version 3 (Rejected)', 'Dropdown has latest version selected by default');
+            .hasText('Version 2 (Rejected)', 'Dropdown has passed in currentVersiom selected by default');
+        assert.dom('[data-test-preprint-version="2"]').exists('Version 2 is shown');
 
-        // check version3 has no DOI
-        assert.dom('[data-test-no-doi-text]').exists('No DOI text exists');
-        assert.dom('[data-test-no-doi-text]').hasText('DOI created after moderator approval', 'No DOI text is correct');
-
-        // check version2 has DOI, but no preprintDoiCreated date
-        await click('[data-test-version-select-dropdown]');
-        await click('[data-test-preprint-version="2"]');
+        // check version2 has DOI text
         assert.dom('[data-test-no-doi-text]').doesNotExist('No DOI text does not exist');
         assert.dom('[data-test-unlinked-doi-url]').exists('Preprint DOI URL exists');
         assert.dom('[data-test-unlinked-doi-description]').exists('Preprint DOI description exists');
         assert.dom('[data-test-unlinked-doi-description]')
             // eslint-disable-next-line max-len
             .hasText('DOIs are minted by a third party, and may take up to 24 hours to be registered.', 'Description is correct');
+
+        // check version3 has DOI, but no preprintDoiCreated date
+        await click('[data-test-version-select-dropdown]');
+        await click('[data-test-preprint-version="3"]');
+        assert.dom('[data-test-unlinked-doi-url]').doesNotExist('Unlinked preprint DOI URL does not exist');
+        assert.dom('[data-test-no-doi-text]').exists('No DOI text exists');
+        assert.dom('[data-test-no-doi-text]').hasText('DOI created after moderator approval', 'No DOI text is correct');
 
         // check version1 has DOI and preprintDoiCreated date
         await click('[data-test-version-select-dropdown]');
@@ -100,11 +104,13 @@ module('Integration | Component | preprint-doi', function(hooks) {
         const versions = await preprint.queryHasMany('versions');
 
         const provider = await this.store.findRecord('preprint-provider', mirageProvider.id);
+        this.set('currentVersion', versions[0]);
         this.set('versions', versions);
         this.set('provider', provider);
 
         await render(hbs`
 <Preprints::-Components::PreprintDoi
+    @currentVersion={{this.currentVersion}}
     @versions={{this.versions}}
     @provider={{this.provider}}
 />

--- a/app/preprints/-components/preprint-doi/component.ts
+++ b/app/preprints/-components/preprint-doi/component.ts
@@ -10,6 +10,7 @@ import PreprintProviderModel from 'ember-osf-web/models/preprint-provider';
 interface InputArgs {
     versions: PreprintModel[];
     provider: PreprintProviderModel;
+    currentVersion: PreprintModel;
 }
 
 export default class PreprintAbstract extends Component<InputArgs> {
@@ -18,7 +19,7 @@ export default class PreprintAbstract extends Component<InputArgs> {
     provider = this.args.provider;
     documentType = this.provider.documentType.singularCapitalized;
 
-    @tracked selectedVersion = this.args.versions[0];
+    @tracked selectedVersion = this.args.currentVersion;
 
     reviewStateLabelKeyMap = VersionStatusSimpleLabelKey;
 

--- a/app/preprints/-components/preprint-doi/styles.scss
+++ b/app/preprints/-components/preprint-doi/styles.scss
@@ -2,3 +2,7 @@
     margin-bottom: 12px;
     width: 200px;
 }
+
+.current-version {
+    font-weight: bold;
+}

--- a/app/preprints/-components/preprint-doi/template.hbs
+++ b/app/preprints/-components/preprint-doi/template.hbs
@@ -12,6 +12,7 @@
             as |version|
         >
             <span
+                local-class={{if (eq version.version @currentVersion.version) 'current-version'}}
                 data-test-preprint-version={{version.version}}
             >
                 {{#let (get this.reviewStateLabelKeyMap version.reviewsState) as |reviewStateLabelKey|}}

--- a/app/preprints/-components/preprint-tombstone/template.hbs
+++ b/app/preprints/-components/preprint-tombstone/template.hbs
@@ -8,7 +8,11 @@
         </div>
     {{/if}}
     <Preprints::-Components::PreprintAbstract @preprint={{@preprint}} />
-    <Preprints::-Components::PreprintDoi @versions={{@versions}} @provider={{@provider}} />
+    <Preprints::-Components::PreprintDoi
+        @currentVersion={{@preprint}}
+        @versions={{@versions}}
+        @provider={{@provider}}
+    />
     <Preprints::-Components::PreprintLicense @preprint={{@preprint}} />
     <Preprints::-Components::PreprintDiscipline @subjects={{@subjects}} />
     <Preprints::-Components::PreprintTag @preprint={{@preprint}} />

--- a/app/preprints/detail/template.hbs
+++ b/app/preprints/detail/template.hbs
@@ -233,6 +233,7 @@
                         </div>
                     {{/if}}
                     <Preprints::-Components::PreprintDoi
+                        @currentVersion={{this.model.preprint}}
                         @versions={{this.model.versions}}
                         @provider={{this.model.provider}}
                     />


### PR DESCRIPTION
-   Ticket: [ENG-6803]
-   Feature flag: n/a

## Purpose
- Indicate currently viewed version in the preprint DOI selection dropdown

## Summary of Changes
- Add a `currentVersion` param to the preprint-doi component
  - Have this version be the selected one by default
  - Add bold font style to current version

## Screenshot(s)
- When viewing version 2 out of 3 possible versions (note the `_v2` in the URL)
![image](https://github.com/user-attachments/assets/2146e925-e1f1-4497-b8b4-0fedaa755389)
- Upon opening dropdown, you can see that version2 is the currently viewed version
![image](https://github.com/user-attachments/assets/09c14480-cfac-4811-9d36-ad1a8e69d564)
 

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6803]: https://openscience.atlassian.net/browse/ENG-6803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ