### PR TITLE
Fix bug where link in doi section would not update

### DIFF
--- a/app/preprints/-components/preprint-doi/template.hbs
+++ b/app/preprints/-components/preprint-doi/template.hbs
@@ -31,7 +31,7 @@
             data-test-view-version-link
             data-analytics-name='View version link'
             @route='preprints.detail'
-            @model={{this.selectedVersion}}
+            @models={{array @provider.id this.selectedVersion.id}}
         >
             {{t 'preprints.detail.view_version' number=this.selectedVersion.version}}
         </OsfLink>


### PR DESCRIPTION
-   Ticket: [Not ticket]
-   Feature flag: n/a

## Purpose
- Fix bug where link to a version in the Preprint DOI section would not update

## Summary of Changes
- Send proper params to OsfLink

## Screenshot(s)
- Fix issue where this link href was not updating correctly
<img width="372" alt="image" src="https://github.com/user-attachments/assets/0dabb440-e257-4483-a36f-a4b0d7b21a7b" />

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
