### PR TITLE
[ENG-6267] Add the ability to turn off the "add a preprint" feature based on the admin section

### DIFF
--- a/lib/app-components/addon/components/branded-navbar/template.hbs
+++ b/lib/app-components/addon/components/branded-navbar/template.hbs
@@ -97,16 +97,18 @@
                                     </OsfLink>
                                 </li>
                             {{/if}}
-                            <li>
-                                <OsfLink
-                                    data-test-add-a-preprint-branded-navbar
-                                    data-analytics-name='{{this.provider.id}}: add a {{this.provider.preprintWord}} link'
-                                    @route='preprints.submit'
-                                    @models={{array this.provider.id}}
-                                >
-                                    <span role='button'>{{t 'navbar.add_a_preprint' preprintWord=this.provider.preprintWord}}</span>
-                                </OsfLink>
-                            </li>
+                            {{#if this.provider.allowSubmissions}}
+                                <li>
+                                    <OsfLink
+                                        data-test-add-a-preprint-branded-navbar
+                                        data-analytics-name='{{this.provider.id}}: add a {{this.provider.preprintWord}} link'
+                                        @route='preprints.submit'
+                                        @models={{array this.provider.id}}
+                                    >
+                                        <span role='button'>{{t 'navbar.add_a_preprint' preprintWord=this.provider.preprintWord}}</span>
+                                    </OsfLink>
+                                </li>
+                            {{/if}}
                         {{/if}}
                         <li>
                             <a

--- a/lib/osf-components/addon/components/osf-navbar/preprint-links/component.ts
+++ b/lib/osf-components/addon/components/osf-navbar/preprint-links/component.ts
@@ -2,12 +2,14 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import CurrentUserService from 'ember-osf-web/services/current-user';
 import config from 'ember-osf-web/config/environment';
+import Theme from 'ember-osf-web/services/theme';
 
 interface Args {
     onLinkClicked: () => void;
 }
 export default class OsfNavbarPreprintLinks extends Component<Args> {
     @service currentUser!: CurrentUserService;
+    @service theme!: Theme;
 
     donateURL = `${config.OSF.donateUrl}`;
     supportURL = `${config.support.faqPageUrl}`;

--- a/lib/osf-components/addon/components/osf-navbar/preprint-links/template.hbs
+++ b/lib/osf-components/addon/components/osf-navbar/preprint-links/template.hbs
@@ -18,16 +18,18 @@
         </OsfLink>
     </li>
 {{/if}}
-<li data-test-nav-submit-preprint-link>
-    <OsfLink
-        data-test-add-a-preprint-osf-navbar
-        data-analytics-name='Add a preprint'
-        @route='preprints.select'
-        {{on 'click' @onLinkClicked}}
-    >
-        {{t 'navbar.add_a_preprint' preprintWord=(t 'documentType.preprint.singularCapitalized')}}
-    </OsfLink>
-</li>
+{{#if this.theme.provider.allowSubmissions}}
+    <li data-test-nav-submit-preprint-link>
+        <OsfLink
+            data-test-add-a-preprint-osf-navbar
+            data-analytics-name='Add a preprint'
+            @route='preprints.select'
+            {{on 'click' @onLinkClicked}}
+        >
+            {{t 'navbar.add_a_preprint' preprintWord=(t 'documentType.preprint.singularCapitalized')}}
+        </OsfLink>
+    </li>
+{{/if}}
 <li data-test-nav-search-link>
     <OsfLink
         @route='search'


### PR DESCRIPTION
-   Ticket: [ENG-6267]
-   Feature flag: n/a

## Purpose

Updated the branded and non-branded preprint navbar to respect the `allowSubmission` attribute on a preprint provider

## Summary of Changes

The Branded Navbar only needed an if statement (this demonstrated that the bug was for all providers and not just the OSF)

On the non-branded navbar for just OSF needed the theme service injected to have the if statement work.



## Screenshot(s)
![Screenshot 2025-04-21 at 12 46 50 PM](https://github.com/user-attachments/assets/6f125a8e-33e9-47b0-b3e2-97bc179098a3)

## Side Effects

Could be many issues.

## QA Notes

Give it a try


[ENG-7799]: https://openscience.atlassian.net/browse/ENG-7799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ENG-6267]: https://openscience.atlassian.net/browse/ENG-6267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ