### PR TITLE
[ENG-8266] Fix "linked item" for linked service configuration

### DIFF
--- a/lib/osf-components/addon/components/addons-service/configured-addon-edit/template.hbs
+++ b/lib/osf-components/addon/components/addons-service/configured-addon-edit/template.hbs
@@ -35,6 +35,8 @@
                     {{this.selectedFolderDisplayName}}
                 {{else if this.selectedItemDisplayName}}
                     {{this.selectedItemDisplayName}}
+                {{else if this.isLinkAddon}}
+                    {{t 'addons.configure.no-item-selected'}}
                 {{else}}
                     {{t 'addons.configure.no-folder-selected'}}
                 {{/if}}

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -374,6 +374,7 @@ addons:
         selected-folder: 'Selected folder:'
         linked-item: 'Linked item:'
         no-folder-selected: 'No folder selected'
+        no-item-selected: 'No item selected'
         go-to-root: 'Go to home folder'
         go-to-folder: 'Go to folder {folderName}'
         select-folder: 'Select {folderName} as root folder'


### PR DESCRIPTION
-   Ticket: [ENG-8266](https://openscience.atlassian.net/browse/ENG-8266)
-   Feature flag: n/a

## Purpose

When no dataverse, dataset or file is connected, "linked item" should say "no item selected" instead of "no folder selected".

## Summary of Changes

When no dataverse, dataset or file is connected, "linked item" should say "no item selected" instead of "no folder selected".

## Screenshot(s)

![Screenshot 2025-06-23 at 14 36 37](https://github.com/user-attachments/assets/625f8dff-cd15-4b9c-b060-b2495cd8bafd)

![Screenshot 2025-06-23 at 14 36 08](https://github.com/user-attachments/assets/fecc58a4-d252-4727-876c-7eb25a01cb83)

## Side Effects

N/A

## QA Notes

N/A


[ENG-8266]: https://openscience.atlassian.net/browse/ENG-8266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ