### PR TITLE
[ENG-7025] Enable save when name or root folder changes

### DIFF
--- a/lib/osf-components/addon/components/addons-service/configured-addon-edit/component.ts
+++ b/lib/osf-components/addon/components/addons-service/configured-addon-edit/component.ts
@@ -25,6 +25,8 @@ export default class ConfiguredAddonEdit extends Component<Args> {
     @tracked selectedFolder = this.args.configuredAddon?.rootFolder;
     @tracked currentItems: Item[] = [];
 
+    originalName = this.displayName;
+    originalRootFolder = this.selectedFolder;
     defaultKwargs: any = {};
 
     constructor(owner: unknown, args: Args) {
@@ -60,7 +62,22 @@ export default class ConfiguredAddonEdit extends Component<Args> {
     }
 
     get disableSave() {
-        return this.invalidDisplayName || this.args.onSave.isRunning || (this.hasRootFolder && !this.selectedFolder);
+        const displayNameUnchanged = this.displayName === this.originalName;
+        const rootFolderUnchanged = this.hasRootFolder && this.selectedFolder === this.originalRootFolder;
+        const needsRootFolder = this.hasRootFolder && !this.selectFolder;
+
+        if (this.invalidDisplayName || needsRootFolder) {
+            return true;
+        }
+        return (rootFolderUnchanged && displayNameUnchanged) || this.args.onSave.isRunning;
+    }
+
+    get nameValid() {
+        return !this.invalidDisplayName && this.displayName !== this.originalName;
+    }
+
+    get folderValid() {
+        return !this.hasRootFolder && this.selectedFolder && this.selectedFolder !== this.originalRootFolder;
     }
 
     get onSaveArgs() {

--- a/mirage/factories/configured-storage-addon.ts
+++ b/mirage/factories/configured-storage-addon.ts
@@ -7,6 +7,7 @@ export default Factory.extend<ConfiguredStorageAddonModel>({
     externalUserId: faker.random.uuid(),
     externalUserDisplayName: faker.name.findName(),
     rootFolder: faker.system.filePath(),
+    currentUserIsOwner: true,
 });
 
 declare module 'ember-cli-mirage/types/registries/model' {

--- a/tests/acceptance/guid-node/addons-test.ts
+++ b/tests/acceptance/guid-node/addons-test.ts
@@ -197,7 +197,7 @@ module('Acceptance | guid-node/addons', hooks => {
             .hasValue(s3AccountsDisplayNamesAndRootFolders[0].displayName, 'Name input has correct value');
         assert.dom('[data-test-go-to-root]').exists('Go to root button is present');
         assert.dom('[data-test-folder-path-option]').exists({ count: 1 }, 'Folder path shown');
-        assert.dom('[data-test-root-folder-save]').isEnabled('Save button is enabled when name is present');
+        assert.dom('[data-test-root-folder-save]').isDisabled('Save button is disabled when no changes are present');
         assert.dom('[data-test-root-folder-cancel]').exists('Cancel button is present');
         // Edit first account display name
         await fillIn('[data-test-display-name-input]', '');
@@ -205,7 +205,7 @@ module('Acceptance | guid-node/addons', hooks => {
         await fillIn('[data-test-display-name-input]', 'New S3 Account Display Name');
         assert.dom('[data-test-root-folder-save]').isEnabled('Save button is enabled with displayName present');
         await fillIn('[data-test-display-name-input]', s3AccountsDisplayNamesAndRootFolders[0].displayName);
-        assert.dom('[data-test-root-folder-save]').isEnabled('Save button is enabled with original displayName');
+        assert.dom('[data-test-root-folder-save]').isDisabled('Save button is enabled when displayName is unchanged');
         // Edit first account root folder
         await click('[data-test-folder-link]:first-child');
         assert.dom('[data-test-folder-path-option]').exists({ count: 2 }, '2 folders in path');

--- a/tests/integration/components/addons-service/configured-addon-edit/component-test.ts
+++ b/tests/integration/components/addons-service/configured-addon-edit/component-test.ts
@@ -67,7 +67,7 @@ module('Integration | Component | addons-service | configured-addon-edit', funct
         // updating and reseting the display name
         assert.dom('[data-test-display-name-error]').doesNotExist('No error message initially');
         await fillIn('[data-test-display-name-input]', '');
-        assert.dom('[data-test-root-folder-save]').isDisabled('Save button is disabled');
+        assert.dom('[data-test-root-folder-save]').isDisabled('Save button is disabled when display name is empty');
         assert.dom('[data-test-display-name-error]').exists('Error message is shown when display name is empty');
         await fillIn('[data-test-display-name-input]', 'My configured addon');
         assert.dom('[data-test-display-name-error]').doesNotExist('No error message after display name is set');


### PR DESCRIPTION
-   Ticket: [ENG-7025]
-   Feature flag: n/a

## Purpose
- Tighten criteria for when "Save" button on configured addon edit page is disabled

## Summary of Changes
- Spent an embarrassing amount of time reasoning through these following conditions to disable save button:
  - configured addon display name is empty
  - configured addon needs a root folder and none is selected
  - the display name has not been changed
  - the root folder has not been changed
- Update mirage factory to assume folks are the account owner for configured-storage-addons

## Screenshot(s)
- When editing a node's configured account and neither the display name or root folder has been changed (not the "Save" button is disabled):
![image](https://github.com/user-attachments/assets/97f0a7c0-5e94-4b56-8e2e-7465ec5e0680)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-7025]: https://openscience.atlassian.net/browse/ENG-7025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ