### PR TITLE
[ENG-8178] remove unnecessary group embed

### DIFF
--- a/lib/osf-components/addon/components/activity-log/component.ts
+++ b/lib/osf-components/addon/components/activity-log/component.ts
@@ -4,7 +4,7 @@ export default class ActivityLogComponent extends Component {
     public loadEmbeds = {
         embed:
             [
-                'group', 'linked_node', 'linked_registration', 'original_node',
+                'linked_node', 'linked_registration', 'original_node',
                 'template_node', 'user',
             ],
     };


### PR DESCRIPTION
## Purpose

OSF Groups is being deprecated this PR removes it's use from the FE

## Summary of Changes

- Don't embed `group` anymore

## Screenshot(s)

<!-- Attach screenshots if applicable. -->

## Side Effects

Speeds up log check

## QA Notes
https://openscience.atlassian.net/browse/ENG-8178