### PR TITLE
[ENG-7714] [ENG-7025] Configure addon page updates

### DIFF
--- a/lib/osf-components/addon/components/addons-service/configured-addon-edit/component.ts
+++ b/lib/osf-components/addon/components/addons-service/configured-addon-edit/component.ts
@@ -23,6 +23,7 @@ interface Args {
 export default class ConfiguredAddonEdit extends Component<Args> {
     @tracked displayName = this.args.configuredAddon?.displayName || this.args.authorizedAccount?.displayName;
     @tracked selectedFolder = this.args.configuredAddon?.rootFolder;
+    @tracked selectedFolderDisplayName = this.args.configuredAddon?.rootFolderName;
     @tracked currentItems: Item[] = [];
 
     originalName = this.displayName;
@@ -49,7 +50,7 @@ export default class ConfiguredAddonEdit extends Component<Args> {
         }
     }
 
-    get hasRootFolder() {
+    get requiresRootFolder() {
         return !(
             this.args.authorizedAccount instanceof AuthorizedComputingAccountModel
             ||
@@ -63,8 +64,8 @@ export default class ConfiguredAddonEdit extends Component<Args> {
 
     get disableSave() {
         const displayNameUnchanged = this.displayName === this.originalName;
-        const rootFolderUnchanged = this.hasRootFolder && this.selectedFolder === this.originalRootFolder;
-        const needsRootFolder = this.hasRootFolder && !this.selectFolder;
+        const rootFolderUnchanged = this.requiresRootFolder && this.selectedFolder === this.originalRootFolder;
+        const needsRootFolder = this.requiresRootFolder && !this.selectedFolder;
 
         if (this.invalidDisplayName || needsRootFolder) {
             return true;
@@ -77,7 +78,7 @@ export default class ConfiguredAddonEdit extends Component<Args> {
     }
 
     get folderValid() {
-        return !this.hasRootFolder && this.selectedFolder && this.selectedFolder !== this.originalRootFolder;
+        return !this.requiresRootFolder && this.selectedFolder && this.selectedFolder !== this.originalRootFolder;
     }
 
     get onSaveArgs() {
@@ -90,5 +91,6 @@ export default class ConfiguredAddonEdit extends Component<Args> {
     @action
     selectFolder(folder: Item) {
         this.selectedFolder = folder.itemId;
+        this.selectedFolderDisplayName = folder.itemName;
     }
 }

--- a/lib/osf-components/addon/components/addons-service/configured-addon-edit/styles.scss
+++ b/lib/osf-components/addon/components/addons-service/configured-addon-edit/styles.scss
@@ -3,7 +3,7 @@
     padding: 1rem;
 }
 
-.display-name-wrapper {
+.input-wrapper {
     margin-bottom: 1rem;
 }
 

--- a/lib/osf-components/addon/components/addons-service/configured-addon-edit/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/configured-addon-edit/template.hbs
@@ -2,7 +2,7 @@
     local-class='configured-addon-edit-wrapper'
     data-analytics-scope='Configured Addon Edit'
 >
-    <div local-class='display-name-wrapper'>
+    <div local-class='input-wrapper'>
         <label>
             {{t 'addons.configure.display-name'}}
             <Input
@@ -21,7 +21,19 @@
             </span>
         {{/if}}
     </div>
-    {{#if this.hasRootFolder }}
+    {{#if this.requiresRootFolder }}
+        <div local-class='input-wrapper'>
+            <b>
+                {{t 'addons.configure.selected-folder'}}
+            </b>
+            <span>
+                {{#if this.selectedFolderDisplayName}}
+                    {{this.selectedFolderDisplayName}}
+                {{else}}
+                    {{t 'addons.configure.no-folder-selected'}}
+                {{/if}}
+            </span>
+        </div>
         <AddonsService::FileManager
             @configuredAddon={{@configuredAddon}}
             @authorizedAccount={{@authorizedAccount}}
@@ -29,6 +41,7 @@
             @startingFolderId={{this.selectedFolder}}
             as |fileManager|
         >
+
             <div local-class='current-path'>
                 <Button
                     data-test-go-to-root
@@ -107,6 +120,7 @@
                                             type='radio'
                                             name='folder'
                                             value={{folder.itemName}}
+                                            checked={{eq folder.itemId this.selectedFolder}}
                                             aria-label={{t 'addons.configure.select-folder' folderName=folder.itemName}}
                                             {{on 'change'(fn this.selectFolder folder)}}
                                         >

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -359,6 +359,8 @@ addons:
     configure:
         heading: 'Configure {providerName}'
         display-name: 'Display name'
+        selected-folder: 'Selected folder:'
+        no-folder-selected: 'No folder selected'
         go-to-root: 'Go to home folder'
         go-to-folder: 'Go to folder {folderName}'
         select-folder: 'Select {folderName} as root folder'


### PR DESCRIPTION
-   Ticket: [ENG-7714] [ENG-7025]
-   Feature flag: n/a

## Purpose
- Fix issue where Configure Addon page's Save button was enabled when users had not yet selected a root folder
- Improve UX so users will see their currently selected root folder at the top of the page and root folder will be selected when navigating back to a view that shows the current root folder selection

## Summary of Changes
- Update logic for when Save button is disabled (`selectFolder` was an action, `selectedFolder` is the correct variable to use 😮‍💨 )
- Update confusing `hasRootFolder` property name to `requiresRootFolder`
- Add a "Selected folder:" display to help users know which folder is the currently selected root
- Add logic to pre-select radio button if the shown item is the currently selected root folder

## Screenshot(s)
- fix issue where Save button was enabled after entering a name (note there is no selected root folder and the Save button is disabled)
![image](https://github.com/user-attachments/assets/0636859f-8a5e-4f61-8dda-14f0ac27618d)

- Show the current "Selected Folder:" and the selection checkbox will remain checked when navigating back to a view where the currently selected folder is visible
![image](https://github.com/user-attachments/assets/b3d5030b-61df-4a23-869a-b133bcc1bc4c)


## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-7714]: https://openscience.atlassian.net/browse/ENG-7714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-7025]: https://openscience.atlassian.net/browse/ENG-7025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ