### PR TITLE
[ENG-7712] Fix issue with write users editing registration metadata

### DIFF
--- a/app/preprints/-components/submit/metadata/component.ts
+++ b/app/preprints/-components/submit/metadata/component.ts
@@ -148,13 +148,6 @@ export default class Metadata extends Component<MetadataArgs>{
     }
 
     @action
-    public async hasSubjects(hasSubjects: boolean): Promise<void> {
-        if (hasSubjects) {
-            this.validate();
-        }
-    }
-
-    @action
     public validate(): void {
         this.setHasRequiredFields();
         this.metadataFormChangeset.validate();

--- a/app/preprints/-components/submit/metadata/template.hbs
+++ b/app/preprints/-components/submit/metadata/template.hbs
@@ -93,9 +93,8 @@
                         <Subjects::Manager
                             @model={{@manager.preprint}}
                             @provider={{@manager.provider}}
-                            @metadataChangeset={{this.metadataFormChangeset}} 
+                            @metadataChangeset={{this.metadataFormChangeset}}
                             @doesAutosave={{true}}
-                            @hasSubjects={{action this.hasSubjects}}
                             @onchange={{action this.validate}}
                             id={{subjectsFieldId}}
                             as |subjectsManager|
@@ -103,7 +102,7 @@
                             <Subjects::Widget
                                 @subjectsManager={{subjectsManager}}
                             />
-                            <ValidationErrors 
+                            <ValidationErrors
                             @changeset={{this.metadataFormChangeset}} @key='subjects'
                             @isValidating={{subjectsManager.isSaving}} />
                         </Subjects::Manager>

--- a/lib/osf-components/addon/components/subjects/manager/component.ts
+++ b/lib/osf-components/addon/components/subjects/manager/component.ts
@@ -60,7 +60,6 @@ export default class SubjectManagerComponent extends Component {
     // optional
     metadataChangeset?: BufferedChangeset;
     onchange?: () => void;
-    hasSubjects?: (_: boolean) => void;
 
     // private
     @service intl!: Intl;
@@ -121,11 +120,6 @@ export default class SubjectManagerComponent extends Component {
         });
         this.incrementProperty('selectedSubjectsChanges');
         this.incrementProperty('savedSubjectsChanges');
-        this.model.set('subjects', savedSubjects);
-        if (this.hasSubjects) {
-            this.metadataChangeset?.validate('subjects');
-            this.hasSubjects(savedSubjectIds.size > 0);
-        }
     }
 
     @restartableTask


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-7712]
-   Feature flag: n/a

## Purpose
- Allow write users to update registration metadata without getting yelled at about how "Only admins can edit subjects"

## Summary of Changes
- Remove unnecessary setting of node subjects in the subjects manager
  - This was causing the node's subjects to get included into the PATCH request whenever the subjects::manager component was invoked (which wasn't good when a write-user was viewing a page with it)
  - Remove other unneeded logic that was mucking things up

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-7712]: https://openscience.atlassian.net/browse/ENG-7712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ