### PR TITLE
[ENG-6804] Add link to version in DOI select

### DIFF
--- a/app/preprints/-components/preprint-doi/component-test.ts
+++ b/app/preprints/-components/preprint-doi/component-test.ts
@@ -9,12 +9,15 @@ import { ModelInstance } from 'ember-cli-mirage';
 import PreprintProviderModel from 'ember-osf-web/models/preprint-provider';
 import PreprintModel from 'ember-osf-web/models/preprint';
 import { ReviewsState } from 'ember-osf-web/models/provider';
+import { OsfLinkRouterStub } from 'ember-osf-web/tests/integration/helpers/osf-link-router-stub';
 
 module('Integration | Component | preprint-doi', function(hooks) {
     setupRenderingTest(hooks);
     setupMirage(hooks);
 
     test('it renders', async function(assert) {
+        this.owner.unregister('service:router');
+        this.owner.register('service:router', OsfLinkRouterStub);
         this.store = this.owner.lookup('service:store');
         server.loadFixtures('preprint-providers');
         const mirageProvider = server.schema.preprintProviders.find('osf') as ModelInstance<PreprintProviderModel>;
@@ -62,6 +65,9 @@ module('Integration | Component | preprint-doi', function(hooks) {
             .hasText('Version 2 (Rejected)', 'Dropdown has passed in currentVersiom selected by default');
         assert.dom('[data-test-preprint-version="2"]').exists('Version 2 is shown');
 
+        assert.dom('[data-test-view-version-link]').exists('View in OSF button exists');
+        assert.dom('[data-test-view-version-link]').hasText('View version 2', 'View version link has correct text');
+
         // check version2 has DOI text
         assert.dom('[data-test-no-doi-text]').doesNotExist('No DOI text does not exist');
         assert.dom('[data-test-unlinked-doi-url]').exists('Preprint DOI URL exists');
@@ -86,6 +92,8 @@ module('Integration | Component | preprint-doi', function(hooks) {
     });
 
     test('it renders statuses', async function(assert) {
+        this.owner.unregister('service:router');
+        this.owner.register('service:router', OsfLinkRouterStub);
         this.store = this.owner.lookup('service:store');
         server.loadFixtures('preprint-providers');
         const mirageProvider = server.schema.preprintProviders.find('osf') as ModelInstance<PreprintProviderModel>;

--- a/app/preprints/-components/preprint-doi/template.hbs
+++ b/app/preprints/-components/preprint-doi/template.hbs
@@ -27,6 +27,14 @@
         <p>{{t 'preprints.detail.no_versions'}}</p>
     {{/if}}
     {{#if this.selectedVersion}}
+        <OsfLink
+            data-test-view-version-link
+            data-analytics-name='View version link'
+            @route='preprints.detail'
+            @model={{this.selectedVersion}}
+        >
+            {{t 'preprints.detail.view_version' number=this.selectedVersion.version}}
+        </OsfLink>
         {{#if this.selectedVersion.preprintDoiUrl}}
             {{#if this.selectedVersion.preprintDoiCreated}}
                 <OsfLink

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -1445,6 +1445,7 @@ preprints:
         orphan_preprint: 'The user has removed this file.'
         preprint_doi: '{documentType} DOI'
         version_doi_title: 'Version {number}'
+        view_version: 'View version {number}'
         version_status:
             pending: '(Pending)'
             rejected: '(Rejected)'


### PR DESCRIPTION
-   Ticket: [ENG-6804]
-   Feature flag: n/a

## Purpose
- Add a link to the version when selecting a different version in the DOI selection dropdown

## Summary of Changes
- Add link to preprint DOI dropdown
- Update tests

## Screenshot(s)
![image](https://github.com/user-attachments/assets/f7388c6f-c038-42bf-aeaf-40e4a1e5060e)

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6804]: https://openscience.atlassian.net/browse/ENG-6804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ