### PR TITLE
[ENG-8146] Follow-up Fix: Hide manual guid and doi fields for preprint edit flow

### DIFF
--- a/app/preprints/-components/submit/title-and-abstract/template.hbs
+++ b/app/preprints/-components/submit/title-and-abstract/template.hbs
@@ -48,7 +48,7 @@
                     @onKeyUp={{this.validate}}
                 />
             {{/let}}
-            {{#if (feature-flag 'manual_doi_and_guid')}}
+            {{#if (and (feature-flag 'manual_doi_and_guid') (not @manager.isEditFlow))}}
                 {{#let (unique-id 'manualDoi') as |manualDoiField|}}
                     <label for={{manualDoiField}}
                         data-test-manual-doi-label


### PR DESCRIPTION
-   Ticket: [ENG-8146](https://openscience.atlassian.net/browse/ENG-8146)
-   Feature flag: n/a

## Purpose

Hide manual guid and doi fields for preprint edit flow

## Summary of Changes

N/A

## Screenshot(s)

N/A

## Side Effects
N/A

## QA Notes

N/A

[ENG-8146]: https://openscience.atlassian.net/browse/ENG-8146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ