### PR TITLE
[ENG-7174] Update Preprint versions to be a relationship

### DIFF
--- a/app/models/preprint.ts
+++ b/app/models/preprint.ts
@@ -1,6 +1,9 @@
 import { attr, belongsTo, hasMany, AsyncBelongsTo, AsyncHasMany } from '@ember-data/model';
 import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
+
+import getRelatedHref from 'ember-osf-web/utils/get-related-href';
+
 import AbstractNodeModel from 'ember-osf-web/models/abstract-node';
 import CitationModel from 'ember-osf-web/models/citation';
 import PreprintRequestModel from 'ember-osf-web/models/preprint-request';
@@ -141,6 +144,14 @@ export default class PreprintModel extends AbstractNodeModel {
 
     get canCreateNewVersion(): boolean {
         return this.currentUserIsAdmin && this.datePublished && this.isLatestVersion;
+    }
+
+    makeNewVersion(): Promise<PreprintModel> {
+        const url = getRelatedHref(this.links.relationships!.versions);
+        return this.currentUser.authenticatedAJAX({
+            url,
+            type: 'POST',
+        });
     }
 }
 

--- a/app/preprints/detail/controller.ts
+++ b/app/preprints/detail/controller.ts
@@ -187,11 +187,7 @@ export default class PrePrintsDetailController extends Controller {
     @waitFor
     async createNewVersion() {
         try {
-            const url = this.model.preprint.links.preprint_versions as string;
-            const newVersion = await this.currentUser.authenticatedAJAX({
-                url,
-                type: 'POST',
-            });
+            const newVersion = await this.model.preprint.makeNewVersion();
             this.transitionToRoute('preprints.new-version', this.model.provider.id, newVersion.data.id);
         } catch (e) {
             const errorTitle = this.intl.t('preprints.submit.new-version.error.title');

--- a/app/serializers/preprint.ts
+++ b/app/serializers/preprint.ts
@@ -1,19 +1,6 @@
-import Model from '@ember-data/model';
-import { Resource } from 'osf-api';
-
 import OsfSerializer from './osf-serializer';
 
 export default class PreprintSerializer extends OsfSerializer {
-    normalize(modelClass: Model, resourceHash: Resource) {
-        const result = super.normalize(modelClass, resourceHash);
-        // Insert a `versions` relationship to the model
-        result.data.relationships!.versions = {
-            links: {
-                related: resourceHash.links!.preprint_versions!,
-            },
-        };
-        return result;
-    }
 }
 
 declare module 'ember-data/types/registries/serializer' {

--- a/mirage/serializers/preprint.ts
+++ b/mirage/serializers/preprint.ts
@@ -11,7 +11,6 @@ export default class PreprintSerializer extends ApplicationSerializer<PreprintMi
             self: `${apiUrl}/v2/preprints/${model.id}/`,
             doi: model.doi ?  `https://doi.org/${model.doi}` : null,
             preprint_doi: model.isPreprintDoi ? `https://doi.org/10.31219/osf.io/${model.id}` : null,
-            preprint_versions: `${apiUrl}/v2/preprints/${model.id}/versions/`,
         };
     }
 
@@ -168,6 +167,17 @@ export default class PreprintSerializer extends ApplicationSerializer<PreprintMi
                     related: {
                         href: `${apiUrl}/v2/licenses/${id}`,
                         meta: {},
+                    },
+                },
+            };
+        }
+
+        if (model.versions) {
+            relationships.versions = {
+                links: {
+                    related: {
+                        href: `${apiUrl}/v2/preprints/${model.id}/versions/`,
+                        meta: this.buildRelatedLinkMeta(model, 'versions'),
                     },
                 },
             };

--- a/types/osf-api.d.ts
+++ b/types/osf-api.d.ts
@@ -96,6 +96,5 @@ export interface NormalLinks extends JSONAPI.Links {
     self?: JSONAPI.Link;
     html?: JSONAPI.Link;
     iri?: JSONAPI.Link;
-    preprint_versions?: JSONAPI.Link;
 }
 /* eslint-enable camelcase */


### PR DESCRIPTION
-   Ticket: [ENG-7174]
-   Feature flag: n/a

## Purpose
- Update how the FE expects a preprint's versions to be serialized from the API

## Summary of Changes
- stop using the `preprint_versions` link for preprint version fetching/creating
  - API should return a normal `versions` relationship in the API, so no need to do any FE serializing shenanigans
- Add new versions relationship to mirage preprint response

## Screenshot(s)
- NA

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-7174]: https://openscience.atlassian.net/browse/ENG-7174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ