### PR TITLE
[ENG-8362] UAT - FE: Fix typo in empty linked service pages

### DIFF
--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -396,7 +396,7 @@ links:
     linked-service: 'Linked Service'
     display-name: 'Display Name'
     resource-type: 'Resource Type'
-    empty-screen-message: 'This project has no configured linked services at a moment '
+    empty-screen-message: 'This project has no configured linked services at the moment '
     point-to-addons-message: 'In order to add linked service visit'
     link: 'Link'
     edit: 'Edit'


### PR DESCRIPTION
-   Ticket: [ENG-8362](https://openscience.atlassian.net/browse/ENG-8362)
-   Feature flag: n/a

## Purpose

Fix typo in empty linked service pages

## Summary of Changes

Fix typo in empty linked service pages

## Screenshot(s)

N/A

## Side Effects

N/A

## QA Notes

N/A


[ENG-8362]: https://openscience.atlassian.net/browse/ENG-8362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ