### PR TITLE
[ENG-6926] [ENG-6927] Added explanatory text to the add-on settings page 

### DIFF
--- a/app/guid-node/addons/index/template.hbs
+++ b/app/guid-node/addons/index/template.hbs
@@ -349,6 +349,7 @@
                     data-test-configured-addons-tab
                     data-analytics-scope='Connected accounts tab'
                 >
+                    {{t 'addons.list.sync-details-3'}}
                     <div local-class='addons-list-wrapper {{if this.isMobile 'mobile'}}'>
                         <div
                             data-analytics-scope='Addon List Filter'

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -249,6 +249,7 @@ addons:
         root-folder-not-set: 'Root folder not set'
         sync-details-1: 'Sync your projects with external services to help stay connected and organized. Select a category and browse the options.'
         sync-details-2: 'To manage all add-ons connected to your account, visit your profile settings.'
+        sync-details-3: 'Manage your connected Add-ons, re-authorize, disconnect account, or disconnect project'
         filter-placeholder: 'Filter add-ons'
         filter:
             all: 'All'


### PR DESCRIPTION


-   Ticket: [ENG-6926] and [ENG-6927]
-   Feature flag: n/a

## Purpose

Added enhanced descriptions to the add-on settings page. The tickets eng-6926 and eng-6927 show that I should text to both tabs. However, I found the text already in the code.

I'm not certain if there was a 3rd ticket or what.

## Summary of Changes

I added line 252 in en-us.yml file. I should have also added lines 250 and 251. They already existed. I did confirm with Blaine that the tickets are correct.

## Screenshot(s)

I attempted to hook-up an add-on using the back-end and got an error because "localhost" is a valid callback. I spoke with Futa about how to get around this and his reply reminded me of the two wasted weeks on the "Activity Log" project and opted to just follow the precendence in the code without actually seeing it until it reaches the test environment.

## Side Effects

Formatting may be off, though it will match the other tab which would then also be off.

## QA Notes

Finally an easy test.


[ENG-6926]: https://openscience.atlassian.net/browse/ENG-6926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-6927]: https://openscience.atlassian.net/browse/ENG-6927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ