### PR TITLE
[Hotfix] [ENG-7553] Fix logic to show/hide file version download

### DIFF
--- a/app/preprints/-components/preprint-file-render/template.hbs
+++ b/app/preprints/-components/preprint-file-render/template.hbs
@@ -16,7 +16,7 @@
             </div>
         </div>
         <div local-class='version-container'>
-            {{#if @primaryFileHasVersions}}
+            {{#if this.primaryFileHasVersions}}
                 <ResponsiveDropdown
                     @renderInPlace={{true}}
                     @buttonStyling={{true}}


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-7553]
-   Feature flag: n/a

## Purpose
- Fix bug where dropdown to download prior versions was removed

## Summary of Changes
- Undo some bad find-and-replace done in this commit https://github.com/CenterForOpenScience/ember-osf-web/pull/2447/commits/a4535b7aa43b3e34c7b9e33f7c3955e6fa1a1cde

## Screenshot(s)
- Screenshot available in JIRA ticket

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes
- This is to allow users to download previous *file versions* of a preprint (the old workflow for updating a preprint). This is *not* the same as the "preprint version".


[ENG-7553]: https://openscience.atlassian.net/browse/ENG-7553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ