### PR TITLE
[ENG-5996] Added a new optional variable when validating urls

### DIFF
--- a/app/preprints/-components/submit/author-assertions/link-widget/link/component-test.ts
+++ b/app/preprints/-components/submit/author-assertions/link-widget/link/component-test.ts
@@ -171,7 +171,8 @@ module('Integration | Preprint | Component | author-assertions | link-widget | l
             assert.dom(inputElement).hasValue('');
 
             // And the required text is visible
-            assert.dom('[data-test-validation-errors="value"] p').hasText('This field must be a valid url.');
+            assert.dom('[data-test-validation-errors="value"] p')
+                .hasText('This field must start with http:// or https:// to be a valid url.');
         });
 
 });

--- a/app/preprints/-components/submit/author-assertions/link-widget/link/component.ts
+++ b/app/preprints/-components/submit/author-assertions/link-widget/link/component.ts
@@ -34,7 +34,10 @@ export default class Link extends Component<LinkArgs>{
 
     linkFormValidation: ValidationObject<LinkForm> = {
         value: validateUrlWithProtocols({
-            translationArgs: { description: this.intl.t('validationErrors.description') },
+            translationArgs: {
+                description: this.intl.t('validationErrors.description'),
+                validationType: 'urlPrefix',
+            },
         }),
     };
 

--- a/app/validators/url-with-protocol.ts
+++ b/app/validators/url-with-protocol.ts
@@ -10,13 +10,14 @@ interface Options {
     acceptedProtocols?: string[];
     translationArgs?: {
         description: string,
+        validationType?: string,
     };
 }
 
 export function validateUrlWithProtocols(options?: Options) {
     return (key: string, newValue: string, _: any, __: any, ___: any) => {
         const acceptedProtocols = options?.acceptedProtocols || [Protocols.http, Protocols.https];
-        const translationArgs = options?.translationArgs || { description: '' };
+        const translationArgs = options?.translationArgs || { description: '', validationType: 'url' };
 
         let url;
         try {
@@ -25,7 +26,7 @@ export function validateUrlWithProtocols(options?: Options) {
             return buildMessage(key, {
                 type: 'url',
                 context: {
-                    type: 'url',
+                    type: translationArgs.validationType || 'url',
                     translationArgs,
                 },
             });
@@ -35,7 +36,7 @@ export function validateUrlWithProtocols(options?: Options) {
             return buildMessage(key, {
                 type: 'url',
                 context: {
-                    type: 'url',
+                    type: translationArgs.validationType || 'url',
                     translationArgs,
                 },
             });

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -788,6 +788,7 @@ validationErrors:
     tooLong: '{description} is too long (maximum is {max} characters).'
     tooShort: '{description} is too short (minimum is {min} characters).'
     url: '{description} must be a valid url.'
+    urlPrefix: '{description} must start with http:// or https:// to be a valid url.'
     wrongDateFormat: '{description} must be in the format of {format}.'
     wrongLength: '{description} is the wrong length (should be {is} characters).'
     year_format: 'Please specify a valid year format (YYYY).'


### PR DESCRIPTION
-   Ticket: [ENG-5996]
-   Feature flag: n/a

## Purpose

Product requested that the error validation was more descriptive when entering urls for Public Data and Preregistration.

## Summary of Changes

Added an optional parameter of 'validationType' to the validateUrlWithProtocols to ensure backward compatibility while allowing for variations in messages

## Screenshot(s)
![Screenshot 2025-01-31 at 2 46 17 PM](https://github.com/user-attachments/assets/48f6e53c-ebe3-47a9-8825-bd2a35150080)

## Side Effects

It appears there is only one usage of the validator, so the optional parameter might not have been needed.

In the en-us.yml file there is already a `https_url` and it only covered https and not http. It appears not to be used. I didn't prune it and wanted to though.

## QA Notes

Give it a look.


[ENG-5996]: https://openscience.atlassian.net/browse/ENG-5996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ