### PR TITLE
Reimplement bug fix and account for permissions when accessing preprint requests

### DIFF
--- a/app/preprints/-components/preprint-status-banner/component.ts
+++ b/app/preprints/-components/preprint-status-banner/component.ts
@@ -96,7 +96,7 @@ export default class PreprintStatusBanner extends Component<InputArgs>{
     }
 
     get reviewerName(): string | undefined {
-        return this.args.latestAction?.creator.fullName;
+        return this.args.latestAction?.creator.get('fullName');
     }
 
     get isWithdrawn() {

--- a/app/preprints/detail/route.ts
+++ b/app/preprints/detail/route.ts
@@ -96,20 +96,22 @@ export default class PreprintsDetail extends Route {
             let hasPendingWithdrawal = false;
             let latestWithdrawalRequest = null;
             let latestAction = null;
-            if (preprintWithdrawableState && preprint.currentUserIsAdmin) {
+            if (preprint.currentUserPermissions.length > 0) {
                 const reviewActions = await preprint?.queryHasMany('reviewActions');
                 latestAction = reviewActions.firstObject;
-                const withdrawalRequests = await preprint?.queryHasMany('requests');
-                latestWithdrawalRequest = withdrawalRequests.firstObject;
-                if (latestWithdrawalRequest) {
-                    hasPendingWithdrawal = latestWithdrawalRequest.machineState === 'pending';
-                    const requestActions = await withdrawalRequests.firstObject?.queryHasMany('actions', {
-                        sort: '-modified',
-                    });
-                    latestAction = requestActions.firstObject;
-                    // @ts-ignore: ActionTrigger is never
-                    if (latestAction && latestAction.actionTrigger === 'reject') {
-                        isWithdrawalRejected = true;
+                if (preprintWithdrawableState && preprint.currentUserIsAdmin) {
+                    const withdrawalRequests = await preprint?.queryHasMany('requests');
+                    latestWithdrawalRequest = withdrawalRequests.firstObject;
+                    if (latestWithdrawalRequest) {
+                        hasPendingWithdrawal = latestWithdrawalRequest.machineState === 'pending';
+                        const requestActions = await withdrawalRequests.firstObject?.queryHasMany('actions', {
+                            sort: '-modified',
+                        });
+                        latestAction = requestActions.firstObject;
+                        // @ts-ignore: ActionTrigger is never
+                        if (latestAction && latestAction.actionTrigger === 'reject') {
+                            isWithdrawalRejected = true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose
- Reimplement [this PR](https://github.com/CenterForOpenScience/ember-osf-web/pull/2482) but account for the fact that only admins have access to a preprint's `requests`

## Summary of Changes
- Reimplement aforementioned PR but check that user has admin permission before fetching `requests` as only admins have access to a preprint's `requests` endpoint

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
