### PR TITLE
[ENG-7337] Send metrics for unverified DOIs

### DIFF
--- a/app/models/preprint.ts
+++ b/app/models/preprint.ts
@@ -129,11 +129,8 @@ export default class PreprintModel extends AbstractNodeModel {
         return this.dateWithdrawn !== null;
     }
 
-    get verifiedDoi(): string {
-        if (this.preprintDoiCreated) {
-            return extractDoi(this.preprintDoiUrl) || '';
-        }
-        return '';
+    get extractedDoi(): string {
+        return extractDoi(this.preprintDoiUrl) || '';
     }
 
     @computed('license', 'licenseRecord')

--- a/app/preprints/detail/route.ts
+++ b/app/preprints/detail/route.ts
@@ -214,7 +214,7 @@ export default class PreprintsDetail extends Route {
         return {
             osfMetrics: {
                 itemGuid: preprint.id,
-                itemDoi: preprint.verifiedDoi,
+                itemDoi: preprint.extractedDoi,
             },
         };
     }

--- a/app/preprints/detail/template.hbs
+++ b/app/preprints/detail/template.hbs
@@ -181,7 +181,7 @@
                                 local-class='btn btn-primary'
                                 target='_blank'
                                 @href={{ this.fileDownloadUrl }}
-                                {{track-download this.model.preprint.id doi=this.model.preprint.verifiedDoi}}
+                                {{track-download this.model.preprint.id doi=this.model.preprint.extractedDoi}}
                             >
                                 {{t 'preprints.detail.share.download' documentType=this.model.provider.documentType.singular}}
                             </OsfLink>

--- a/app/services/analytics.ts
+++ b/app/services/analytics.ts
@@ -262,7 +262,9 @@ export default class Analytics extends Service {
     @task
     @waitFor
     async _trackDownloadTask(itemGuid: string, doi?: string) {
-        const _doi = doi || await this._getDoiForGuid(itemGuid);
+        // if doi is undefined/null, try finding a DOI via the api based on itemGuid
+        // (if doi is an empty string, assume there's no DOI; don't try to find one)
+        const _doi = doi ?? await this._getDoiForGuid(itemGuid);
         if (_doi) {
             this._sendDataciteUsage(_doi, DataCiteMetricType.Download);
         }

--- a/app/services/analytics.ts
+++ b/app/services/analytics.ts
@@ -436,7 +436,9 @@ export default class Analytics extends Service {
 
     async _sendDataciteView(): Promise<void> {
         const { itemGuid, itemDoi } = this._getRouteMetricsMetadata();
-        const _doi = itemDoi || await this._getDoiForGuid(itemGuid);
+        // if itemDoi is undefined/null, try finding a DOI via the api based on itemGuid
+        // (if itemDoi is an empty string, assume there's no DOI; don't try to find one)
+        const _doi = itemDoi ?? await this._getDoiForGuid(itemGuid);
         if (_doi) {
             this._sendDataciteUsage(_doi, DataCiteMetricType.View);
         }


### PR DESCRIPTION
-   Ticket: [ENG-7337]
-   Feature flag: n/a

## Purpose
- Send metrics for preprints with unverified DOIs
  - Should be released in conjunction with this PR to avoid potential console errors https://github.com/CenterForOpenScience/ember-osf-web/pull/2517

## Summary of Changes
- Remove check to see if preprint DOI has been verified (checked using the `PreprintModel. preprintDoiCreated` property as a proxy)
  - Rename `verifiedDoi` property to `extractedDoi` to avoid misleading name

## Screenshot(s)
- NA

## Side Effects
- Will likely lead to requests that will come back with a `422` code to datacite usage tracker while the DOI is not verified

## QA Notes
- Verify that this fix is working by testing on a newly published and public preprint that does not have a `preprint_doi_created` in the API
  - Viewing/downloading this preprint in the OSF should trigger a request to Datacite (`analytics.datacite.org/api/metric`). This request will likely respond with a `422` code, but this should be expected


[ENG-7337]: https://openscience.atlassian.net/browse/ENG-7337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ