### PR TITLE
Remove a query to the addons endpoint to improve page load performance

### DIFF
--- a/app/guid-node/files/provider/route.ts
+++ b/app/guid-node/files/provider/route.ts
@@ -23,7 +23,7 @@ export default class GuidNodeFilesProviderRoute extends Route.extend({}) {
     @waitFor
     async fileProviderTask(guidRouteModel: GuidRouteModel<NodeModel>, fileProviderId: string) {
         const node = await guidRouteModel.taskInstance;
-        await taskFor(node.getEnabledAddons).perform();
+        // await taskFor(node.getEnabledAddons).perform();
         try {
             const fileProviders = await node.queryHasMany(
                 'files',
@@ -61,12 +61,12 @@ export default class GuidNodeFilesProviderRoute extends Route.extend({}) {
         }
     }
 
-    model(params: { providerId: string }) {
+    async model(params: { providerId: string }) {
         const node = this.modelFor('guid-node');
-        let configuredStorageAddonTask;
+        let configuredStorageAddon;
         let fileProviderId = params.providerId;
         if(this.features.isEnabled('gravy_waffle')){
-            configuredStorageAddonTask = taskFor(this.configuredStorageAddonTask).perform(params.providerId);
+            configuredStorageAddon = await taskFor(this.configuredStorageAddonTask).perform(params.providerId);
             if (params.providerId === 'osfstorage'){
                 fileProviderId = node.guid + ':' + params.providerId;
             }
@@ -74,7 +74,7 @@ export default class GuidNodeFilesProviderRoute extends Route.extend({}) {
             fileProviderId = node.guid + ':' + params.providerId;
         }
         return {
-            configuredStorageAddonTask,
+            configuredStorageAddon,
             node,
             providerName: params.providerId,
             providerTask: taskFor(this.fileProviderTask).perform(node, fileProviderId),

--- a/app/guid-node/files/provider/template.hbs
+++ b/app/guid-node/files/provider/template.hbs
@@ -2,7 +2,7 @@
     <StorageProviderManager::StorageManager
         @provider={{this.model.providerTask.value.provider}}
         @isViewOnly={{this.model.providerTask.value.currentUser.viewOnlyToken}}
-        @configuredStorageAddon={{this.model.configuredStorageAddonTask.value}}
+        @configuredStorageAddon={{this.model.configuredStorageAddon}}
         as |manager|
     >
         <div local-class='FileBrowser'>


### PR DESCRIPTION
-   Ticket: []
-   Feature flag: n/a

## Purpose

Improve performance of files page

## Summary of Changes
- Commented out a line in `fileProviderTask` that was for fetching enabled addons
  - The reason we need to fetch enabled addons is because we need to know whether BOA is enabled. But since the upcoming release does not include BOA we can disable this task.
- Instead of having the route model hook return a `configuredStorageAddonTask`, we return the actual model instance.
  - The reason this call is needed is because there is some weird race condition happening here. If we don't make this change, `configuredStorageAddonTask` itself would not finish running before its resolved value is used downstream.
 
## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
