### PR TITLE
[ENG-6823] Explicitly list columns for SHARE download

### DIFF
--- a/app/institutions/dashboard/-components/object-list/component-test.ts
+++ b/app/institutions/dashboard/-components/object-list/component-test.ts
@@ -24,8 +24,9 @@ module('Integration | institutions | dashboard | -components | object-list', hoo
         const columns = [
             {
                 name: 'Title',
-                sortKey: 'title',
+                isSortable: true,
                 getValue: () => 'Title of some object',
+                propertyPathKey: 'title',
             },
             {
                 name: 'Description',

--- a/app/institutions/dashboard/-components/object-list/component.ts
+++ b/app/institutions/dashboard/-components/object-list/component.ts
@@ -17,6 +17,7 @@ interface Column {
     name: string;
     sortKey?: string;
     sortParam?: string;
+    columnKey?: string;
 }
 interface ValueColumn extends Column {
     getValue(searchResult: SearchResultModel): string;
@@ -92,6 +93,16 @@ export default class InstitutionalObjectList extends Component<InstitutionalObje
         cardSearchUrl.searchParams.set('page[size]', '10000');
         cardSearchUrl.searchParams.set('acceptMediatype', format);
         cardSearchUrl.searchParams.set('withFileName', `${this.args.objectType}-search-results`);
+
+        const columnDownloadKeys = this.args.columns.map(column => {
+            if (column.columnKey && this.visibleColumns.includes(column.name)) {
+                return column.columnKey;
+            }
+            return null;
+        });
+        const { resourceType } = this.args.defaultQueryOptions.cardSearchFilter;
+
+        cardSearchUrl.searchParams.set(`fields[${resourceType}]`, columnDownloadKeys.filter(Boolean).join(','));
         return cardSearchUrl.toString();
     }
 

--- a/app/institutions/dashboard/-components/object-list/component.ts
+++ b/app/institutions/dashboard/-components/object-list/component.ts
@@ -15,9 +15,9 @@ const shareDownloadFlag = config.featureFlagNames.shareDownload;
 
 interface Column {
     name: string;
-    sortKey?: string;
+    isSortable?: boolean;
     sortParam?: string;
-    columnKey?: string;
+    propertyPathKey?: string;
 }
 interface ValueColumn extends Column {
     getValue(searchResult: SearchResultModel): string;
@@ -95,8 +95,8 @@ export default class InstitutionalObjectList extends Component<InstitutionalObje
         cardSearchUrl.searchParams.set('withFileName', `${this.args.objectType}-search-results`);
 
         const columnDownloadKeys = this.args.columns.map(column => {
-            if (column.columnKey && this.visibleColumns.includes(column.name)) {
-                return column.columnKey;
+            if (column.propertyPathKey && this.visibleColumns.includes(column.name)) {
+                return column.propertyPathKey;
             }
             return null;
         });

--- a/app/institutions/dashboard/-components/object-list/template.hbs
+++ b/app/institutions/dashboard/-components/object-list/template.hbs
@@ -149,10 +149,10 @@ as |list|>
                                             >
                                                 <span>
                                                     {{column.name}}
-                                                    {{#if column.sortKey}}
+                                                    {{#if column.isSortable}}
                                                         <SortArrow
-                                                            @sortBy={{column.sortKey}}
-                                                            @sortAction={{queue (fn this.updateSortKey column.sortKey column.sortParam) (perform list.searchObjectsTask)}}
+                                                            @sortBy={{column.propertyPathKey}}
+                                                            @sortAction={{queue (fn this.updateSortKey column.propertyPathKey column.sortParam) (perform list.searchObjectsTask)}}
                                                         />
                                                     {{/if}}
                                                 </span>

--- a/app/institutions/dashboard/preprints/controller.ts
+++ b/app/institutions/dashboard/preprints/controller.ts
@@ -17,6 +17,7 @@ export default class InstitutionDashboardPreprints extends Controller {
             type: 'link',
             getHref: searchResult => searchResult.indexCard.get('osfIdentifier'),
             getLinkText: searchResult => searchResult.displayTitle,
+            columnKey: 'title',
         },
         { // Link
             name: this.intl.t('institutions.dashboard.object-list.table-headers.link'),
@@ -28,23 +29,28 @@ export default class InstitutionDashboardPreprints extends Controller {
             name: this.intl.t('institutions.dashboard.object-list.table-headers.created_date'),
             getValue: searchResult => getSingleOsfmapValue(searchResult.resourceMetadata, ['dateCreated']),
             sortKey: 'dateCreated',
+            columnKey: 'dateCreated',
         },
         { // Date modified
             name: this.intl.t('institutions.dashboard.object-list.table-headers.modified_date'),
             getValue: searchResult => getSingleOsfmapValue(searchResult.resourceMetadata, ['dateModified']),
             sortKey: 'dateModified',
+            columnKey: 'dateModified',
         },
         { // DOI
             name: this.intl.t('institutions.dashboard.object-list.table-headers.doi'),
             type: 'doi',
+            columnKey: 'resourceIdentifier',
         },
         { // License
             name: this.intl.t('institutions.dashboard.object-list.table-headers.license'),
             getValue: searchResult => searchResult.license?.name || this.missingItemPlaceholder,
+            columnKey: 'rights.name',
         },
         { // Contributor name + permissions
             name: this.intl.t('institutions.dashboard.object-list.table-headers.contributor_name'),
             type: 'contributors',
+            columnKey: 'creator.name',
         },
         { // View count
             name: this.intl.t('institutions.dashboard.object-list.table-headers.view_count'),
@@ -54,6 +60,7 @@ export default class InstitutionDashboardPreprints extends Controller {
             },
             sortKey: 'usage.viewCount',
             sortParam: 'integer-value',
+            columnKey: 'usage.viewCount',
         },
         { // Download count
             name: this.intl.t('institutions.dashboard.object-list.table-headers.download_count'),
@@ -63,6 +70,7 @@ export default class InstitutionDashboardPreprints extends Controller {
             },
             sortKey: 'usage.downloadCount',
             sortParam: 'integer-value',
+            columnKey: 'usage.downloadCount',
         },
     ];
 

--- a/app/institutions/dashboard/preprints/controller.ts
+++ b/app/institutions/dashboard/preprints/controller.ts
@@ -17,7 +17,7 @@ export default class InstitutionDashboardPreprints extends Controller {
             type: 'link',
             getHref: searchResult => searchResult.indexCard.get('osfIdentifier'),
             getLinkText: searchResult => searchResult.displayTitle,
-            columnKey: 'title',
+            propertyPathKey: 'title',
         },
         { // Link
             name: this.intl.t('institutions.dashboard.object-list.table-headers.link'),
@@ -28,29 +28,29 @@ export default class InstitutionDashboardPreprints extends Controller {
         { // Date created
             name: this.intl.t('institutions.dashboard.object-list.table-headers.created_date'),
             getValue: searchResult => getSingleOsfmapValue(searchResult.resourceMetadata, ['dateCreated']),
-            sortKey: 'dateCreated',
-            columnKey: 'dateCreated',
+            isSortable: true,
+            propertyPathKey: 'dateCreated',
         },
         { // Date modified
             name: this.intl.t('institutions.dashboard.object-list.table-headers.modified_date'),
             getValue: searchResult => getSingleOsfmapValue(searchResult.resourceMetadata, ['dateModified']),
-            sortKey: 'dateModified',
-            columnKey: 'dateModified',
+            isSortable: true,
+            propertyPathKey: 'dateModified',
         },
         { // DOI
             name: this.intl.t('institutions.dashboard.object-list.table-headers.doi'),
             type: 'doi',
-            columnKey: 'resourceIdentifier',
+            propertyPathKey: 'resourceIdentifier',
         },
         { // License
             name: this.intl.t('institutions.dashboard.object-list.table-headers.license'),
             getValue: searchResult => searchResult.license?.name || this.missingItemPlaceholder,
-            columnKey: 'rights.name',
+            propertyPathKey: 'rights.name',
         },
         { // Contributor name + permissions
             name: this.intl.t('institutions.dashboard.object-list.table-headers.contributor_name'),
             type: 'contributors',
-            columnKey: 'creator.name',
+            propertyPathKey: 'creator.name',
         },
         { // View count
             name: this.intl.t('institutions.dashboard.object-list.table-headers.view_count'),
@@ -58,9 +58,9 @@ export default class InstitutionDashboardPreprints extends Controller {
                 const metrics = searchResult.usageMetrics;
                 return metrics ? metrics.viewCount : this.missingItemPlaceholder;
             },
-            sortKey: 'usage.viewCount',
+            isSortable: true,
             sortParam: 'integer-value',
-            columnKey: 'usage.viewCount',
+            propertyPathKey: 'usage.viewCount',
         },
         { // Download count
             name: this.intl.t('institutions.dashboard.object-list.table-headers.download_count'),
@@ -68,9 +68,9 @@ export default class InstitutionDashboardPreprints extends Controller {
                 const metrics = searchResult.usageMetrics;
                 return metrics ? metrics.downloadCount : this.missingItemPlaceholder;
             },
-            sortKey: 'usage.downloadCount',
+            isSortable: true,
             sortParam: 'integer-value',
-            columnKey: 'usage.downloadCount',
+            propertyPathKey: 'usage.downloadCount',
         },
     ];
 

--- a/app/institutions/dashboard/projects/controller.ts
+++ b/app/institutions/dashboard/projects/controller.ts
@@ -17,7 +17,7 @@ export default class InstitutionDashboardProjects extends Controller {
             type: 'link',
             getHref: searchResult => searchResult.indexCard.get('osfIdentifier'),
             getLinkText: searchResult => searchResult.displayTitle,
-            columnKey: 'title',
+            propertyPathKey: 'title',
         },
         { // Link
             name: this.intl.t('institutions.dashboard.object-list.table-headers.link'),
@@ -28,24 +28,24 @@ export default class InstitutionDashboardProjects extends Controller {
         { // Date created
             name: this.intl.t('institutions.dashboard.object-list.table-headers.created_date'),
             getValue: searchResult => getSingleOsfmapValue(searchResult.resourceMetadata, ['dateCreated']),
-            sortKey: 'dateCreated',
-            columnKey: 'dateCreated',
+            propertyPathKey: 'dateCreated',
+            isSortable: true,
         },
         { // Date modified
             name: this.intl.t('institutions.dashboard.object-list.table-headers.modified_date'),
             getValue: searchResult => getSingleOsfmapValue(searchResult.resourceMetadata, ['dateModified']),
-            sortKey: 'dateModified',
-            columnKey: 'dateModified',
+            propertyPathKey: 'dateModified',
+            isSortable: true,
         },
         { // DOI
             name: this.intl.t('institutions.dashboard.object-list.table-headers.doi'),
             type: 'doi',
-            columnKey: 'resourceIdentifier',
+            propertyPathKey: 'resourceIdentifier',
         },
         { // Storage location
             name: this.intl.t('institutions.dashboard.object-list.table-headers.storage_location'),
             getValue: searchResult => searchResult.storageRegion,
-            columnKey: 'storageRegion.prefLabel',
+            propertyPathKey: 'storageRegion.prefLabel',
         },
         { // Total data stored
             name: this.intl.t('institutions.dashboard.object-list.table-headers.total_data_stored'),
@@ -53,14 +53,14 @@ export default class InstitutionDashboardProjects extends Controller {
                 const byteCount = getSingleOsfmapValue(searchResult.resourceMetadata, ['storageByteCount']);
                 return byteCount ? humanFileSize(byteCount) : this.missingItemPlaceholder;
             },
-            sortKey: 'storageByteCount',
+            isSortable: true,
             sortParam: 'integer-value',
-            columnKey: 'storageByteCount',
+            propertyPathKey: 'storageByteCount',
         },
         { // Contributor name + permissions
             name: this.intl.t('institutions.dashboard.object-list.table-headers.contributor_name'),
             type: 'contributors',
-            columnKey: 'creator.name',
+            propertyPathKey: 'creator.name',
         },
         { // View count
             name: this.intl.t('institutions.dashboard.object-list.table-headers.view_count'),
@@ -68,25 +68,25 @@ export default class InstitutionDashboardProjects extends Controller {
                 const metrics = searchResult.usageMetrics;
                 return metrics ? metrics.viewCount : this.missingItemPlaceholder;
             },
-            sortKey: 'usage.viewCount',
+            isSortable: true,
             sortParam: 'integer-value',
-            columnKey: 'usage.viewCount',
+            propertyPathKey: 'usage.viewCount',
         },
         { // Resource type
             name: this.intl.t('institutions.dashboard.object-list.table-headers.resource_nature'),
             getValue: searchResult => searchResult.resourceNature || this.missingItemPlaceholder,
-            columnKey: 'resourceNature.displayLabel',
+            propertyPathKey: 'resourceNature.displayLabel',
         },
         { // License
             name: this.intl.t('institutions.dashboard.object-list.table-headers.license'),
             getValue: searchResult => searchResult.license?.name || this.missingItemPlaceholder,
-            columnKey: 'rights.name',
+            propertyPathKey: 'rights.name',
         },
         { // addons associated
             name: this.intl.t('institutions.dashboard.object-list.table-headers.addons'),
             getValue: searchResult => searchResult.configuredAddonNames.length ?  searchResult.configuredAddonNames :
                 this.missingItemPlaceholder,
-            columnKey: 'hasOsfAddon.prefLabel',
+            propertyPathKey: 'hasOsfAddon.prefLabel',
         },
         { // Funder name
             name: this.intl.t('institutions.dashboard.object-list.table-headers.funder_name'),
@@ -96,7 +96,8 @@ export default class InstitutionDashboardProjects extends Controller {
                 }
                 return searchResult.funders.map((funder: { name: string }) => funder.name).join(', ');
             },
-            columnKey: 'funder.name',
+            propertyPathKey: 'funder.name',
+
         },
     ];
 

--- a/app/institutions/dashboard/projects/controller.ts
+++ b/app/institutions/dashboard/projects/controller.ts
@@ -17,6 +17,7 @@ export default class InstitutionDashboardProjects extends Controller {
             type: 'link',
             getHref: searchResult => searchResult.indexCard.get('osfIdentifier'),
             getLinkText: searchResult => searchResult.displayTitle,
+            columnKey: 'title',
         },
         { // Link
             name: this.intl.t('institutions.dashboard.object-list.table-headers.link'),
@@ -28,19 +29,23 @@ export default class InstitutionDashboardProjects extends Controller {
             name: this.intl.t('institutions.dashboard.object-list.table-headers.created_date'),
             getValue: searchResult => getSingleOsfmapValue(searchResult.resourceMetadata, ['dateCreated']),
             sortKey: 'dateCreated',
+            columnKey: 'dateCreated',
         },
         { // Date modified
             name: this.intl.t('institutions.dashboard.object-list.table-headers.modified_date'),
             getValue: searchResult => getSingleOsfmapValue(searchResult.resourceMetadata, ['dateModified']),
             sortKey: 'dateModified',
+            columnKey: 'dateModified',
         },
         { // DOI
             name: this.intl.t('institutions.dashboard.object-list.table-headers.doi'),
             type: 'doi',
+            columnKey: 'resourceIdentifier',
         },
         { // Storage location
             name: this.intl.t('institutions.dashboard.object-list.table-headers.storage_location'),
             getValue: searchResult => searchResult.storageRegion,
+            columnKey: 'storageRegion.prefLabel',
         },
         { // Total data stored
             name: this.intl.t('institutions.dashboard.object-list.table-headers.total_data_stored'),
@@ -50,10 +55,12 @@ export default class InstitutionDashboardProjects extends Controller {
             },
             sortKey: 'storageByteCount',
             sortParam: 'integer-value',
+            columnKey: 'storageByteCount',
         },
         { // Contributor name + permissions
             name: this.intl.t('institutions.dashboard.object-list.table-headers.contributor_name'),
             type: 'contributors',
+            columnKey: 'creator.name',
         },
         { // View count
             name: this.intl.t('institutions.dashboard.object-list.table-headers.view_count'),
@@ -63,19 +70,23 @@ export default class InstitutionDashboardProjects extends Controller {
             },
             sortKey: 'usage.viewCount',
             sortParam: 'integer-value',
+            columnKey: 'usage.viewCount',
         },
         { // Resource type
             name: this.intl.t('institutions.dashboard.object-list.table-headers.resource_nature'),
             getValue: searchResult => searchResult.resourceNature || this.missingItemPlaceholder,
+            columnKey: 'resourceNature.displayLabel',
         },
         { // License
             name: this.intl.t('institutions.dashboard.object-list.table-headers.license'),
             getValue: searchResult => searchResult.license?.name || this.missingItemPlaceholder,
+            columnKey: 'rights.name',
         },
         { // addons associated
             name: this.intl.t('institutions.dashboard.object-list.table-headers.addons'),
             getValue: searchResult => searchResult.configuredAddonNames.length ?  searchResult.configuredAddonNames :
                 this.missingItemPlaceholder,
+            columnKey: 'hasOsfAddon.prefLabel',
         },
         { // Funder name
             name: this.intl.t('institutions.dashboard.object-list.table-headers.funder_name'),
@@ -85,6 +96,7 @@ export default class InstitutionDashboardProjects extends Controller {
                 }
                 return searchResult.funders.map((funder: { name: string }) => funder.name).join(', ');
             },
+            columnKey: 'funder.name',
         },
     ];
 

--- a/app/institutions/dashboard/registrations/controller.ts
+++ b/app/institutions/dashboard/registrations/controller.ts
@@ -16,7 +16,7 @@ export default class InstitutionDashboardRegistrations extends Controller {
             type: 'link',
             getHref: searchResult => searchResult.indexCard.get('osfIdentifier'),
             getLinkText: searchResult => searchResult.displayTitle,
-            columnKey: 'title',
+            propertyPathKey: 'title',
         },
         { // Link
             name: this.intl.t('institutions.dashboard.object-list.table-headers.link'),
@@ -27,24 +27,24 @@ export default class InstitutionDashboardRegistrations extends Controller {
         { // Date created
             name: this.intl.t('institutions.dashboard.object-list.table-headers.created_date'),
             getValue: searchResult => getSingleOsfmapValue(searchResult.resourceMetadata, ['dateCreated']),
-            sortKey: 'dateCreated',
-            columnKey: 'dateCreated',
+            isSortable: true,
+            propertyPathKey: 'dateCreated',
         },
         { // Date modified
             name: this.intl.t('institutions.dashboard.object-list.table-headers.modified_date'),
             getValue: searchResult => getSingleOsfmapValue(searchResult.resourceMetadata, ['dateModified']),
-            sortKey: 'dateModified',
-            columnKey: 'dateModified',
+            isSortable: true,
+            propertyPathKey: 'dateModified',
         },
         { // DOI
             name: this.intl.t('institutions.dashboard.object-list.table-headers.doi'),
             type: 'doi',
-            columnKey: 'resourceIdentifier',
+            propertyPathKey: 'resourceIdentifier',
         },
         { // Storage location
             name: this.intl.t('institutions.dashboard.object-list.table-headers.storage_location'),
             getValue: searchResult => searchResult.storageRegion,
-            columnKey: 'storageRegion.prefLabel',
+            propertyPathKey: 'storageRegion.prefLabel',
         },
         { // Total data stored
             name: this.intl.t('institutions.dashboard.object-list.table-headers.total_data_stored'),
@@ -52,14 +52,14 @@ export default class InstitutionDashboardRegistrations extends Controller {
                 const byteCount = getSingleOsfmapValue(searchResult.resourceMetadata, ['storageByteCount']);
                 return byteCount ? humanFileSize(byteCount) : this.missingItemPlaceholder;
             },
-            sortKey: 'storageByteCount',
+            isSortable: true,
             sortParam: 'integer-value',
-            columnKey: 'storageByteCount',
+            propertyPathKey: 'storageByteCount',
         },
         { // Contributor name + permissions
             name: this.intl.t('institutions.dashboard.object-list.table-headers.contributor_name'),
             type: 'contributors',
-            columnKey: 'creator.name',
+            propertyPathKey: 'creator.name',
         },
         { // View count
             name: this.intl.t('institutions.dashboard.object-list.table-headers.view_count'),
@@ -67,19 +67,19 @@ export default class InstitutionDashboardRegistrations extends Controller {
                 const metrics = searchResult.usageMetrics;
                 return metrics ? metrics.viewCount : this.missingItemPlaceholder;
             },
-            sortKey: 'usage.viewCount',
+            isSortable: true,
             sortParam: 'integer-value',
-            columnKey: 'usage.viewCount',
+            propertyPathKey: 'usage.viewCount',
         },
         { // Resource type
             name: this.intl.t('institutions.dashboard.object-list.table-headers.resource_nature'),
             getValue: searchResult => searchResult.resourceNature || this.missingItemPlaceholder,
-            columnKey: 'resourceNature.displayLabel',
+            propertyPathKey: 'resourceNature.displayLabel',
         },
         { // License
             name: this.intl.t('institutions.dashboard.object-list.table-headers.license'),
             getValue: searchResult => searchResult.license?.name || this.missingItemPlaceholder,
-            columnKey: 'rights.name',
+            propertyPathKey: 'rights.name',
         },
         { // Funder name
             name: this.intl.t('institutions.dashboard.object-list.table-headers.funder_name'),
@@ -89,12 +89,12 @@ export default class InstitutionDashboardRegistrations extends Controller {
                 }
                 return searchResult.funders.map((funder: { name: string }) => funder.name).join(', ');
             },
-            columnKey: 'funders.name',
+            propertyPathKey: 'funders.name',
         },
         { // schema
             name: this.intl.t('institutions.dashboard.object-list.table-headers.registration_schema'),
             getValue: searchResult => searchResult.registrationTemplate,
-            columnKey: 'conformsTo.title',
+            propertyPathKey: 'conformsTo.title',
         },
     ];
 

--- a/app/institutions/dashboard/registrations/controller.ts
+++ b/app/institutions/dashboard/registrations/controller.ts
@@ -16,6 +16,7 @@ export default class InstitutionDashboardRegistrations extends Controller {
             type: 'link',
             getHref: searchResult => searchResult.indexCard.get('osfIdentifier'),
             getLinkText: searchResult => searchResult.displayTitle,
+            columnKey: 'title',
         },
         { // Link
             name: this.intl.t('institutions.dashboard.object-list.table-headers.link'),
@@ -27,19 +28,23 @@ export default class InstitutionDashboardRegistrations extends Controller {
             name: this.intl.t('institutions.dashboard.object-list.table-headers.created_date'),
             getValue: searchResult => getSingleOsfmapValue(searchResult.resourceMetadata, ['dateCreated']),
             sortKey: 'dateCreated',
+            columnKey: 'dateCreated',
         },
         { // Date modified
             name: this.intl.t('institutions.dashboard.object-list.table-headers.modified_date'),
             getValue: searchResult => getSingleOsfmapValue(searchResult.resourceMetadata, ['dateModified']),
             sortKey: 'dateModified',
+            columnKey: 'dateModified',
         },
         { // DOI
             name: this.intl.t('institutions.dashboard.object-list.table-headers.doi'),
             type: 'doi',
+            columnKey: 'resourceIdentifier',
         },
         { // Storage location
             name: this.intl.t('institutions.dashboard.object-list.table-headers.storage_location'),
             getValue: searchResult => searchResult.storageRegion,
+            columnKey: 'storageRegion.prefLabel',
         },
         { // Total data stored
             name: this.intl.t('institutions.dashboard.object-list.table-headers.total_data_stored'),
@@ -49,10 +54,12 @@ export default class InstitutionDashboardRegistrations extends Controller {
             },
             sortKey: 'storageByteCount',
             sortParam: 'integer-value',
+            columnKey: 'storageByteCount',
         },
         { // Contributor name + permissions
             name: this.intl.t('institutions.dashboard.object-list.table-headers.contributor_name'),
             type: 'contributors',
+            columnKey: 'creator.name',
         },
         { // View count
             name: this.intl.t('institutions.dashboard.object-list.table-headers.view_count'),
@@ -62,14 +69,17 @@ export default class InstitutionDashboardRegistrations extends Controller {
             },
             sortKey: 'usage.viewCount',
             sortParam: 'integer-value',
+            columnKey: 'usage.viewCount',
         },
         { // Resource type
             name: this.intl.t('institutions.dashboard.object-list.table-headers.resource_nature'),
             getValue: searchResult => searchResult.resourceNature || this.missingItemPlaceholder,
+            columnKey: 'resourceNature.displayLabel',
         },
         { // License
             name: this.intl.t('institutions.dashboard.object-list.table-headers.license'),
             getValue: searchResult => searchResult.license?.name || this.missingItemPlaceholder,
+            columnKey: 'rights.name',
         },
         { // Funder name
             name: this.intl.t('institutions.dashboard.object-list.table-headers.funder_name'),
@@ -79,10 +89,12 @@ export default class InstitutionDashboardRegistrations extends Controller {
                 }
                 return searchResult.funders.map((funder: { name: string }) => funder.name).join(', ');
             },
+            columnKey: 'funders.name',
         },
         { // schema
             name: this.intl.t('institutions.dashboard.object-list.table-headers.registration_schema'),
             getValue: searchResult => searchResult.registrationTemplate,
+            columnKey: 'conformsTo.title',
         },
     ];
 


### PR DESCRIPTION
-   Ticket: [ENG-6823]
-   Feature flag: n/a

## Purpose
- Tell SHARE what information to download when downloading institutional dashboard data

## Summary of Changes
- Add a new `propertyPathKey` property to the object-list columns
 - this is used to tell SHARE the format of each column
- Remove `sortKey` property from column, and replace it with `isSortable` boolean property since `sortKey` is the same as `propertyPathKey`
- Example links for Project download
 - With all columns shown: 
```
https://share.osf.io/api/v2/index-card-search/55b755ce-3096-4db4-9640-277a95a8b9e8?
page[size]=10000&
acceptMediatype=text/csv&
withFileName=projects-search-results&
fields[Project]=title,dateCreated,dateModified,resourceIdentifier,storageRegion.prefLabel,storageByteCount,creator.name,usage.viewCount,resourceNature.displayLabel,rights.name,hasOsfAddon.prefLabel,funder.name
```
 - With only two columns shown: 
```
https://share.osf.io/api/v2/index-card-search/55b755ce-3096-4db4-9640-277a95a8b9e8?
page[size]=10000&
acceptMediatype=text/csv&
withFileName=projects-search-results&
fields[Project]=title,dateModified
```

## Screenshot(s)
- NA

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6823]: https://openscience.atlassian.net/browse/ENG-6823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ