### PR TITLE
[ENG-6822] [ENG-6871] Fix bug where preprint status banner does not update

### DIFF
--- a/app/preprints/-components/preprint-status-banner/template.hbs
+++ b/app/preprints/-components/preprint-status-banner/template.hbs
@@ -1,5 +1,5 @@
 <div local-class='preprint-banner-status-container  {{if this.isMobile 'mobile'}}'>
-    {{#if (or this.submission.provider?.isPending this.loadPreprintState.isRunning) }}
+    {{#if this.loadPreprintState.isRunning}}
         {{ t 'preprints.detail.status_banner.loading' }}
     {{else}}
         <div local-class='preprint-banner-status {{this.getClassName}}'>
@@ -15,7 +15,7 @@
                         <strong data-test-status>{{t this.status }}:</strong>
                         <span data-test-status-explanation>{{this.bannerContent}}</span>
                     </div>
-                    {{#if (and this.reviewerComment (not this.submission.provider.reviewsCommentsPrivate))}}
+                    {{#if (and this.reviewerComment (not @submission.provider.reviewsCommentsPrivate))}}
                         <div local-class='reviewer-feedback'>
                             <Button
                                 data-test-view-comments
@@ -23,7 +23,7 @@
                                 @type='default'
                                 {{on 'click' (action (mut this.displayComment) (not this.displayComment))}}
                             >
-                                {{t this.labelModeratorFeedback}} 
+                                {{t this.labelModeratorFeedback}}
                                 <FaIcon @icon='caret-down' @prefix='fas' aria-hidden='true'/>
                             </Button>
                             <OsfDialog
@@ -42,7 +42,7 @@
                                     </div>
                                     <div local-class='moderator-comment' aria-labelledby='moderator-feedback'>
                                         <p>{{this.reviewerComment}}</p>
-                                        {{#unless this.submission.provider.reviewsCommentsAnonymous}}
+                                        {{#unless @submission.provider.reviewsCommentsAnonymous}}
                                             <div>{{this.reviewerName}}</div>
                                         {{/unless}}
                                         {{if this.theme.isProvider this.theme.provider.name (t 'preprints.detail.status_banner.brand_name')}} {{t this.moderator}}


### PR DESCRIPTION
-   Ticket: [ENG-6822] [ENG-6871]
-   Feature flag: n/a

## Purpose
- Fix an issue where the preprint status banner doesn't update when selecting a different version

## Summary of Changes
- Refactor status banner component to use arguments instead of a cached arg reference

## Screenshot(s)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-6822]: https://openscience.atlassian.net/browse/ENG-6822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-6871]: https://openscience.atlassian.net/browse/ENG-6871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ