### PR TITLE
[ENG-6815] Update condition to show edit button

### DIFF
--- a/app/preprints/detail/controller.ts
+++ b/app/preprints/detail/controller.ts
@@ -78,11 +78,25 @@ export default class PrePrintsDetailController extends Controller {
             DATE_LABEL.created;
     }
 
+    get showEditButton() {
+        const providerIsPremod = this.model.provider.reviewsWorkflow === PreprintProviderReviewsWorkFlow.PRE_MODERATION;
+        const preprintIsRejected = this.model.preprint.reviewsState === ReviewsState.REJECTED;
+        const preprintIsInitialVersion = this.model.preprint.version === 1;
+        if (this.userIsContrib && this.model.preprint.isLatestVersion) {
+            if (providerIsPremod && preprintIsRejected && !preprintIsInitialVersion) {
+                return false;
+            }
+            return true;
+        }
+        return false;
+    }
     get editButtonLabel(): string {
+        const providerIsPremod = this.model.provider.reviewsWorkflow === PreprintProviderReviewsWorkFlow.PRE_MODERATION;
+        const preprintIsRejected = this.model.preprint.reviewsState === ReviewsState.REJECTED;
+
         const editPreprint = 'preprints.detail.edit_preprint';
         const editResubmitPreprint = 'preprints.detail.edit_resubmit_preprint';
-        const translation = this.model.provider.reviewsWorkflow === PreprintProviderReviewsWorkFlow.PRE_MODERATION
-            && this.model.preprint.reviewsState === ReviewsState.REJECTED && this.model.preprint.currentUserIsAdmin
+        const translation = providerIsPremod && preprintIsRejected && this.model.preprint.currentUserIsAdmin
             ? editResubmitPreprint : editPreprint;
         return this.intl.t(translation, {
             documentType: this.model.provider.documentType.singular,

--- a/app/preprints/detail/template.hbs
+++ b/app/preprints/detail/template.hbs
@@ -51,7 +51,7 @@
                         </dropdown.content>
                     </ResponsiveDropdown>
                 {{else}}
-                    {{#if (and this.userIsContrib (not this.isPendingWithdrawal))}}
+                    {{#if this.showEditButton}}
                         <OsfLink
                             data-test-edit-preprint-button
                             data-analytics-name='Edit preprint button'


### PR DESCRIPTION
-   Ticket: [ENG-6815]
-   Feature flag: n/a

## Purpose
- Fix issues of "Edit" and "Edit and Resubmit" button showing up at inappropriate preprint states

## Summary of Changes
- Update condition to show Edit button
 - Only read-write and admin contributors should be able to edit
 - Only latest version should be editable
 - Non-initial, rejected (pre-mod) versions should not be editable


## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
