### PR TITLE
Use proper key for DOI field download

### DIFF
--- a/app/institutions/dashboard/preprints/controller.ts
+++ b/app/institutions/dashboard/preprints/controller.ts
@@ -40,7 +40,7 @@ export default class InstitutionDashboardPreprints extends Controller {
         { // DOI
             name: this.intl.t('institutions.dashboard.object-list.table-headers.doi'),
             type: 'doi',
-            propertyPathKey: 'resourceIdentifier',
+            propertyPathKey: 'sameAs',
         },
         { // License
             name: this.intl.t('institutions.dashboard.object-list.table-headers.license'),

--- a/app/institutions/dashboard/projects/controller.ts
+++ b/app/institutions/dashboard/projects/controller.ts
@@ -40,7 +40,7 @@ export default class InstitutionDashboardProjects extends Controller {
         { // DOI
             name: this.intl.t('institutions.dashboard.object-list.table-headers.doi'),
             type: 'doi',
-            propertyPathKey: 'resourceIdentifier',
+            propertyPathKey: 'sameAs',
         },
         { // Storage location
             name: this.intl.t('institutions.dashboard.object-list.table-headers.storage_location'),

--- a/app/institutions/dashboard/registrations/controller.ts
+++ b/app/institutions/dashboard/registrations/controller.ts
@@ -39,7 +39,7 @@ export default class InstitutionDashboardRegistrations extends Controller {
         { // DOI
             name: this.intl.t('institutions.dashboard.object-list.table-headers.doi'),
             type: 'doi',
-            propertyPathKey: 'resourceIdentifier',
+            propertyPathKey: 'sameAs',
         },
         { // Storage location
             name: this.intl.t('institutions.dashboard.object-list.table-headers.storage_location'),


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Fix DOI field on downloaded file

## Summary of Changes
- Use `sameAs` key instead of `resourceIdentifier`

## Screenshot(s)
- NA
<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
