### PR TITLE
[ENG-6326] Bug fix for supplements caching

### DIFF
--- a/app/preprints/-components/submit/supplements/component.ts
+++ b/app/preprints/-components/submit/supplements/component.ts
@@ -70,7 +70,9 @@ export default class Supplements extends Component<SupplementsArgs>{
     public async removeSelectedProject(): Promise<void> {
         try {
             await this.args.manager.preprint.removeM2MRelationship('node'); // Remove relationship
-            this.args.manager.preprint.set('node', null); // Ensure local cache is updated
+            // Remove relationship on the node side, this only clears the cache locally
+            this.args.manager.preprint.node.get('preprints')
+                .removeObject(this.args.manager.preprint);
             this.isSupplementAttached = false;
             this.validate();
         } catch (error) {


### PR DESCRIPTION
-   Ticket: [ENG-6326]
-   Feature flag: n/a

## Purpose

Prevent supplements from caching on the review page after removal

## Summary of Changes

Reviewed the preprint from the node which was reverse of what was happening

## Screenshot(s)

N/A

## Side Effects

Likely and at this point, uncertain.

## QA Notes

Should work now!


[ENG-6326]: https://openscience.atlassian.net/browse/ENG-6326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ