### PR TITLE
[ENG-8236] Fix missing resource-type dropdown during linked service configuration

### DIFF
--- a/lib/osf-components/addon/components/addons-service/configured-addon-edit/component.ts
+++ b/lib/osf-components/addon/components/addons-service/configured-addon-edit/component.ts
@@ -66,7 +66,8 @@ export default class ConfiguredAddonEdit extends Component<Args> {
     }
 
     get isLinkAddon() {
-        return this.args.configuredAddon instanceof ConfiguredLinkAddonModel;
+        return this.args.configuredAddon instanceof ConfiguredLinkAddonModel ||
+            this.args.authorizedAccount instanceof AuthorizedLinkAccountModel;
     }
 
     get requiresFilesWidget() {


### PR DESCRIPTION
-   Ticket: [ENG-8236](https://openscience.atlassian.net/browse/ENG-8236)
-   Feature flag: n/a

## Purpose

Fix missing resource-type dropdown during linked service configuration

## Summary of Changes

Fix missing resource-type dropdown during linked service configuration

## Screenshot(s)

https://github.com/user-attachments/assets/4253792b-dafe-481c-ba16-507df8e5f874


## Side Effects

N/A

## QA Notes

N/A


[ENG-8236]: https://openscience.atlassian.net/browse/ENG-8236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ