### PR TITLE
[ENG-8374] fix: stop objecting to 10k+ search results

### DIFF
--- a/app/institutions/dashboard/-components/object-list/component-test.ts
+++ b/app/institutions/dashboard/-components/object-list/component-test.ts
@@ -71,7 +71,7 @@ module('Integration | institutions | dashboard | -components | object-list', hoo
         assert.dom('[data-test-page-tab="summary"]').exists('Summary tab exists');
 
         // Elements in the top bar are present
-        assert.dom('[data-test-object-count]').containsText('10 total thingies', 'Object count is correct');
+        assert.dom('[data-test-object-count]').containsText('10,000+ total thingies', 'Object count is correct');
         assert.dom('[data-test-toggle-filter-button]').exists('Filter button exists');
         assert.dom('[data-test-customize-columns-button]').exists('Columns button exists');
 

--- a/app/models/index-card-search.ts
+++ b/app/models/index-card-search.ts
@@ -1,5 +1,7 @@
+import { inject as service } from '@ember/service';
 import Model, { AsyncHasMany, attr, hasMany } from '@ember-data/model';
 import {Links} from 'jsonapi-typescript';
+import Intl from 'ember-intl/services/intl';
 
 import RelatedPropertyPathModel from './related-property-path';
 import SearchResultModel from './search-result';
@@ -10,12 +12,12 @@ export interface SearchFilter {
     filterType?: string;
 }
 
-export const ShareMoreThanTenThousand = 'trove:ten-thousands-and-more';
-
 export default class IndexCardSearchModel extends Model {
+    @service intl!: Intl;
+
     @attr('string') cardSearchText!: string;
     @attr('array') cardSearchFilters!: SearchFilter[];
-    @attr('string') totalResultCount!: number | typeof ShareMoreThanTenThousand;
+    @attr totalResultCount!: number | object;
     @attr('object') links!: Links;
 
     @hasMany('search-result', { inverse: null })
@@ -46,6 +48,14 @@ export default class IndexCardSearchModel extends Model {
             return nextPageLinkUrl.searchParams.get('page[cursor]');
         }
         return null;
+    }
+
+    get displayCount(): number | string {
+        return (
+            typeof this.totalResultCount === 'number'
+                ? this.totalResultCount
+                : this.intl.t('search.ten-thousand-plus')
+        );
     }
 }
 

--- a/lib/osf-components/addon/components/index-card-searcher/component.ts
+++ b/lib/osf-components/addon/components/index-card-searcher/component.ts
@@ -23,7 +23,7 @@ export default class IndexCardSearcher extends Component<IndexCardSearcherArgs> 
     debounceTime = this.args.debounceTime || 1000;
 
     @tracked searchResults: SearchResultModel[] = [];
-    @tracked totalResultCount = 0;
+    @tracked totalResultCount: number | string = 0;
 
     @tracked relatedProperties?: RelatedPropertyPathModel[] = [];
     @tracked booleanFilters?: RelatedPropertyPathModel[] = [];
@@ -71,7 +71,7 @@ export default class IndexCardSearcher extends Component<IndexCardSearcherArgs> 
             this.nextPageCursor = searchResult.nextPageCursor;
             this.prevPageCursor = searchResult.prevPageCursor;
             this.searchResults = searchResult.searchResultPage.toArray();
-            this.totalResultCount = searchResult.totalResultCount;
+            this.totalResultCount = searchResult.displayCount;
 
             return searchResult;
         } catch (error) {

--- a/lib/osf-components/addon/components/search-page/component.ts
+++ b/lib/osf-components/addon/components/search-page/component.ts
@@ -11,7 +11,6 @@ import Store from '@ember-data/store';
 import { action } from '@ember/object';
 import Media from 'ember-responsive';
 
-import { ShareMoreThanTenThousand } from 'ember-osf-web/models/index-card-search';
 import InstitutionModel from 'ember-osf-web/models/institution';
 import SearchResultModel from 'ember-osf-web/models/search-result';
 import ProviderModel from 'ember-osf-web/models/provider';
@@ -83,7 +82,7 @@ export default class SearchPage extends Component<SearchArgs> {
     @tracked relatedProperties?: RelatedPropertyPathModel[] = [];
     @tracked booleanFilters?: RelatedPropertyPathModel[] = [];
     @tracked page?: string = '';
-    @tracked totalResultCount?: number | {'@id': string};
+    @tracked totalResultCount?: number | string;
     @tracked firstPageCursor?: string | null;
     @tracked prevPageCursor?: string | null;
     @tracked nextPageCursor?: string | null;
@@ -263,8 +262,7 @@ export default class SearchPage extends Component<SearchArgs> {
             this.nextPageCursor = searchResult.nextPageCursor;
             this.prevPageCursor = searchResult.prevPageCursor;
             this.searchResults = searchResult.searchResultPage.toArray();
-            this.totalResultCount = searchResult.totalResultCount?.['@id'] === ShareMoreThanTenThousand ? '10,000+' :
-                searchResult.totalResultCount;
+            this.totalResultCount = searchResult.displayCount;
         } catch (e) {
             this.toast.error(e);
         }

--- a/mirage/views/search.ts
+++ b/mirage/views/search.ts
@@ -300,7 +300,7 @@ export function cardSearch(_: Schema, request: Request) {
                         ],
                     },
                 ],
-                totalResultCount: 10,
+                totalResultCount: {'@id': 'trove:ten-thousands-and-more'},
             },
             relationships: {
                 relatedProperties: {

--- a/translations/en-us.yml
+++ b/translations/en-us.yml
@@ -602,6 +602,7 @@ search:
     search-help-label: 'Help tutorial'
     total-results: '{count} {count, plural, one {result} other {results} }'
     no-results: 'No results found'
+    ten-thousand-plus: '10,000+'
     resource-type:
         search-by: 'Search by object type'
         all: 'All'


### PR DESCRIPTION
<!--
  Before you submit your Pull Request, make sure you picked the right branch:
    - For hotfixes, select "master" as the target branch
    - For new features and non-hotfix bugfixes, select "develop" as the target branch
    - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch

  Ticketd PRs should be prefixed with the ticket id, e.g. `[FOO-123] some really great stuff`
-->

-   Ticket: [ENG-8374]
-   Feature flag: n/a

## Purpose
when there are 10000+ search results, display that instead of "[object Object]" (as delightful as that is)
<!-- Describe the purpose of your changes. -->

## QA Notes
check osf search page `/search`
<!--
  Does this change need QA? If so, this section is required.
    - What pages should be tested?
    - Is cross-browser testing required/recommended?
    - What edge cases should QA be aware of?
    - What level of risk would you expect these changes to have?
    - For each feature flag (if any), what is the expected behavior with the flag enabled vs disabled?
-->


[ENG-8374]: https://openscience.atlassian.net/browse/ENG-8374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ