### PR TITLE
[ENG-6814] Show toast message on 409 error

### DIFF
--- a/app/preprints/-components/submit/preprint-state-machine/component.ts
+++ b/app/preprints/-components/submit/preprint-state-machine/component.ts
@@ -11,7 +11,7 @@ import { task } from 'ember-concurrency';
 import { waitFor } from '@ember/test-waiters';
 import FileModel from 'ember-osf-web/models/file';
 import Toast from 'ember-toastr/services/toast';
-import captureException, { getApiErrorMessage } from 'ember-osf-web/utils/capture-exception';
+import captureException, { getApiError, getApiErrorMessage } from 'ember-osf-web/utils/capture-exception';
 import { Permission } from 'ember-osf-web/models/osf-model';
 import { ReviewsState } from 'ember-osf-web/models/provider';
 import { taskFor } from 'ember-concurrency-ts';
@@ -253,7 +253,9 @@ export default class PreprintStateMachine extends Component<StateMachineArgs>{
                 const errorTitle = this.intl.t('preprints.submit.new-version.error.title');
                 let errorMessage = this.intl.t('preprints.submit.new-version.error.description',
                     { preprintWord: this.provider.documentType.singular });
-                if (e.errors[0].status === 409) { // Conflict
+                captureException(e, { errorMessage });
+                const error = getApiError(e);
+                if (error?.status === '409') { // Conflict
                     errorMessage = this.intl.t('preprints.submit.new-version.error.conflict');
                 }
                 this.toast.error(errorMessage, errorTitle);

--- a/app/preprints/detail/controller.ts
+++ b/app/preprints/detail/controller.ts
@@ -16,6 +16,7 @@ import { VersionStatusSimpleLabelKey } from 'ember-osf-web/models/preprint';
 import { PreprintProviderReviewsWorkFlow, ReviewsState } from 'ember-osf-web/models/provider';
 import CurrentUserService from 'ember-osf-web/services/current-user';
 import Theme from 'ember-osf-web/services/theme';
+import captureException, { getApiError } from 'ember-osf-web/utils/capture-exception';
 
 
 /**
@@ -161,8 +162,11 @@ export default class PrePrintsDetailController extends Controller {
             const errorTitle = this.intl.t('preprints.submit.new-version.error.title');
             let errorMessage = this.intl.t('preprints.submit.new-version.error.description',
                 { preprintWord: this.model.provider.documentType.singular });
-            if (e.errors[0].status === 409) { // Conflict
-                errorMessage = this.intl.t('preprints.submit.new-version.error.conflict');
+            captureException(e, { errorMessage });
+            const error = getApiError(e);
+            if (error?.status === '409') { // Conflict
+                errorMessage = this.intl.t('preprints.submit.new-version.error.conflict',
+                    { preprintWord: this.model.provider.documentType.singular });
             }
             this.toast.error(errorMessage, errorTitle);
         }

--- a/app/preprints/detail/route.ts
+++ b/app/preprints/detail/route.ts
@@ -4,6 +4,7 @@ import RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 import { waitFor } from '@ember/test-waiters';
 import { taskFor } from 'ember-concurrency-ts';
+import Intl from 'ember-intl/services/intl';
 import { all, restartableTask } from 'ember-concurrency';
 import moment from 'moment-timezone';
 
@@ -16,8 +17,9 @@ import MetaTags, { HeadTagDef } from 'ember-osf-web/services/meta-tags';
 import Ready from 'ember-osf-web/services/ready';
 import Theme from 'ember-osf-web/services/theme';
 import captureException from 'ember-osf-web/utils/capture-exception';
+import { notFoundURL } from 'ember-osf-web/utils/clean-url';
 import pathJoin from 'ember-osf-web/utils/path-join';
-import Intl from 'ember-intl/services/intl';
+
 import PrePrintsDetailController from './controller';
 
 
@@ -91,7 +93,7 @@ export default class PreprintsDetail extends Route {
 
         } catch (error) {
             captureException(error);
-            this.router.transitionTo('not-found', this.router.currentURL.slice(1));
+            this.router.transitionTo('not-found', notFoundURL(window.location.pathname));
             return null;
         }
     }

--- a/app/preprints/detail/template.hbs
+++ b/app/preprints/detail/template.hbs
@@ -69,6 +69,7 @@
                         data-test-create-new-version-button
                         data-analytics-name='Create new version'
                         local-class='btn btn-primary'
+                        disabled={{this.createNewVersion.isRunning}}
                         @layout='fake-link'
                         {{on 'click' (perform this.createNewVersion)}}
                     >


### PR DESCRIPTION
-   Ticket: [ENG-6814]
-   Feature flag: n/a

## Purpose
- Show helpful toast message if the request to create a new version returns a 409 error

## Summary of Changes
- Fix logic for how to display toast error
- Update template so the "Create new version" button is disabled when the task is running
- Update page-not-found reroute logic to be more robust

## Screenshot(s)
- Disabled "Create new version" button
![image](https://github.com/user-attachments/assets/2cdb437a-9839-4d57-9c18-056101aea005)
- Toast error message
![image](https://github.com/user-attachments/assets/d2bef2cf-b6ef-447d-9d8d-3a07951dfb6e)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
