### PR TITLE
[ENG-7095] Fixed code for the original title to be accurate

### DIFF
--- a/lib/osf-components/addon/components/activity-log/-components/activity-log-display/component-test.ts
+++ b/lib/osf-components/addon/components/activity-log/-components/activity-log-display/component-test.ts
@@ -109,7 +109,7 @@ module('Integration | Activity Log Display | Component | validate activity log',
 />
 `);
         assert.dom('[data-test-action-text]').hasHtml(
-            '<span><a href="/utu98/">Futa Geiger</a> changed the title from <a href="/ww3a2/">The original node for testing</a> to <a href="/ww3a2/">The new title</a></span>',
+            '<span><a href="/utu98/">Futa Geiger</a> changed the title from <a href="/ww3a2/">The original title</a> to <a href="/ww3a2/">The new title</a></span>',
             'Project edit title is correct',
         );
 

--- a/lib/osf-components/addon/components/activity-log/-components/activity-log-display/component.ts
+++ b/lib/osf-components/addon/components/activity-log/-components/activity-log-display/component.ts
@@ -126,7 +126,7 @@ export default class ActivityLogDisplayComponent extends Component<ActivityLogDi
             tag: this.buildTagUrl(),
             template: this.getEmbeddedUrl(),
             title_new: this.buildTitleNew(),
-            title_original: this.getEmbeddedUrl(),
+            title_original: this.buildTitleOriginal(),
             updated_fields: this.buildUpdatedFields(),
             user: this.buildUserUrl(),
             value: this.log?.params?.value,
@@ -277,9 +277,6 @@ export default class ActivityLogDisplayComponent extends Component<ActivityLogDi
         } else if (this.templateNode?.links?.html) {
             return this.buildAHrefElement(this.templateNode.links.html.toString(),
                 this.templateNode.title);
-        } else if (this.originalNode?.links?.html) {
-            return this.buildAHrefElement(this.originalNode.links.html.toString(),
-                this.originalNode.title);
         } else {
             return this.intl.t('activity-log.defaults.a_title');
         }
@@ -508,6 +505,20 @@ export default class ActivityLogDisplayComponent extends Component<ActivityLogDi
         return this.originalNode?.links ?
             this.buildAHrefElement(
                 `${this.originalNode.links.html}`, this.log.params.titleNew,
+            ) : this.intl.t('activity-log.defaults.a_title');
+    }
+
+    /**
+     * buildTitleOriginal
+     *
+     * @description Abstracted method to build the original title
+     *
+     * @returns a formatted string
+     */
+    private buildTitleOriginal(): string {
+        return this.originalNode?.links ?
+            this.buildAHrefElement(
+                `${this.originalNode.links.html}`, this.log.params.titleOriginal,
             ) : this.intl.t('activity-log.defaults.a_title');
     }
 


### PR DESCRIPTION
-   Ticket: [ENG-7095]
-   Feature flag: n/a

## Purpose

There was an error where the title on a changed registration was not correct.

## Summary of Changes

Added a new method to get the correct title.
Pruned unused code
Fixed the tests

## Screenshot(s)

N/A

## Side Effects

None

## QA Notes

Please review


[ENG-7095]: https://openscience.atlassian.net/browse/ENG-7095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ