### PR TITLE
fix: add dcut tracking to folder-download buttons

### DIFF
--- a/lib/osf-components/addon/components/file-browser/folder-item/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/folder-item/template.hbs
@@ -65,6 +65,7 @@
                             <OsfLink
                                 @href={{@item.links.download}}
                                 data-test-download-button
+                                {{track-download (or @item.fileModel.guid @item.fileModel.target.id)}}
                             >
                                 <FaIcon @icon='download' />
                                 {{t 'general.download'}}
@@ -154,4 +155,4 @@
     @onClose={{fn (mut this.renameModalOpen) false}}
     @item={{@item}}
     @manager={{@manager}}
-/>    
+/>

--- a/lib/osf-components/addon/components/file-browser/template.hbs
+++ b/lib/osf-components/addon/components/file-browser/template.hbs
@@ -136,6 +136,7 @@
                         data-analytics-name='Download all files from current folder'
                         @href={{@manager.currentFolder.links.download}}
                         local-class='DownloadAllFromCurrent'
+                        {{track-download (or @manager.currentFolder.guid @manager.currentFolder.target.id)}}
                     >
                         <FaIcon @icon='download' />
                         {{t 'osf-components.file-browser.download_all'}}


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: []
-   Feature flag: n/a

## Purpose

<!-- Describe the purpose of your changes. -->

## Summary of Changes
add `{{track-download ...}}` modifier to the buttons for download folders
<!-- Briefly describe or list your changes. -->

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->
