### PR TITLE
[ENG-7337] fix(dcut): avoid resolving preprint guids

### DIFF
--- a/app/models/preprint.ts
+++ b/app/models/preprint.ts
@@ -126,11 +126,8 @@ export default class PreprintModel extends AbstractNodeModel {
         return this.dateWithdrawn !== null;
     }
 
-    get verifiedDoi(): string {
-        if (this.preprintDoiCreated) {
-            return extractDoi(this.preprintDoiUrl) || '';
-        }
-        return '';
+    get preprintDoi(): string {
+        return extractDoi(this.preprintDoiUrl) || '';
     }
 
     @computed('license', 'licenseRecord')

--- a/app/preprints/detail/route.ts
+++ b/app/preprints/detail/route.ts
@@ -214,7 +214,7 @@ export default class PreprintsDetail extends Route {
         return {
             osfMetrics: {
                 itemGuid: preprint.id,
-                itemDoi: preprint.verifiedDoi,
+                itemDoi: preprint.preprintDoi,
             },
         };
     }

--- a/app/preprints/detail/template.hbs
+++ b/app/preprints/detail/template.hbs
@@ -181,7 +181,7 @@
                                 local-class='btn btn-primary'
                                 target='_blank'
                                 @href={{ this.fileDownloadUrl }}
-                                {{track-download this.model.preprint.id doi=this.model.preprint.verifiedDoi}}
+                                {{track-download this.model.preprint.id doi=this.model.preprint.preprintDoi}}
                             >
                                 {{t 'preprints.detail.share.download' documentType=this.model.provider.documentType.singular}}
                             </OsfLink>

--- a/app/services/analytics.ts
+++ b/app/services/analytics.ts
@@ -262,7 +262,9 @@ export default class Analytics extends Service {
     @task
     @waitFor
     async _trackDownloadTask(itemGuid: string, doi?: string) {
-        const _doi = doi || await this._getDoiForGuid(itemGuid);
+        // if doi is undefined/null, try finding a DOI via the api based on itemGuid
+        // (if doi is an empty string, assume there's no DOI; don't try to find one)
+        const _doi = doi ?? await this._getDoiForGuid(itemGuid);
         if (_doi) {
             this._sendDataciteUsage(_doi, DataCiteMetricType.Download);
         }

--- a/app/services/analytics.ts
+++ b/app/services/analytics.ts
@@ -436,7 +436,9 @@ export default class Analytics extends Service {
 
     async _sendDataciteView(): Promise<void> {
         const { itemGuid, itemDoi } = this._getRouteMetricsMetadata();
-        const _doi = itemDoi || await this._getDoiForGuid(itemGuid);
+        // if itemDoi is undefined/null, try finding a DOI via the api based on itemGuid
+        // (if itemDoi is an empty string, assume there's no DOI; don't try to find one)
+        const _doi = itemDoi ?? await this._getDoiForGuid(itemGuid);
         if (_doi) {
             this._sendDataciteUsage(_doi, DataCiteMetricType.View);
         }


### PR DESCRIPTION
when `itemDoi` is set to an empty string, do not try finding a DOI for that item by more convoluted means -- let the empty be.

<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-7337]
-   Feature flag: n/a

## Purpose

<!-- Describe the purpose of your changes. -->

## Summary of Changes

<!-- Briefly describe or list your changes. -->

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-7337]: https://openscience.atlassian.net/browse/ENG-7337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ