### PR TITLE
[ENG-7712] Write user subjects

### DIFF
--- a/lib/osf-components/addon/components/subjects/manager/component.ts
+++ b/lib/osf-components/addon/components/subjects/manager/component.ts
@@ -121,7 +121,6 @@ export default class SubjectManagerComponent extends Component {
         });
         this.incrementProperty('selectedSubjectsChanges');
         this.incrementProperty('savedSubjectsChanges');
-        this.model.set('subjects', savedSubjects);
         if (this.hasSubjects) {
             this.metadataChangeset?.validate('subjects');
             this.hasSubjects(savedSubjectIds.size > 0);


### PR DESCRIPTION
-   Ticket: [ENG-7712]
-   Feature flag: n/a

## Purpose
- Prevent bug that prevents a write-user from updating registration metadata

## Summary of Changes
- Remove subjects relationship data from PUT request payload
  - Subjects are only editable by registration admins, so having this included in the request payload was preventing write users from editing metadata

## Screenshot(s)
- ember remove subjects in PATCH request payload
Before:
![image](https://github.com/user-attachments/assets/36fe799d-816d-46d3-b138-8cd1038641b0)

After:
![image](https://github.com/user-attachments/assets/03d57025-d2e2-4e46-b326-b5a2cb9e4abe)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-7712]: https://openscience.atlassian.net/browse/ENG-7712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ