### PR TITLE
[ENG-8159] Allow collections without metadata to be submitted.

### DIFF
--- a/app/serializers/collection-submission.ts
+++ b/app/serializers/collection-submission.ts
@@ -11,7 +11,8 @@ export default class CollectionSubmissionSerializer extends OsfSerializer {
      */
     serialize(snapshot: DS.Snapshot, options: {}) {
         const serialized = super.serialize(snapshot, options);
-        const { data, data: { attributes, relationships } } = serialized;
+        const { data, data: { relationships } } = serialized;
+        data.attributes = data.attributes || { };
 
         data.type = 'collection-submissions';
 
@@ -19,8 +20,9 @@ export default class CollectionSubmissionSerializer extends OsfSerializer {
             const { guid } = relationships;
             if ('data' in guid) {
                 const { data: guidData } = guid;
+
                 if (guidData && 'id' in guidData) {
-                    attributes!.guid = guidData.id;
+                    data.attributes!.guid = guidData.id;
                     delete relationships.guid;
                 }
             }


### PR DESCRIPTION
-   Ticket: [ENG-8159]
-   Feature flag: n/a

## Purpose

Collections without meta-data were throwing errors because the `attributes` object was null.

## Summary of Changes

If the `attributes` object is null then it is instantiated with an empty object

## Screenshot(s)

N.A

## Side Effects

Lots regarding the user experience which I have documented for Mark.

## QA Notes

You will need to turn off all metadata in the admin before testing

![image](https://github.com/user-attachments/assets/8845a42a-655a-46ec-ae2c-79f34ef3325f)



[ENG-8159]: https://openscience.atlassian.net/browse/ENG-8159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ