### PR TITLE
[ENG-7472] fixed recent preprint rejected versions doesnt have option to resubmit

### DIFF
--- a/app/preprints/detail/controller.ts
+++ b/app/preprints/detail/controller.ts
@@ -87,7 +87,6 @@ export default class PrePrintsDetailController extends Controller {
     get showEditButton() {
         const providerIsPremod = this.model.provider.reviewsWorkflow === PreprintProviderReviewsWorkFlow.PRE_MODERATION;
         const preprintIsRejected = this.model.preprint.reviewsState === ReviewsState.REJECTED;
-        const preprintIsFirstVersion = this.model.preprint.version === 1;
 
         if (!this.userIsContrib) {
             return false;
@@ -105,8 +104,7 @@ export default class PrePrintsDetailController extends Controller {
                 return true;
             }
             // Edit and resubmit
-            if (preprintIsFirstVersion && preprintIsRejected
-                && this.model.preprint.currentUserIsAdmin) {
+            if (preprintIsRejected && this.model.preprint.currentUserIsAdmin) {
                 return true;
             }
         }

--- a/tests/acceptance/preprints/detail-test.ts
+++ b/tests/acceptance/preprints/detail-test.ts
@@ -199,7 +199,7 @@ module('Acceptance | preprints | detail', hooks => {
         assert.dom('[data-test-edit-preprint-button]')
             .doesNotExist('Edit button is not displayed for non-latest versions');
 
-        // Not initial, pre-mod, rejected
+        // Not initial, pre-mod, rejected, not latest
         preprint.setProperties({
             reviewsState: ReviewsState.REJECTED,
             version: 4,
@@ -208,7 +208,18 @@ module('Acceptance | preprints | detail', hooks => {
         });
         await settled();
         assert.dom('[data-test-edit-preprint-button]')
-            .doesNotExist('Edit button is not displayed for non-initial pre-mod rejected');
+            .exists('Edit button is not displayed for non-initial pre-mod not latest rejected');
+
+        // Not initial, pre-mod, rejected, latest
+        preprint.setProperties({
+            reviewsState: ReviewsState.REJECTED,
+            version: 4,
+            isLatestVersion: true,
+            currentUserPermissions: Object.values(Permission),
+        });
+        await settled();
+        assert.dom('[data-test-edit-preprint-button]')
+            .exists('Edit button is not displayed for non-initial pre-mod latest rejected');
 
         // Initial, pre-mod, rejected
         preprint.setProperties({

--- a/tests/acceptance/preprints/detail-test.ts
+++ b/tests/acceptance/preprints/detail-test.ts
@@ -208,7 +208,7 @@ module('Acceptance | preprints | detail', hooks => {
         });
         await settled();
         assert.dom('[data-test-edit-preprint-button]')
-            .exists('Edit button is not displayed for non-initial pre-mod not latest rejected');
+            .exists('Edit button is displayed for non-initial pre-mod not latest rejected');
 
         // Not initial, pre-mod, rejected, latest
         preprint.setProperties({
@@ -219,7 +219,7 @@ module('Acceptance | preprints | detail', hooks => {
         });
         await settled();
         assert.dom('[data-test-edit-preprint-button]')
-            .exists('Edit button is not displayed for non-initial pre-mod latest rejected');
+            .exists('Edit button is displayed for non-initial pre-mod latest rejected');
 
         // Initial, pre-mod, rejected
         preprint.setProperties({


### PR DESCRIPTION
-   Ticket: https://openscience.atlassian.net/browse/ENG-7472
-   Feature flag: n/a

## Purpose

Make it possible to resubmit rejected preprint versions

## Summary of Changes

Make it possible to resubmit rejected preprint versions

## Screenshot(s)
<img width="1250" alt="Знімок екрана 2025-03-18 о 12 49 51" src="https://github.com/user-attachments/assets/4ee0632b-536f-4fac-8c36-4bbe970eb5a7" />
<img width="1176" alt="Знімок екрана 2025-03-18 о 12 49 42" src="https://github.com/user-attachments/assets/ed80975c-7cf6-40d9-adaf-9759fe7cf2a4" />
<img width="1336" alt="Знімок екрана 2025-03-18 о 12 49 31" src="https://github.com/user-attachments/assets/f0b7fd0c-f74d-456a-92a6-afe6bf753e4c" />

## Side Effects

TBD

## QA Notes

TBD
