### PR TITLE
[ENG-7805] Fix to prevent a race-condition removing a supplement from a preprint

### DIFF
--- a/app/preprints/-components/submit/supplements/component.ts
+++ b/app/preprints/-components/submit/supplements/component.ts
@@ -69,7 +69,7 @@ export default class Supplements extends Component<SupplementsArgs>{
     @waitFor
     public async removeSelectedProject(): Promise<void> {
         try {
-            this.args.manager.validateSupplements(false);
+            this.validate(false);
             await this.args.manager.preprint.removeM2MRelationship('node'); // Remove relationship
             // Remove relationship on the node side, this only clears the cache locally
             this.args.manager.preprint.node.get('preprints')
@@ -90,7 +90,7 @@ export default class Supplements extends Component<SupplementsArgs>{
     }
 
     @action
-    public validate(): void {
-        this.args.manager.validateSupplements(true);
+    public validate(isValid = true): void {
+        this.args.manager.validateSupplements(isValid);
     }
 }


### PR DESCRIPTION
-   Ticket: [ENG-7805]
-   Feature flag: n/a

## Purpose

 Fix to prevent a race-condition removing a supplement from a preprint

## Summary of Changes

When removing a supplement the "next" button was active and a quick click of delete and next would throw an error.

## Screenshot(s)

N/A

## Side Effects

N/A

## QA Notes

Should be working.


[ENG-7805]: https://openscience.atlassian.net/browse/ENG-7805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ