### PR TITLE
[ENG-8174] Updates to fix the viewOnlyToken in cases there is a / or %2fF at the end

### DIFF
--- a/app/decorators/check-auth.ts
+++ b/app/decorators/check-auth.ts
@@ -37,10 +37,12 @@ export default function checkAuth<T extends ConcreteSubclass<Route>>(
             // Need to handle view-only links before checking auth, and this is the only reasonable place to do it.
             // This limitation points toward replacing this decorator with a service method meant to be
             // called in Route.beforeModel. Decorator mixins should probably be considered an anti-pattern.
-            const { viewOnlyToken = '' } = this.paramsFor('application') as Record<string, string>;
+            let { viewOnlyToken = '' } = this.paramsFor('application') as Record<string, string>;
 
             try {
                 if (!this.session.isAuthenticated || this.currentUser.viewOnlyToken !== viewOnlyToken) {
+                    // This is for ENG-8174 where occasionally a %2F or / is at the end of the viewOnlyToken
+                    viewOnlyToken = viewOnlyToken.replace(/(%2[fF]|\/)$/g, '');
                     this.currentUser.setProperties({ viewOnlyToken });
 
                     // Check whether user is actually logged in.

--- a/mirage/views/addons.ts
+++ b/mirage/views/addons.ts
@@ -478,7 +478,7 @@ function fakeCheckCredentials(
 async function emulateUserDoingOAuthFlow(authorizedAccount: ModelInstance<AllAuthorizedAccountTypes>, schema: Schema) {
     await timeout(1000);
     // eslint-disable-next-line no-console
-    console.log('Mirage addons view: emulateUserDoingOAuthFlow done');
+    console.info('Mirage addons view: emulateUserDoingOAuthFlow done');
     const currentUser = schema.roots.first().currentUser;
     authorizedAccount.update({
         credentialsAvailable: true,


### PR DESCRIPTION
-   Ticket: [ENG-8174]
-   Feature flag: n/a

## Purpose

Users were experiencing errors when either a %2[fF] or / was at the end of the viewOnlyToken

## Summary of Changes

Added a regex to remove %2[fF] or / from the end of the viewOnlyToken.

Also change a miscellaneous console.log to be console.info to make it easier to find and remove console.logs while debugging.

## Screenshot(s)

N/A

## Side Effects

There could be other characters at the end of the viewOnlyToken added by the user or a rogue url parser that is not covered in this fix.

## QA Notes

Super hard to duplicate. I wasn't able to. Good Luck


[ENG-8174]: https://openscience.atlassian.net/browse/ENG-8174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ