### PR TITLE
[ENG-7712]  Redo write-user subjects handling

### DIFF
--- a/lib/osf-components/addon/components/node-metadata-form/template.hbs
+++ b/lib/osf-components/addon/components/node-metadata-form/template.hbs
@@ -415,20 +415,28 @@
         <dl>
             <dt>{{t 'osf-components.node-metadata-form.subjects'}}</dt>
             <dd>
-                <Subjects::Manager
-                    @model={{@manager.node}}
-                    @provider={{@manager.node.provider}}
-                    @doesAutosave={{true}}
-                    as |subjectsManager|
-                >
-                    {{#if subjectsManager.loadingNodeSubjects}}
-                        <LoadingIndicator data-test-loading-indicator @dark={{true}} />
+                {{#if @manager.userIsAdmin}}
+                    <Subjects::Manager
+                        @model={{@manager.node}}
+                        @provider={{@manager.node.provider}}
+                        @doesAutosave={{true}}
+                        as |subjectsManager|
+                    >
+                        {{#if subjectsManager.loadingNodeSubjects}}
+                            <LoadingIndicator data-test-loading-indicator @dark={{true}} />
+                        {{else}}
+                            <Subjects::Widget
+                                @subjectsManager={{subjectsManager}}
+                            />
+                        {{/if}}
+                    </Subjects::Manager>
+                {{else}}
+                    {{#if @manager.subjects}}
+                        <Subjects::Display @subjects={{@manager.subjects}} />
                     {{else}}
-                        <Subjects::Widget
-                            @subjectsManager={{subjectsManager}}
-                        />
+                        <span>{{t 'osf-components.node-metadata-form.no-subjects'}}</span>
                     {{/if}}
-                </Subjects::Manager>
+                {{/if}}
             </dd>
         </dl>
     </div>

--- a/lib/osf-components/addon/components/node-metadata-manager/component.ts
+++ b/lib/osf-components/addon/components/node-metadata-manager/component.ts
@@ -26,6 +26,7 @@ import LicenseModel from 'ember-osf-web/models/license';
 import IdentifierModel from 'ember-osf-web/models/identifier';
 import CurrentUser from 'ember-osf-web/services/current-user';
 import UserModel from 'ember-osf-web/models/user';
+import SubjectModel from 'ember-osf-web/models/subject';
 
 interface Args {
     node: (NodeModel);
@@ -49,6 +50,7 @@ export interface NodeMetadataManager {
     inEditMode: boolean;
     isSaving: boolean;
     userCanEdit: boolean;
+    userIsAdmin: boolean;
     isDirty: boolean;
     isGatheringData: boolean;
     license: LicenseModel;
@@ -84,6 +86,7 @@ export default class NodeMetadataManagerComponent extends Component<Args> {
     @tracked isEditingResources = false;
     @tracked isEditingInstitutions = false;
     @tracked userCanEdit!: boolean;
+    @tracked userIsAdmin!: boolean;
     @or(
         'getGuidMetadata.isRunning',
         'cancelMetadata.isRunning',
@@ -97,6 +100,7 @@ export default class NodeMetadataManagerComponent extends Component<Args> {
     @tracked guidType!: string | undefined;
     @tracked affiliatedList!: InstitutionModel[];
     @tracked currentAffiliatedList!: InstitutionModel[];
+    @tracked subjects!: SubjectModel[];
     resourceTypeGeneralOptions: string[] = resourceTypeGeneralOptions;
     languageCodes: LanguageCode[] = languageCodes;
     saveErrored = false;
@@ -111,6 +115,7 @@ export default class NodeMetadataManagerComponent extends Component<Args> {
         try {
             taskFor(this.getGuidMetadata).perform();
             this.userCanEdit = this.node.currentUserPermissions.includes(Permission.Write);
+            this.userIsAdmin = this.node.currentUserPermissions.includes(Permission.Admin);
         } catch (e) {
             const errorTitle = this.intl.t('osf-components.item-metadata-manager.error-getting-metadata');
             this.toast.error(getApiErrorMessage(e), errorTitle);
@@ -137,6 +142,7 @@ export default class NodeMetadataManagerComponent extends Component<Args> {
             this.currentAffiliatedList = [...this.affiliatedList];
             this.license = await node.license;
             this.identifiers = await node.queryHasMany('identifiers');
+            this.subjects = await node.queryHasMany('subjects');
             this.changeset = buildChangeset(this.metadata, null);
             this.changeset.languageObject = {
                 code: this.metadata.language,

--- a/lib/osf-components/addon/components/node-metadata-manager/template.hbs
+++ b/lib/osf-components/addon/components/node-metadata-manager/template.hbs
@@ -34,8 +34,10 @@
     saveInstitutions=(perform this.saveInstitutions)
     saveMetadata=(perform this.saveMetadata)
     saveNode=(perform this.saveNode)
+    subjects=this.subjects
     toggleInstitution=(action this.toggleInstitution)
     user=this.currentUser.user
     userCanEdit=this.userCanEdit
+    userIsAdmin=this.userIsAdmin
     resourceTypeGeneralOptions=this.resourceTypeGeneralOptions
 )}}

--- a/lib/osf-components/addon/components/subjects/manager/component.ts
+++ b/lib/osf-components/addon/components/subjects/manager/component.ts
@@ -121,6 +121,7 @@ export default class SubjectManagerComponent extends Component {
         });
         this.incrementProperty('selectedSubjectsChanges');
         this.incrementProperty('savedSubjectsChanges');
+        this.model.set('subjects', savedSubjects);
         if (this.hasSubjects) {
             this.metadataChangeset?.validate('subjects');
             this.hasSubjects(savedSubjectIds.size > 0);

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -2839,6 +2839,7 @@ osf-components:
         funding-information: 'Funding/Support Information'
         funding-information-help: 'More information about funding information'
         subjects: 'Subjects'
+        no-subjects: 'No subjects'
         tags: 'Tags'
         edit-button: 'Edit Metadata'
         resource-type: 'Resource type:'


### PR DESCRIPTION
-   Ticket: [ENG-7712]
-   Feature flag: n/a

## Purpose
- Fix issues with write-users not being able to update registration metadata due to subjects being added to request payloads

## Summary of Changes
- Undo changes made in this PR https://github.com/CenterForOpenScience/ember-osf-web/pull/2534
- Update the node metadata form to show subject picker only for admin users
- Only show selected subjects for write and read users

## Screenshot(s)
- Write user and no subjects on the registration
![image](https://github.com/user-attachments/assets/83a8e303-c935-4d83-b87c-d5114145138f)
- Write user and some subjects on the registration
![image](https://github.com/user-attachments/assets/f9d0bd92-6c75-44e4-921e-48b257c5d155)
- Admin users view (unchanged)
![image](https://github.com/user-attachments/assets/1f19a542-bb5c-4a4e-96fb-d8c9afb1d431)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-7712]: https://openscience.atlassian.net/browse/ENG-7712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ