### PR TITLE
[ENG-7937] fix: use compact IRIs to match the api

### DIFF
--- a/app/models/index-card-search.ts
+++ b/app/models/index-card-search.ts
@@ -10,7 +10,7 @@ export interface SearchFilter {
     filterType?: string;
 }
 
-export const ShareMoreThanTenThousand = 'https://share.osf.io/vocab/2023/trove/ten-thousands-and-more';
+export const ShareMoreThanTenThousand = 'trove:ten-thousands-and-more';
 
 export default class IndexCardSearchModel extends Model {
     @attr('string') cardSearchText!: string;

--- a/app/models/search-result.ts
+++ b/app/models/search-result.ts
@@ -314,7 +314,7 @@ export default class SearchResultModel extends Model {
     }
 
     get isWithdrawn() {
-        return this.resourceMetadata.dateWithdrawn || this.resourceMetadata['https://osf.io/vocab/2022/withdrawal'];
+        return this.resourceMetadata.dateWithdrawn || this.resourceMetadata['osf:withdrawal'];
     }
 
     get configuredAddonNames() {

--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -263,7 +263,7 @@ export default class SearchPage extends Component<SearchArgs> {
             this.nextPageCursor = searchResult.nextPageCursor;
             this.prevPageCursor = searchResult.prevPageCursor;
             this.searchResults = searchResult.searchResultPage.toArray();
-            this.totalResultCount = searchResult.totalResultCount === ShareMoreThanTenThousand ? '10,000+' :
+            this.totalResultCount = searchResult.totalResultCount['@id'] === ShareMoreThanTenThousand ? '10,000+' :
                 searchResult.totalResultCount;
         } catch (e) {
             this.toast.error(e);

--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -83,7 +83,7 @@ export default class SearchPage extends Component<SearchArgs> {
     @tracked relatedProperties?: RelatedPropertyPathModel[] = [];
     @tracked booleanFilters?: RelatedPropertyPathModel[] = [];
     @tracked page?: string = '';
-    @tracked totalResultCount?: string | number;
+    @tracked totalResultCount?: number | {'@id': string};
     @tracked firstPageCursor?: string | null;
     @tracked prevPageCursor?: string | null;
     @tracked nextPageCursor?: string | null;
@@ -263,7 +263,7 @@ export default class SearchPage extends Component<SearchArgs> {
             this.nextPageCursor = searchResult.nextPageCursor;
             this.prevPageCursor = searchResult.prevPageCursor;
             this.searchResults = searchResult.searchResultPage.toArray();
-            this.totalResultCount = searchResult.totalResultCount['@id'] === ShareMoreThanTenThousand ? '10,000+' :
+            this.totalResultCount = searchResult.totalResultCount?.['@id'] === ShareMoreThanTenThousand ? '10,000+' :
                 searchResult.totalResultCount;
         } catch (e) {
             this.toast.error(e);


### PR DESCRIPTION

<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-7937]
-   Feature flag: n/a

## Purpose
fix wrong text displaying on the search page when there are many results (shows `trove:ten-thousands-and-more`, should show something like "10,000+ results")
<!-- Describe the purpose of your changes. -->

## Summary of Changes
update literal IRIs to compact IRIs to align with the search api (`https://share.osf.io/vocab/2023/trove/...` and `https://osf.io/vocab/2022/...` are namespaces, given prefixes `trove:...` and `osf:...` respectively)

(yet todo: json-ld parsing that would handle either)
<!-- Briefly describe or list your changes. -->

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

<!-- Any possible side effects? (https://en.wikipedia.org/wiki/Side_effect_%28computer_science%29) -->

## QA Notes

<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-7937]: https://openscience.atlassian.net/browse/ENG-7937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ