### PR TITLE
[ENG-7267] Allow updating registration title and contributors

### DIFF
--- a/app/adapters/contributor.ts
+++ b/app/adapters/contributor.ts
@@ -18,12 +18,15 @@ export default class ContributorAdapter extends OsfAdapter {
         if (requestType === 'findRecord') {
             const [objectId, userId] = (id || '').split('-');
             const node = this.store.peekRecord('node', objectId);
+            const reg = this.store.peekRecord('registration', objectId);
             const preprint = this.store.peekRecord('preprint', objectId);
             const draft = this.store.peekRecord('draft-registration', objectId);
             let baseUrl;
             assert(`"contributorId" must be "objectId-userId": got ${objectId}-${userId}`, Boolean(objectId && userId));
             if (node) {
                 baseUrl = this.buildRelationshipURL((node as any)._internalModel.createSnapshot(), 'contributors');
+            } else if (reg) {
+                baseUrl = this.buildRelationshipURL((reg as any)._internalModel.createSnapshot(), 'contributors');
             } else if (preprint) {
                 baseUrl = this.buildRelationshipURL((preprint as any)._internalModel.createSnapshot(), 'contributors');
             } else {

--- a/lib/osf-components/addon/components/contributors/list/template.hbs
+++ b/lib/osf-components/addon/components/contributors/list/template.hbs
@@ -29,7 +29,7 @@
             local-class='ContributorList'
         >
             {{#each @contributorsManager.contributors as |contributor|}}
-                <li 
+                <li
                     {{sortable-item
                         distance=30
                         model=contributor

--- a/lib/osf-components/addon/components/editable-field/title-manager/component.ts
+++ b/lib/osf-components/addon/components/editable-field/title-manager/component.ts
@@ -1,0 +1,58 @@
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { waitFor } from '@ember/test-waiters';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { task } from 'ember-concurrency';
+import Intl from 'ember-intl/services/intl';
+import Toast from 'ember-toastr/services/toast';
+
+import Node from 'ember-osf-web/models/node';
+import captureException, { getApiErrorMessage } from 'ember-osf-web/utils/capture-exception';
+import { taskFor } from 'ember-concurrency-ts';
+
+export interface TitleManagerArgs {
+    node: Node;
+}
+
+export default class TitleManagerComponent extends Component<TitleManagerArgs> {
+    @service intl!: Intl;
+    @service toast!: Toast;
+
+    @tracked currentTitle = this.args.node.title;
+
+    get userCanEdit() {
+        return this.args.node.userHasWritePermission;
+    }
+
+    get fieldIsEmpty() {
+        return !this.currentTitle;
+    }
+
+    get disableSave() {
+        return this.fieldIsEmpty || taskFor(this.save).isRunning;
+    }
+
+    @action
+    onOpen() {
+        this.currentTitle = this.args.node.title;
+    }
+
+    @task
+    @waitFor
+    async save() {
+        if (this.args.node) {
+            this.args.node.title = this.currentTitle;
+            try {
+                await this.args.node.save();
+            } catch (e) {
+                const errorMessage = this.intl.t('registries.registration_metadata.edit_title.error');
+                captureException(e, { errorMessage });
+                this.args.node.rollbackAttributes();
+                this.toast.error(getApiErrorMessage(e), errorMessage);
+                throw e;
+            }
+            this.toast.success(this.intl.t('registries.registration_metadata.edit_title.success'));
+        }
+    }
+}

--- a/lib/osf-components/addon/components/editable-field/title-manager/component.ts
+++ b/lib/osf-components/addon/components/editable-field/title-manager/component.ts
@@ -22,7 +22,7 @@ export default class TitleManagerComponent extends Component<TitleManagerArgs> {
     @tracked currentTitle = this.args.node.title;
 
     get userCanEdit() {
-        return this.args.node.userHasWritePermission;
+        return this.args.node.userHasAdminPermission;
     }
 
     get fieldIsEmpty() {

--- a/lib/osf-components/addon/components/editable-field/title-manager/template.hbs
+++ b/lib/osf-components/addon/components/editable-field/title-manager/template.hbs
@@ -2,7 +2,6 @@
     <OsfDialog
         @closeOnOutsideClick={{false}}
         @onOpen={{this.onOpen}}
-        {{!-- @onClose={{this.cancel}} --}}
     as |dialog|>
         <dialog.trigger>
             <Button

--- a/lib/osf-components/addon/components/editable-field/title-manager/template.hbs
+++ b/lib/osf-components/addon/components/editable-field/title-manager/template.hbs
@@ -1,0 +1,47 @@
+{{#if this.userCanEdit}}
+    <OsfDialog
+        @closeOnOutsideClick={{false}}
+        @onOpen={{this.onOpen}}
+        {{!-- @onClose={{this.cancel}} --}}
+    as |dialog|>
+        <dialog.trigger>
+            <Button
+                aria-label={{t 'registries.registration_metadata.edit_title.heading'}}
+                data-test-edit-registration-title
+                data-analytics-name='Edit title'
+                @layout='fake-link'
+                {{on 'click' dialog.open}}
+            >
+                <FaIcon @icon='pencil-alt' />
+            </Button>
+        </dialog.trigger>
+        <dialog.heading>
+            {{t 'registries.registration_metadata.edit_title.heading'}}
+        </dialog.heading>
+        <dialog.main>
+            <Textarea
+                data-test-registration-title-input
+                @value={{this.currentTitle}}
+            />
+        </dialog.main>
+        <dialog.footer>
+            <Button
+                data-test-discard-edits
+                data-analytics-name='Discard'
+                @type='secondary'
+                {{on 'click' dialog.close}}
+            >
+                {{t 'general.cancel'}}
+            </Button>
+            <Button
+                data-test-save-edits
+                data-analytics-name='Save'
+                disabled={{this.disableSave}}
+                @type='primary'
+                {{on 'click' (queue (perform this.save) dialog.close)}}
+            >
+                {{t 'general.save'}}
+            </Button>
+        </dialog.footer>
+    </OsfDialog>
+{{/if}}

--- a/lib/osf-components/addon/components/node-metadata-form/styles.scss
+++ b/lib/osf-components/addon/components/node-metadata-form/styles.scss
@@ -73,6 +73,14 @@
     }
 }
 
+.edit-contributors {
+    margin-bottom: 8px;
+
+    .fake-label {
+        font-weight: bold;
+    }
+}
+
 .contributor-list {
     flex-direction: column;
 

--- a/lib/osf-components/addon/components/node-metadata-form/styles.scss
+++ b/lib/osf-components/addon/components/node-metadata-form/styles.scss
@@ -51,6 +51,10 @@
     }
 }
 
+.edit-metadata-title {
+    margin-bottom: 8px;
+}
+
 .edit-metadata-description {
     flex-direction: column;
 

--- a/lib/osf-components/addon/components/node-metadata-form/template.hbs
+++ b/lib/osf-components/addon/components/node-metadata-form/template.hbs
@@ -105,30 +105,60 @@
         {{/if}}
     </FormControls>
     {{#unless @manager.node.isAnonymous}}
-        <div data-test-contributors-list local-class='contributor-list'>
-            <dl>
-                <dt>
+        {{#if @manager.isEditingContributors}}
+            <div local-class='edit-contributors'>
+                <span local-class='fake-label'>
                     {{t 'osf-components.node-metadata-form.contributors'}}
-                    {{#if (and @manager.userCanEdit (not @manager.inEditMode))}}
-                        <a
-                            aria-label={{t 'osf-components.node-metadata-form.edit-button'}}
-                            data-test-edit-contributors
-                            href={{concat '/' @manager.nodeId '/contributors/'}}
-                        >
-                            <FaIcon @icon='pencil-alt' />
-                        </a>
+                </span>
+                <Contributors::Widget
+                    @node={{@manager.node}}
+                    @shouldShowAdd={{true}}
+                    @widgetMode={{'editable'}}
+                    @displayPermissionWarning={{false}}
+                />
+                <Button
+                    data-test-finish-node-contributor-editing-button
+                    data-analytics-name='Finish editing node contributors'
+                    aria-label={{if @manager.finishContributorEditing.isRunning (t 'general.loading') (t 'general.done')}}
+                    disabled={{@manager.finishContributorEditing.isRunning}}
+                    @type='primary'
+                    {{on 'click' (perform @manager.finishContributorEditing)}}
+                >
+                    {{#if @manager.finishContributorEditing.isRunning}}
+                        <LoadingIndicator @inline={{true}} />
+                    {{else}}
+                        {{t 'general.done'}}
                     {{/if}}
-                </dt>
-                <dd>
-                    <ContributorList
-                        data-test-target-contributors
-                        @model={{@manager.node}}
-                        @shouldLinkUsers={{true}}
-                        @shouldTruncate={{false}}
-                    />
-                </dd>
-            </dl>
-        </div>
+                </Button>
+            </div>
+        {{else}}
+            <div data-test-contributors-list local-class='contributor-list'>
+                <dl>
+                    <dt>
+                        {{t 'osf-components.node-metadata-form.contributors'}}
+                        {{#if (and @manager.userCanEdit (not @manager.inEditMode))}}
+                            <Button
+                                data-test-edit-node-contributors-button
+                                data-analytics-name='Edit Contributors Metadata'
+                                aria-label={{t 'osf-components.node-metadata-form.edit-button'}}
+                                {{on 'click' @manager.editContributors}}
+                                @layout='fake-link'
+                            >
+                                <FaIcon @icon='pencil-alt' />
+                            </Button>
+                        {{/if}}
+                    </dt>
+                    <dd>
+                        <ContributorList
+                            data-test-target-contributors
+                            @model={{@manager.node}}
+                            @shouldLinkUsers={{true}}
+                            @shouldTruncate={{false}}
+                        />
+                    </dd>
+                </dl>
+            </div>
+        {{/if}}
     {{/unless}}
     <FormControls @changeset={{@manager.changeset}} as |form|>
         {{#if @manager.isEditingResources}}

--- a/lib/osf-components/addon/components/node-metadata-form/template.hbs
+++ b/lib/osf-components/addon/components/node-metadata-form/template.hbs
@@ -1,5 +1,55 @@
 <div local-class='container'>
     <FormControls @changeset={{@manager.nodeChangeset}} as |form|>
+        {{#if @manager.isEditingTitle}}
+            <div local-class='edit-metadata-title'>
+                <form.textarea
+                    data-test-title-field
+                    @label={{t 'osf-components.node-metadata-form.title'}}
+                    @valuePath='title'
+                />
+                <Button
+                    data-analytics-name='Cancel editing node title'
+                    data-test-cancel-editing-node-title-button
+                    disabled={{@manager.isSaving}}
+                    {{on 'click' @manager.cancelNode}}
+                    @type='secondary'
+                >
+                    {{t 'general.cancel'}}
+                </Button>
+                <Button
+                    data-analytics-name='Save node title'
+                    data-test-save-node-title-button
+                    disabled={{or (not @manager.nodeChangeset.isDirty) @manager.isSaving}}
+                    {{on 'click' @manager.saveNode}}
+                    @type='primary'
+                >
+                    {{t 'general.save'}}
+                </Button>
+            </div>
+        {{else}}
+            <dl>
+                <dt>
+                    {{t 'osf-components.node-metadata-form.title'}}
+                    {{#if (and @manager.userCanEdit (not @manager.inEditMode))}}
+                        <Button
+                            aria-label={{t 'osf-components.node-metadata-form.edit-button'}}
+                            data-analytics-name='Edit Node Title'
+                            data-test-edit-node-title-button
+                            {{on 'click' @manager.editTitle}}
+                            @layout='fake-link'
+                        >
+                            <FaIcon @icon='pencil-alt' />
+                        </Button>
+                    {{/if}}
+                </dt>
+                <dd
+                    data-test-display-node-title
+                    local-class='metadata-title-field'
+                >
+                    {{@manager.node.title}}
+                </dd>
+            </dl>
+        {{/if}}
         {{#if @manager.isEditingDescription}}
             <div local-class='edit-metadata-description'>
                 <form.textarea
@@ -242,7 +292,7 @@
                                 >
                                     <FaIcon @icon='pencil-alt' />
                                 </Button>
-                            {{/if}} 
+                            {{/if}}
                         </div>
                     {{/if}}
                 </div>
@@ -294,7 +344,7 @@
                             >
                                 <FaIcon @icon='pencil-alt' />
                             </Button>
-                        {{/if}} 
+                        {{/if}}
                     </div>
                     <InstitutionsList @manager={{@manager}} />
                 {{/if}}

--- a/lib/osf-components/addon/components/node-metadata-manager/component.ts
+++ b/lib/osf-components/addon/components/node-metadata-manager/component.ts
@@ -72,12 +72,14 @@ export default class NodeMetadataManagerComponent extends Component<Args> {
     @or(
         'isEditingTitle',
         'isEditingDescription',
+        'isEditingContributors',
         'isEditingFunding',
         'isEditingResources',
         'isEditingInstitutions',
     ) inEditMode!: boolean;
     @tracked isEditingTitle = false;
     @tracked isEditingDescription = false;
+    @tracked isEditingContributors = false;
     @tracked isEditingFunding = false;
     @tracked isEditingResources = false;
     @tracked isEditingInstitutions = false;
@@ -158,6 +160,19 @@ export default class NodeMetadataManagerComponent extends Component<Args> {
     @action
     editDescription(){
         this.isEditingDescription = true;
+    }
+
+    @action
+    editContributors() {
+        this.isEditingContributors = true;
+    }
+
+    @task
+    @waitFor
+    async finishContributorEditing() {
+        await this.node.reload();
+        await this.node.hasMany('bibliographicContributors').reload();
+        this.isEditingContributors = false;
     }
 
     @action

--- a/lib/osf-components/addon/components/node-metadata-manager/component.ts
+++ b/lib/osf-components/addon/components/node-metadata-manager/component.ts
@@ -70,11 +70,13 @@ export default class NodeMetadataManagerComponent extends Component<Args> {
     @tracked changeset!: BufferedChangeset;
     @tracked nodeChangeset!: BufferedChangeset;
     @or(
+        'isEditingTitle',
         'isEditingDescription',
         'isEditingFunding',
         'isEditingResources',
         'isEditingInstitutions',
     ) inEditMode!: boolean;
+    @tracked isEditingTitle = false;
     @tracked isEditingDescription = false;
     @tracked isEditingFunding = false;
     @tracked isEditingResources = false;
@@ -149,6 +151,11 @@ export default class NodeMetadataManagerComponent extends Component<Args> {
     }
 
     @action
+    editTitle() {
+        this.isEditingTitle = true;
+    }
+
+    @action
     editDescription(){
         this.isEditingDescription = true;
     }
@@ -203,6 +210,7 @@ export default class NodeMetadataManagerComponent extends Component<Args> {
             this.saveNodeErrored = false;
         }
         this.nodeChangeset.rollback();
+        this.isEditingTitle = false;
         this.isEditingDescription = false;
     }
 
@@ -242,6 +250,7 @@ export default class NodeMetadataManagerComponent extends Component<Args> {
     async saveNode(){
         try {
             await this.nodeChangeset.save();
+            this.isEditingTitle = false;
             this.isEditingDescription = false;
             this.saveNodeErrored = false;
         } catch (e) {

--- a/lib/osf-components/addon/components/node-metadata-manager/template.hbs
+++ b/lib/osf-components/addon/components/node-metadata-manager/template.hbs
@@ -7,6 +7,8 @@
     changeset=this.changeset
     editTitle=(action this.editTitle)
     editDescription=(action this.editDescription)
+    editContributors=(action this.editContributors)
+    finishContributorEditing=this.finishContributorEditing
     editFunding=(action this.editFunding)
     editInstitutions=(action this.editInstitutions)
     editResources=(action this.editResources)
@@ -16,6 +18,7 @@
     isDirty=this.isDirty
     isEditingTitle=this.isEditingTitle
     isEditingDescription=this.isEditingDescription
+    isEditingContributors=this.isEditingContributors
     isEditingFunding=this.isEditingFunding
     isEditingInstitutions=this.isEditingInstitutions
     isEditingResources=this.isEditingResources

--- a/lib/osf-components/addon/components/node-metadata-manager/template.hbs
+++ b/lib/osf-components/addon/components/node-metadata-manager/template.hbs
@@ -5,6 +5,7 @@
     cancelNode=(perform this.cancelNode)
     changeLanguage=(action this.changeLanguage)
     changeset=this.changeset
+    editTitle=(action this.editTitle)
     editDescription=(action this.editDescription)
     editFunding=(action this.editFunding)
     editInstitutions=(action this.editInstitutions)
@@ -13,6 +14,7 @@
     inEditMode=this.inEditMode
     institutions=this.institutions
     isDirty=this.isDirty
+    isEditingTitle=this.isEditingTitle
     isEditingDescription=this.isEditingDescription
     isEditingFunding=this.isEditingFunding
     isEditingInstitutions=this.isEditingInstitutions

--- a/lib/osf-components/app/components/editable-field/title-manager/component.js
+++ b/lib/osf-components/app/components/editable-field/title-manager/component.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/editable-field/title-manager/component';

--- a/lib/osf-components/app/components/editable-field/title-manager/template.js
+++ b/lib/osf-components/app/components/editable-field/title-manager/template.js
@@ -1,0 +1,1 @@
+export { default } from 'osf-components/components/editable-field/title-manager/template';

--- a/lib/registries/addon/components/registries-metadata/styles.scss
+++ b/lib/registries/addon/components/registries-metadata/styles.scss
@@ -9,3 +9,7 @@
 .LinkButton {
     padding: 0;
 }
+
+.float-right {
+    float: right;
+}

--- a/lib/registries/addon/components/registries-metadata/template.hbs
+++ b/lib/registries/addon/components/registries-metadata/template.hbs
@@ -9,6 +9,14 @@
                     >
                         {{t 'registries.registration_metadata.contributors'}}
                     </OsfLink>
+                    <OsfLink
+                        aria-label={{t 'registries.registration_metadata.edit_contributors'}}
+                        local-class='float-right'
+                        @route='registries.overview.metadata'
+                        @models={{array this.registration.id}}
+                    >
+                        <FaIcon @icon='pencil-alt' />
+                    </OsfLink>
                 {{else}}
                     {{t 'registries.registration_metadata.contributors'}}
                 {{/if}}

--- a/lib/registries/addon/overview/-components/overview-header/styles.scss
+++ b/lib/registries/addon/overview/-components/overview-header/styles.scss
@@ -8,7 +8,7 @@
 
 .Header {
     display: flex;
-    flex-direction: column;
+    align-items: center;
     justify-content: center;
     min-height: 80px;
     margin: 20px 15px;

--- a/lib/registries/addon/overview/-components/overview-header/template.hbs
+++ b/lib/registries/addon/overview/-components/overview-header/template.hbs
@@ -2,7 +2,7 @@
     <div local-class='HeaderContainer'>
         <div local-class='Header'>
             <h1 data-test-registration-title>{{@registration.title}}</h1>
-            {{#if @registration.userHasWritePermission}}
+            {{#if @registration.userHasAdminPermission}}
                 <div local-class='EditTitle'>
                     <EditableField::TitleManager @node={{this.registration}} />
                 </div>

--- a/lib/registries/addon/overview/-components/overview-header/template.hbs
+++ b/lib/registries/addon/overview/-components/overview-header/template.hbs
@@ -2,6 +2,11 @@
     <div local-class='HeaderContainer'>
         <div local-class='Header'>
             <h1 data-test-registration-title>{{@registration.title}}</h1>
+            {{#if @registration.userHasWritePermission}}
+                <div local-class='EditTitle'>
+                    <EditableField::TitleManager @node={{this.registration}} />
+                </div>
+            {{/if}}
         </div>
         {{#if this.showTopbar}}
             <div local-class='ActionBar'>

--- a/tests/acceptance/guid-node/metadata-test.ts
+++ b/tests/acceptance/guid-node/metadata-test.ts
@@ -128,6 +128,18 @@ module('Acceptance | guid-node/metadata', hooks => {
         assert.dom('[data-test-contributors-list]').exists();
         assert.dom('[data-test-subjects-list]').exists('Subjects list is displayed for projects');
 
+        assert.dom('[data-test-edit-node-title-button]').exists();
+        await click('[data-test-edit-node-title-button]');
+        await fillIn('[data-test-title-field] textarea', 'New title');
+        await click('[data-test-cancel-editing-node-title-button]');
+        assert.dom('[data-test-display-node-title]')
+            .doesNotContainText('New title', 'Title is not incorrect after cancelling edit');
+        await click('[data-test-edit-node-title-button]');
+        await fillIn('[data-test-title-field] textarea', 'New title');
+        await click('[data-test-save-node-title-button]');
+        assert.dom('[data-test-display-node-title]')
+            .containsText('New title', 'Title is changed');
+
         assert.dom('[data-test-edit-node-description-button]').exists();
         await click('[data-test-edit-node-description-button]');
         await fillIn('[data-test-description-field] textarea', 'New description');

--- a/tests/acceptance/guid-node/metadata-test.ts
+++ b/tests/acceptance/guid-node/metadata-test.ts
@@ -50,7 +50,7 @@ module('Acceptance | guid-node/metadata', hooks => {
         assert.dom('[data-test-edit-node-description-button]').doesNotExist();
         assert.dom('[data-test-edit-resource-metadata-button]').doesNotExist();
         assert.dom('[data-test-edit-funding-metadata-button]').doesNotExist();
-        assert.dom('[data-test-edit-contributors]').doesNotExist();
+        assert.dom('[data-test-edit-node-contributors-button]').doesNotExist();
     });
 
     test('AVOL', async function(this: TestContext, assert) {
@@ -91,7 +91,7 @@ module('Acceptance | guid-node/metadata', hooks => {
         assert.dom('[data-test-edit-node-description-button]').doesNotExist();
         assert.dom('[data-test-edit-resource-metadata-button]').doesNotExist();
         assert.dom('[data-test-edit-funding-metadata-button]').doesNotExist();
-        assert.dom('[data-test-edit-contributors]').doesNotExist();
+        assert.dom('[data-test-edit-node-contributors-button]').doesNotExist();
     });
 
     test('Editable', async function(this: TestContext, assert) {
@@ -204,8 +204,13 @@ module('Acceptance | guid-node/metadata', hooks => {
         }
         // TODO: Test the edit-save flow with the new funding widget when it's in
 
-        assert.dom('[data-test-edit-contributors]').exists();
-        assert.dom('[data-test-edit-contributors]').hasAttribute('href', '/mtadt/contributors/');
+        assert.dom('[data-test-edit-node-contributors-button]').exists();
+        await click('[data-test-edit-node-contributors-button]');
+        assert.dom('[data-test-edit-node-contributors-button]').doesNotExist('Edit button is hidden when in edit mode');
+        assert.dom('[data-test-heading-name]').exists('Contributor name field exists');
+        assert.dom('[data-test-user-search-input]').exists('User search input exists');
+        await click('[data-test-finish-node-contributor-editing-button]');
+        assert.dom('[data-test-edit-node-contributors-button]').exists('Edit button is shown after saving');
         await percySnapshot(assert);
     });
 

--- a/tests/engines/registries/acceptance/overview/index-test.ts
+++ b/tests/engines/registries/acceptance/overview/index-test.ts
@@ -1,5 +1,5 @@
 import Service from '@ember/service';
-import { currentRouteName } from '@ember/test-helpers';
+import { currentRouteName, fillIn } from '@ember/test-helpers';
 import { ModelInstance } from 'ember-cli-mirage';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { percySnapshot } from 'ember-percy';
@@ -156,5 +156,23 @@ module('Registries | Acceptance | overview.index', hooks => {
             'This registration is currently archiving, and no changes can be made at this time.',
             'Correct tombstone title',
         );
+    });
+
+    test('editable title', async function(this: OverviewTestContext, assert: Assert) {
+        this.set('registration', server.create('registration', {
+            title: 'Some flashy title',
+            registrationSchema: server.schema.registrationSchemas.find('prereg_challenge'),
+        }, 'withContributors', 'currentUserAdmin'));
+        await visit(`/${this.registration.id}`);
+
+        assert.dom('[data-test-registration-title]').hasText('Some flashy title', 'Correct title shown');
+        assert.dom('[data-test-edit-registration-title]').exists('Editable title button shown');
+        await click('[data-test-edit-registration-title]');
+        await fillIn('[data-test-registration-title-input]', '');
+        assert.dom('[data-test-save-edits]').isDisabled('Save button disabled when title is empty');
+        await fillIn('[data-test-registration-title-input]', 'New even flashier title');
+
+        await click('[data-test-save-edits]');
+        assert.dom('[data-test-registration-title]').hasText('New even flashier title', 'Correct title saved');
     });
 });

--- a/tests/engines/registries/acceptance/overview/index-test.ts
+++ b/tests/engines/registries/acceptance/overview/index-test.ts
@@ -9,6 +9,7 @@ import { module, test } from 'qunit';
 import Registration, { RegistrationReviewStates } from 'ember-osf-web/models/registration';
 import { click, currentURL, visit } from 'ember-osf-web/tests/helpers';
 import { loadEngine, setupEngineApplicationTest } from 'ember-osf-web/tests/helpers/engines';
+import { Permission } from 'ember-osf-web/models/osf-model';
 
 interface OverviewTestContext extends TestContext {
     registration: ModelInstance<Registration>;
@@ -174,5 +175,10 @@ module('Registries | Acceptance | overview.index', hooks => {
 
         await click('[data-test-save-edits]');
         assert.dom('[data-test-registration-title]').hasText('New even flashier title', 'Correct title saved');
+
+        this.registration.currentUserPermissions = [Permission.Read, Permission.Write];
+        await visit(`/${this.registration.id}`);
+        assert.dom('[data-test-edit-registration-title]')
+            .doesNotExist('Editable title button not shown for non-admins');
     });
 });

--- a/tests/engines/registries/acceptance/overview/metadata-test.ts
+++ b/tests/engines/registries/acceptance/overview/metadata-test.ts
@@ -55,7 +55,7 @@ module('Registries | Acceptance | overview/metadata', hooks => {
         assert.dom('[data-test-edit-node-description-button]').doesNotExist();
         assert.dom('[data-test-edit-resource-metadata-button]').doesNotExist();
         assert.dom('[data-test-edit-funding-metadata-button]').doesNotExist();
-        assert.dom('[data-test-edit-contributors]').doesNotExist();
+        assert.dom('[data-test-edit-node-contributors-button]').doesNotExist();
         await percySnapshot(assert);
     });
 });

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -864,7 +864,7 @@ node_card:
             archiving: 'Archiving'
     registration_template: 'Registration template:'
     registry: 'Registry:'
-    resource-type: 
+    resource-type:
         title: 'Resource Type:'
         none-selected: 'None selected'
         show-resource-type: 'Show resource type'
@@ -908,7 +908,7 @@ node:
         load-more:
             loading: Loading…
             load-more: 'Load More Projects'
-    components: 
+    components:
         title: Components
         no_components: 'This project has no components.'
     registrations:
@@ -2679,6 +2679,7 @@ osf-components:
         next_slide: 'Next slide'
         go_to_slide: 'Go to slide {slideIndex}'
     node-metadata-form:
+        title: 'Title'
         description: 'Description'
         creation-date: 'Date created'
         modification-date: 'Date modified'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -2047,6 +2047,7 @@ registries:
         sorted: 'Sorted by last updated'
     registration_metadata:
         add_description: 'Add description'
+        edit_contributors: 'Edit contributors'
         add_contributors:
             section_heading: 'Add Contributors'
             add_new_button: 'Add new contributors'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -2105,6 +2105,10 @@ registries:
         tags_context: 'Enter specific keywords that describe the key elements and concepts of your research. These keywords will improve the discoverability of your registration in search results and databases.'
         title: Title
         title_context: 'Provide a concise and descriptive title for your registration that accurately reflects the main focus of your research. A clear and specific title will help others quickly understand the essence of your study.'
+        edit_title:
+            heading: 'Edit title'
+            success: 'Title successfully updated.'
+            error: 'Unable to save title.'
         edit_description:
             success: 'Description successfully updated.'
             error: 'Unable to save description.'


### PR DESCRIPTION
-   Ticket: [ENG-7267]
-   Feature flag: n/a

## Purpose
- Allow registration admins to update registration title and contributors

## Summary of Changes
- Add logic to allow admin users to update registration title
- Add logic to allow admin users to update registration contributors

## Screenshot(s)
- On any registration page, title should be editable for admin users
![image](https://github.com/user-attachments/assets/7dc2e358-d3fb-426a-8dfc-a503ca53f79d)

- On registration metadata page, admins should be able to update the registration title
![image](https://github.com/user-attachments/assets/e93436f1-93fd-4e22-a46f-3c2e183133ba)

- On registration metadata page, contributors should be editable
![Screen Shot 2025-02-28 at 3 11 21 PM](https://github.com/user-attachments/assets/84f70404-9210-4ff3-9815-8f0f1e277c45)
![image](https://github.com/user-attachments/assets/1fb30ec3-d246-408c-8b9c-26d52983e7a4)


## Side Effects
- This will also allow admin users to update project/component contributors on the project metadata tab

## QA Notes


[ENG-7267]: https://openscience.atlassian.net/browse/ENG-7267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ