### PR TITLE
[ENG-7555] Use the same share filters for dashboard, institutions preprints and global searches

### DIFF
--- a/app/institutions/discover/controller.ts
+++ b/app/institutions/discover/controller.ts
@@ -22,9 +22,6 @@ export default class InstitutionDiscoverController extends Controller {
         let key = 'affiliation';
         const { resourceType } = this;
         switch (resourceType) {
-        case ResourceTypeFilterValue.Preprints:
-            key = 'creator.affiliation';
-            break;
         case ResourceTypeFilterValue.Files:
             key = 'isContainedBy.affiliation';
             break;


### PR DESCRIPTION
## Purpose

Institutions preprints search page has `creator.affiliation` filter that is implicitly added to share request and results different number of preprints than dashboard and global search pages. On the other hand, dashboard and global searches add `affiliation` filter instead.

## Summary of Changes

Use default `affiliation` key instead of replacing it by `creator.affiliation` for preprints

## Ticket

https://openscience.atlassian.net/jira/software/c/projects/ENG/boards/145?selectedIssue=ENG-7555