### PR TITLE
[ENG-5027] Pass deleted user info into contributor

### DIFF
--- a/tests/integration/components/contributor-list/contributor/component-test.ts
+++ b/tests/integration/components/contributor-list/contributor/component-test.ts
@@ -28,4 +28,35 @@ module('Integration | Component | contributor-list/contributor', hooks => {
         assert.dom(this.element).hasText(fakeUser.fullName);
         assert.dom('a').exists({ count: 1 });
     });
+
+    test('it renders deleted users', async function(assert) {
+        const fakeUser = {
+            relationshipLinks: {
+                users: {
+                    data: {
+                        meta: {
+                            fullName: 'Gone User',
+                            familyName: 'User',
+                            givenName: 'Gone',
+                        },
+                        status: 410,
+                    },
+                },
+            },
+            users: null,
+        };
+        this.set('contrib', fakeUser);
+
+        await render(hbs`{{contributor-list/contributor contributor=this.contrib}}`);
+        assert.dom(this.element).hasText('Gone User');
+        assert.dom('a').doesNotExist();
+
+        await render(hbs`{{contributor-list/contributor contributor=this.contrib shouldShortenName=true}}`);
+        assert.dom(this.element).hasText('User');
+        assert.dom('a').doesNotExist();
+
+        await render(hbs`{{contributor-list/contributor contributor=this.contrib shouldLinkUser=true}}`);
+        assert.dom(this.element).hasText('Gone User');
+        assert.dom('a').doesNotExist('Deleted users should not be linked');
+    });
 });


### PR DESCRIPTION
-   Ticket: [ENG-5027]
-   Feature flag: n/a

## Purpose
- Show deleted user's names in contributor fields

## Summary of Changes
- Add logic in osf-serializer to finagle deleted user data onto contributor model
- Update contributor-list/contributor component to look for deleted user data in case ContributorModel.user relationship is undefined

## Screenshot(s)
- Prevents deleted user names from showing up as blank on the preprint overview page

![image](https://github.com/user-attachments/assets/dbfc4083-b06a-419c-8639-3e2e9d80d1ac)


## Side Effects
- _may_ be introducing a new error when setting head tags, specifically these lines where we try to sparse-load contributors and their users https://github.com/CenterForOpenScience/ember-osf-web/blob/master/app/preprints/detail/route.ts#L155-L158

## QA Notes
- Verify that deleted users (probably via the admin app GDPR delete them?) have their names shown in preprint detail page

[ENG-5027]: https://openscience.atlassian.net/browse/ENG-5027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ