### PR TITLE
Fix bug to allow any contributor to see preprint rejection comments

### DIFF
--- a/app/preprints/detail/route.ts
+++ b/app/preprints/detail/route.ts
@@ -96,20 +96,22 @@ export default class PreprintsDetail extends Route {
             let hasPendingWithdrawal = false;
             let latestWithdrawalRequest = null;
             let latestAction = null;
-            if (preprintWithdrawableState && preprint.currentUserIsAdmin) {
+            if (preprint.currentUserPermissions.length > 0) {
                 const reviewActions = await preprint?.queryHasMany('reviewActions');
                 latestAction = reviewActions.firstObject;
-                const withdrawalRequests = await preprint?.queryHasMany('requests');
-                latestWithdrawalRequest = withdrawalRequests.firstObject;
-                if (latestWithdrawalRequest) {
-                    hasPendingWithdrawal = latestWithdrawalRequest.machineState === 'pending';
-                    const requestActions = await withdrawalRequests.firstObject?.queryHasMany('actions', {
-                        sort: '-modified',
-                    });
-                    latestAction = requestActions.firstObject;
-                    // @ts-ignore: ActionTrigger is never
-                    if (latestAction && latestAction.actionTrigger === 'reject') {
-                        isWithdrawalRejected = true;
+                if (preprintWithdrawableState) {
+                    const withdrawalRequests = await preprint?.queryHasMany('requests');
+                    latestWithdrawalRequest = withdrawalRequests.firstObject;
+                    if (latestWithdrawalRequest) {
+                        hasPendingWithdrawal = latestWithdrawalRequest.machineState === 'pending';
+                        const requestActions = await withdrawalRequests.firstObject?.queryHasMany('actions', {
+                            sort: '-modified',
+                        });
+                        latestAction = requestActions.firstObject;
+                        // @ts-ignore: ActionTrigger is never
+                        if (latestAction && latestAction.actionTrigger === 'reject') {
+                            isWithdrawalRejected = true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Fix bug which prevented users from seeing moderator feedback

## Summary of Changes
- Decouple fetching the latest review-action to preprint-state
- Allow all preprint contributors to see moderator feedback

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
